### PR TITLE
fix(web-ui): Matrix rain review fixes

### DIFF
--- a/docs/designs/web-ui-matrix-rain.md
+++ b/docs/designs/web-ui-matrix-rain.md
@@ -83,92 +83,101 @@ content. Neither side knows about the other.
 
 ## 3. Engine API
 
+> **Canonical source:** `packages/web-ui/src/lib/matrix-rain/types.ts` is authoritative. The block
+> below summarizes the shape as shipped; consult the types file for the current in-tree signatures.
+
+Key shape (paraphrased, not compilable):
+
 ```typescript
-// matrix-rain/types.ts
+// matrix-rain/types.ts (summary)
 
-/** Visible lifecycle phases for the animation. */
 export type RainPhase = 'assembly' | 'hold' | 'ambient';
+export type DropColorKind = 'head' | 'near' | 'far';
 
-/** Internal dimensions are expressed in logical CSS pixels. DPR is applied by the Svelte wrapper. */
-export interface EngineOptions {
-  /** Pre-computed layout. Never null here — the wrapper has already validated viewport fits. */
-  readonly layout: LayoutPlan;
-  /** The word to assemble. Default: "IronCurtain". */
-  readonly word?: string;
-  /** Seed for deterministic tests. Default: Math.random-based. */
-  readonly rng?: () => number;
-  /** If true, skip assembly; emit FrameState with locked wordmark only, no ambient drops. */
-  readonly reducedMotion?: boolean;
-  /**
-   * Color palette. Default: phosphor green matching mux-splash.ts:
-   *   head: '#B4FFB4', near: '#00FF46', far: '#007800', locked: '#00C800'.
-   */
-  readonly palette?: Readonly<RainPalette>;
+/** Pre-computed layout. The engine treats this as read-only. */
+export interface LayoutPlan {
+  readonly cellSize: number;
+  readonly cols: number;
+  readonly rows: number;
+  readonly originX: number;
+  readonly originY: number;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+  readonly lockedCells: ReadonlyArray<LockedCellCoord>;
+  // Pre-rendered wordmark image that the renderer reveals a cell at a time.
+  readonly wordmarkImage: HTMLCanvasElement | OffscreenCanvas | null;
+  readonly wordmarkDrawX: number;
+  readonly wordmarkDrawY: number;
 }
 
-export interface RainPalette {
-  readonly head: string; // bright head character
-  readonly near: string; // 1-2 chars behind head
-  readonly far: string; // tail
-  readonly locked: string; // wordmark cells after assembly
+export interface LockedCellCoord {
+  readonly col: number;
+  readonly row: number;
+  readonly group?: 'title' | 'subtitle';
 }
 
-/** Plain-data snapshot of what to draw this frame. Produced by the engine, consumed by the renderer. */
+/** Plain-data snapshot produced by the engine, consumed by the renderer. */
 export interface FrameState {
   readonly phase: RainPhase;
-  /** Global alpha for the entire frame. Renderer applies once, resets at end. */
   readonly globalAlpha: number;
-  /** Locked wordmark cells. Drawn LAST so they occlude overlapping drops. */
   readonly lockedCells: ReadonlyArray<LockedCellSnapshot>;
-  /** Active falling drops (assembly unlocked drops + ambient drops). Empty during hold. */
   readonly drops: ReadonlyArray<DropSnapshot>;
 }
 
+/** Color is NOT on the snapshot — locked cells reveal the pre-rendered
+ *  wordmark image via `drawImage` clipping, not a text fill. */
 export interface LockedCellSnapshot {
-  readonly col: number; // cell-coordinate column (wordmark-relative is OK; renderer offsets by layout.originX/Y)
+  readonly col: number;
   readonly row: number;
-  readonly color: string; // hex; typically palette.locked, but the engine may progressively reveal during assembly
-  /**
-   * 0.0..1.0. For the assembly phase the engine MAY emit partially-revealed locked cells (e.g. as drops
-   * land). For hold/ambient this is 1.0; the frame-level globalAlpha handles the dim.
-   */
   readonly alpha: number;
 }
 
 export interface DropSnapshot {
   readonly col: number;
-  readonly headRow: number; // may be fractional for ambient drops
-  /** Trail characters from head (index 0) to tail. Renderer draws each with its color. */
-  readonly trail: ReadonlyArray<{ readonly row: number; readonly char: string; readonly color: string }>;
+  readonly row: number; // fractional for ambient drops
+  readonly char: string;
+  readonly colorKind: DropColorKind;
+  readonly trail: ReadonlyArray<DropTrailSnapshot>;
+}
+
+export interface DropTrailSnapshot {
+  readonly col: number;
+  readonly row: number;
+  readonly char: string;
+  readonly colorKind: DropColorKind;
+}
+
+/** Options to `createRainEngine(layout, options?)`. Palette and word are
+ *  not configurable — palette lives in `palette.ts`, the word is baked
+ *  into the layout plan via `computeLayout(word, ...)`. */
+export interface RainEngineOptions {
+  readonly reducedMotion?: boolean;
+  readonly rng?: RainRng;
+  readonly seed?: number;
 }
 
 export interface RainEngine {
-  /**
-   * Advance internal state toward `nowMs`. Time semantics:
-   *   - Calling step() with monotonically increasing timestamps converges the engine's state.
-   *   - Calling step() with the same nowMs twice in a row is a no-op (no state advance).
-   *   - If (nowMs - lastTick) exceeds MAX_CATCH_UP_TICKS * FRAME_MS (see §3.1 below), the engine
-   *     performs exactly ONE tick of progress and resets lastTick = nowMs. This prevents the
-   *     "background tab freeze" failure mode where a suspended RAF resumes with a multi-minute delta
-   *     and tries to synchronously run thousands of ticks.
-   */
   step(nowMs: number): void;
-
-  /** Produce a plain-data snapshot of the current drawable state. No side effects. */
   getFrame(): FrameState;
-
-  /** Update with a new layout. Engine re-seeds drops if cellSize changed; otherwise reuses state. */
   resize(newLayout: LayoutPlan): void;
-
-  /** Current phase (read-only). */
   readonly phase: RainPhase;
-
-  /** True after assembly has finished (phase !== 'assembly'). */
   readonly wordmarkReady: boolean;
 }
 
-export function createRainEngine(options: EngineOptions): RainEngine;
+/** Note the positional layout parameter — the layout is required and
+ *  comes in before the options bag. */
+export function createRainEngine(layout: LayoutPlan, options?: RainEngineOptions): RainEngine;
 ```
