### PR TITLE
fix(web-ui): recover gracefully from a bad auth token

### DIFF
--- a/packages/web-ui/e2e/auth.spec.ts
+++ b/packages/web-ui/e2e/auth.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { resetMockServer } from './helpers.js';
+
+// ---------------------------------------------------------------------------
+// Auth gate — the HTTP preflight lets the UI distinguish a bad token
+// from a down daemon. Before this fix, a wrong token flashed the
+// dashboard and the client spun reconnects forever.
+// ---------------------------------------------------------------------------
+
+test.describe('Auth gate', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetMockServer(request);
+  });
+
+  test('rejects a bad token without flashing the dashboard', async ({ page }) => {
+    await page.goto('/?token=definitely-wrong-token');
+
+    // The error banner should appear — this is the *only* way for the
+    // user to learn their token was wrong, because browsers hide the
+    // WS upgrade's 401 from JS.
+    await expect(page.getByTestId('auth-error')).toBeVisible({ timeout: 5_000 });
+
+    // The sidebar nav only renders once past the auth gate; it must
+    // never appear for a rejected token.
+    await expect(page.locator('nav')).not.toBeVisible();
+
+    // And the bad token must be purged from sessionStorage so a
+    // subsequent page load doesn't re-offer it.
+    const stored = await page.evaluate(() => sessionStorage.getItem('ic-auth-token'));
+    expect(stored).toBeNull();
+  });
+
+  test('accepts a valid token and hides the error banner on retry', async ({ page }) => {
+    // First try a bad token — banner shows.
+    await page.goto('/?token=wrong');
+    await expect(page.getByTestId('auth-error')).toBeVisible({ timeout: 5_000 });
+
+    // Then paste the real token into the form.
+    const input = page.getByPlaceholder('Auth token...');
+    await input.fill('mock-dev-token');
+    await page.getByRole('button', { name: 'Connect' }).click();
+
+    // Auth gate drops and we land in the app.
+    await expect(page.locator('nav')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('auth-error')).not.toBeVisible();
+  });
+});

--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -1229,10 +1229,60 @@ function isRpcError(value: unknown): value is RpcErrorResult {
 }
 
 // ---------------------------------------------------------------------------
-// WebSocket server
+// WebSocket + HTTP server (shared port for WS upgrade and /ws/auth preflight)
 // ---------------------------------------------------------------------------
 
