### PR TITLE
fix: resolve PTY size mismatch in Docker agent sessions

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -119,25 +119,21 @@ exec claude --dangerously-skip-permissions \\
 
     // Helper script to resize the PTY that Claude Code is actually running on.
     // docker exec stty targets a transient exec session PTY, not socat's PTY.
-    // Falls back to start-claude.sh PID when Claude hasn't started yet.
+    // If Claude hasn't started yet, we exit silently — start-claude.sh sets
+    // the initial size from env vars, so no fallback is needed.
     // Diagnostic output goes to stderr (captured by host-side logger).
     const resizeScript = `#!/bin/bash
 # Called from the host via: docker exec <cid> /etc/ironcurtain/resize-pty.sh <cols> <rows>
 COLS=$1
 ROWS=$2
 
-# Find the PTY device -- try Claude first, then fall back to start script
-PTS=""
 CLAUDE_PID=$(pgrep -x claude | head -1)
-if [ -n "$CLAUDE_PID" ]; then
-  PTS=$(readlink /proc/$CLAUDE_PID/fd/0 2>/dev/null)
+if [ -z "$CLAUDE_PID" ]; then
+  echo "no-claude" >&2
+  exit 0
 fi
-if [ -z "$PTS" ]; then
-  SCRIPT_PID=$(pgrep -f "start-claude" | head -1)
-  if [ -n "$SCRIPT_PID" ]; then
-    PTS=$(readlink /proc/$SCRIPT_PID/fd/0 2>/dev/null)
-  fi
-fi
+
+PTS=$(readlink /proc/$CLAUDE_PID/fd/0 2>/dev/null)
 if [ -z "$PTS" ] || ! [ -e "$PTS" ]; then
   echo "no-pty pid=$CLAUDE_PID pts=$PTS" >&2
   exit 0
@@ -145,26 +141,16 @@ fi
 
 stty -F "$PTS" cols "$COLS" rows "$ROWS" 2>/dev/null
 RC=$?
-if [ -n "$CLAUDE_PID" ]; then
-  kill -WINCH "$CLAUDE_PID" 2>/dev/null
-fi
+kill -WINCH "$CLAUDE_PID" 2>/dev/null
 echo "ok pid=$CLAUDE_PID pts=$PTS stty=$RC \${COLS}x\${ROWS}" >&2
 `;
 
     // Helper script to report the current PTY size for host-side verification.
     const checkSizeScript = `#!/bin/bash
 # Returns "rows cols" of the container PTY
-PTS=""
 CLAUDE_PID=$(pgrep -x claude | head -1)
-if [ -n "$CLAUDE_PID" ]; then
-  PTS=$(readlink /proc/$CLAUDE_PID/fd/0 2>/dev/null)
-fi
-if [ -z "$PTS" ]; then
-  SCRIPT_PID=$(pgrep -f "start-claude" | head -1)
-  if [ -n "$SCRIPT_PID" ]; then
-    PTS=$(readlink /proc/$SCRIPT_PID/fd/0 2>/dev/null)
-  fi
-fi
+if [ -z "$CLAUDE_PID" ]; then echo "0 0"; exit 0; fi
+PTS=$(readlink /proc/$CLAUDE_PID/fd/0 2>/dev/null)
 if [ -z "$PTS" ] || ! [ -e "$PTS" ]; then echo "0 0"; exit 0; fi
 stty -F "$PTS" size 2>/dev/null || echo "0 0"
 `;

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -413,9 +413,9 @@ function attachPty(options: PtyProxyOptions): Promise<number> {
             (err, _stdout, stderr) => {
               if (err) {
                 logger.warn(`resize-pty.sh failed: ${err.message}`);
-              }
-              if (stderr) {
-                logger.info(`resize-pty.sh: ${stderr.trim()}`);
+                if (stderr) {
+                  logger.warn(`resize-pty.sh stderr: ${stderr.trim()}`);
+                }
               }
             },
           );
@@ -457,6 +457,7 @@ function attachPty(options: PtyProxyOptions): Promise<number> {
         stdin.removeListener('data', onData);
         conn.unpipe(stdout);
         stdin.pause();
+        verifyAbort.abort();
         options.signal?.removeEventListener('abort', onAbort);
       }
       function onAbort(): void {


### PR DESCRIPTION
## Summary

- Fix initial PTY size by setting dimensions via `stty` in `start-claude.sh` from host-provided env vars (`IRONCURTAIN_INITIAL_COLS`/`ROWS`), eliminating the startup race condition
- Fix runtime resize by switching from `pgrep -f "claude --dangerously"` (matches cmdline) to `pgrep -x claude` (matches process name) — Claude Code overwrites `/proc/PID/cmdline` to just `"claude"` with null-padded arguments stripped
- Add background verify+retry loop for initial resize (canceled via AbortController on first user resize to prevent size ping-pong)
- Add `check-pty-size.sh` orientation file and diagnostic stderr logging from `resize-pty.sh`

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 1439 tests pass (11 in pty-session.test.ts)
- [x] New socat-based integration tests verify `stty -F` resize on real PTY pairs
- [x] Validated against live Docker container: `pgrep -x claude` finds PID 15, `readlink /proc/15/fd/0` → `/dev/pts/2`, `stty -F` resize confirmed working
- [ ] Manual: `ironcurtain start --pty "hello"` — verify Claude Code TUI fills terminal and adjusts on resize