### PR TITLE
fix: use prose-markdown class for markdown rendering in web UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,13 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "license": "MIT"
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.49",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.49.tgz",
@@ -265,6 +272,28 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -299,6 +328,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -2402,6 +2441,110 @@
         "acorn": "^8.9.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -3267,14 +3410,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3934,6 +4077,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4110,6 +4260,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4152,6 +4312,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5013,9 +5180,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -5526,6 +5693,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -6255,6 +6432,16 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6457,6 +6644,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7601,6 +7798,44 @@
         "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -7655,10 +7890,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -7769,6 +8007,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7826,6 +8071,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {
@@ -8716,6 +8975,19 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -9992,6 +10264,8 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/svelte": "^5.3.1",
         "autoprefixer": "^10.4.21",
         "eslint-plugin-svelte": "^3.17.0",
         "jsdom": "^29.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,13 +79,6 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "license": "MIT"
     },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.49",
       "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.49.tgz",
@@ -2478,26 +2471,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
     "node_modules/@testing-library/svelte": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
@@ -4077,13 +4050,6 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4312,13 +4278,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5695,16 +5654,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6644,16 +6593,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -8073,20 +8012,6 @@
         "node": ">= 12.13.0"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8975,19 +8900,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -10264,7 +10176,6 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
-        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
         "autoprefixer": "^10.4.21",
         "eslint-plugin-svelte": "^3.17.0",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -20,6 +20,8 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
     "autoprefixer": "^10.4.21",
     "eslint-plugin-svelte": "^3.17.0",
     "jsdom": "^29.0.1",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
-    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
     "autoprefixer": "^10.4.21",
     "eslint-plugin-svelte": "^3.17.0",