-const wss = new WebSocketServer({ port: PORT });
+/**
+ * Simulate the daemon's bearer-token check. Real daemon uses a 32-byte
+ * random token; here we just compare to the well-known mock token so
+ * E2E tests can exercise the bad-token path.
+ */
+function isMockTokenValid(token: string | null): boolean {
+  return token === MOCK_TOKEN;
+}
+
+const wsHttpServer = createServer((req, res) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+  if (req.method === 'GET' && url.pathname === '/ws/auth') {
+    const token = url.searchParams.get('token');
+    // CORS is not needed in production (Vite proxies same-origin), but
+    // is convenient when a test hits this endpoint directly from another
+    // origin. Keep it permissive for the mock only.
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    if (isMockTokenValid(token)) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"ok":true}');
+    } else {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end('{"ok":false,"error":"invalid_token"}');
+    }
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+
+const wss = new WebSocketServer({ noServer: true });
+
+wsHttpServer.on('upgrade', (req, socket, head) => {
+  const url = new URL(req.url ?? '', `http://${req.headers.host ?? 'localhost'}`);
+  if (url.pathname !== '/ws') {
+    socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+  const token = url.searchParams.get('token');
+  if (!isMockTokenValid(token)) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => {
+    wss.emit('connection', ws, req);
+  });
+});
+
+wsHttpServer.listen(PORT);
 
 wss.on('connection', (ws) => {
   clients.add(ws);

--- a/packages/web-ui/src/App.svelte
+++ b/packages/web-ui/src/App.svelte
@@ -125,14 +125,17 @@
   onMount(() => {
     currentTheme = getTheme();
     document.documentElement.setAttribute('data-theme', currentTheme);
-    initConnection();
+    // Fire-and-forget: initConnection is async because of the HTTP
+    // preflight, but onMount doesn't need (and Svelte discourages)
+    // awaiting it here. Errors surface through appState.authError.
+    void initConnection();
   });
 
   function handleTokenSubmit(e: Event): void {
     e.preventDefault();
-    if (tokenInput.trim()) {
-      connectWithToken(tokenInput.trim());
-    }
+    const trimmed = tokenInput.trim();
+    if (!trimmed) return;
+    void connectWithToken(trimmed);
   }
 
   function switchTheme(theme: ThemeId): void {
@@ -172,6 +175,15 @@
         style="animation-delay: {cardDelayMs}ms; animation-fill-mode: both; opacity: 0;"
       >
         <div class="bg-card/75 backdrop-blur-md border border-border/50 rounded-xl p-6 shadow-2xl shadow-black/40">
+          {#if appState.authError === 'invalid_token'}
+            <div
+              data-testid="auth-error"
+              role="alert"
+              class="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              That token was rejected. Copy a fresh one from the daemon's output.
+            </div>
+          {/if}
           <p class="text-sm text-muted-foreground mb-5">Paste the auth token from the daemon output to connect.</p>
           <form onsubmit={handleTokenSubmit}>
             <Input type="text" bind:value={tokenInput} placeholder="Auth token..." class="font-mono" />

--- a/packages/web-ui/src/lib/__tests__/preflight.test.ts
+++ b/packages/web-ui/src/lib/__tests__/preflight.test.ts
@@ -41,12 +41,22 @@ describe('verifyAuthToken preflight', () => {
     expect(result).toBe('invalid');
   });
 
-  it('returns "invalid" on other non-2xx (403, 500, etc.)', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 500 }));
+  it('returns "offline" on 503 (transient reverse-proxy / daemon-restarting)', async () => {
+    // A transient 5xx must NOT be treated as invalid — that would purge
+    // a good token on a brief blip. Keep the token, keep retrying.
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 503 }));
 
     const result = await verifyAuthToken('some-token', fetchMock);
 
-    expect(result).toBe('invalid');
+    expect(result).toBe('offline');
+  });
+
+  it('returns "offline" on other non-200/non-401 (403, 500, 502, 504, etc.)', async () => {
+    for (const status of [403, 500, 502, 504]) {
+      const fetchMock = vi.fn().mockResolvedValue(new Response('', { status }));
+      const result = await verifyAuthToken('some-token', fetchMock);
+      expect(result, `status ${status}`).toBe('offline');
+    }
   });
 
   it('returns "offline" when fetch rejects (network error, daemon down)', async () => {

--- a/packages/web-ui/src/lib/__tests__/preflight.test.ts
+++ b/packages/web-ui/src/lib/__tests__/preflight.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { verifyAuthToken } from '../stores.svelte.js';
+
+// ---------------------------------------------------------------------------
+// verifyAuthToken — HTTP preflight against `/ws/auth`
+//
+// The function exists because browsers collapse WS-upgrade 401s into the
+// same onclose(1006) event as a network failure. These tests pin the
+// three branches that drive downstream UI state.
+// ---------------------------------------------------------------------------
+
+describe('verifyAuthToken preflight', () => {
+  beforeEach(() => {
+    // window.location.host is read inside verifyAuthToken. jsdom gives
+    // us a stable "localhost" host by default, which is fine — we just
+    // assert on the fetch URL the function constructs.
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns "ok" on 200 response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    const result = await verifyAuthToken('good-token', fetchMock);
+
+    expect(result).toBe('ok');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/ws/auth?token=good-token');
+    expect(init?.method).toBe('GET');
+    expect(init?.cache).toBe('no-store');
+  });
+
+  it('returns "invalid" on 401 response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":false}', { status: 401 }));
+
+    const result = await verifyAuthToken('bad-token', fetchMock);
+
+    expect(result).toBe('invalid');
+  });
+
+  it('returns "invalid" on other non-2xx (403, 500, etc.)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 500 }));
+
+    const result = await verifyAuthToken('some-token', fetchMock);
+
+    expect(result).toBe('invalid');
+  });
+
+  it('returns "offline" when fetch rejects (network error, daemon down)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const result = await verifyAuthToken('any-token', fetchMock);
+
+    expect(result).toBe('offline');
+  });
+
+  it('URL-encodes tokens with special characters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+
+    await verifyAuthToken('token with spaces & slashes/', fetchMock);
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('/ws/auth?token=token%20with%20spaces%20%26%20slashes%2F');
+  });
+});

--- a/packages/web-ui/src/lib/__tests__/ws-client.test.ts
+++ b/packages/web-ui/src/lib/__tests__/ws-client.test.ts
@@ -233,4 +233,25 @@ describe('WsClient', () => {
     expect(authErrorHandler).not.toHaveBeenCalled();
     expect(connectionHandler).toHaveBeenCalledWith(true);
   });
