### PR TITLE
fix: web UI stays stuck at waiting_human after gate rejection

### DIFF
--- a/packages/web-ui/src/lib/__tests__/event-handler.test.ts
+++ b/packages/web-ui/src/lib/__tests__/event-handler.test.ts
@@ -519,6 +519,128 @@ describe('handleEvent', () => {
       expect(state.pendingGates.size).toBe(0);
     });
 
+    it('transitions phase from waiting_human to running on gate_dismissed when no gates remain', () => {
+      const state = createMockState();
+      state.workflows = new Map([
+        [
+          'wf-1',
+          {
+            workflowId: 'wf-1',
+            name: 'test',
+            phase: 'waiting_human' as const,
+            currentState: 'plan_review',
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]);
+      state.pendingGates = new Map([
+        [
+          'wf-1-plan_review',
+          {
+            gateId: 'wf-1-plan_review',
+            workflowId: 'wf-1',
+            stateName: 'plan_review',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Review',
+          },
+        ],
+      ]);
+
+      handleEvent(state, createMockEffects(), 'workflow.gate_dismissed', {
+        workflowId: 'wf-1',
+        gateId: 'wf-1-plan_review',
+      });
+
+      expect(state.pendingGates.size).toBe(0);
+      expect(state.workflows.get('wf-1')?.phase).toBe('running');
+    });
+
+    it('keeps waiting_human phase on gate_dismissed when other gates remain for same workflow', () => {
+      const state = createMockState();
+      state.workflows = new Map([
+        [
+          'wf-1',
+          {
+            workflowId: 'wf-1',
+            name: 'test',
+            phase: 'waiting_human' as const,
+            currentState: 'plan_review',
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]);
+      state.pendingGates = new Map([
+        [
+          'wf-1-gate-a',
+          {
+            gateId: 'wf-1-gate-a',
+            workflowId: 'wf-1',
+            stateName: 'review_a',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Review A',
+          },
+        ],
+        [
+          'wf-1-gate-b',
+          {
+            gateId: 'wf-1-gate-b',
+            workflowId: 'wf-1',
+            stateName: 'review_b',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Review B',
+          },
+        ],
+      ]);
+
+      handleEvent(state, createMockEffects(), 'workflow.gate_dismissed', {
+        workflowId: 'wf-1',
+        gateId: 'wf-1-gate-a',
+      });
+
+      expect(state.pendingGates.size).toBe(1);
+      expect(state.workflows.get('wf-1')?.phase).toBe('waiting_human');
+    });
+
+    it('does not change phase on gate_dismissed when workflow is not waiting_human', () => {
+      const state = createMockState();
+      state.workflows = new Map([
+        [
+          'wf-1',
+          {
+            workflowId: 'wf-1',
+            name: 'test',
+            phase: 'completed' as const,
+            currentState: 'done',
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]);
+      state.pendingGates = new Map([
+        [
+          'wf-1-leftover',
+          {
+            gateId: 'wf-1-leftover',
+            workflowId: 'wf-1',
+            stateName: 'review',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Leftover gate',
+          },
+        ],
+      ]);
+
+      handleEvent(state, createMockEffects(), 'workflow.gate_dismissed', {
+        workflowId: 'wf-1',
+        gateId: 'wf-1-leftover',
+      });
+
+      expect(state.pendingGates.size).toBe(0);
+      expect(state.workflows.get('wf-1')?.phase).toBe('completed');
+    });
+
     it('cleans up gates on workflow.completed', () => {
       const state = createMockState();
       state.workflows = new Map([
@@ -550,6 +672,133 @@ describe('handleEvent', () => {
       handleEvent(state, createMockEffects(), 'workflow.completed', { workflowId: 'wf-1' });
 
       expect(state.pendingGates.size).toBe(0);
+    });
+
+    it('removes gate on gate_dismissed even when workflowId is unknown', () => {
+      const state = createMockState();
+      state.pendingGates = new Map([
+        [
+          'orphan-gate',
+          {
+            gateId: 'orphan-gate',
+            workflowId: 'wf-unknown',
+            stateName: 'review',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Orphan gate',
+          },
+        ],
+      ]);
+
+      handleEvent(state, createMockEffects(), 'workflow.gate_dismissed', {
+        workflowId: 'wf-unknown',
+        gateId: 'orphan-gate',
+      });
+
+      expect(state.pendingGates.size).toBe(0);
+      // workflows map should remain empty (unchanged)
+      expect(state.workflows.size).toBe(0);
+    });
+
+    it('handles gate_dismissed with unknown gateId without crashing', () => {
+      const state = createMockState();
+      state.workflows = new Map([
+        [
+          'wf-1',
+          {
+            workflowId: 'wf-1',
+            name: 'test',
+            phase: 'running' as const,
+            currentState: 'plan',
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]);
+      state.pendingGates = new Map([
+        [
+          'wf-1-real-gate',
+          {
+            gateId: 'wf-1-real-gate',
+            workflowId: 'wf-1',
+            stateName: 'review',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Real gate',
+          },
+        ],
+      ]);
+
+      const result = handleEvent(state, createMockEffects(), 'workflow.gate_dismissed', {
+        workflowId: 'wf-1',
+        gateId: 'wf-1-nonexistent',
+      });
+
+      expect(result).toBe(true);
+      // The real gate should still be present
+      expect(state.pendingGates.size).toBe(1);
+      expect(state.pendingGates.has('wf-1-real-gate')).toBe(true);
+    });
+
+    it('keeps waiting_human phase on state_entered when workflow has active gates', () => {
+      const state = createMockState();
+      state.workflows = new Map([
+        [
+          'wf-1',
+          {
+            workflowId: 'wf-1',
+            name: 'test',
+            phase: 'waiting_human' as const,
+            currentState: 'plan_review',
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]);
+      state.pendingGates = new Map([
+        [
+          'wf-1-gate',
+          {
+            gateId: 'wf-1-gate',
+            workflowId: 'wf-1',
+            stateName: 'plan_review',
+            acceptedEvents: ['APPROVE'],
+            presentedArtifacts: [],
+            summary: 'Review gate',
+          },
+        ],
+      ]);
+
+      handleEvent(state, createMockEffects(), 'workflow.state_entered', {
+        workflowId: 'wf-1',
+        state: 'implement',
+      });
+
+      expect(state.workflows.get('wf-1')?.currentState).toBe('implement');
+      expect(state.workflows.get('wf-1')?.phase).toBe('waiting_human');
+    });
+
+    it('sets running phase on state_entered when workflow has no active gates', () => {
+      const state = createMockState();
+      state.workflows = new Map([
+        [
+          'wf-1',
+          {
+            workflowId: 'wf-1',
+            name: 'test',
+            phase: 'waiting_human' as const,
+            currentState: 'plan_review',
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      ]);
+      // No pending gates
+
+      handleEvent(state, createMockEffects(), 'workflow.state_entered', {
+        workflowId: 'wf-1',
+        state: 'implement',
+      });
+
+      expect(state.workflows.get('wf-1')?.currentState).toBe('implement');
+      expect(state.workflows.get('wf-1')?.phase).toBe('running');
     });
 
     it('returns true for workflow.agent_started and workflow.agent_completed', () => {

--- a/packages/web-ui/src/lib/event-handler.ts
+++ b/packages/web-ui/src/lib/event-handler.ts
@@ -16,6 +16,7 @@ import type {
   WorkflowSummaryDto,
   HumanGateRequestDto,
 } from './types.js';
+import { PHASE } from './types.js';
 
 /** Minimal state surface that handleEvent needs to read and write. */
 export interface AppStateLike {
@@ -35,6 +36,18 @@ export interface AppStateLike {
 export interface EventSideEffects {
   refreshJobs(): void;
   assignDisplayNumber(escalationId: string): number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if any gate in the map belongs to the given workflow. */
+function hasGateForWorkflow(gates: ReadonlyMap<string, HumanGateRequestDto>, workflowId: string): boolean {
+  for (const gate of gates.values()) {
+    if (gate.workflowId === workflowId) return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -267,7 +280,7 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
       const entry: WorkflowSummaryDto = {
         workflowId,
         name,
-        phase: 'running',
+        phase: PHASE.RUNNING,
         currentState: 'starting...',
         startedAt: new Date().toISOString(),
       };
@@ -281,14 +294,7 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
       if (!existing) return true;
       // Preserve 'waiting_human' only if there is still an active gate for this workflow.
       // Without this check, the phase would stay sticky after the gate is resolved.
-      let hasActiveGate = false;
-      for (const gate of state.pendingGates.values()) {
-        if (gate.workflowId === workflowId) {
-          hasActiveGate = true;
-          break;
-        }
-      }
-      const phase = hasActiveGate ? 'waiting_human' : 'running';
+      const phase = hasGateForWorkflow(state.pendingGates, workflowId) ? PHASE.WAITING_HUMAN : PHASE.RUNNING;
       const updated: WorkflowSummaryDto = { ...existing, currentState: stateName, phase };
       state.workflows = new Map(state.workflows).set(workflowId, updated);
       return true;
@@ -305,7 +311,7 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
       if (!wf) return true;
       state.workflows = new Map(state.workflows).set(workflowId, {
         ...wf,
-        phase: 'completed',
+        phase: PHASE.COMPLETED,
       });
       const nextGates = new Map(state.pendingGates);
       for (const [gateId, gate] of nextGates) {
@@ -321,7 +327,7 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
       if (!wf) return true;
       state.workflows = new Map(state.workflows).set(workflowId, {
         ...wf,
-        phase: 'failed',
+        phase: PHASE.FAILED,
       });
       return true;
     }
@@ -333,7 +339,7 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
       if (wf) {
         state.workflows = new Map(state.workflows).set(workflowId, {
           ...wf,
-          phase: 'waiting_human',
+          phase: PHASE.WAITING_HUMAN,
           currentState: gate.stateName,
         });
       }
@@ -341,10 +347,17 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
     }
 
     case 'workflow.gate_dismissed': {
-      const { gateId } = parsed.payload;
+      const { workflowId, gateId } = parsed.payload;
       const nextGates = new Map(state.pendingGates);
       nextGates.delete(gateId);
       state.pendingGates = nextGates;
+      const wf = state.workflows.get(workflowId);
+      if (wf && wf.phase === PHASE.WAITING_HUMAN && !hasGateForWorkflow(nextGates, workflowId)) {
+        state.workflows = new Map(state.workflows).set(workflowId, {
+          ...wf,
+          phase: PHASE.RUNNING,
+        });
+      }
       return true;
     }
 

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -26,6 +26,7 @@ import type {
   FileContentResponseDto,
   ArtifactContentDto,
 } from './types.js';
+import { PHASE } from './types.js';
 import { createWsClient, type WsClient } from './ws-client.js';
 import { handleEvent as handleEventPure } from './event-handler.js';
 
@@ -119,6 +120,16 @@ class AppState {
 
 export const appState = new AppState();
 
+/**
+ * Monotonically increasing counter bumped whenever connection-driven
+ * refresh state is triggered, including the initial WebSocket connect
+ * and any later reconnects.
+ * Components can read `.value` as a $effect dependency to force
+ * re-fetches after a connection event, even when other reactive
+ * values haven't changed.
+ */
+export const connectionGeneration = $state({ value: 0 });
+
 // WebSocket client singleton
 let wsClient: WsClient | null = null;
 
@@ -143,7 +154,7 @@ function wireEventHandlers(client: WsClient): void {
       appState,
       {
         refreshJobs: () => refreshJobs(client),
-        assignDisplayNumber: () => ++appState.escalationDisplayNumber,
+        assignDisplayNumber: (_escalationId: string) => ++appState.escalationDisplayNumber,
       },
       event,
       payload,
@@ -178,6 +189,33 @@ async function refreshAll(client: WsClient): Promise<void> {
       newWorkflows.set(wf.workflowId, wf);
     }
     appState.workflows = newWorkflows;
+
+    // Repopulate pending gates for any workflow stuck at a human gate.
+    // Events may have been lost during disconnect, leaving pendingGates empty.
+    const newGates = new Map<string, HumanGateRequestDto>();
+    const gatePromises = workflowsList
+      .filter((wf) => wf.phase === PHASE.WAITING_HUMAN)
+      .map(async (wf) => {
+        try {
+          const detail = await client.request<WorkflowDetailDto>('workflows.get', { workflowId: wf.workflowId });
+          if (detail.gate) {
+            newGates.set(detail.gate.gateId, detail.gate);
+          }
+        } catch {
+          // Best-effort -- gate will appear on next event
+        }
+      });
+    await Promise.all(gatePromises);
+    // Merge fetched gates into current pendingGates rather than replacing,
+    // so gate_raised events that arrived during the async fetch are preserved.
+    const merged = new Map(appState.pendingGates);
+    for (const [id, gate] of newGates) {
+      merged.set(id, gate);
+    }
+    appState.pendingGates = merged;
+
+    // Bump connection generation so detail views re-fetch
+    connectionGeneration.value++;
 
     const newEscalations = new Map<string, PendingEscalation>();
     for (const esc of escalations) {

--- a/packages/web-ui/src/lib/types.ts
+++ b/packages/web-ui/src/lib/types.ts
@@ -169,6 +169,15 @@ export interface ResumableWorkflowDto {
 
 export type WorkflowPhase = 'running' | 'waiting_human' | 'completed' | 'failed' | 'aborted';
 
+/** Constants for WorkflowPhase values — avoids magic strings in event handlers. */
+export const PHASE = {
+  RUNNING: 'running',
+  WAITING_HUMAN: 'waiting_human',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  ABORTED: 'aborted',
+} as const satisfies Record<string, WorkflowPhase>;
+
 export interface WorkflowSummaryDto {
   readonly workflowId: string;
   readonly name: string;

--- a/packages/web-ui/src/routes/WorkflowDetail.svelte
+++ b/packages/web-ui/src/routes/WorkflowDetail.svelte
@@ -2,6 +2,7 @@
   import type { WorkflowDetailDto, WorkflowSummaryDto, HumanGateRequestDto } from '$lib/types.js';
   import {
     appState,
+    connectionGeneration,
     getWorkflowDetail,
     resolveWorkflowGate,
     getWorkflowFileTree,
@@ -56,8 +57,10 @@
     // These fields are updated by workflow.state_entered / workflow.completed / etc.
     // events via the event handler, which triggers a fresh getWorkflowDetail() call
     // so the transition history, context, and gate stay up-to-date.
-    const _currentState = summary.currentState;
-    const _phase = summary.phase;
+    void summary.currentState;
+    void summary.phase;
+    // Force re-fetch on WebSocket reconnect so we pick up any missed events.
+    void connectionGeneration.value;
     const version = ++fetchVersion;
     // Only show the loading spinner on the initial fetch, not on re-fetches.
     // Use the version counter instead of reading `detail` to avoid making it

--- a/packages/web-ui/src/routes/WorkflowDetail.test.ts
+++ b/packages/web-ui/src/routes/WorkflowDetail.test.ts
@@ -36,6 +36,7 @@ const {
 
 vi.mock('$lib/stores.svelte.js', () => ({
   appState: mockAppState,
+  connectionGeneration: { value: 0 },
   getWorkflowDetail: (...args: unknown[]) => mockGetWorkflowDetail(...(args as [string])),
   resolveWorkflowGate: (...args: unknown[]) =>
     mockResolveWorkflowGate(...(args as [string, string, string | undefined])),


### PR DESCRIPTION
## Summary

- **gate_dismissed phase update**: The `gate_dismissed` event handler now transitions the workflow phase from `waiting_human` to `running` when no gates remain, fixing a bug where the UI stayed stuck after rejecting a human gate
- **Reconnect resilience**: `refreshAll` repopulates `pendingGates` on WebSocket reconnect by fetching detail for workflows in `waiting_human` phase; a `reconnectCounter` forces `WorkflowDetail` to re-fetch after reconnect
- **Code quality**: Extract `hasGateForWorkflow` helper to deduplicate gate-checking loops, add `PHASE` constants to replace magic strings, fix `assignDisplayNumber` parameter signature mismatch, use consistent `void` pattern for `$effect` reactive dependencies

## Test plan

- [x] 7 new unit tests covering gate_dismissed phase transitions, edge cases (unknown workflowId/gateId), and state_entered gate-aware logic
- [x] All 181 web-ui tests pass
- [x] ESLint + Prettier clean
- [ ] Manual: reject a human gate in the web UI and verify the phase transitions to "running"
- [ ] Manual: disconnect/reconnect WebSocket while a workflow is at a human gate and verify the gate reappears