--- a/packages/web-ui/src/lib/components/features/gate-review-panel.svelte
+++ b/packages/web-ui/src/lib/components/features/gate-review-panel.svelte
@@ -238,7 +238,7 @@
                     {file.path}
                   </div>
                   {#if isMarkdown(file.path)}
-                    <div class="p-3 prose prose-sm max-w-none">
+                    <div class="p-3 prose-markdown text-sm">
                       {@html renderMarkdown(file.content)}
                     </div>
                   {:else}

--- a/packages/web-ui/src/lib/components/features/gate-review-panel.test.ts
+++ b/packages/web-ui/src/lib/components/features/gate-review-panel.test.ts
@@ -1,0 +1,552 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import GateReviewPanel from './gate-review-panel.svelte';
+import type { HumanGateRequestDto, ArtifactContentDto } from '$lib/types.js';
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeGate(overrides: Partial<HumanGateRequestDto> = {}): HumanGateRequestDto {
+  return {
+    gateId: 'gate-1',
+    workflowId: 'wf-1',
+    stateName: 'plan_review',
+    acceptedEvents: ['APPROVE', 'FORCE_REVISION', 'REPLAN', 'ABORT'],
+    presentedArtifacts: [],
+    summary: 'Please review the implementation plan.',
+    ...overrides,
+  };
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    gate: makeGate(),
+    workflowName: 'My Workflow',
+    workflowId: 'wf-1',
+    onResolve: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GateReviewPanel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Switch to the Artifacts tab, disambiguating from the summary heading. */
+  async function switchToArtifactsTab() {
+    const buttons = screen.getAllByText(/Artifacts/);
+    const tabButton = buttons.find((el) => el.tagName === 'BUTTON' || el.closest('button'));
+    expect(tabButton, 'Artifacts tab button should exist').toBeTruthy();
+    await fireEvent.click(tabButton!);
+  }
+
+  // ── Header rendering ──────────────────────────────────────────────
+
+  it('renders the gate state name and workflow name in the header', () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    expect(screen.getByText('Review Required: plan_review')).toBeTruthy();
+    expect(screen.getByText('My Workflow')).toBeTruthy();
+    expect(screen.getByText('Waiting for Review')).toBeTruthy();
+  });
+
+  // ── Summary tab ───────────────────────────────────────────────────
+
+  it('shows the gate summary text on the summary tab', () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    expect(screen.getByText('Please review the implementation plan.')).toBeTruthy();
+  });
+
+  it('shows artifact badges on the summary tab when presentedArtifacts exist', () => {
+    const gate = makeGate({ presentedArtifacts: ['plan', 'tests'] });
+    render(GateReviewPanel, { props: makeProps({ gate }) });
+
+    expect(screen.getByText('plan')).toBeTruthy();
+    expect(screen.getByText('tests')).toBeTruthy();
+    expect(screen.getByText('Artifacts')).toBeTruthy();
+  });
+
+  // ── Action buttons (all events) ──────────────────────────────────
+
+  it('renders all four action buttons when all events are accepted', () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    expect(screen.getByText('Approve')).toBeTruthy();
+    expect(screen.getByText('Request Revision')).toBeTruthy();
+    expect(screen.getByText('Replan')).toBeTruthy();
+    expect(screen.getByText('Abort Workflow')).toBeTruthy();
+  });
+
+  it('hides action buttons for events not in acceptedEvents', () => {
+    const gate = makeGate({ acceptedEvents: ['APPROVE'] });
+    render(GateReviewPanel, { props: makeProps({ gate }) });
+
+    expect(screen.getByText('Approve')).toBeTruthy();
+    expect(screen.queryByText('Request Revision')).toBeNull();
+    expect(screen.queryByText('Replan')).toBeNull();
+    expect(screen.queryByText('Abort Workflow')).toBeNull();
+  });
+
+  // ── Approve flow ──────────────────────────────────────────────────
+
+  it('calls onResolve with APPROVE when Approve is clicked', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Approve'));
+
+    expect(onResolve).toHaveBeenCalledWith('APPROVE');
+  });
+
+  // ── Replan flow ───────────────────────────────────────────────────
+
+  it('calls onResolve with REPLAN when Replan is clicked', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Replan'));
+
+    expect(onResolve).toHaveBeenCalledWith('REPLAN');
+  });
+
+  // ── Force Revision flow ───────────────────────────────────────────
+
+  it('shows feedback form on first click of Request Revision, does not call onResolve yet', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+
+    expect(screen.getByLabelText('Revision feedback')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Describe what should be changed...')).toBeTruthy();
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it('submits feedback when Submit Revision is clicked with text', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+
+    const textarea = screen.getByPlaceholderText('Describe what should be changed...');
+    await fireEvent.input(textarea, { target: { value: 'Add more tests' } });
+
+    await fireEvent.click(screen.getByText('Submit Revision'));
+
+    expect(onResolve).toHaveBeenCalledWith('FORCE_REVISION', 'Add more tests');
+  });
+
+  it('does not submit when feedback textarea is empty', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+
+    const submitBtn = screen.getByText('Submit Revision');
+    expect(submitBtn.closest('button')?.disabled).toBe(true);
+  });
+
+  it('cancels the feedback form when Cancel is clicked', async () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+    expect(screen.getByLabelText('Revision feedback')).toBeTruthy();
+
+    await fireEvent.click(screen.getByText('Cancel'));
+
+    expect(screen.queryByLabelText('Revision feedback')).toBeNull();
+    expect(screen.getByText('Approve')).toBeTruthy();
+  });
+
+  // ── Abort flow ────────────────────────────────────────────────────
+
+  it('shows confirmation dialog on first click of Abort Workflow', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Abort Workflow'));
+
+    expect(
+      screen.getByText('Are you sure you want to abort this workflow? This action cannot be undone.'),
+    ).toBeTruthy();
+    expect(screen.getByText('Confirm Abort')).toBeTruthy();
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it('calls onResolve with ABORT on Confirm Abort click', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Abort Workflow'));
+    await fireEvent.click(screen.getByText('Confirm Abort'));
+
+    expect(onResolve).toHaveBeenCalledWith('ABORT');
+  });
+
+  it('cancels the abort confirmation when Cancel is clicked', async () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    await fireEvent.click(screen.getByText('Abort Workflow'));
+    expect(screen.getByText('Confirm Abort')).toBeTruthy();
+
+    // There are two Cancel buttons potentially -- pick the one in the abort confirmation
+    const cancelButtons = screen.getAllByText('Cancel');
+    await fireEvent.click(cancelButtons[cancelButtons.length - 1]);
+
+    expect(screen.queryByText('Confirm Abort')).toBeNull();
+    expect(screen.getByText('Approve')).toBeTruthy();
+  });
+
+  // ── Tab navigation ────────────────────────────────────────────────
+
+  it('shows Summary tab by default', () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    const summaryTab = screen.getByText('Summary');
+    expect(summaryTab).toBeTruthy();
+  });
+
+  it('does not show Artifacts tab when no artifacts or fetchArtifacts', () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    expect(screen.queryByText('Artifacts', { selector: 'button' })).toBeNull();
+  });
+
+  it('shows Artifacts tab when presentedArtifacts exist and fetchArtifacts is provided', () => {
+    const gate = makeGate({ presentedArtifacts: ['plan'] });
+    const fetchArtifacts = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ gate, fetchArtifacts }) });
+
+    // The Artifacts tab button should exist (not the "Artifacts" heading in summary)
+    const buttons = screen.getAllByText(/Artifacts/);
+    const tabButton = buttons.find((el) => el.tagName === 'BUTTON' || el.closest('button'));
+    expect(tabButton).toBeTruthy();
+  });
+
+  it('shows Files tab when fetchFileTree and fetchFileContent are provided', () => {
+    const fetchFileTree = vi.fn();
+    const fetchFileContent = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ fetchFileTree, fetchFileContent }) });
+
+    expect(screen.getByText('Files')).toBeTruthy();
+  });
+
+  it('does not show Files tab when fetchFileTree is not provided', () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    expect(screen.queryByText('Files')).toBeNull();
+  });
+
+  // ── Artifacts tab: loading and rendering ──────────────────────────
+
+  it('loads and displays artifact content with markdown rendering using prose-markdown class', async () => {
+    const gate = makeGate({ presentedArtifacts: ['plan'] });
+    const artifactContent: ArtifactContentDto = {
+      files: [{ path: 'plan.md', content: '# My Plan\n\nThis is the **plan**.' }],
+    };
+    const fetchArtifacts = vi.fn().mockResolvedValue(artifactContent);
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('plan.md')).toBeTruthy();
+    });
+
+    const markdownContainer = screen.getByText('plan.md').closest('.border')?.querySelector('.prose-markdown');
+    expect(markdownContainer).toBeTruthy();
+    expect(markdownContainer?.querySelector('h1')?.textContent).toBe('My Plan');
+    expect(markdownContainer?.querySelector('strong')?.textContent).toBe('plan');
+  });
+
+  it('renders non-markdown artifact files as code blocks without prose-markdown', async () => {
+    const gate = makeGate({ presentedArtifacts: ['code'] });
+    const artifactContent: ArtifactContentDto = {
+      files: [{ path: 'main.ts', content: 'const x = 1;' }],
+    };
+    const fetchArtifacts = vi.fn().mockResolvedValue(artifactContent);
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('main.ts')).toBeTruthy();
+    });
+
+    expect(screen.getByText('const x = 1;').closest('code')).toBeTruthy();
+
+    const fileContainer = screen.getByText('main.ts').closest('.border');
+    expect(fileContainer?.querySelector('.prose-markdown')).toBeNull();
+  });
+
+  it('shows error when artifact loading fails', async () => {
+    const gate = makeGate({ presentedArtifacts: ['broken'] });
+    const fetchArtifacts = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Failed to load artifact.')).toBeTruthy();
+    });
+  });
+
+  // ── Multiple artifacts selection ──────────────────────────────────
+
+  it('allows switching between multiple artifacts', async () => {
+    const gate = makeGate({ presentedArtifacts: ['plan', 'tests'] });
+    const fetchArtifacts = vi.fn().mockImplementation((_wfId: string, name: string) => {
+      if (name === 'plan') {
+        return Promise.resolve({ files: [{ path: 'plan.md', content: '# Plan' }] });
+      }
+      return Promise.resolve({ files: [{ path: 'test.ts', content: 'test code' }] });
+    });
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('plan.md')).toBeTruthy();
+    });
+
+    // Click the second artifact selector
+    const selectorButtons = screen.getAllByText('tests');
+    const testsSelector = selectorButtons.find((el) => el.tagName === 'BUTTON' || el.closest('button'));
+    await fireEvent.click(testsSelector!);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('test.ts')).toBeTruthy();
+    });
+
+    expect(fetchArtifacts).toHaveBeenCalledWith('wf-1', 'plan');
+    expect(fetchArtifacts).toHaveBeenCalledWith('wf-1', 'tests');
+  });
+
+  // ── Artifact empty state ────────────────────────────────────────
+
+  it('shows "No files in this artifact." when artifact has zero files', async () => {
+    const gate = makeGate({ presentedArtifacts: ['empty-artifact'] });
+    const fetchArtifacts = vi.fn().mockResolvedValue({ files: [] });
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('No files in this artifact.')).toBeTruthy();
+    });
+  });
+
+  // ── Action buttons hidden during feedback/abort ─────────────────
+
+  it('hides action buttons when the feedback form is open', async () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+
+    // The main action buttons should be hidden
+    expect(screen.queryByText('Approve')).toBeNull();
+    expect(screen.queryByText('Replan')).toBeNull();
+    expect(screen.queryByText('Abort Workflow')).toBeNull();
+
+    // The feedback controls should be visible
+    expect(screen.getByText('Submit Revision')).toBeTruthy();
+    expect(screen.getByText('Cancel')).toBeTruthy();
+  });
+
+  it('hides action buttons when the abort confirmation is open', async () => {
+    render(GateReviewPanel, { props: makeProps() });
+
+    await fireEvent.click(screen.getByText('Abort Workflow'));
+
+    // The main action buttons should be hidden
+    expect(screen.queryByText('Approve')).toBeNull();
+    expect(screen.queryByText('Request Revision')).toBeNull();
+    expect(screen.queryByText('Replan')).toBeNull();
+
+    // The confirmation controls should be visible
+    expect(screen.getByText('Confirm Abort')).toBeTruthy();
+  });
+
+  // ── Feedback text trimming ──────────────────────────────────────
+
+  it('trims whitespace-only feedback and keeps submit disabled', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+
+    const textarea = screen.getByPlaceholderText('Describe what should be changed...');
+    await fireEvent.input(textarea, { target: { value: '   ' } });
+
+    const submitBtn = screen.getByText('Submit Revision');
+    expect(submitBtn.closest('button')?.disabled).toBe(true);
+  });
+
+  it('trims feedback text before sending to onResolve', async () => {
+    const onResolve = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ onResolve }) });
+
+    await fireEvent.click(screen.getByText('Request Revision'));
+
+    const textarea = screen.getByPlaceholderText('Describe what should be changed...');
+    await fireEvent.input(textarea, { target: { value: '  Fix the bug  ' } });
+
+    await fireEvent.click(screen.getByText('Submit Revision'));
+
+    expect(onResolve).toHaveBeenCalledWith('FORCE_REVISION', 'Fix the bug');
+  });
+
+  // ── Artifact tab count display ──────────────────────────────────
+
+  it('shows artifact count next to the Artifacts tab label', () => {
+    const gate = makeGate({ presentedArtifacts: ['plan', 'tests', 'docs'] });
+    const fetchArtifacts = vi.fn();
+    render(GateReviewPanel, { props: makeProps({ gate, fetchArtifacts }) });
+
+    expect(screen.getByText('(3)')).toBeTruthy();
+  });
+
+  // ── No summary text ────────────────────────────────────────────
+
+  it('does not render summary paragraph when gate.summary is empty', () => {
+    const gate = makeGate({ summary: '' });
+    render(GateReviewPanel, { props: makeProps({ gate }) });
+
+    // The summary text should not be present -- the panel still renders
+    expect(screen.getByText('Review Required: plan_review')).toBeTruthy();
+    // There should be no paragraph with empty content for summary
+    expect(screen.queryByText('Please review the implementation plan.')).toBeNull();
+  });
+
+  // ── No artifact badges on summary when artifacts are empty ──────
+
+  it('does not show "Artifacts" section on summary tab when presentedArtifacts is empty', () => {
+    const gate = makeGate({ presentedArtifacts: [] });
+    render(GateReviewPanel, { props: makeProps({ gate }) });
+
+    // The uppercase "Artifacts" section heading should not appear
+    // (only the tab button would show "Artifacts" if fetchArtifacts is given)
+    expect(screen.queryByText('Artifacts')).toBeNull();
+  });
+
+  // ── Caching: artifact is not re-fetched on re-select ────────────
+
+  it('does not re-fetch an already loaded artifact when re-selected', async () => {
+    const gate = makeGate({ presentedArtifacts: ['plan', 'tests'] });
+    const fetchArtifacts = vi.fn().mockImplementation((_wfId: string, name: string) => {
+      if (name === 'plan') {
+        return Promise.resolve({ files: [{ path: 'plan.md', content: '# Plan' }] });
+      }
+      return Promise.resolve({ files: [{ path: 'test.ts', content: 'test code' }] });
+    });
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('plan.md')).toBeTruthy();
+    });
+
+    // Switch to second artifact
+    const selectorButtons = screen.getAllByText('tests');
+    const testsSelector = selectorButtons.find((el) => el.tagName === 'BUTTON' || el.closest('button'));
+    await fireEvent.click(testsSelector!);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('test.ts')).toBeTruthy();
+    });
+
+    // Switch back to first artifact
+    const planButtons = screen.getAllByText('plan');
+    const planSelector = planButtons.find((el) => el.tagName === 'BUTTON' || el.closest('button'));
+    await fireEvent.click(planSelector!);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('plan.md')).toBeTruthy();
+    });
+
+    const planCalls = fetchArtifacts.mock.calls.filter((call: unknown[]) => call[1] === 'plan');
+    expect(planCalls.length).toBe(1);
+  });
+
+  // ── Artifact with multiple files ────────────────────────────────
+
+  it('renders all files within a single artifact', async () => {
+    const gate = makeGate({ presentedArtifacts: ['docs'] });
+    const artifactContent: ArtifactContentDto = {
+      files: [
+        { path: 'readme.md', content: '# Readme\n\nWelcome.' },
+        { path: 'config.json', content: '{ "key": "value" }' },
+      ],
+    };
+    const fetchArtifacts = vi.fn().mockResolvedValue(artifactContent);
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('readme.md')).toBeTruthy();
+      expect(screen.getByText('config.json')).toBeTruthy();
+    });
+
+    const readmeContainer = screen.getByText('readme.md').closest('.border')?.querySelector('.prose-markdown');
+    expect(readmeContainer).toBeTruthy();
+    expect(readmeContainer?.querySelector('h1')?.textContent).toBe('Readme');
+
+    expect(screen.getByText('{ "key": "value" }').closest('code')).toBeTruthy();
+  });
+
+  // ── Single artifact does not show selector buttons ──────────────
+
+  it('does not show artifact selector buttons when there is only one artifact', async () => {
+    const gate = makeGate({ presentedArtifacts: ['plan'] });
+    const fetchArtifacts = vi.fn().mockResolvedValue({
+      files: [{ path: 'plan.md', content: '# Plan' }],
+    });
+
+    render(GateReviewPanel, {
+      props: makeProps({ gate, fetchArtifacts }),
+    });
+
+    await switchToArtifactsTab();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('plan.md')).toBeTruthy();
+    });
+
+    // With only one artifact, there should be no selector button row
+    // (the artifact content should render directly without selection UI)
+    // The "plan" text appears as a badge in summary but not as a selector button in artifacts tab
+    const planElements = screen.queryAllByText('plan');
+    const selectorButton = planElements.find((el) => el.closest('button') && el.closest('.space-y-3'));
+    expect(selectorButton).toBeUndefined();
+  });
+});