+
+  // 9. A rejected preflight must not kill the reconnect loop: treat as 'offline'.
+  it('treats a rejected preflight as "offline" and keeps retrying', async () => {
+    const preflight = vi
+      .fn<(token: string) => Promise<'ok' | 'invalid' | 'offline'>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('ok');
+    const client = createWsClient(preflight);
+    const authErrorHandler = vi.fn();
+    const connectionHandler = vi.fn();
+    client.onAuthError(authErrorHandler);
+    client.onConnectionChange(connectionHandler);
+
+    client.connect('ws://localhost:7400/ws', 'some-token');
+
+    await vi.runAllTimersAsync();
+
+    expect(preflight).toHaveBeenCalledTimes(2);
+    expect(authErrorHandler).not.toHaveBeenCalled();
+    expect(connectionHandler).toHaveBeenCalledWith(true);
+  });
 });

--- a/packages/web-ui/src/lib/__tests__/ws-client.test.ts
+++ b/packages/web-ui/src/lib/__tests__/ws-client.test.ts
@@ -168,4 +168,69 @@ describe('WsClient', () => {
     expect(connectionHandler).toHaveBeenCalledTimes(3); // true, false, true
     expect(connectionHandler).toHaveBeenLastCalledWith(true);
   });
+
+  // ---------------------------------------------------------------------
+  // Preflight — gate the WS upgrade on an HTTP probe so a bad token is
+  // detectable (the browser WebSocket API hides 401s from JS).
+  // ---------------------------------------------------------------------
+
+  // 6. Preflight "invalid" stops reconnects and fires onAuthError
+  it('fires onAuthError and does not open a WS when preflight returns "invalid"', async () => {
+    const preflight = vi.fn().mockResolvedValue('invalid' as const);
+    const client = createWsClient(preflight);
+    const authErrorHandler = vi.fn();
+    const connectionHandler = vi.fn();
+    client.onAuthError(authErrorHandler);
+    client.onConnectionChange(connectionHandler);
+
+    client.connect('ws://localhost:7400/ws', 'bad-token');
+
+    // Flush the preflight microtask and any scheduled timers.
+    await vi.runAllTimersAsync();
+
+    expect(preflight).toHaveBeenCalledWith('bad-token');
+    expect(authErrorHandler).toHaveBeenCalledOnce();
+    expect(connectionHandler).not.toHaveBeenCalledWith(true);
+    // No WS should have been constructed; mockWs from earlier tests
+    // leaks across describe blocks, but re-opening here would have
+    // reset it — we assert on the absence of a "true" connection event.
+  });
+
+  // 7. Preflight "ok" proceeds with the WS upgrade
+  it('opens the WS when preflight returns "ok"', async () => {
+    const preflight = vi.fn().mockResolvedValue('ok' as const);
+    const client = createWsClient(preflight);
+    const connectionHandler = vi.fn();
+    client.onConnectionChange(connectionHandler);
+
+    client.connect('ws://localhost:7400/ws', 'good-token');
+
+    await vi.runAllTimersAsync();
+
+    expect(preflight).toHaveBeenCalledWith('good-token');
+    expect(connectionHandler).toHaveBeenCalledWith(true);
+  });
+
+  // 8. Preflight "offline" reschedules without firing authError
+  it('schedules a reconnect (but does not flip authError) when preflight returns "offline"', async () => {
+    // First call: offline (daemon down). Second call: ok (daemon came back).
+    const preflight = vi
+      .fn<(token: string) => Promise<'ok' | 'invalid' | 'offline'>>()
+      .mockResolvedValueOnce('offline')
+      .mockResolvedValueOnce('ok');
+    const client = createWsClient(preflight);
+    const authErrorHandler = vi.fn();
+    const connectionHandler = vi.fn();
+    client.onAuthError(authErrorHandler);
+    client.onConnectionChange(connectionHandler);
+
+    client.connect('ws://localhost:7400/ws', 'some-token');
+
+    // Let the first preflight resolve and the reconnect timer schedule.
+    await vi.runAllTimersAsync();
+
+    expect(preflight).toHaveBeenCalledTimes(2);
+    expect(authErrorHandler).not.toHaveBeenCalled();
+    expect(connectionHandler).toHaveBeenCalledWith(true);
+  });
 });

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -157,6 +157,14 @@ export function getWsClient(): WsClient {
  * first, we can surface a meaningful error to the user and stop the
  * reconnect loop when the token is known-bad.
  *
+ * Status-to-result mapping:
+ *   - 200 → 'ok': token accepted, open the WS
+ *   - 401 → 'invalid': token rejected, clear it and stop retrying
+ *   - anything else (502/503/504 from a reverse proxy, daemon restarting,
+ *     fetch reject on network error) → 'offline': keep the stored token
+ *     and let the reconnect loop keep probing. Treating transient 5xx as
+ *     'invalid' would destructively purge a good token on a brief blip.
+ *
  * Exported for testing.
  */
 export async function verifyAuthToken(token: string, fetchImpl: typeof fetch = fetch): Promise<PreflightResult> {
@@ -166,9 +174,7 @@ export async function verifyAuthToken(token: string, fetchImpl: typeof fetch = f
     const res = await fetchImpl(url, { method: 'GET', cache: 'no-store' });
     if (res.status === 200) return 'ok';
     if (res.status === 401) return 'invalid';
-    // Any other status (e.g. 403 from reverse proxy) — treat as invalid
-    // rather than offline so we don't spin on an unrecoverable state.
-    return 'invalid';
+    return 'offline';
   } catch {
     // fetch throws on network failure, CORS issues, aborted requests, etc.
     return 'offline';
@@ -494,7 +500,10 @@ export async function compilePersonaPolicy(name: string): Promise<PersonaCompile
 
 export async function connectWithToken(token: string): Promise<void> {
   sessionStorage.setItem('ic-auth-token', token);
-  appState.authError = null;
+  // Deliberately do NOT clear `authError` here. If the user re-pastes the
+  // same bad token, clearing upfront blanks the banner for one tick and
+  // then `handleAuthError()` sets it back — a visible flash. The banner
+  // is cleared on successful connection in `onConnectionChange(true)`.
   const client = getWsClient();
   await startConnectionWithToken(client, token);
 }

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -27,7 +27,7 @@ import type {
   ArtifactContentDto,
 } from './types.js';
 import { PHASE } from './types.js';
-import { createWsClient, type WsClient } from './ws-client.js';
+import { createWsClient, type PreflightResult, type WsClient } from './ws-client.js';
 import { handleEvent as handleEventPure } from './event-handler.js';
 
 export type ViewId = 'dashboard' | 'sessions' | 'escalations' | 'jobs' | 'workflows' | 'personas';
@@ -51,6 +51,13 @@ export function setTheme(theme: ThemeId): void {
 class AppState {
   connected: boolean = $state(false);
   hasToken: boolean = $state(false);
+  /**
+   * Non-null when the last auth preflight (or server-side rejection)
+   * indicated the token is bad. The browser WebSocket API hides HTTP
+   * status codes, so we rely on an HTTP preflight to `/ws/auth` and
+   * surface the result here to drive UI state.
+   */
+  authError: string | null = $state(null);
   daemonStatus: DaemonStatusDto | null = $state(null);
   sessions: Map<number, SessionDto> = $state(new Map());
   selectedSessionLabel: number | null = $state(null);
@@ -135,18 +142,52 @@ let wsClient: WsClient | null = null;
 
 export function getWsClient(): WsClient {
   if (!wsClient) {
-    wsClient = createWsClient();
+    wsClient = createWsClient(verifyAuthToken);
     wireEventHandlers(wsClient);
   }
   return wsClient;
+}
+
+/**
+ * HTTP preflight against the daemon's `/ws/auth` endpoint.
+ *
+ * The browser WebSocket API collapses HTTP 401 rejections and network
+ * errors into the same `onclose(1006)` event, leaving the client unable
+ * to tell "bad token" from "daemon down". By probing over plain HTTP
+ * first, we can surface a meaningful error to the user and stop the
+ * reconnect loop when the token is known-bad.
+ *
+ * Exported for testing.
+ */
+export async function verifyAuthToken(token: string, fetchImpl: typeof fetch = fetch): Promise<PreflightResult> {
+  try {
+    const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
+    const url = `${protocol}//${window.location.host}/ws/auth?token=${encodeURIComponent(token)}`;
+    const res = await fetchImpl(url, { method: 'GET', cache: 'no-store' });
+    if (res.status === 200) return 'ok';
+    if (res.status === 401) return 'invalid';
+    // Any other status (e.g. 403 from reverse proxy) — treat as invalid
+    // rather than offline so we don't spin on an unrecoverable state.
+    return 'invalid';
+  } catch {
+    // fetch throws on network failure, CORS issues, aborted requests, etc.
+    return 'offline';
+  }
 }
 
 function wireEventHandlers(client: WsClient): void {
   client.onConnectionChange((connected) => {
     appState.connected = connected;
     if (connected) {
+      // Connection success clears any stale auth error from a previous
+      // attempt (e.g. user pasted a bad token, then a good one).
+      appState.authError = null;
       refreshAll(client);
     }
+  });
+
+  client.onAuthError(() => {
+    handleAuthError();
   });
 
   client.onEvent((event, payload) => {
@@ -160,6 +201,13 @@ function wireEventHandlers(client: WsClient): void {
       payload,
     );
   });
+}
+
+/** Purge the bad token and flip the UI back to the token input. */
+function handleAuthError(): void {
+  sessionStorage.removeItem('ic-auth-token');
+  appState.hasToken = false;
+  appState.authError = 'invalid_token';
 }
 
 let isInitialConnect = true;
@@ -265,9 +313,11 @@ function buildWsUrl(): string {
 
 /**
  * Initialize the WebSocket connection. Extracts token from URL
- * or sessionStorage.
+ * or sessionStorage. `hasToken` is only flipped to `true` after the
+ * HTTP preflight (in the ws client) succeeds or returns 'offline' — we
+ * don't flip it here so a bad token doesn't flash the dashboard.
  */
-export function initConnection(): void {
+export async function initConnection(): Promise<void> {
   const client = getWsClient();
 
   const params = new URLSearchParams(window.location.search);
@@ -286,8 +336,7 @@ export function initConnection(): void {
     return;
   }
 
-  appState.hasToken = true;
-  client.connect(buildWsUrl(), token);
+  await startConnectionWithToken(client, token);
 }
 
 /**
@@ -443,9 +492,28 @@ export async function compilePersonaPolicy(name: string): Promise<PersonaCompile
   return getWsClient().request<PersonaCompileResultDto>('personas.compile', { name });
 }
 
-export function connectWithToken(token: string): void {
+export async function connectWithToken(token: string): Promise<void> {
   sessionStorage.setItem('ic-auth-token', token);
-  appState.hasToken = true;
+  appState.authError = null;
   const client = getWsClient();
+  await startConnectionWithToken(client, token);
+}
+
+/**
+ * Shared entry point for starting a connection with a token: runs the
+ * HTTP preflight so the UI can distinguish an invalid token from an
+ * unreachable daemon, then kicks off the WS client. The client's
+ * reconnect loop will preflight again on each retry.
+ */
+async function startConnectionWithToken(client: WsClient, token: string): Promise<void> {
+  const result = await verifyAuthToken(token);
+  if (result === 'invalid') {
+    handleAuthError();
+    return;
+  }
+  // 'ok' or 'offline' — in both cases we're committing to the token and
+  // want the UI past the login gate. On 'offline' the WS client will
+  // enter the reconnect loop and preflight again each time.
+  appState.hasToken = true;
   client.connect(buildWsUrl(), token);
 }

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -321,8 +321,9 @@ function buildWsUrl(): string {
 /**
  * Initialize the WebSocket connection. Extracts token from URL
  * or sessionStorage. `hasToken` is only flipped to `true` after the
- * HTTP preflight (in the ws client) succeeds or returns 'offline' — we
- * don't flip it here so a bad token doesn't flash the dashboard.
+ * store-level preflight inside `startConnectionWithToken()` succeeds or
+ * returns 'offline' — we don't flip it here so a bad token doesn't
+ * flash the dashboard.
  */
 export async function initConnection(): Promise<void> {
   const client = getWsClient();

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -35,6 +35,7 @@ export type ThemeId = 'iron' | 'daylight' | 'midnight';
 
 const MAX_OUTPUT_LINES = 2000;
 const THEME_KEY = 'ic-theme';
+const AUTH_TOKEN_KEY = 'ic-auth-token';
 
 const VALID_THEMES: ReadonlySet<string> = new Set<ThemeId>(['iron', 'daylight', 'midnight']);
 
@@ -57,7 +58,7 @@ class AppState {
    * status codes, so we rely on an HTTP preflight to `/ws/auth` and
    * surface the result here to drive UI state.
    */
-  authError: string | null = $state(null);
+  authError: 'invalid_token' | null = $state(null);
   daemonStatus: DaemonStatusDto | null = $state(null);
   sessions: Map<number, SessionDto> = $state(new Map());
   selectedSessionLabel: number | null = $state(null);
@@ -149,34 +150,23 @@ export function getWsClient(): WsClient {
 }
 
 /**
- * HTTP preflight against the daemon's `/ws/auth` endpoint.
- *
- * The browser WebSocket API collapses HTTP 401 rejections and network
- * errors into the same `onclose(1006)` event, leaving the client unable
- * to tell "bad token" from "daemon down". By probing over plain HTTP
- * first, we can surface a meaningful error to the user and stop the
- * reconnect loop when the token is known-bad.
- *
- * Status-to-result mapping:
- *   - 200 → 'ok': token accepted, open the WS
- *   - 401 → 'invalid': token rejected, clear it and stop retrying
- *   - anything else (502/503/504 from a reverse proxy, daemon restarting,
- *     fetch reject on network error) → 'offline': keep the stored token
- *     and let the reconnect loop keep probing. Treating transient 5xx as
- *     'invalid' would destructively purge a good token on a brief blip.
+ * HTTP preflight against the daemon's `/ws/auth` endpoint. The status is
+ * mapped to three outcomes:
+ *   - 200 → 'ok'
+ *   - 401 → 'invalid' (clear the token and stop retrying)
+ *   - anything else, including network errors → 'offline' (keep retrying;
+ *     a transient 5xx must not destructively purge a good token)
  *
  * Exported for testing.
  */
 export async function verifyAuthToken(token: string, fetchImpl: typeof fetch = fetch): Promise<PreflightResult> {
   try {
-    const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
-    const url = `${protocol}//${window.location.host}/ws/auth?token=${encodeURIComponent(token)}`;
+    const url = buildDaemonUrl(`/ws/auth?token=${encodeURIComponent(token)}`, { ws: false });
     const res = await fetchImpl(url, { method: 'GET', cache: 'no-store' });
     if (res.status === 200) return 'ok';
     if (res.status === 401) return 'invalid';
     return 'offline';
   } catch {
-    // fetch throws on network failure, CORS issues, aborted requests, etc.
     return 'offline';
   }
 }
@@ -211,7 +201,7 @@ function wireEventHandlers(client: WsClient): void {
 
 /** Purge the bad token and flip the UI back to the token input. */
 function handleAuthError(): void {
-  sessionStorage.removeItem('ic-auth-token');
+  sessionStorage.removeItem(AUTH_TOKEN_KEY);
   appState.hasToken = false;
   appState.authError = 'invalid_token';
 }
@@ -312,9 +302,20 @@ function refreshJobs(client: WsClient): void {
   }, 300);
 }
 
+/**
+ * Build a daemon-relative URL. `ws: true` selects ws(s) for the WebSocket
+ * endpoint; otherwise http(s) is used for plain HTTP requests like the
+ * auth preflight. The scheme mirrors the page's own protocol so dev
+ * (http) and prod (https) Just Work.
+ */
+function buildDaemonUrl(path: string, opts: { ws: boolean }): string {
+  const isHttps = window.location.protocol === 'https:';
+  const protocol = opts.ws ? (isHttps ? 'wss:' : 'ws:') : isHttps ? 'https:' : 'http:';
+  return `${protocol}//${window.location.host}${path}`;
+}
+
 function buildWsUrl(): string {
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return `${protocol}//${window.location.host}/ws`;
+  return buildDaemonUrl('/ws', { ws: true });
 }
 
 /**
@@ -330,12 +331,12 @@ export async function initConnection(): Promise<void> {
   let token = params.get('token');
 
   if (token) {
-    sessionStorage.setItem('ic-auth-token', token);
+    sessionStorage.setItem(AUTH_TOKEN_KEY, token);
     const url = new URL(window.location.href);
     url.searchParams.delete('token');
     window.history.replaceState({}, '', url.toString());
   } else {
-    token = sessionStorage.getItem('ic-auth-token');
+    token = sessionStorage.getItem(AUTH_TOKEN_KEY);
   }
 
   if (!token) {
@@ -499,7 +500,7 @@ export async function compilePersonaPolicy(name: string): Promise<PersonaCompile
 }
 
 export async function connectWithToken(token: string): Promise<void> {
-  sessionStorage.setItem('ic-auth-token', token);
+  sessionStorage.setItem(AUTH_TOKEN_KEY, token);
   // Deliberately do NOT clear `authError` here. If the user re-pastes the
   // same bad token, clearing upfront blanks the banner for one tick and
   // then `handleAuthError()` sets it back — a visible flash. The banner

--- a/packages/web-ui/src/lib/ws-client.ts
+++ b/packages/web-ui/src/lib/ws-client.ts
@@ -72,8 +72,15 @@ export function createWsClient(preflight?: PreflightFn): WsClient {
     // Preflight before opening the WebSocket. The browser WebSocket API
     // hides HTTP 401s (they surface as a generic close 1006), so we use
     // an HTTP probe to distinguish "bad token" from "daemon unreachable".
+    // An unexpected rejection from the preflight is treated as 'offline'
+    // so an ill-behaved callback can't crash the reconnect loop.
     if (preflight) {
-      const result = await preflight(authToken);
+      let result: PreflightResult;
+      try {
+        result = await preflight(authToken);
+      } catch {
+        result = 'offline';
+      }
       if (closed) return;
       if (result === 'invalid') {
         closed = true;

--- a/packages/web-ui/src/lib/ws-client.ts
+++ b/packages/web-ui/src/lib/ws-client.ts
@@ -12,11 +12,24 @@ type PendingRequest = {
 
 type EventHandler = (event: string, payload: unknown) => void;
 type ConnectionHandler = (connected: boolean) => void;
+type AuthErrorHandler = () => void;
+
+/**
+ * Result of the HTTP auth preflight.
+ * - 'ok': token verified, proceed with WS upgrade
+ * - 'invalid': server rejected the token (401); stop retrying
+ * - 'offline': network/CORS error; daemon may be down; keep retrying
+ */
+export type PreflightResult = 'ok' | 'invalid' | 'offline';
+
+export type PreflightFn = (token: string) => Promise<PreflightResult>;
 
 export interface WsClient {
   request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
   onEvent(handler: EventHandler): () => void;
   onConnectionChange(handler: ConnectionHandler): () => void;
+  /** Fires once when the preflight returns 'invalid'. Reconnects stop. */
+  onAuthError(handler: AuthErrorHandler): () => void;
   readonly isConnected: boolean;
   connect(url: string, token: string): void;
   disconnect(): void;
@@ -26,7 +39,7 @@ const REQUEST_TIMEOUT_MS = 120_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const BASE_RECONNECT_DELAY_MS = 1_000;
 
-export function createWsClient(): WsClient {
+export function createWsClient(preflight?: PreflightFn): WsClient {
   let ws: WebSocket | null = null;
   let connected = false;
   let closed = false;
@@ -37,6 +50,7 @@ export function createWsClient(): WsClient {
   const pending = new Map<string, PendingRequest>();
   const eventHandlers = new Set<EventHandler>();
   const connectionHandlers = new Set<ConnectionHandler>();
+  const authErrorHandlers = new Set<AuthErrorHandler>();
   let idCounter = 0;
 
   function setConnected(value: boolean): void {
@@ -46,8 +60,31 @@ export function createWsClient(): WsClient {
     }
   }
 
-  function doConnect(): void {
+  function fireAuthError(): void {
+    for (const handler of authErrorHandlers) {
+      handler();
+    }
+  }
+
+  async function doConnect(): Promise<void> {
     if (closed) return;
+
+    // Preflight before opening the WebSocket. The browser WebSocket API
+    // hides HTTP 401s (they surface as a generic close 1006), so we use
+    // an HTTP probe to distinguish "bad token" from "daemon unreachable".
+    if (preflight) {
+      const result = await preflight(authToken);
+      if (closed) return;
+      if (result === 'invalid') {
+        closed = true;
+        fireAuthError();
+        return;
+      }
+      if (result === 'offline') {
+        scheduleReconnect();
+        return;
+      }
+    }
 
     const separator = wsUrl.includes('?') ? '&' : '?';
     const fullUrl = `${wsUrl}${separator}token=${authToken}`;
@@ -118,7 +155,9 @@ export function createWsClient(): WsClient {
     reconnectAttempts++;
     const delay = Math.min(BASE_RECONNECT_DELAY_MS * Math.pow(1.5, reconnectAttempts), MAX_RECONNECT_DELAY_MS);
     setTimeout(() => {
-      if (!closed) doConnect();
+      if (!closed) {
+        void doConnect();
+      }
     }, delay);
   }
 
@@ -132,7 +171,7 @@ export function createWsClient(): WsClient {
       authToken = token;
       closed = false;
       reconnectAttempts = 0;
-      doConnect();
+      void doConnect();
     },
 
     disconnect() {
@@ -176,6 +215,11 @@ export function createWsClient(): WsClient {
     onConnectionChange(handler: ConnectionHandler): () => void {
       connectionHandlers.add(handler);
       return () => connectionHandlers.delete(handler);
+    },
+
+    onAuthError(handler: AuthErrorHandler): () => void {
+      authErrorHandlers.add(handler);
+      return () => authErrorHandlers.delete(handler);
     },
   };
 }

--- a/packages/web-ui/vite.config.ts
+++ b/packages/web-ui/vite.config.ts
@@ -20,9 +20,14 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      // Matches both GET /ws/auth (preflight) and the WS upgrade at /ws.
+      // http-proxy with `ws: true` handles both HTTP and WS over the
+      // same target; the http:// scheme works for both paths because
+      // the proxy inspects the Upgrade header to decide which to use.
       '/ws': {
-        target: 'ws://127.0.0.1:7400',
+        target: 'http://127.0.0.1:7400',
         ws: true,
+        changeOrigin: true,
       },
     },
   },

--- a/src/web-ui/web-ui-server.ts
+++ b/src/web-ui/web-ui-server.ts
@@ -323,7 +323,9 @@ export class WebUiServer {
     // Auth preflight endpoint -- lets the client distinguish a bad token
     // (stop retrying, show error) from a daemon-down condition (keep
     // retrying). Uses the same timing-safe verifier as the WS upgrade.
-    if (pathname === '/ws/auth') {
+    // GET only; anything else falls through to the static handler which
+    // will 404 (parity with the mock server and the rest of this file).
+    if (pathname === '/ws/auth' && req.method === 'GET') {
       const token = url.searchParams.get('token');
       if (token && this.verifyToken(token)) {
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -332,6 +334,11 @@ export class WebUiServer {
         res.writeHead(401, { 'Content-Type': 'application/json' });
         res.end('{"ok":false,"error":"invalid_token"}');
       }
+      return;
+    }
+    if (pathname === '/ws/auth') {
+      res.writeHead(404);
+      res.end('Not Found');
       return;
     }
 

--- a/src/web-ui/web-ui-server.ts
+++ b/src/web-ui/web-ui-server.ts
@@ -320,6 +320,21 @@ export class WebUiServer {
       return;
     }
 
+    // Auth preflight endpoint -- lets the client distinguish a bad token
+    // (stop retrying, show error) from a daemon-down condition (keep
+    // retrying). Uses the same timing-safe verifier as the WS upgrade.
+    if (pathname === '/ws/auth') {
+      const token = url.searchParams.get('token');
+      if (token && this.verifyToken(token)) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{"ok":true}');
+      } else {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end('{"ok":false,"error":"invalid_token"}');
+      }
+      return;
+    }
+
     const rawFilePath =
       pathname === '/' ? resolve(this.staticRoot, 'index.html') : resolve(this.staticRoot, pathname.slice(1));
 

--- a/src/web-ui/web-ui-server.ts
+++ b/src/web-ui/web-ui-server.ts
@@ -323,15 +323,17 @@ export class WebUiServer {
     // Auth preflight endpoint -- lets the client distinguish a bad token
     // (stop retrying, show error) from a daemon-down condition (keep
     // retrying). Uses the same timing-safe verifier as the WS upgrade.
-    // GET only; anything else falls through to the static handler which
-    // will 404 (parity with the mock server and the rest of this file).
+    // GET only; any other method hits the explicit 404 branch below.
+    // `Cache-Control: no-store` keeps the browser and any intermediary
+    // from caching a response keyed by the token-bearing URL.
     if (pathname === '/ws/auth' && req.method === 'GET') {
       const token = url.searchParams.get('token');
+      const headers = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
       if (token && this.verifyToken(token)) {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.writeHead(200, headers);
         res.end('{"ok":true}');
       } else {
-        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.writeHead(401, headers);
         res.end('{"ok":false,"error":"invalid_token"}');
       }
       return;


### PR DESCRIPTION
## Summary

- Adds an HTTP preflight (`GET /ws/auth`) so the web UI can distinguish a rejected token (401) from a daemon-down condition (network error) on WebSocket connect — the browser WebSocket API collapses both into `onclose(1006)`, which is why the UI previously flipped to the dashboard and showed a permanent "Offline" banner on a bad token.
- Daemon exposes `/ws/auth` (GET-only) using the existing timing-safe token verifier. `401` clears sessionStorage, sets `authError='invalid_token'`, and stops the reconnect loop. Any other non-200 status, plus outright network failure, is treated as "daemon offline" so the reconnect loop keeps probing. Only `401` destructively purges the stored token.
- `hasToken` is no longer flipped to `true` optimistically on form submit — it only flips after the preflight resolves, so there's no dashboard flash between paste and rejection.
- Login card now renders an inline banner when `authError === 'invalid_token'` so the user understands why they're back on the token page.
- Vite dev proxy target switched from `ws://…` to `http://…` with `changeOrigin: true` so the preflight HTTP GET and the WS upgrade both pass through the same `/ws` prefix rule.
- Mock WS server now shares a single HTTP port (`http.createServer()` + `WebSocketServer({ noServer: true })`) so it can serve `/ws/auth`, and rejects anything but `mock-dev-token` on both the preflight and the upgrade — needed for E2E coverage of the bad-token path.

## Test plan

- [x] `npm test -w packages/web-ui` — 252 passing (+8 unit tests across `preflight.test.ts` and `ws-client.test.ts`).
- [x] `npx tsc --noEmit` in `packages/web-ui` — clean.
- [x] `npm run lint` and `npm run format:check` — clean.
- [x] `npx playwright test e2e/auth.spec.ts` — 2 new tests pass (bad token shows banner + doesn't navigate + sessionStorage purged; valid token after rejection clears banner and lands in the app).
- [x] Pre-existing `e2e/workflows.spec.ts` failures verified on master, unrelated to this change.
- [ ] Manual: paste a bad token in the login form → stays on login with banner.
- [ ] Manual: kill daemon mid-session → reconnect loop runs; restart daemon → reconnects silently.
- [ ] Manual: kill daemon before page load → UI shows "Offline" (waiting for daemon) rather than "invalid token".