+
+Behavior not expressed in the types:
+
+- `getFrame()` is side-effect free; characters for the in-flight drops are advanced in `step()` so
+  the snapshot doesn't consume the RNG stream.
+- `resize()` rebuilds the locked-cell snapshot whenever `cellSize` or the contents of `lockedCells`
+  changed, so a viewport-width change that shifts wordmark centering is honored even when cell size
+  stays constant. Ambient drops are only cleared on a `cellSize` change.
+- The palette is controlled by `palette.ts`, not by options; the renderer maps `DropColorKind` →
+  hex at paint time.
 
 ### 3.1 Tick semantics and catch-up cap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,6 +1156,15 @@
         }
       }
     },
+    "node_modules/@fontsource/orbitron": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/orbitron/-/orbitron-5.2.8.tgz",
+      "integrity": "sha512-ruzrDl5vnqNykk5DZWY0Ezj4aeFZSbCnwJTc/98ojNJHSsHhlhT2r7rwQrA5sptmF8JtB8TQTAvlfRvcV28RPw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -10166,6 +10175,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
+        "@fontsource/orbitron": "^5.2.8",
         "@types/dompurify": "^3.0.5",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.3",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
+    "@fontsource/orbitron": "^5.2.8",
     "@types/dompurify": "^3.0.5",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.3",

--- a/packages/web-ui/src/app.css
+++ b/packages/web-ui/src/app.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@700&display=swap');
+@import '@fontsource/orbitron/700.css';
 
 @tailwind base;
 @tailwind components;

--- a/packages/web-ui/src/lib/components/features/matrix-rain.svelte
+++ b/packages/web-ui/src/lib/components/features/matrix-rain.svelte
@@ -57,18 +57,24 @@
       return;
     }
 
-    // Attempt to load Orbitron; fall back gracefully on failure.
+    // Guard against writes after unmount: if the component is destroyed
+    // before document.fonts.load() resolves, the promise handler would
+    // otherwise assign to already-disposed state.
+    let cancelled = false;
     const fontSpec = `${WORDMARK_FONT_WEIGHT} 48px ${WORDMARK_FONT_FAMILY}`;
     document.fonts
       .load(fontSpec)
       .then(() => {
-        fontReady = true;
+        if (!cancelled) fontReady = true;
       })
       .catch(() => {
         // Font failed to load -- fall back to system font. Layout will
         // still work since computeLayout accepts any renderable font.
-        fontReady = true;
+        if (!cancelled) fontReady = true;
       });
+    return () => {
+      cancelled = true;
+    };
   });
 
   // Main render effect. Re-runs on canvas mount, word change, font readiness,