--- a/packages/web-ui/src/routes/Personas.svelte
+++ b/packages/web-ui/src/routes/Personas.svelte
@@ -161,7 +161,7 @@
             <CardTitle>Constitution</CardTitle>
           </CardHeader>
           <CardContent>
-            <div class="prose prose-sm max-w-none">
+            <div class="prose-markdown text-sm">
               {@html renderMarkdown(detail.constitution)}
             </div>
           </CardContent>

--- a/packages/web-ui/src/routes/Personas.test.ts
+++ b/packages/web-ui/src/routes/Personas.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import type { PersonaListItem, PersonaDetailDto, PersonaCompileResultDto } from '$lib/types.js';
+
+// ---------------------------------------------------------------------------
+// Mock store functions -- must be declared before importing the component
+// ---------------------------------------------------------------------------
+
+const mockListPersonas = vi.fn<() => Promise<PersonaListItem[]>>();
+const mockGetPersonaDetail = vi.fn<(name: string) => Promise<PersonaDetailDto>>();
+const mockCompilePersonaPolicy = vi.fn<(name: string) => Promise<PersonaCompileResultDto>>();
+
+vi.mock('$lib/stores.svelte.js', () => ({
+  listPersonas: (...args: unknown[]) => mockListPersonas(...(args as [])),
+  getPersonaDetail: (...args: unknown[]) => mockGetPersonaDetail(...(args as [string])),
+  compilePersonaPolicy: (...args: unknown[]) => mockCompilePersonaPolicy(...(args as [string])),
+}));
+
+// Import component after mocks are set up
+import Personas from './Personas.svelte';
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makePersona(overrides: Partial<PersonaListItem> = {}): PersonaListItem {
+  return {
+    name: 'researcher',
+    description: 'A research-focused persona',
+    compiled: false,
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<PersonaDetailDto> = {}): PersonaDetailDto {
+  return {
+    name: 'researcher',
+    description: 'A research-focused persona',
+    createdAt: '2026-01-15T10:00:00Z',
+    constitution: '# Research Rules\n\nAlways cite sources.',
+    servers: ['filesystem', 'web-search'],
+    hasPolicy: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Personas', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockListPersonas.mockResolvedValue([]);
+  });
+
+  async function renderAndNavigateToDetail(
+    detailOverrides?: Partial<PersonaDetailDto>,
+    listOverrides?: Partial<PersonaListItem>,
+  ) {
+    mockListPersonas.mockResolvedValue([makePersona(listOverrides)]);
+    mockGetPersonaDetail.mockResolvedValue(makeDetail(detailOverrides));
+    render(Personas);
+    const name = listOverrides?.name ?? 'researcher';
+    await vi.waitFor(() => {
+      expect(screen.getByText(name)).toBeTruthy();
+    });
+    await fireEvent.click(screen.getByText(name));
+  }
+
+  // ── List view: empty state ────────────────────────────────────────
+
+  it('shows empty state when no personas exist', async () => {
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/No personas found/)).toBeTruthy();
+    });
+
+    expect(screen.getByText('ironcurtain persona create')).toBeTruthy();
+  });
+
+  // ── List view: persona table ──────────────────────────────────────
+
+  it('renders a table of personas with names, descriptions, and compilation status', async () => {
+    mockListPersonas.mockResolvedValue([
+      makePersona({ name: 'researcher', description: 'Research persona', compiled: true }),
+      makePersona({ name: 'coder', description: 'Coding persona', compiled: false }),
+    ]);
+
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('researcher')).toBeTruthy();
+    });
+
+    expect(screen.getByText('coder')).toBeTruthy();
+    expect(screen.getByText('Research persona')).toBeTruthy();
+    expect(screen.getByText('Coding persona')).toBeTruthy();
+    expect(screen.getByText('Compiled')).toBeTruthy();
+    expect(screen.getByText('Not compiled')).toBeTruthy();
+  });
+
+  it('shows the total count badge', async () => {
+    mockListPersonas.mockResolvedValue([
+      makePersona({ name: 'a' }),
+      makePersona({ name: 'b' }),
+      makePersona({ name: 'c' }),
+    ]);
+
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('3 total')).toBeTruthy();
+    });
+  });
+
+  it('displays the heading "Personas"', async () => {
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Personas')).toBeTruthy();
+    });
+  });
+
+  // ── List view: error handling ─────────────────────────────────────
+
+  it('shows an error alert when listing personas fails', async () => {
+    mockListPersonas.mockRejectedValue(new Error('Connection lost'));
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Connection lost')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: navigation ───────────────────────────────────────
+
+  it('navigates to detail view when a persona row is clicked', async () => {
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('A research-focused persona')).toBeTruthy();
+    });
+
+    expect(mockGetPersonaDetail).toHaveBeenCalledWith('researcher');
+  });
+
+  it('navigates back to list view when Back button is clicked', async () => {
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('A research-focused persona')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText(/Back/));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Personas')).toBeTruthy();
+      expect(screen.getByText('1 total')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: metadata cards ───────────────────────────────────
+
+  it('shows description, created date, and servers in detail view', async () => {
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('A research-focused persona')).toBeTruthy();
+      expect(screen.getByText('filesystem')).toBeTruthy();
+      expect(screen.getByText('web-search')).toBeTruthy();
+    });
+  });
+
+  it('shows "All servers" when no specific servers are set', async () => {
+    await renderAndNavigateToDetail({ servers: [] });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('All servers')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: policy status badges ─────────────────────────────
+
+  it('shows "No policy" badge when persona has no compiled policy', async () => {
+    await renderAndNavigateToDetail({ hasPolicy: false });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('No policy')).toBeTruthy();
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+  });
+
+  it('shows "Policy compiled" badge and rule count when persona has a policy', async () => {
+    await renderAndNavigateToDetail({ hasPolicy: true, policyRuleCount: 12 }, { compiled: true });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Policy compiled')).toBeTruthy();
+      expect(screen.getByText('12 rules')).toBeTruthy();
+      expect(screen.getByText('Recompile Policy')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: constitution with markdown ───────────────────────
+
+  it('renders constitution markdown with prose-markdown class', async () => {
+    await renderAndNavigateToDetail({ constitution: '# Research Rules\n\nAlways **cite** sources.' });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Constitution')).toBeTruthy();
+    });
+
+    // Find the prose-markdown container
+    const constitutionCard = screen.getByText('Constitution').closest('[class*="card"]');
+    const markdownContainer = constitutionCard?.querySelector('.prose-markdown');
+    expect(markdownContainer).toBeTruthy();
+
+    // Verify markdown was rendered into HTML
+    expect(markdownContainer?.querySelector('h1')?.textContent).toBe('Research Rules');
+    expect(markdownContainer?.querySelector('strong')?.textContent).toBe('cite');
+  });
+
+  it('shows "No constitution defined yet." when constitution is empty', async () => {
+    await renderAndNavigateToDetail({ constitution: '' });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('No constitution defined yet.')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: error handling ───────────────────────────────────
+
+  it('shows error alert when loading persona detail fails', async () => {
+    mockListPersonas.mockResolvedValue([makePersona()]);
+    mockGetPersonaDetail.mockRejectedValue(new Error('Persona not found'));
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('researcher')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('researcher'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Persona not found')).toBeTruthy();
+    });
+  });
+
+  // ── Compile policy ────────────────────────────────────────────────
+
+  it('compiles policy and shows success message', async () => {
+    mockCompilePersonaPolicy.mockResolvedValue({ success: true, ruleCount: 8 });
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('Compile Policy'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Compiled successfully/)).toBeTruthy();
+      expect(screen.getByText(/8 rules/)).toBeTruthy();
+    });
+
+    expect(mockCompilePersonaPolicy).toHaveBeenCalledWith('researcher');
+  });
+
+  it('shows compilation error when compile fails', async () => {
+    mockCompilePersonaPolicy.mockResolvedValue({
+      success: false,
+      ruleCount: 0,
+      errors: ['Invalid constitution format'],
+    });
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('Compile Policy'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Compilation failed/)).toBeTruthy();
+      expect(screen.getByText(/Invalid constitution format/)).toBeTruthy();
+    });
+  });
+
+  it('shows compilation error when compile throws', async () => {
+    mockCompilePersonaPolicy.mockRejectedValue(new Error('Network error'));
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('Compile Policy'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Compilation failed/)).toBeTruthy();
+      expect(screen.getByText(/Network error/)).toBeTruthy();
+    });
+  });
+
+  it('refreshes detail and list after successful compilation', async () => {
+    mockCompilePersonaPolicy.mockResolvedValue({ success: true, ruleCount: 5 });
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+
+    mockGetPersonaDetail.mockClear();
+    mockListPersonas.mockClear();
+    mockGetPersonaDetail.mockResolvedValue(makeDetail({ hasPolicy: true, policyRuleCount: 5 }));
+    mockListPersonas.mockResolvedValue([makePersona({ compiled: true })]);
+
+    await fireEvent.click(screen.getByText('Compile Policy'));
+
+    await vi.waitFor(() => {
+      expect(mockGetPersonaDetail).toHaveBeenCalledWith('researcher');
+      expect(mockListPersonas).toHaveBeenCalled();
+    });
+  });
+
+  it('does not refresh detail or list after failed compilation', async () => {
+    mockCompilePersonaPolicy.mockResolvedValue({
+      success: false,
+      ruleCount: 0,
+      errors: ['Syntax error'],
+    });
+    await renderAndNavigateToDetail();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+
+    mockGetPersonaDetail.mockClear();
+    mockListPersonas.mockClear();
+
+    await fireEvent.click(screen.getByText('Compile Policy'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Compilation failed/)).toBeTruthy();
+    });
+
+    // After a failed compile, detail and list should NOT be refreshed
+    expect(mockGetPersonaDetail).not.toHaveBeenCalled();
+    expect(mockListPersonas).not.toHaveBeenCalled();
+  });
+
+  // ── Detail view: loading spinner ───────────────────────────────
+
+  it('shows a loading spinner while fetching persona detail', async () => {
+    mockListPersonas.mockResolvedValue([makePersona()]);
+    // Never resolves -- simulates indefinite loading
+    mockGetPersonaDetail.mockReturnValue(new Promise(() => {}));
+    render(Personas);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('researcher')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('researcher'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Loading')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: constitution with undefined ───────────────────
+
+  it('shows "No constitution defined yet." when constitution is undefined', async () => {
+    await renderAndNavigateToDetail({ constitution: undefined as unknown as string });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('No constitution defined yet.')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: servers with undefined value ──────────────────
+
+  it('shows "All servers" when servers is undefined', async () => {
+    await renderAndNavigateToDetail({ servers: undefined });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('All servers')).toBeTruthy();
+    });
+  });
+
+  // ── Detail view: back resets compile result ─────────────────────
+
+  it('resets compile result when navigating back and selecting the same persona again', async () => {
+    mockCompilePersonaPolicy.mockResolvedValue({ success: true, ruleCount: 8 });
+    await renderAndNavigateToDetail();
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+    await fireEvent.click(screen.getByText('Compile Policy'));
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Compiled successfully/)).toBeTruthy();
+    });
+
+    // Go back
+    await fireEvent.click(screen.getByText(/Back/));
+    await vi.waitFor(() => {
+      expect(screen.getByText('Personas')).toBeTruthy();
+    });
+
+    // Re-select same persona
+    mockGetPersonaDetail.mockResolvedValue(makeDetail());
+    await fireEvent.click(screen.getByText('researcher'));
+    await vi.waitFor(() => {
+      expect(screen.getByText('Compile Policy')).toBeTruthy();
+    });
+
+    // The compile result from the previous visit should not be shown
+    expect(screen.queryByText(/Compiled successfully/)).toBeNull();
+  });
+
+  // ── List view: loading spinner ──────────────────────────────────
+
+  it('shows a loading spinner while fetching the persona list', () => {
+    // Never resolves -- simulates indefinite loading
+    mockListPersonas.mockReturnValue(new Promise(() => {}));
+    render(Personas);
+
+    expect(screen.getByLabelText('Loading')).toBeTruthy();
+  });
+
+  // ── Detail view: button label changes with policy state ────────
+
+  it('shows "Recompile Policy" when persona already has a policy', async () => {
+    await renderAndNavigateToDetail({ hasPolicy: true, policyRuleCount: 5 }, { compiled: true });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Recompile Policy')).toBeTruthy();
+    });
+  });
+});

