### PR TITLE
fix: use --session-id/--resume in Docker batch mode

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -163,10 +163,20 @@ exit $STATUS
       ];
     },
 
-    buildCommand(message: string, systemPrompt: string): readonly string[] {
+    buildCommand(
+      message: string,
+      systemPrompt: string,
+      options: { readonly sessionId: string; readonly firstTurn: boolean },
+    ): readonly string[] {
+      // `claude -p --continue` in non-interactive print mode does NOT update
+      // ~/.claude.json's project->session mapping, so subsequent `--continue`
+      // calls silently start new sessions. Instead, pin the session UUID on
+      // the first turn with `--session-id`, then resume it explicitly with
+      // `--resume <uuid>` on later turns.
       const cmd = [
         'claude',
-        '--continue',
+        options.firstTurn ? '--session-id' : '--resume',
+        options.sessionId,
         '--dangerously-skip-permissions',
         '--output-format',
         'json',

--- a/src/docker/adapters/goose.ts
+++ b/src/docker/adapters/goose.ts
@@ -214,7 +214,12 @@ export function createGooseAdapter(userConfig?: ResolvedUserConfig): AgentAdapte
       ];
     },
 
-    buildCommand(message: string, systemPrompt: string): readonly string[] {
+    buildCommand(
+      message: string,
+      systemPrompt: string,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Goose batch mode does not use session resume options
+      _options: { readonly sessionId: string; readonly firstTurn: boolean },
+    ): readonly string[] {
       const instructions = `${systemPrompt}\n\n---\n\nUser request:\n${message}`;
       const { delimiter } = escapeHeredoc(instructions);
 

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -141,8 +141,19 @@ export interface AgentAdapter {
    *
    * @param message - the user's message for this turn
    * @param systemPrompt - the orientation prompt
+   * @param options - per-turn options:
+   *   - sessionId: stable identifier for the conversation (e.g., for
+   *     `claude --session-id <uuid>` / `--resume <uuid>`). Typically
+   *     the session's UUID.
+   *   - firstTurn: true when this is the first turn of a fresh
+   *     conversation state; false when resuming an existing
+   *     conversation. Adapters that don't distinguish may ignore.
    */
-  buildCommand(message: string, systemPrompt: string): readonly string[];
+  buildCommand(
+    message: string,
+    systemPrompt: string,
+    options: { readonly sessionId: string; readonly firstTurn: boolean },
+  ): readonly string[];
 
   /**
    * Builds the system prompt to append to the agent's default system prompt.

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -12,7 +12,7 @@
  * 3. close() -- stop container, stop proxies, clean up
  */
 
-import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { quote } from 'shell-quote';
 import type {
@@ -97,6 +97,16 @@ export class DockerAgentSession implements Session {
   private status: SessionStatus = 'initializing';
   private readonly createdAt: string;
 
+  /**
+   * Whether the first turn of this conversation has completed at least once.
+   * Used to decide whether to pin a fresh session id (`--session-id`) or
+   * resume an existing one (`--resume`) for agents like Claude Code. Set to
+   * true in the constructor if the conversation state dir already contains
+   * prior content (resumed session); otherwise flipped to true after the
+   * first successful sendMessage() turn.
+   */
+  private firstTurnComplete = false;
+
   private containerId: string | null = null;
   private sidecarContainerId: string | null = null;
   private networkName: string | null = null;
@@ -138,6 +148,13 @@ export class DockerAgentSession implements Session {
     this.onDiagnostic = deps.onDiagnostic;
     this.preBuiltInfrastructure = deps.preBuiltInfrastructure;
     this.createdAt = new Date().toISOString();
+
+    // If the conversation state dir already has real content (beyond the
+    // empty `projects/` seed), treat this as a resumed session -- the next
+    // turn should use `--resume <uuid>` rather than pin a fresh session id.
+    if (this.conversationStateDir && hasConversationStateContent(this.conversationStateDir)) {
+      this.firstTurnComplete = true;
+    }
   }
 
   /**
@@ -440,7 +457,10 @@ export class DockerAgentSession implements Session {
     // Write user context for the auto-approver
     this.writeUserContext(userMessage);
 
-    const command = this.adapter.buildCommand(userMessage, this.systemPrompt);
+    const command = this.adapter.buildCommand(userMessage, this.systemPrompt, {
+      sessionId: this.sessionId,
+      firstTurn: !this.firstTurnComplete,
+    });
     logger.info(`[docker-agent] exec: ${formatCommand(command)}`);
 
     const execStartMs = Date.now();
@@ -481,6 +501,13 @@ export class DockerAgentSession implements Session {
       timestamp: turnStart,
     };
     this.turns.push(turn);
+
+    // Only mark the first turn as complete on success. On a failed turn
+    // (non-zero exit), the agent may not have created the session yet, so
+    // the next turn must still pin a fresh session id rather than resume.
+    if (exitCode === 0) {
+      this.firstTurnComplete = true;
+    }
 
     this.status = 'ready';
     return response.text;
@@ -591,6 +618,35 @@ export class DockerAgentSession implements Session {
     } catch {
       // Ignore write failures
     }
+  }
+}
+
+/**
+ * Returns true if the conversation state dir contains prior content beyond
+ * the empty seed (i.e., the agent has actually written session metadata).
+ *
+ * On fresh sessions, `prepareConversationStateDir()` seeds an empty
+ * `projects/` directory; we must look inside it to detect whether the
+ * agent has populated any per-project session files. Any file anywhere
+ * under the state dir (outside of the hidden `.credentials.json` that is
+ * scrubbed on every start) counts as "prior content".
+ */
+/**
+ * Check whether the conversation state dir contains a prior Claude Code
+ * conversation transcript. Claude Code writes transcripts as .jsonl files
+ * under `projects/<cwd-hash>/`. Seed files (hook scripts, configs) are not
+ * considered — only actual conversation history.
+ */
+function hasConversationStateContent(stateDir: string): boolean {
+  try {
+    const projectsDir = resolve(stateDir, 'projects');
+    if (!existsSync(projectsDir)) return false;
+    for (const entry of readdirSync(projectsDir, { withFileTypes: true, recursive: true })) {
+      if (entry.isFile() && entry.name.endsWith('.jsonl')) return true;
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -622,20 +622,15 @@ export class DockerAgentSession implements Session {
 }
 
 /**
- * Returns true if the conversation state dir contains prior content beyond
- * the empty seed (i.e., the agent has actually written session metadata).
+ * Returns true if the conversation state dir contains prior Claude Code
+ * conversation history beyond the empty seed.
  *
  * On fresh sessions, `prepareConversationStateDir()` seeds an empty
- * `projects/` directory; we must look inside it to detect whether the
- * agent has populated any per-project session files. Any file anywhere
- * under the state dir (outside of the hidden `.credentials.json` that is
- * scrubbed on every start) counts as "prior content".
- */
-/**
- * Check whether the conversation state dir contains a prior Claude Code
- * conversation transcript. Claude Code writes transcripts as .jsonl files
- * under `projects/<cwd-hash>/`. Seed files (hook scripts, configs) are not
- * considered — only actual conversation history.
+ * `projects/` directory. Claude Code writes transcripts as `.jsonl` files
+ * under `projects/<cwd-hash>/`, so we must look inside that tree to detect
+ * whether the agent has populated any per-project session files. Seed files
+ * (hook scripts, configs) are not considered; only actual conversation
+ * history counts as prior content.
  */
 function hasConversationStateContent(stateDir: string): boolean {
   try {

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -41,11 +41,24 @@ describe('Claude Code Adapter', () => {
     expect(servers.ironcurtain.args).toContain('UNIX-CONNECT:/run/ironcurtain/proxy.sock');
   });
 
-  it('builds command with --continue and --append-system-prompt', () => {
-    const cmd = claudeCodeAdapter.buildCommand('Fix the bug', 'You are sandboxed');
+  it('pins a fresh session id on the first turn via --session-id', () => {
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const cmd = claudeCodeAdapter.buildCommand('Fix the bug', 'You are sandboxed', {
+      sessionId,
+      firstTurn: true,
+    });
 
     expect(cmd).toContain('claude');
-    expect(cmd).toContain('--continue');
+    expect(cmd).toContain('--session-id');
+    expect(cmd).toContain(sessionId);
+    expect(cmd).not.toContain('--resume');
+    expect(cmd).not.toContain('--continue');
+
+    // --session-id and the uuid must be adjacent, in that order
+    const flagIdx = cmd.indexOf('--session-id');
+    expect(cmd[flagIdx + 1]).toBe(sessionId);
+
+    // Other standard flags must still be present
     expect(cmd).toContain('--dangerously-skip-permissions');
     expect(cmd).toContain('--output-format');
     expect(cmd).toContain('json');
@@ -55,6 +68,23 @@ describe('Claude Code Adapter', () => {
     expect(cmd).toContain('You are sandboxed');
     expect(cmd).toContain('-p');
     expect(cmd).toContain('Fix the bug');
+  });
+
+  it('resumes an existing session on subsequent turns via --resume', () => {
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const cmd = claudeCodeAdapter.buildCommand('Next step', 'You are sandboxed', {
+      sessionId,
+      firstTurn: false,
+    });
+
+    expect(cmd).toContain('--resume');
+    expect(cmd).toContain(sessionId);
+    expect(cmd).not.toContain('--session-id');
+    expect(cmd).not.toContain('--continue');
+
+    // --resume and the uuid must be adjacent, in that order
+    const flagIdx = cmd.indexOf('--resume');
+    expect(cmd[flagIdx + 1]).toBe(sessionId);
   });
 
   it('builds system prompt with Code Mode + Docker layers', () => {

--- a/test/goose-adapter.test.ts
+++ b/test/goose-adapter.test.ts
@@ -170,7 +170,10 @@ describe('GooseAdapter.buildCommand', () => {
   const adapter = createGooseAdapter();
 
   it('returns a shell command with goose run --no-session', () => {
-    const cmd = adapter.buildCommand('Fix the bug', 'You are sandboxed');
+    const cmd = adapter.buildCommand('Fix the bug', 'You are sandboxed', {
+      sessionId: 'test-session',
+      firstTurn: true,
+    });
 
     expect(cmd).toHaveLength(3);
     expect(cmd[0]).toBe('/bin/sh');
@@ -179,23 +182,32 @@ describe('GooseAdapter.buildCommand', () => {
   });
 
   it('includes -i flag for instructions file', () => {
-    const cmd = adapter.buildCommand('Fix the bug', 'You are sandboxed');
+    const cmd = adapter.buildCommand('Fix the bug', 'You are sandboxed', {
+      sessionId: 'test-session',
+      firstTurn: true,
+    });
     expect(cmd[2]).toContain('-i "$PROMPT_FILE"');
   });
 
   it('includes system prompt in instructions', () => {
-    const cmd = adapter.buildCommand('Fix the bug', 'You are sandboxed');
+    const cmd = adapter.buildCommand('Fix the bug', 'You are sandboxed', {
+      sessionId: 'test-session',
+      firstTurn: true,
+    });
     expect(cmd[2]).toContain('You are sandboxed');
     expect(cmd[2]).toContain('Fix the bug');
   });
 
   it('uses IRONCURTAIN_EOF delimiter for heredoc', () => {
-    const cmd = adapter.buildCommand('hello', 'prompt');
+    const cmd = adapter.buildCommand('hello', 'prompt', { sessionId: 'test-session', firstTurn: true });
     expect(cmd[2]).toContain('IRONCURTAIN_EOF');
   });
 
   it('escapes heredoc delimiter when input contains IRONCURTAIN_EOF', () => {
-    const cmd = adapter.buildCommand('IRONCURTAIN_EOF', 'system prompt');
+    const cmd = adapter.buildCommand('IRONCURTAIN_EOF', 'system prompt', {
+      sessionId: 'test-session',
+      firstTurn: true,
+    });
     // The delimiter should have a suffix to avoid collision
     const shellCmd = cmd[2];
     // The default delimiter should not appear without a suffix


### PR DESCRIPTION
## Summary

- Fix multi-turn context loss in Docker agent batch mode (web UI, cron, workflows)
- `claude -p --continue` silently no-ops in non-interactive print mode because Claude Code doesn't update `~/.claude.json`'s project→session mapping
- Switch to `--session-id <uuid>` on first turn + `--resume <uuid>` on subsequent turns, using a stable UUID per IronCurtain session

## Root cause

Each `docker exec claude -p --continue ...` call in batch mode appeared to pass the right flag, but Claude Code's non-interactive mode doesn't persist the session→project mapping that `--continue` needs to find the prior conversation. Result: every turn silently started fresh, losing all context from previous messages.

PTY mode is unaffected — interactive `claude --continue` updates `.claude.json` correctly.

## Changes

- `agent-adapter.ts`: `buildCommand()` signature extended with `{ sessionId, firstTurn }` options
- `adapters/claude-code.ts`: drop `--continue`; use `--session-id` (first turn) or `--resume` (after)
- `adapters/goose.ts`: signature update (Goose ignores these options)
- `docker-agent-session.ts`: add `firstTurnComplete` state; initialize based on presence of `projects/**/*.jsonl` transcripts in the conversation state dir
- Tests updated for the two-stage behavior

## What's NOT changed

- `start-claude.sh` (PTY wrapper) — unaffected
- Mux code — goes through PTY
- Workflow code — benefits automatically through the fixed batch path

## Test plan

- [x] All existing tests pass (3689 + 174 web-UI)
- [x] New session: first turn creates session with `--session-id`, subsequent turns resume with `--resume`
- [x] Live multi-turn web UI session retains context across messages
- [ ] Resume from prior session: if `conversationStateDir/projects/**/*.jsonl` exists, first turn uses `--resume` directly