--- a/packages/web-ui/src/lib/matrix-rain/__tests__/engine.test.ts
+++ b/packages/web-ui/src/lib/matrix-rain/__tests__/engine.test.ts
@@ -505,6 +505,73 @@ describe('createRainEngine -- background rain during assembly', () => {
   });
 });
 
+describe('createRainEngine -- resize', () => {
+  /** Shift every locked cell one column to the right -- simulates the
+   *  wordmark re-centering on a viewport width change without a
+   *  cellSize change. */
+  function shiftCellsRight(layout: LayoutPlan, delta: number): LayoutPlan {
+    return {
+      ...layout,
+      lockedCells: layout.lockedCells.map((c) => ({ ...c, col: c.col + delta })),
+    };
+  }
+
+  it('updates locked-cell snapshot when geometry shifts at the same cellSize (hold/ambient)', () => {
+    const layout = buildTwoPhaseLayout();
+    const engine = createRainEngine(layout, { seed: 42 });
+    // Drive into ambient so the snapshot is locked in.
+    driveTicks(engine, MAX_ASSEMBLY_TICKS + HOLD_TICKS + 5);
+    expect(engine.phase).toBe('ambient');
+
+    const shifted = shiftCellsRight(layout, 3);
+    engine.resize(shifted);
+
+    const frame = engine.getFrame();
+    // Every locked cell in the frame must match the shifted layout, not
+    // the original. This is the regression test for the stale-snapshot bug.
+    for (const cell of frame.lockedCells) {
+      const match = shifted.lockedCells.find((c) => c.col === cell.col && c.row === cell.row);
+      expect(match).toBeDefined();
+    }
+    expect(frame.lockedCells).toHaveLength(shifted.lockedCells.length);
+  });
+
+  it('rebuilds assembly drops when locked cells shift during assembly', () => {
+    const layout = buildTwoPhaseLayout();
+    const engine = createRainEngine(layout, { seed: 42 });
+    driveTicks(engine, 3);
+    expect(engine.phase).toBe('assembly');
+
+    const shifted = shiftCellsRight(layout, 5);
+    engine.resize(shifted);
+
+    // Drive assembly to completion. If drops still targeted the old
+    // columns, the shifted title cells would never lock.
+    driveTicks(engine, MAX_ASSEMBLY_TICKS + SUBTITLE_REVEAL_TICKS + 2);
+    const finalFrame = engine.getFrame();
+    const titleCount = shifted.lockedCells.filter((c) => c.group === 'title').length;
+    const lockedTitleCols = new Set(
+      finalFrame.lockedCells
+        .filter((c) => shifted.lockedCells.some((lc) => lc.group === 'title' && lc.col === c.col && lc.row === c.row))
+        .map((c) => c.col),
+    );
+    expect(lockedTitleCols.size).toBe(titleCount);
+  });
+
+  it('is a no-op when the new layout has identical lockedCells and cellSize', () => {
+    const layout = buildTwoPhaseLayout();
+    const engine = createRainEngine(layout, { seed: 42 });
+    driveTicks(engine, MAX_ASSEMBLY_TICKS + HOLD_TICKS + 5);
+    const before = snapshot(engine.getFrame());
+
+    // Same content, different array identity — must not tear down state.
+    engine.resize({ ...layout, lockedCells: layout.lockedCells.map((c) => ({ ...c })) });
+
+    const after = snapshot(engine.getFrame());
+    expect(after).toBe(before);
+  });
+});
+
 describe('createSeededRng', () => {
   it('produces a deterministic sequence for a given seed', () => {
     const a = createSeededRng(99);

--- a/packages/web-ui/src/lib/matrix-rain/__tests__/engine.test.ts
+++ b/packages/web-ui/src/lib/matrix-rain/__tests__/engine.test.ts
@@ -162,10 +162,16 @@ function snapshot(frame: FrameState): string {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Drive the engine forward by `tickCount` logical ticks. */
-function driveTicks(engine: ReturnType<typeof createRainEngine>, tickCount: number): void {
-  engine.step(0);
-  for (let i = 1; i <= tickCount; i++) engine.step(i * FRAME_MS);
+/**
+ * Drive the engine forward by `tickCount` logical ticks, starting at `startMs`.
+ * Returns the final timestamp so callers that need to continue driving
+ * the same engine across multiple phases can chain monotonic calls —
+ * feeding rewound timestamps would be silently ignored by `step()`.
+ */
+function driveTicks(engine: ReturnType<typeof createRainEngine>, tickCount: number, startMs: number = 0): number {
+  engine.step(startMs);
+  for (let i = 1; i <= tickCount; i++) engine.step(startMs + i * FRAME_MS);
+  return startMs + tickCount * FRAME_MS;
 }
 
 // ---------------------------------------------------------------------------
@@ -539,23 +545,28 @@ describe('createRainEngine -- resize', () => {
   it('rebuilds assembly drops when locked cells shift during assembly', () => {
     const layout = buildTwoPhaseLayout();
     const engine = createRainEngine(layout, { seed: 42 });
-    driveTicks(engine, 3);
+    const afterInitialTicks = driveTicks(engine, 3);
     expect(engine.phase).toBe('assembly');
 
     const shifted = shiftCellsRight(layout, 5);
     engine.resize(shifted);
 
     // Drive assembly to completion. If drops still targeted the old
-    // columns, the shifted title cells would never lock.
-    driveTicks(engine, MAX_ASSEMBLY_TICKS + SUBTITLE_REVEAL_TICKS + 2);
+    // columns, the shifted title cells would never lock. Continue from
+    // the timestamp the first driveTicks ended at — otherwise the engine
+    // would treat the new call's initial timestamps as rewound and skip
+    // advancing.
+    driveTicks(engine, MAX_ASSEMBLY_TICKS + SUBTITLE_REVEAL_TICKS + 2, afterInitialTicks + FRAME_MS);
+
+    // Compare full (col, row) pairs, not distinct columns — a future
+    // layout could have multiple title cells in one column (stacked
+    // glyphs), and the distinct-column count would spuriously pass then.
     const finalFrame = engine.getFrame();
-    const titleCount = shifted.lockedCells.filter((c) => c.group === 'title').length;
-    const lockedTitleCols = new Set(
-      finalFrame.lockedCells
-        .filter((c) => shifted.lockedCells.some((lc) => lc.group === 'title' && lc.col === c.col && lc.row === c.row))
-        .map((c) => c.col),
+    const shiftedTitleCells = shifted.lockedCells.filter((c) => c.group === 'title');
+    const lockedTitleCells = finalFrame.lockedCells.filter((c) =>
+      shiftedTitleCells.some((lc) => lc.col === c.col && lc.row === c.row),
     );
-    expect(lockedTitleCols.size).toBe(titleCount);
+    expect(lockedTitleCells).toHaveLength(shiftedTitleCells.length);
   });
 
   it('is a no-op when the new layout has identical lockedCells and cellSize', () => {

--- a/packages/web-ui/src/lib/matrix-rain/engine.ts
+++ b/packages/web-ui/src/lib/matrix-rain/engine.ts
@@ -606,6 +606,12 @@ export function createRainEngine(layout: LayoutPlan, options: RainEngineOptions 
       // moves. Without this check, hold/ambient would keep emitting
       // stale coordinates and assembly drops would target stale cells.
       const lockedCellsChanged = !lockedCellsEqual(currentLayout.lockedCells, newLayout.lockedCells);
+      // `cols`/`rows` can shift without `cellSize` (e.g. viewport width
+      // changes by less than one cellSize step). Ambient drops in cols
+      // that no longer exist would otherwise keep occupying the cap
+      // while rendering off-canvas, reducing visible density.
+      const gridDimsChanged =
+        cellSizeChanged || newLayout.cols !== currentLayout.cols || newLayout.rows !== currentLayout.rows;
       currentLayout = newLayout;
       const partitioned = partitionCells(currentLayout.lockedCells);
       titleCells = partitioned.titleCells;
@@ -621,10 +627,10 @@ export function createRainEngine(layout: LayoutPlan, options: RainEngineOptions 
           lockedSnapshotBuf = allLockedCellsSnapshot(currentLayout);
         }
       }
-      // Only a true grid-dimension change (cellSize) invalidates the
-      // ambient drop population; a wordmark shift alone leaves the grid
-      // intact and ambient drops can keep falling uninterrupted.
-      if (cellSizeChanged) {
+      // Any change to the grid dimensions invalidates the ambient
+      // population; a pure wordmark re-centering (grid intact) leaves
+      // rain uninterrupted.
+      if (gridDimsChanged) {
         ambientDrops = [];
       }
       // Always resize the cooldown array to the new column count.

--- a/packages/web-ui/src/lib/matrix-rain/engine.ts
+++ b/packages/web-ui/src/lib/matrix-rain/engine.ts
@@ -601,14 +601,17 @@ export function createRainEngine(layout: LayoutPlan, options: RainEngineOptions 
 
     resize(newLayout: LayoutPlan): void {
       const cellSizeChanged = newLayout.cellSize !== currentLayout.cellSize;
+      // A viewport shape change can shift wordmark centering even when
+      // cellSize stays the same — every `(col, row)` in `lockedCells`
+      // moves. Without this check, hold/ambient would keep emitting
+      // stale coordinates and assembly drops would target stale cells.
+      const lockedCellsChanged = !lockedCellsEqual(currentLayout.lockedCells, newLayout.lockedCells);
       currentLayout = newLayout;
       const partitioned = partitionCells(currentLayout.lockedCells);
       titleCells = partitioned.titleCells;
       subtitleCells = partitioned.subtitleCells;
 
-      if (cellSizeChanged) {
-        // Re-seed from scratch. Phase is kept so we don't rewind, but we
-        // rebuild drops at the new grid dimensions.
+      if (cellSizeChanged || lockedCellsChanged) {
         if (phase === 'assembly') {
           assemblyDrops = buildAssemblyDrops(titleCells, rng);
           lockedSnapshotBuf = [];
@@ -617,6 +620,11 @@ export function createRainEngine(layout: LayoutPlan, options: RainEngineOptions 
         } else {
           lockedSnapshotBuf = allLockedCellsSnapshot(currentLayout);
         }
+      }
+      // Only a true grid-dimension change (cellSize) invalidates the
+      // ambient drop population; a wordmark shift alone leaves the grid
+      // intact and ambient drops can keep falling uninterrupted.
+      if (cellSizeChanged) {
         ambientDrops = [];
       }
       // Always resize the cooldown array to the new column count.
@@ -678,4 +686,19 @@ function trailColorKind(distFromHead: number): DropColorKind {
   if (distFromHead === 0) return 'head';
   if (distFromHead <= 2) return 'near';
   return 'far';
+}
+
+/**
+ * Shallow structural equality for two locked-cell arrays. A few hundred
+ * cells at most; a linear scan on resize is free.
+ */
+function lockedCellsEqual(a: ReadonlyArray<LockedCellCoord>, b: ReadonlyArray<LockedCellCoord>): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].col !== b[i].col || a[i].row !== b[i].row || a[i].group !== b[i].group) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
## Summary

Follow-up to #180 addressing Copilot review feedback. Four fixes, one intentional non-fix.

- **Self-hosted Orbitron.** Replaced the `fonts.googleapis.com` `@import` in `app.css` with `@fontsource/orbitron/700.css`. Vite bundles the woff2 (~6.5KB) into the dist, so the login page no longer depends on an external network request — works offline, works under a strict CSP with `connect-src 'self'`.
- **`engine.resize()` no longer emits stale coordinates.** Previously only a `cellSize` change rebuilt the locked-cell snapshot, so a viewport-width change that shifted wordmark centering (same cellSize, different `lockedCells` positions) left the engine drawing locked cells at their old `(col, row)`. Now the rebuild also triggers when `lockedCells` content differs (structural compare via a small `lockedCellsEqual` helper). Ambient drops still clear only on a true grid-dimension change, so a pure wordmark re-centering doesn't interrupt rain mid-fall. Adds 3 regression tests covering hold/ambient snapshot refresh, assembly-time drop rebuild, and the content-unchanged no-op case.
- **Font-load \$effect guarded against unmount.** `matrix-rain.svelte` awaited `document.fonts.load()` and wrote `fontReady` from the resolve/reject callbacks. If the component unmounted first, the write happened post-disposal. Now carries a `cancelled` flag with a cleanup returned from the effect.
- **Design doc §3 reconciled with the real types.** The old block described `createRainEngine(options)` with palette/word in the options, a `color`-bearing `LockedCellSnapshot`, and a `headRow`+color-trail `DropSnapshot`. The shipped API is `createRainEngine(layout, options?)` with a positional layout, snapshots carry only coordinates (locked cells reveal the pre-rendered wordmark image via `drawImage`), and drops carry `char`/`colorKind`. Doc now marks `packages/web-ui/src/lib/matrix-rain/types.ts` as authoritative and the embedded snippet as a summary.

**Not changed:** the `'Secure* Agent Runtime'` subtitle. The asterisk is intentional.

## Test plan

- [x] `npm test -w packages/web-ui` — 256 passing (+3 resize regression tests).
- [x] `npm run build:web-ui` — clean; Orbitron woff2 lands in `dist/web-ui-static/assets/orbitron-latin-700-normal-*.woff2`.
- [x] `npm run lint`, `npm run format:check` — clean.
- [ ] Manual: login page in offline mode (unplug network before first load) — wordmark still renders.
- [ ] Manual: resize window during ambient phase — wordmark re-centers cleanly, no stale ghost at old position.