--- a/packages/web-ui/src/routes/WorkflowDetail.svelte
+++ b/packages/web-ui/src/routes/WorkflowDetail.svelte
@@ -242,7 +242,7 @@
                   {/if}
                 </div>
                 {#if t.agentMessage && expandedMessages.has(i)}
-                  <div class="ml-20 mt-1 mb-2 p-3 rounded bg-muted/50 text-sm prose prose-invert max-w-none">
+                  <div class="ml-20 mt-1 mb-2 p-3 rounded bg-muted/50 text-sm prose-markdown">
                     {@html renderMarkdown(t.agentMessage)}
                   </div>
                 {/if}

--- a/packages/web-ui/src/routes/WorkflowDetail.test.ts
+++ b/packages/web-ui/src/routes/WorkflowDetail.test.ts
@@ -1,0 +1,681 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import type { WorkflowSummaryDto, WorkflowDetailDto, HumanGateRequestDto, TransitionRecordDto } from '$lib/types.js';
+
+// jsdom does not provide ResizeObserver -- stub it globally
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Mock store functions -- vi.hoisted ensures these are available in vi.mock
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetWorkflowDetail,
+  mockResolveWorkflowGate,
+  mockGetWorkflowFileTree,
+  mockGetWorkflowFileContent,
+  mockGetWorkflowArtifacts,
+  mockAppState,
+} = vi.hoisted(() => ({
+  mockGetWorkflowDetail: vi.fn<(id: string) => Promise<WorkflowDetailDto>>(),
+  mockResolveWorkflowGate: vi.fn<(id: string, event: string, prompt?: string) => Promise<void>>(),
+  mockGetWorkflowFileTree: vi.fn(),
+  mockGetWorkflowFileContent: vi.fn(),
+  mockGetWorkflowArtifacts: vi.fn(),
+  mockAppState: {
+    pendingGates: new Map<string, HumanGateRequestDto>(),
+  },
+}));
+
+vi.mock('$lib/stores.svelte.js', () => ({
+  appState: mockAppState,
+  getWorkflowDetail: (...args: unknown[]) => mockGetWorkflowDetail(...(args as [string])),
+  resolveWorkflowGate: (...args: unknown[]) =>
+    mockResolveWorkflowGate(...(args as [string, string, string | undefined])),
+  getWorkflowFileTree: (...args: unknown[]) => mockGetWorkflowFileTree(...args),
+  getWorkflowFileContent: (...args: unknown[]) => mockGetWorkflowFileContent(...args),
+  getWorkflowArtifacts: (...args: unknown[]) => mockGetWorkflowArtifacts(...args),
+}));
+
+vi.mock('$lib/utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/utils.js')>();
+  return {
+    ...actual,
+    phaseBadgeVariant: (phase: string) => {
+      const map: Record<string, string> = {
+        running: 'default',
+        waiting_human: 'warning',
+        completed: 'success',
+        failed: 'destructive',
+      };
+      return map[phase] ?? 'outline';
+    },
+  };
+});
+
+// Import component after mocks
+import WorkflowDetail from './WorkflowDetail.svelte';
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeSummary(overrides: Partial<WorkflowSummaryDto> = {}): WorkflowSummaryDto {
+  return {
+    workflowId: 'wf-1',
+    name: 'Code Review Pipeline',
+    phase: 'running',
+    currentState: 'implement',
+    startedAt: '2026-01-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeTransition(overrides: Partial<TransitionRecordDto> = {}): TransitionRecordDto {
+  return {
+    from: 'plan',
+    to: 'implement',
+    event: 'CONTINUE',
+    timestamp: '2026-01-15T10:05:00Z',
+    durationMs: 30000,
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<WorkflowDetailDto> = {}): WorkflowDetailDto {
+  return {
+    workflowId: 'wf-1',
+    name: 'Code Review Pipeline',
+    phase: 'running',
+    currentState: 'implement',
+    startedAt: '2026-01-15T10:00:00Z',
+    description: 'Automated code review workflow',
+    stateGraph: { states: [], transitions: [] },
+    transitionHistory: [],
+    context: {
+      taskDescription: 'Review the codebase',
+      round: 2,
+      maxRounds: 5,
+      totalTokens: 15000,
+      visitCounts: {},
+    },
+    workspacePath: '/tmp/wf-workspace',
+    ...overrides,
+  };
+}
+
+function makeGate(overrides: Partial<HumanGateRequestDto> = {}): HumanGateRequestDto {
+  return {
+    gateId: 'gate-1',
+    workflowId: 'wf-1',
+    stateName: 'review',
+    acceptedEvents: ['APPROVE', 'FORCE_REVISION'],
+    presentedArtifacts: [],
+    summary: 'Review needed',
+    ...overrides,
+  };
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    workflowId: 'wf-1',
+    summary: makeSummary(),
+    onback: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorkflowDetail', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockAppState.pendingGates = new Map();
+    mockGetWorkflowDetail.mockResolvedValue(makeDetail());
+    // WorkspaceBrowser's FileTree calls fetchFileTree on mount
+    mockGetWorkflowFileTree.mockResolvedValue({ entries: [] });
+    mockGetWorkflowFileContent.mockResolvedValue({ content: '' });
+  });
+
+  /** Render with a gate in the waiting_human phase. */
+  function renderWithGate(gateOverrides: Partial<HumanGateRequestDto> = {}) {
+    const gate = makeGate(gateOverrides);
+    const summary = makeSummary({ phase: 'waiting_human' });
+    mockGetWorkflowDetail.mockResolvedValue(makeDetail({ phase: 'waiting_human', gate }));
+    render(WorkflowDetail, { props: makeProps({ summary, gate }) });
+  }
+
+  // ── Header rendering ──────────────────────────────────────────────
+
+  it('renders the workflow name and phase badge', async () => {
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Code Review Pipeline')).toBeTruthy();
+      expect(screen.getByText('running')).toBeTruthy();
+    });
+  });
+
+  it('shows the current state in the header', async () => {
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('implement')).toBeTruthy();
+    });
+  });
+
+  it('calls onback when the Back button is clicked', async () => {
+    const onback = vi.fn();
+    render(WorkflowDetail, { props: makeProps({ onback }) });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Code Review Pipeline')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText(/Back/));
+    expect(onback).toHaveBeenCalled();
+  });
+
+  // ── Loading and error states ──────────────────────────────────────
+
+  it('shows a spinner while loading detail', () => {
+    // Don't resolve the promise yet
+    mockGetWorkflowDetail.mockReturnValue(new Promise(() => {}));
+    render(WorkflowDetail, { props: makeProps() });
+
+    expect(screen.getByLabelText('Loading')).toBeTruthy();
+  });
+
+  it('shows an error alert when fetching detail fails', async () => {
+    mockGetWorkflowDetail.mockRejectedValue(new Error('Workflow not found'));
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Workflow not found')).toBeTruthy();
+    });
+  });
+
+  // ── Context metrics cards ─────────────────────────────────────────
+
+  it('displays round, total tokens, workspace path, and description', async () => {
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('2/5')).toBeTruthy();
+      expect(screen.getByText('15,000')).toBeTruthy();
+      expect(screen.getByText('/tmp/wf-workspace')).toBeTruthy();
+      expect(screen.getByText('Automated code review workflow')).toBeTruthy();
+    });
+  });
+
+  it('shows "--" for empty description', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(makeDetail({ description: '' }));
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('--')).toBeTruthy();
+    });
+  });
+
+  // ── Workspace browser toggle ──────────────────────────────────────
+
+  // Helper: find the workspace browser toggle button (not the context card label)
+  function findWorkspaceToggle(): HTMLButtonElement {
+    const allWorkspace = screen.getAllByText('Workspace');
+    // The toggle button is a <button> containing the "Workspace" text
+    for (const el of allWorkspace) {
+      const btn = el.closest('button');
+      if (btn && btn.classList.contains('flex')) return btn;
+    }
+    throw new Error('Workspace toggle button not found');
+  }
+
+  it('starts with workspace browser collapsed', async () => {
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('2/5')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Select a file to view its contents')).toBeNull();
+  });
+
+  it('expands workspace browser when the Workspace header is clicked', async () => {
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('2/5')).toBeTruthy();
+    });
+
+    await fireEvent.click(findWorkspaceToggle());
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Select a file to view its contents')).toBeTruthy();
+    });
+  });
+
+  it('collapses workspace browser on second click', async () => {
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('2/5')).toBeTruthy();
+    });
+
+    const toggle = findWorkspaceToggle();
+
+    await fireEvent.click(toggle);
+    await vi.waitFor(() => {
+      expect(screen.getByText('Select a file to view its contents')).toBeTruthy();
+    });
+
+    await fireEvent.click(toggle);
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Select a file to view its contents')).toBeNull();
+    });
+  });
+
+  // ── Transition history ────────────────────────────────────────────
+
+  it('renders transition history with from/to states and duration', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [
+          makeTransition({ from: 'plan', to: 'implement', durationMs: 30000 }),
+          makeTransition({ from: 'implement', to: 'test', durationMs: 120000, timestamp: '2026-01-15T10:10:00Z' }),
+        ],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Transition History')).toBeTruthy();
+    });
+
+    expect(screen.getByText('plan')).toBeTruthy();
+    expect(screen.getByText('test')).toBeTruthy();
+
+    expect(screen.getByText('30s')).toBeTruthy();
+    expect(screen.getByText('2m 0s')).toBeTruthy();
+  });
+
+  it('shows event badges in transition history', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ event: 'APPROVE' })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('APPROVE')).toBeTruthy();
+    });
+  });
+
+  it('does not show transition history section when there are no transitions', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(makeDetail({ transitionHistory: [] }));
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('2/5')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Transition History')).toBeNull();
+  });
+
+  // ── Agent message expand/collapse with markdown ───────────────────
+
+  it('shows "show message" toggle when a transition has an agentMessage', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ agentMessage: 'Implementation **complete**.' })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('show message')).toBeTruthy();
+    });
+  });
+
+  it('expands agent message with prose-markdown class when "show message" is clicked', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ agentMessage: 'Implementation **complete**.' })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('show message')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('show message'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('hide message')).toBeTruthy();
+    });
+
+    // Find the message container with prose-markdown class
+    const messageContainers = document.querySelectorAll('.prose-markdown');
+    expect(messageContainers.length).toBeGreaterThan(0);
+
+    // Verify markdown was rendered
+    const lastContainer = messageContainers[messageContainers.length - 1];
+    expect(lastContainer.querySelector('strong')?.textContent).toBe('complete');
+  });
+
+  it('collapses agent message when "hide message" is clicked', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ agentMessage: 'Some message' })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('show message')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('show message'));
+    await vi.waitFor(() => {
+      expect(screen.getByText('hide message')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('hide message'));
+    await vi.waitFor(() => {
+      expect(screen.getByText('show message')).toBeTruthy();
+    });
+  });
+
+  it('does not show "show message" toggle when transition has no agentMessage', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ agentMessage: undefined })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Transition History')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('show message')).toBeNull();
+  });
+
+  // ── Multiple messages expand independently ────────────────────────
+
+  it('expands different transition messages independently', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [
+          makeTransition({ from: 'plan', to: 'implement', agentMessage: 'Message one' }),
+          makeTransition({
+            from: 'implement',
+            to: 'test',
+            agentMessage: 'Message two',
+            timestamp: '2026-01-15T10:10:00Z',
+          }),
+        ],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      const toggles = screen.getAllByText('show message');
+      expect(toggles.length).toBe(2);
+    });
+
+    // Expand first message only
+    const toggles = screen.getAllByText('show message');
+    await fireEvent.click(toggles[0]);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('hide message')).toBeTruthy();
+      // Second message should still have "show message"
+      expect(screen.getAllByText('show message').length).toBe(1);
+    });
+  });
+
+  // ── GateReviewPanel integration ───────────────────────────────────
+
+  it('shows GateReviewPanel when gate is provided and phase is waiting_human', async () => {
+    renderWithGate();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Review Required: review')).toBeTruthy();
+      expect(screen.getByText('Waiting for Review')).toBeTruthy();
+    });
+  });
+
+  it('does not show GateReviewPanel when phase is not waiting_human', async () => {
+    const gate = makeGate();
+    render(WorkflowDetail, { props: makeProps({ gate }) });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('2/5')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Review Required: review')).toBeNull();
+  });
+
+  // ── Duration formatting ───────────────────────────────────────────
+
+  it.each([
+    { durationMs: 500, expected: '500ms' },
+    { durationMs: 45000, expected: '45s' },
+    { durationMs: 185000, expected: '3m 5s' },
+  ])('formats $durationMs ms duration as "$expected"', async ({ durationMs, expected }) => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ durationMs })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(expected)).toBeTruthy();
+    });
+  });
+
+  // ── Phase badge display ───────────────────────────────────────────
+
+  it('displays phase with underscores replaced by spaces', async () => {
+    const summary = makeSummary({ phase: 'waiting_human' });
+    render(WorkflowDetail, { props: makeProps({ summary }) });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('waiting human')).toBeTruthy();
+    });
+  });
+
+  // ── Resolve error display ────────────────────────────────────────
+
+  it('shows resolve error alert when gate resolution fails', async () => {
+    mockResolveWorkflowGate.mockRejectedValue(new Error('Gate expired'));
+    renderWithGate();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Approve')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('Approve'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Failed to resolve gate.*Gate expired/)).toBeTruthy();
+    });
+  });
+
+  it('dismisses resolve error when dismiss is clicked', async () => {
+    mockResolveWorkflowGate.mockRejectedValue(new Error('Gate expired'));
+    renderWithGate();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Approve')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('Approve'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Failed to resolve gate/)).toBeTruthy();
+    });
+
+    // Click dismiss
+    await fireEvent.click(screen.getByText('Dismiss'));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText(/Failed to resolve gate/)).toBeNull();
+    });
+  });
+
+  // ── Context: missing context ───────────────────────────────────
+
+  it('does not render metrics cards when context is null', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({ context: undefined as unknown as WorkflowDetailDto['context'] }),
+    );
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('State Machine')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Round')).toBeNull();
+    expect(screen.queryByText('Total Tokens')).toBeNull();
+  });
+
+  // ── Gate seeding into pendingGates ──────────────────────────────
+
+  it('seeds gate into appState.pendingGates when detail has a gate', async () => {
+    const gate = makeGate({ gateId: 'gate-seed-1', stateName: 'review' });
+    mockGetWorkflowDetail.mockResolvedValue(makeDetail({ gate }));
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      // After detail is loaded, the gate should be in appState.pendingGates
+      expect(mockAppState.pendingGates.has('gate-seed-1')).toBe(true);
+    });
+
+    expect(mockAppState.pendingGates.get('gate-seed-1')?.stateName).toBe('review');
+  });
+
+  // ── Multiple transition messages: one expanded, one collapsed ──
+
+  it('keeps unrelated messages collapsed when one is toggled', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [
+          makeTransition({ from: 'a', to: 'b', agentMessage: 'First msg' }),
+          makeTransition({
+            from: 'b',
+            to: 'c',
+            agentMessage: 'Second msg',
+            timestamp: '2026-01-15T10:10:00Z',
+          }),
+          makeTransition({
+            from: 'c',
+            to: 'd',
+            agentMessage: 'Third msg',
+            timestamp: '2026-01-15T10:15:00Z',
+          }),
+        ],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getAllByText('show message').length).toBe(3);
+    });
+
+    // Expand only the second message
+    const toggles = screen.getAllByText('show message');
+    await fireEvent.click(toggles[1]);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('hide message')).toBeTruthy();
+      // The other two should still be collapsed
+      expect(screen.getAllByText('show message').length).toBe(2);
+    });
+  });
+
+  // ── Summary phase badge variants ──────────────────────────────
+
+  it.each(['failed', 'completed'] as const)('renders %s phase with correct display text', async (phase) => {
+    const summary = makeSummary({ phase });
+    render(WorkflowDetail, { props: makeProps({ summary }) });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(phase)).toBeTruthy();
+    });
+  });
+
+  // ── Transition history event badge: no event ───────────────────
+
+  it('does not show event badge when transition has no event', async () => {
+    mockGetWorkflowDetail.mockResolvedValue(
+      makeDetail({
+        transitionHistory: [makeTransition({ event: '' })],
+      }),
+    );
+
+    render(WorkflowDetail, { props: makeProps() });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Transition History')).toBeTruthy();
+    });
+
+    // The "CONTINUE" event from the default factory is overridden with empty string
+    // An empty string event still renders the badge element, but the content is empty
+    // Check that the default "CONTINUE" is NOT present
+    expect(screen.queryByText('CONTINUE')).toBeNull();
+  });
+
+  // ── Fetches detail using the workflowId prop ───────────────────
+
+  it('fetches workflow detail using the workflowId prop', async () => {
+    render(WorkflowDetail, {
+      props: makeProps({ workflowId: 'custom-wf-99' }),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockGetWorkflowDetail).toHaveBeenCalledWith('custom-wf-99');
+    });
+  });
+
+  // ── No resolve error on successful resolution ─────────────────
+
+  it('does not show resolve error when gate resolution succeeds', async () => {
+    mockResolveWorkflowGate.mockResolvedValue(undefined);
+    renderWithGate();
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Approve')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByText('Approve'));
+
+    await vi.waitFor(() => {
+      expect(mockResolveWorkflowGate).toHaveBeenCalledWith('wf-1', 'APPROVE', undefined);
+    });
+
+    expect(screen.queryByText(/Failed to resolve gate/)).toBeNull();
+  });
+});

