### PR TITLE
fix: bypass MCP SDK client-side outputSchema validation on error responses

### DIFF
--- a/scripts/mcp-discovery.ts
+++ b/scripts/mcp-discovery.ts
@@ -9,7 +9,7 @@
 import { mkdirSync } from 'node:fs';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { permissiveOutputValidator } from '../src/trusted-process/permissive-output-validator.js';
+import { permissiveJsonSchemaValidator } from '../src/trusted-process/permissive-output-validator.js';
 import type { IronCurtainConfig } from '../src/config/types.js';
 import type { ServerListing } from '../src/session/prompts.js';
 
@@ -45,7 +45,7 @@ export async function discoverTools(config: IronCurtainConfig, clientName: strin
 
       const client = new Client(
         { name: clientName, version: '0.0.0' },
-        { jsonSchemaValidator: permissiveOutputValidator },
+        { jsonSchemaValidator: permissiveJsonSchemaValidator },
       );
       await client.connect(transport);
       clients.push({ client, transport });

--- a/src/pipeline/annotate.ts
+++ b/src/pipeline/annotate.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import type { LanguageModel } from 'ai';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { permissiveOutputValidator } from '../trusted-process/permissive-output-validator.js';
+import { permissiveJsonSchemaValidator } from '../trusted-process/permissive-output-validator.js';
 import chalk from 'chalk';
 import type { MCPServerConfig } from '../config/types.js';
 import {
@@ -63,7 +63,7 @@ async function connectAndDiscoverTools(
           }
           client = new Client(
             { name: 'ironcurtain-annotator', version: VERSION },
-            { jsonSchemaValidator: permissiveOutputValidator },
+            { jsonSchemaValidator: permissiveJsonSchemaValidator },
           );
           await client.connect(transport);
 

--- a/src/pipeline/compile.ts
+++ b/src/pipeline/compile.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 import type { LanguageModel, SystemModelMessage } from 'ai';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { permissiveOutputValidator } from '../trusted-process/permissive-output-validator.js';
+import { permissiveJsonSchemaValidator } from '../trusted-process/permissive-output-validator.js';
 import chalk from 'chalk';
 import { extractServerDomainAllowlists } from '../config/index.js';
 import type { MCPServerConfig } from '../config/types.js';
@@ -476,7 +476,7 @@ export async function connectMcpServersForLists(
 
     const client = new Client(
       { name: 'ironcurtain-list-resolver', version: VERSION },
-      { jsonSchemaValidator: permissiveOutputValidator },
+      { jsonSchemaValidator: permissiveJsonSchemaValidator },
     );
     await client.connect(transport);
     const toolsResult = await client.listTools();

--- a/src/trusted-process/mcp-client-manager.ts
+++ b/src/trusted-process/mcp-client-manager.ts
@@ -4,7 +4,7 @@ import { CompatibilityCallToolResultSchema, ListRootsRequestSchema } from '@mode
 import type { MCPServerConfig } from '../config/types.js';
 import * as logger from '../logger.js';
 import { VERSION } from '../version.js';
-import { permissiveOutputValidator } from './permissive-output-validator.js';
+import { permissiveJsonSchemaValidator } from './permissive-output-validator.js';
 
 export const ROOTS_REFRESH_TIMEOUT_MS = 5_000;
 
@@ -37,7 +37,7 @@ export class MCPClientManager {
       { name: 'ironcurtain', version: VERSION },
       {
         ...(roots ? { capabilities: { roots: { listChanged: true } } } : {}),
-        jsonSchemaValidator: permissiveOutputValidator,
+        jsonSchemaValidator: permissiveJsonSchemaValidator,
       },
     );
 
@@ -128,7 +128,8 @@ export class MCPClientManager {
     }
 
     // CompatibilityCallToolResultSchema accepts the legacy `toolResult` response format.
-    // Output schema validation is handled by the permissiveOutputValidator on the Client.
+    // Output schema validation is intentionally bypassed by the permissiveJsonSchemaValidator
+    // on the Client (always returns { valid: true }) so schema issues don't hide real MCP tool errors.
     return server.client.callTool({ name: toolName, arguments: args }, CompatibilityCallToolResultSchema);
   }
 

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -72,7 +72,7 @@ import { wrapLanguageModel } from 'ai';
 import { createLlmLoggingMiddleware } from '../pipeline/llm-logger.js';
 import { extractMcpErrorMessage } from './mcp-error-utils.js';
 import { type ServerContextMap, updateServerContext, formatServerContext } from './server-context.js';
-import { permissiveOutputValidator } from './permissive-output-validator.js';
+import { permissiveJsonSchemaValidator } from './permissive-output-validator.js';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 import type { MCPServerConfig, SandboxAvailabilityPolicy } from '../config/types.js';
 import { VERSION } from '../version.js';
@@ -714,8 +714,8 @@ export async function handleCallTool(
     const client = clientState.client;
 
     // CompatibilityCallToolResultSchema accepts the legacy `toolResult` response format
-    // (protocol version 2024-10-07). Output schema validation is separately handled by
-    // the permissiveOutputValidator injected at Client construction time.
+    // (protocol version 2024-10-07). Output schema validation is intentionally
+    // bypassed by the permissiveJsonSchemaValidator injected at Client construction time.
     const result = await client.callTool(
       {
         name: toolInfo.name,
@@ -883,7 +883,7 @@ async function main(): Promise<void> {
       { name: 'ironcurtain-proxy', version: VERSION },
       {
         capabilities: { roots: { listChanged: true } },
-        jsonSchemaValidator: permissiveOutputValidator,
+        jsonSchemaValidator: permissiveJsonSchemaValidator,
       },
     );
 

--- a/src/trusted-process/permissive-output-validator.ts
+++ b/src/trusted-process/permissive-output-validator.ts
@@ -12,15 +12,16 @@
  * the real error message from the agent.
  *
  * IronCurtain acts as a proxy -- it does not consume structuredContent itself,
- * so skipping this validation is safe. The real MCP server already performed
- * its own validation before sending the response.
+ * so it intentionally bypasses this client-side schema validation and simply
+ * forwards whatever the MCP server returns, even if the server skipped its
+ * own structuredContent validation for error responses.
  *
  * See: https://github.com/modelcontextprotocol/typescript-sdk/pull/1428
  * TODO: Remove once the SDK ships the isError skip fix for client-side validation.
  */
 import type { jsonSchemaValidator, JsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/types.js';
 
-export const permissiveOutputValidator: jsonSchemaValidator = {
+export const permissiveJsonSchemaValidator: jsonSchemaValidator = {
   getValidator<T>(): JsonSchemaValidator<T> {
     return (input: unknown) => ({
       valid: true as const,

--- a/test/permissive-output-validator.test.ts
+++ b/test/permissive-output-validator.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { permissiveOutputValidator } from '../src/trusted-process/permissive-output-validator.js';
+import { permissiveJsonSchemaValidator } from '../src/trusted-process/permissive-output-validator.js';
 
-describe('permissiveOutputValidator', () => {
+describe('permissiveJsonSchemaValidator', () => {
   it('always returns valid for any input', () => {
-    const validator = permissiveOutputValidator.getValidator({
+    const validator = permissiveJsonSchemaValidator.getValidator({
       type: 'object',
       required: ['success', 'commitHash'],
       properties: {
@@ -20,7 +20,7 @@ describe('permissiveOutputValidator', () => {
   });
 
   it('returns valid for empty objects', () => {
-    const validator = permissiveOutputValidator.getValidator({
+    const validator = permissiveJsonSchemaValidator.getValidator({
       type: 'object',
       required: ['name'],
     });
@@ -28,7 +28,7 @@ describe('permissiveOutputValidator', () => {
   });
 
   it('returns valid for null/undefined input', () => {
-    const validator = permissiveOutputValidator.getValidator({ type: 'object' });
+    const validator = permissiveJsonSchemaValidator.getValidator({ type: 'object' });
     expect(validator(null).valid).toBe(true);
     expect(validator(undefined).valid).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Adds a permissive JSON Schema validator (`permissive-output-validator.ts`) that bypasses MCP SDK client-side `outputSchema` validation
- Injects the validator into all `new Client()` call sites (trusted process, pipeline, and scripts)
- MCP SDK v1.12.0+ validates `structuredContent` against `outputSchema` even when `isError=true`, hiding real error messages (e.g. "ssh: Could not resolve hostname") behind opaque schema validation errors
- Workaround until [SDK PR #1428](https://github.com/modelcontextprotocol/typescript-sdk/pull/1428) ships the client-side fix

## Test plan

- [x] Unit tests for permissive validator (schema-violating data, empty objects, null/undefined)
- [ ] Manual test with an MCP server that declares `outputSchema` and returns errors (e.g. git-mcp-server with no network)