### PR TITLE
feat: first-start onboarding wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "annotate-tools": "tsx src/cli.ts annotate-tools",
     "compile-policy": "tsx src/cli.ts compile-policy",
     "config": "tsx src/cli.ts config",
+    "setup": "tsx src/cli.ts setup",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ Usage:
 
 Commands:
   start [task]         Run the agent (interactive or single-shot)
+  setup                Run the first-start wizard (always runs)
   annotate-tools       Classify MCP tool arguments via LLM
   compile-policy       Compile constitution into enforceable policy rules
   refresh-lists        Re-resolve dynamic lists without full recompilation
@@ -99,6 +100,11 @@ switch (subcommand) {
   case 'config': {
     const { runConfigCommand } = await import('./config/config-command.js');
     await runConfigCommand();
+    break;
+  }
+  case 'setup': {
+    const { runFirstStart } = await import('./config/first-start.js');
+    await runFirstStart();
     break;
   }
   default:

--- a/src/config/first-start.ts
+++ b/src/config/first-start.ts
@@ -1,0 +1,126 @@
+/**
+ * First-start wizard for IronCurtain.
+ *
+ * Runs once when ~/.ironcurtain/config.json does not yet exist,
+ * educating the user about the security model, validating API keys,
+ * and pointing to customization options.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as p from '@clack/prompts';
+import { USER_CONFIG_DEFAULTS } from './user-config.js';
+import { parseModelId, type ProviderId } from './model-provider.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Maps provider IDs to their expected environment variable names. */
+const PROVIDER_ENV_VARS: Record<ProviderId, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
+  openai: 'OPENAI_API_KEY',
+};
+
+/** Checks if a prompt result was cancelled and exits cleanly. */
+function handleCancel(value: unknown): void {
+  if (p.isCancel(value)) {
+    p.cancel('Setup cancelled.');
+    process.exit(0);
+  }
+}
+
+/**
+ * Extracts the set of unique providers required by the default model configuration.
+ */
+function getRequiredProviders(): Set<ProviderId> {
+  const modelIds = [
+    USER_CONFIG_DEFAULTS.agentModelId,
+    USER_CONFIG_DEFAULTS.policyModelId,
+    USER_CONFIG_DEFAULTS.autoCompact.summaryModelId,
+    USER_CONFIG_DEFAULTS.autoApprove.modelId,
+  ];
+  const providers = new Set<ProviderId>();
+  for (const id of modelIds) {
+    providers.add(parseModelId(id).provider);
+  }
+  return providers;
+}
+
+export async function runFirstStart(): Promise<void> {
+  // Step 1: Welcome & security philosophy
+  p.intro('Welcome to IronCurtain');
+  p.note(
+    'In theater, an iron curtain is a fireproof barrier between the stage and\n' +
+      'the audience. If something goes wrong on stage, the curtain drops to\n' +
+      'contain the disaster. That is the metaphor.\n\n' +
+      'AI agents today operate under your full authority. They hold your\n' +
+      'credentials, process untrusted input, and execute code — all in the\n' +
+      'same trust domain. A single prompt injection can cause an agent to\n' +
+      'exfiltrate your data, and the agent has every capability to do so.',
+    'The problem',
+  );
+  p.note(
+    'IronCurtain mediates every tool call between the AI agent and MCP servers.\n' +
+      'A policy engine evaluates each call against a constitution you control.\n' +
+      'The agent can only produce typed function calls from a V8 isolate.\n' +
+      'Each MCP server runs in its own OS-level sandbox.\n\n' +
+      'We assume the LLM will be compromised or confused and constrain the\n' +
+      'consequences through architecture — not prevention.\n\n' +
+      'A word of caution: when you read "secure," mistrust it. There is a\n' +
+      'strong tension between security and utility. IronCurtain limits major\n' +
+      'unintended consequences but cannot guarantee nothing unintended will\n' +
+      'happen. The policy and sandbox constraints are there to limit the damage.',
+    'How IronCurtain helps',
+  );
+
+  const cont = await p.confirm({ message: 'Continue with setup?', initialValue: true });
+  handleCancel(cont);
+  if (!cont) {
+    p.cancel('Setup cancelled.');
+    process.exit(0);
+  }
+
+  // Step 2: Show the default constitution
+  const constitutionPath = resolve(__dirname, 'constitution.md');
+  let constitutionText: string;
+  try {
+    constitutionText = readFileSync(constitutionPath, 'utf-8');
+  } catch {
+    constitutionText = '(Could not read default constitution)';
+  }
+  p.note(constitutionText, 'Default Constitution');
+
+  // Step 3: API key validation
+  const requiredProviders = getRequiredProviders();
+  let allPresent = true;
+  for (const provider of requiredProviders) {
+    const envVar = PROVIDER_ENV_VARS[provider];
+    if (process.env[envVar]) {
+      p.log.success(`API key configured for ${provider} (${envVar})`);
+    } else {
+      allPresent = false;
+      p.log.warn(
+        `Missing API key for ${provider}.\n` +
+          `  Set it via: export ${envVar}=<your-key>\n` +
+          `  Or add ${envVar}=<your-key> to a .env file in your project directory.`,
+      );
+    }
+  }
+  if (allPresent) {
+    p.log.info('All required API keys are configured.');
+  }
+
+  // Step 4: Suggest customization
+  p.note(
+    'You can customize IronCurtain to fit your workflow:\n\n' +
+      '  ironcurtain config             — change models, resource limits, and other settings\n' +
+      '  ironcurtain customize-policy   — LLM-assisted interactive policy customization\n' +
+      '  ironcurtain compile-policy     — recompile after constitution changes\n' +
+      '  ironcurtain annotate-tools     — reclassify tool arguments after server changes',
+    'Customization',
+  );
+
+  // Step 5: Outro
+  p.outro('Run `ironcurtain start` to begin.');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import chalk from 'chalk';
 import ora from 'ora';
 import { loadConfig, loadGeneratedPolicy, checkConstitutionFreshness, getPackageGeneratedDir } from './config/index.js';
+import { getUserConfigPath } from './config/paths.js';
 import * as logger from './logger.js';
 import { CliTransport } from './session/cli-transport.js';
 import { createSession } from './session/index.js';
@@ -31,6 +33,12 @@ export async function main(args?: string[]): Promise<void> {
       process.stderr.write(`  ${agent.id}  ${agent.displayName}\n`);
     }
     return;
+  }
+
+  // First-start wizard: run when config file does not exist and stdin is a TTY
+  if (!existsSync(getUserConfigPath()) && process.stdin.isTTY) {
+    const { runFirstStart } = await import('./config/first-start.js');
+    await runFirstStart();
   }
 
   const task = positionals.join(' ');


### PR DESCRIPTION
## Summary
- Adds an interactive first-start wizard that runs when `~/.ironcurtain/config.json` doesn't exist
- Explains the security model (ambient authority problem, architectural approach, "mistrust secure" caveat)
- Shows the default constitution, validates API keys, and lists customization commands
- Adds `ironcurtain setup` subcommand to re-run the wizard at any time
- Skipped silently in non-TTY environments; existing tests unaffected

## Test plan
- [x] Delete `~/.ironcurtain/config.json`, run `npm start` — wizard appears
- [x] Run `npm start` again — wizard does not appear
- [x] Run `npm run setup` — wizard always appears
- [x] Unset `ANTHROPIC_API_KEY`, run setup — shows warning
- [x] Set `ANTHROPIC_API_KEY`, run setup — shows success
- [x] `echo "" | npm start` — wizard skipped (non-TTY)
- [x] Ctrl+C during wizard — exits cleanly
- [x] `npm test` — all existing tests pass