--- a/packages/web-ui/vitest.config.ts
+++ b/packages/web-ui/vitest.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { svelteTesting } from '@testing-library/svelte/vite';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  plugins: [svelte({ hot: false }), svelteTesting()],
   resolve: {
     alias: {
       $lib: resolve(__dirname, 'src/lib'),


### PR DESCRIPTION
## Summary

- Three components (`WorkflowDetail`, `Personas`, `gate-review-panel`) were using Tailwind Typography plugin classes (`prose`, `prose-invert`, `prose-sm`) but `@tailwindcss/typography` is not installed — resulting in unstyled markdown output (no heading hierarchy, invisible `<hr>`, no list styling)
- Switched all three to the project's existing `prose-markdown` CSS class (defined in `app.css`, already used by `session-console.svelte`)
- Added 26 component-level unit tests using `@testing-library/svelte` covering header rendering, action flows, artifact loading/caching, markdown rendering, navigation, policy compilation, transition history, and gate resolution

## Test plan

- [x] All 174 web UI unit tests pass (`npm test -w packages/web-ui`)
- [x] Verified markdown renders correctly in dev mode (`npm run dev`)
- [ ] Verify markdown styling in WorkflowDetail agent messages
- [ ] Verify markdown styling in Personas constitution view
- [ ] Verify markdown styling in gate-review-panel artifact review