### PR TITLE
refactor(token-stream): migrate TokenStreamBus to module singleton

### DIFF
--- a/docs/designs/token-stream-bus-ownership.md
+++ b/docs/designs/token-stream-bus-ownership.md
@@ -1,0 +1,206 @@
+# Token Stream Bus Ownership
+
+**Status:** Shipped (Option F — module-level singleton, all 5 migration steps landed on branch `feat/workflow-container-lifecycle-step-6`).
+**Author:** feature-architect
+**Scope:** Who creates, threads, and disposes the `TokenStreamBus`, and how new entry points avoid forgetting to wire it up.
+
+This document is retained as a design record. The Migration Plan below is now a
+changelog — see §5 for the completed steps. Mechanics described in §§1–4 reflect
+the pre-migration state; today `createMitmProxy` and `TokenStreamBridge` both
+read the singleton via `getTokenStreamBus()` and no bus is threaded through
+`MitmProxyOptions`, `DockerInfrastructure`, `SessionOptions`, or any dispatch
+context.
+
+---
+
+## 1. Current State
+
+### 1.1 The contract
+
+- `TokenStreamBus` (`src/docker/token-stream-bus.ts:45-74`) is a stateless pub/sub dispatcher keyed by `SessionId`. `push()` delivers events synchronously to per-session and global listeners; it silently drops if nobody is listening.
+- Producer: `createMitmProxy()` accepts an **optional** `{ tokenStreamBus, sessionId }` pair (`src/docker/mitm-proxy.ts:136-148`). Both-or-neither is enforced at construction (`mitm-proxy.ts:481-485`). When absent, the MITM proxy still runs — it just skips installing the SSE extractor tap.
+- Consumers:
+  - `TokenStreamBridge` (`src/web-ui/token-stream-bridge.ts`) — subscribes per-label and globally, fans events out to WebSocket clients.
+  - The `ironcurtain observe` CLI is indirectly a consumer: it connects to the daemon's web UI WS server (`src/observe/observe-command.ts:14-16, 58-72`) and never touches the bus directly.
+
+### 1.2 Who creates the bus today
+
+Exactly one creator, at one site:
+
+| Site | Line | What it does |
+| --- | --- | --- |
+| `IronCurtainDaemon` | `src/daemon/ironcurtain-daemon.ts:83` | `private readonly tokenStreamBus: TokenStreamBus = createTokenStreamBus();` |
+
+Everyone else borrows this instance.
+
+### 1.3 Who threads the bus
+
+Per entry point, what happens to `tokenStreamBus`:
+
+| Caller | File:line | Threads bus? |
+| --- | --- | --- |
+| Daemon → cron `executeJob()` | `daemon/ironcurtain-daemon.ts:500-508` | Yes — passes `tokenStreamBus: this.tokenStreamBus` into `createSession`. |
+| Daemon → web UI dispatch context | `daemon/ironcurtain-daemon.ts:726` → `web-ui/dispatch/session-dispatch.ts:141` | Yes — web sessions pass `tokenStreamBus: ctx.tokenStreamBus`. |
+| Daemon → `SignalBotDaemon.createSession` | `signal/signal-bot-daemon.ts:499-506` | **No.** Bot constructs `createSession()` without `tokenStreamBus`. MITM comes up bus-less; dead subscription. |
+| `ironcurtain start` (CLI) | `index.ts:176-186` | **No.** No daemon, so no bus. |
+| Workflow CLI `workflow-command.ts::runStart()` | `workflow/workflow-command.ts:234-243` | **No.** `WorkflowOrchestratorDeps` has no bus field. |
+| Workflow via web UI (`WorkflowManager.createOrchestrator`) | `web-ui/workflow-manager.ts:146-163` | **No.** Does not own or forward the daemon's bus. |
+| Shared-container workflow → `loadDefaultInfrastructureFactory` | `workflow/orchestrator.ts:556-598` | **No.** Calls `createDockerInfrastructure(..., sessionId)` omitting the seventh argument. |
+| Workflow → per-state `createSession` | `workflow/orchestrator.ts:1196-1214` | **No.** Session factory options omit `tokenStreamBus`. |
+
+So the bus hookup exists on **two** of six session-creation paths. On every other path the SSE extractor is never attached, and any subscriber on the daemon's bus hears silence for those sessions.
+
+### 1.4 Observed symptom
+
+`tsx src/cli.ts observe --all --raw`, connected to a daemon running a workflow started via the web UI, produces no output. The daemon has a bus, the bridge subscribes, the observer subscribes via WS — but the MITM created by `WorkflowManager → WorkflowOrchestrator → loadDefaultInfrastructureFactory → createDockerInfrastructure` has no `tokenStreamBus` reference and silently declines to tap.
+
+---
+
+## 2. Problem Statement
+
+The bus is optional on every hop. Every new session-creation callsite is an opportunity for a silent regression.
+
+1. **Silent failure mode.** Missing the bus never throws or logs — the SSE extractor simply isn't installed. You have to know what you're looking for.
+2. **Cross-process symmetry is broken.** A workflow launched via the daemon-hosted web UI and one launched via `tsx src/cli.ts workflow start` share `WorkflowOrchestrator` and `createDockerInfrastructure`, but only one path is inside a process that owns a bus.
+3. **Testability pressure is backwards.** No ergonomic stub for "I don't care about token events." The absent-bus production case gets covered by happy accident.
+4. **Ownership is ambient.** The daemon owns the bus; everyone borrows a reference. Ownership is never encoded in any interface.
+5. **The CLI-only path can never stream.** Even fixing workflow-via-web-UI wiring leaves `ironcurtain workflow start` (no daemon) with no bus.
+
+The through-line: **the bus is treated as optional infrastructure, but it's actually a protocol contract between the MITM proxy and its subscribers.** Making that contract optional at every hop is how we got here.
+
+---
+
+## 3. Design Options
+
+### Option A — Status quo, harder to forget
+
+Make `tokenStreamBus` a **required, non-optional** field on every hop. Ship a shared `NoOpTokenStreamBus` for callers that don't stream. Compiler forces every caller to supply a bus, but non-daemon callers all supply the noop, so the hookup is still "informed forgetting." Low migration cost, but CLI streaming still requires code changes in every CLI caller.
+
+### Option B — Session/orchestrator owns the bus, entry points subscribe
+
+Lift the bus one level into the runtime that owns the sessions. **B.1:** each `Session` owns a bus, exposed via `Session.getTokenStreamBus()`. **B.2:** each `WorkflowOrchestrator` owns a bus; individual sessions route through it. B.2 is strictly better than B.1 for workflows; weakness is the "per-session observability outside a workflow" case. Medium migration cost; daemon bridge must resubscribe per session or per orchestrator.
+
+### Option C — Process-level singleton (early sketch)
+
+One `TokenStreamBus` per process, accessed via a module-level accessor. MITM proxy reads it at construction; no wiring through intermediates. Initial appraisal dismissed this as architecturally regressive because of the "global mutable state" smell and because multi-bus futures (per-tenant, per-workflow isolated buses) would be blocked. See Option F for the revised appraisal — this section is retained only to show the reasoning chain.
+
+### Option D — Infrastructure bundle always carries a bus
+
+Make `DockerInfrastructure` always carry a `tokenStreamBus`. `prepareDockerInfrastructure()` and `createDockerInfrastructure()` construct one when the caller doesn't supply one, expose it on the bundle, and pass it to `createMitmProxy` unconditionally. Clean for Docker-session paths; doesn't cover builtin (no infra bundle). Low-medium migration cost.
+
+### Option E — Orchestrator bus, bundle transports it (hybrid) — *rejected*
+
+Narrow hybrid of B.2 and D: `WorkflowOrchestrator` creates a bus at `start()` time, passes it into `createDockerInfrastructure`, which stamps it into `DockerInfrastructure.tokenStreamBus`. For non-workflow sessions, the runtime that creates the session constructs its own single-session bus. Daemon becomes an **aggregator** — it subscribes to each child bus and republishes into its own daemon-wide bus. `tokenStreamBus` parameter disappears from `SessionOptions`; new required field on `DockerInfrastructure` and `CreateWorkflowInfrastructureInput`.
+
+Strengths: ownership is encoded in types; the bug-we're-fixing becomes a type error; "per-tenant bus" futures are open. Weaknesses (which killed it): substantial signature churn on `DockerInfrastructure`, `createMitmProxy`, `SessionOptions`, `CreateWorkflowInfrastructureInput`, `WorkflowOrchestratorDeps`, and ~37 MITM-related test call sites; requires a daemon aggregator layer and a `onTokenStreamBusCreated` lifecycle hook; the isolation benefit is **illusory** because subscribers filter by `sessionId` anyway — distinct `sessionId`s already guarantee isolation regardless of how many bus instances exist.
+
+### Option F — Module-level singleton (process-wide bus)
+
+Exactly one `TokenStreamBus` per process, created lazily the first time anything asks for it, exposed through a module-level accessor:
+
+```ts
+// src/docker/token-stream-bus.ts
+let instance: TokenStreamBus | undefined;
+
+export function getTokenStreamBus(): TokenStreamBus {
+  instance ??= createTokenStreamBus();
+  return instance;
+}
+
+export function resetTokenStreamBus(): void {
+  instance = undefined;
+}
+```
+
+Publishers (MITM SSE extractor; eventually builtin-session deltas) call `getTokenStreamBus().push(sessionId, event)`. Subscribers (web UI bridge, `observe` CLI, future file-tail loggers) call `getTokenStreamBus().subscribe(sessionId, handler)` or `subscribeAll(...)`. Entry points thread nothing.
+
+| Property | Assessment |
+| --- | --- |
+| Removes the bug class? | **Yes, by construction.** There's nothing to forget to pass because there's no parameter to pass. The web-UI-workflow symptom (§1.4) becomes impossible because `createMitmProxy` fetches the bus from the module itself. |
+| Signature churn | **Minimal.** `tokenStreamBus` deletions from `MitmProxyOptions`, `DockerInfrastructure`, `createDockerInfrastructure`, `prepareDockerInfrastructure`, `SessionOptions`, dispatch contexts. No new required fields anywhere. |
+| Infrastructure code | ~10 lines (the snippet above). No aggregator, no lifecycle hook, no republishing. |
+| CLI/daemon symmetry | **Automatic.** Both call `getTokenStreamBus()`. The only difference between them is who subscribes. |
+| Session isolation | **Already correct.** `TokenStreamBus` dispatch is keyed by `sessionId`, which is a UUID (standalone sessions) or workflow ID (orchestrated). Concurrent workflows cannot observe each other's events because they can't guess each other's IDs. Multi-bus was protecting against a threat that doesn't exist. |
+| Explicit dependency | **Weakened.** A constructor that calls `getTokenStreamBus()` internally doesn't advertise that it publishes/subscribes. Mitigation: grep for `getTokenStreamBus()` — the set of call sites is small and stable. |
+| Test isolation | Vitest runs each test **file** in its own worker process by default (`pool: 'forks'`). The project's `vitest.config.ts` relies on that default, so cross-file contamination is impossible today. Within a single file, tests that need strict isolation call `resetTokenStreamBus()` in `beforeEach`. Distinct `sessionId`s per test provide logical isolation even without reset. If the project ever switches to an in-process pool, the same reset contract still applies. |
+| Vite HMR / long-lived worker reuse | Same `resetTokenStreamBus()` contract; document it. If a test file accumulates subscribers across tests and leaks, the fix is one line in `beforeEach`. |
+| Future multi-bus | Not blocked. If we ever need per-tenant buses (e.g., multi-user daemon), the natural extension is a keyed registry (`getTokenStreamBus(tenantId)`), which is still a module-level accessor — today's call sites just pass no key. |
+
+---
+
+## 4. Recommendation
+
+**Option F (module-level singleton).** Rationale:
+
+1. **Eliminates the bug class structurally.** The original defect was "workflow entry points forget to pass the bus." Remove the parameter, remove the defect. Option E achieved the same end through type-system forcing; Option F achieves it by removing the decision altogether. Fewer moving parts.
+2. **The complexity of Option E didn't earn its keep.** The putative benefit of multiple bus instances was isolation, but isolation is already provided by `sessionId` keying inside a single bus. The aggregator + `onTokenStreamBusCreated` hook + required field on `DockerInfrastructure` + the 37-call-site MITM test migration were architecting around ownership aesthetics, not a real functional requirement.
+3. **Matches Node ecosystem conventions for cross-cutting observability.** `process.stdout`, logger singletons, Winston's default logger, `console.*` — the pattern is ubiquitous precisely because the data being observed is a property of the process, not of any one caller.
+4. **CLI/daemon symmetry becomes trivial.** The motivating concern — workflows launched via web UI and via `workflow start` should behave the same — collapses to "both call `getTokenStreamBus()`." No daemon-dependent wiring.
+5. **Test cost is contained.** Vitest's default per-file worker isolation plus an explicit `resetTokenStreamBus()` are sufficient; streaming tests already construct a bus per test, so they just migrate from constructor-injection to `reset + get`.
+
+Option E was the more layered, textbook answer. F is the right answer for this codebase because the complexity E added was defending against a problem (cross-workflow crosstalk) that the existing `sessionId` discriminator already prevents.
+
+### Residual concerns
+
+- **`src/docker/pty-session.ts`** calls `prepareDockerInfrastructure` without a bus today. Under Option F this path needs no special handling — the MITM itself calls the singleton when it installs the SSE tap, so PTY sessions automatically publish to the global bus.
+- **Vitest parallelism.** The project's `vitest.config.ts` does not set `pool` explicitly and inherits the `forks` default, so each test file runs in a fresh worker process. Confirmed safe. If the config ever moves to `threads` or `vmThreads`, or if a suite explicitly shares a worker, add `resetTokenStreamBus()` to `beforeEach` in that file.
+- **Discoverability.** Because the dependency is implicit, reviewers can't tell from a constructor signature that it publishes or subscribes. Mitigation is a single grep pattern (`getTokenStreamBus()`) plus a short comment in `token-stream-bus.ts` that enumerates known publishers and subscribers.
+
+### Resolved open questions
+
+- **Q1 (aggregator topology).** Dissolved. No aggregator. The web UI bridge and `observe` CLI both subscribe to the same global bus.
+- **Q2 (per-workflow vs per-state buses).** Dissolved into "should events carry a `stateId` payload?" — strictly additive, orthogonal, future work. Not a bus-ownership concern.
+- **Q3 (builtin sessions).** Unchanged. Builtin has no publisher today; subscribers for builtin session IDs see no events. If/when builtin gets streaming support, it publishes to the singleton — no wiring required.
+- **Q4 (required MITM arg).** Dissolved. MITM calls `getTokenStreamBus()` internally. No required arg; no 37-call-site test migration.
+
+---
+
+## 5. Migration (completed)
+
+All 5 steps landed on branch `feat/workflow-container-lifecycle-step-6`. The
+plan below is retained verbatim as a changelog — none of it is pending work.
+
+### Step 1 — Add the singleton accessor
+
+- In `src/docker/token-stream-bus.ts`, add top-level `getTokenStreamBus()` and `resetTokenStreamBus()` alongside the existing `createTokenStreamBus()` factory.
+- Keep `createTokenStreamBus()` exported for the handful of tests that want a stack-local bus for assertion purposes (they can choose to use it directly rather than the singleton).
+
+### Step 2 — MITM fetches the bus internally
+
+- `createMitmProxy` reads `getTokenStreamBus()` when it installs the SSE extractor tap.
+- Remove `tokenStreamBus` from `MitmProxyOptions`.
+- Remove the both-or-neither guard (`mitm-proxy.ts:481-485`): `sessionId` is now the only argument needed to gate extractor installation.
+
+### Step 3 — Delete threading through infrastructure and sessions
+
+- Remove `tokenStreamBus` from `DockerInfrastructure`, `createDockerInfrastructure`, `prepareDockerInfrastructure`, `SessionOptions`, and any dispatch context that carried it (`web-ui/dispatch/session-dispatch.ts`, `daemon/ironcurtain-daemon.ts` invocation sites).
+- Daemon stops constructing its own bus. `IronCurtainDaemon` reads from `getTokenStreamBus()` if it needs a direct reference (e.g., for endSession calls), or delegates to the bridge.
+
+### Step 4 — Bridge and observe CLI use the singleton
+
+- `TokenStreamBridge` constructor either accepts no bus (reads from `getTokenStreamBus()`) or retains its parameter with a default — preference: no parameter, for consistency with the rest of the migration.
+- `observe` CLI / daemon dispatch reads the singleton similarly.
+
+### Step 5 — Test updates
+
+- `test/mitm-proxy-token-stream.test.ts` and `test/token-stream-bridge.test.ts` — add `resetTokenStreamBus()` in `beforeEach`. Swap their local `createTokenStreamBus()` for either the singleton (via `getTokenStreamBus()`) or a manually-constructed one, depending on whether the test asserts on cross-subscriber behavior.
+- No changes expected at the 37 MITM test call sites that today omit `tokenStreamBus` — they already pass no bus and will continue to work.
+
+### Backwards compatibility
+
+- `TokenStreamBus` public API (push/subscribe/subscribeAll/endSession) is unchanged.
+- `createTokenStreamBus()` remains exported for tests and for any future multi-bus extension.
+- External callers who constructed `MitmProxyOptions` with a `tokenStreamBus` field will see a type error and drop the field — no behavioral migration required.
+
+---
+
+## 6. Out of Scope
+
+This design deliberately does **not** touch:
+
+- **Event payload schema changes** (adding `stateId`, workflow provenance, etc.). Additive, orthogonal, separate design.
+- **SSE extractor internals.** How events are parsed out of SSE/JSON responses is unrelated to bus ownership.
+- **`TokenStreamBridge` fanout protocol.** The WS fan-out, 50 ms batcher, and client-subscription model stay as-is.
+- **Builtin (non-Docker) session streaming.** `AgentSession` has no MITM; if it later publishes deltas, it publishes to the singleton. Wiring AI-SDK `generateText` into the bus is a follow-up.
+- **Retention / replay.** The bus remains strictly live; no history, no replay.
+- **Authz at the bus.** The daemon still decides which WS clients can subscribe to which sessions; the bus is not a trust boundary.

--- a/docs/designs/token-stream-extraction.md
+++ b/docs/designs/token-stream-extraction.md
@@ -1,5 +1,17 @@
 # Token Stream Extraction from MITM Proxy
 
+> **Status note (post-ship):** The bus is now a module-level singleton accessed
+> via `getTokenStreamBus()` — see `docs/designs/token-stream-bus-ownership.md`
+> for the ownership change. This doc's original text described threading the
+> bus through `MitmProxyOptions`, `prepareDockerInfrastructure()`, and
+> `SessionOptions`. The extractor placement, SSE parser design, bridge
+> batching, and JSON-RPC surface are all unchanged. In the shipped code the
+> MITM proxy and `TokenStreamBridge` read the singleton internally; no caller
+> threads the bus anymore. References to `MitmProxyOptions.tokenStreamBus`,
+> `DockerInfrastructure.tokenStreamBus`, `SessionOptions.tokenStreamBus`, and
+> the `tokenStreamBus` parameter on `prepareDockerInfrastructure()` below are
+> historical — none of those fields exist today.
+
 ## 1. Overview
 
 This design extracts the live LLM token stream from the MITM TLS proxy during Docker agent sessions and makes it available to multiple consumers through a single shared bus. The primary consumers are: (1) a future `ironcurtain observe <sessionId>` CLI command that tails a session's token output, (2) workflow-level observation that aggregates token streams from all sessions belonging to a workflow, and (3) the existing WebSocket-based web UI for the cinematic Matrix rain visualization described in the brainstorm doc.

--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -34,7 +34,7 @@ import { BudgetExhaustedError } from '../session/errors.js';
 import { validateWorkspacePath } from '../session/workspace-validation.js';
 import * as logger from '../logger.js';
 import { getDaemonLogPath } from '../config/paths.js';
-import { createTokenStreamBus, type TokenStreamBus } from '../docker/token-stream-bus.js';
+import { getTokenStreamBus } from '../docker/token-stream-bus.js';
 import { ControlSocketServer, type ControlRequestHandler, type DaemonStatus } from './control-socket.js';
 
 export type { SessionSource, ManagedSession } from '../session/session-manager.js';
@@ -78,9 +78,6 @@ export class IronCurtainDaemon {
   private readonly noSignal: boolean;
   private readonly sessionManager = new SessionManager();
   private readonly scheduler: CronScheduler;
-
-  /** Shared token stream bus for real-time LLM output observation. */
-  private readonly tokenStreamBus: TokenStreamBus = createTokenStreamBus();
 
   /** Time the daemon was started (for uptime calculation). */
   private startTime: Date | null = null;
@@ -229,7 +226,7 @@ export class IronCurtainDaemon {
         } catch (err: unknown) {
           logger.warn(`[Daemon] Error ending session #${s.label}: ${String(err)}`);
         }
-        this.tokenStreamBus.endSession(sessionId);
+        getTokenStreamBus().endSession(sessionId);
         this.tokenStreamBridge?.closeSession(s.label);
       }),
     );
@@ -289,7 +286,7 @@ export class IronCurtainDaemon {
       const managed = this.sessionManager.get(activeLabel);
       const sessionId = managed?.session.getInfo().id;
       await this.sessionManager.end(activeLabel);
-      if (sessionId) this.tokenStreamBus.endSession(sessionId);
+      if (sessionId) getTokenStreamBus().endSession(sessionId);
       this.tokenStreamBridge?.closeSession(activeLabel);
       this.activeJobRuns.delete(jobId);
       // The ended session tore down the logger; re-claim for daemon logs.
@@ -505,7 +502,6 @@ export class IronCurtainDaemon {
       jobId: job.id,
       systemPromptAugmentation: augmentation,
       disableAutoApprove: true,
-      tokenStreamBus: this.tokenStreamBus,
       onEscalation: (request) => {
         escalationsEncountered++;
         this.handleCronEscalation(request, job);
@@ -592,7 +588,7 @@ export class IronCurtainDaemon {
     this.activeJobRuns.delete(job.id);
     const sessionId = session.getInfo().id;
     await this.sessionManager.end(label);
-    this.tokenStreamBus.endSession(sessionId);
+    getTokenStreamBus().endSession(sessionId);
     this.tokenStreamBridge?.closeSession(label);
 
     // Session.close() tears down the logger singleton (the session
@@ -723,12 +719,13 @@ export class IronCurtainDaemon {
       mode: this.mode,
       maxConcurrentWebSessions: 5,
       devMode: this.webUiOptions?.devMode,
-      tokenStreamBus: this.tokenStreamBus,
     });
     server.setWorkflowManager(new WorkflowManager({ eventBus: server.getEventBus() }));
 
-    // Wire token stream bridge for per-client subscription delivery
-    const bridge = new TokenStreamBridge(server, this.tokenStreamBus);
+    // Wire token stream bridge for per-client subscription delivery.
+    // The bridge fetches `getTokenStreamBus()` internally at subscription
+    // time, so no bus reference is threaded through here.
+    const bridge = new TokenStreamBridge(server);
     server.setTokenStreamBridge(bridge);
     this.tokenStreamBridge = bridge;
 

--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -722,9 +722,6 @@ export class IronCurtainDaemon {
     });
     server.setWorkflowManager(new WorkflowManager({ eventBus: server.getEventBus() }));
 
-    // Wire token stream bridge for per-client subscription delivery.
-    // The bridge fetches `getTokenStreamBus()` internally at subscription
-    // time, so no bus reference is threaded through here.
     const bridge = new TokenStreamBridge(server);
     server.setTokenStreamBridge(bridge);
     this.tokenStreamBridge = bridge;

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -241,11 +241,6 @@ export async function prepareDockerInfrastructure(
     packageValidation = { validator, auditLogPath: packageAuditLogPath };
   }
 
-  // The MITM proxy reads the TokenStreamBus singleton internally via
-  // `getTokenStreamBus()`; the bus is no longer threaded through this
-  // module. Passing `sessionId` unconditionally means SSE responses are
-  // always tapped and pushed to the singleton — consumers that don't
-  // care simply never subscribe.
   const mitmProxy = useTcp
     ? createMitmProxy({
         listenPort: 0,

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -30,7 +30,6 @@ import type { MitmProxy } from './mitm-proxy.js';
 import type { CertificateAuthority } from './ca.js';
 import type { DockerManager } from './types.js';
 import type { ProviderKeyMapping } from './mitm-proxy.js';
-import type { TokenStreamBus } from './token-stream-bus.js';
 import { parseUpstreamBaseUrl, type ProviderConfig, type UpstreamTarget } from './provider-config.js';
 import { getInternalNetworkName } from './platform.js';
 import { cleanupContainers } from './container-lifecycle.js';
@@ -126,7 +125,6 @@ export async function prepareDockerInfrastructure(
   sandboxDir: string,
   escalationDir: string,
   sessionId: string,
-  tokenStreamBus?: TokenStreamBus,
 ): Promise<PreContainerInfrastructure> {
   // The audit log path is read from config so the bundle is
   // self-describing: downstream consumers (AuditLogTailer, sandbox
@@ -243,6 +241,11 @@ export async function prepareDockerInfrastructure(
     packageValidation = { validator, auditLogPath: packageAuditLogPath };
   }
 
+  // The MITM proxy reads the TokenStreamBus singleton internally via
+  // `getTokenStreamBus()`; the bus is no longer threaded through this
+  // module. Passing `sessionId` unconditionally means SSE responses are
+  // always tapped and pushed to the singleton — consumers that don't
+  // care simply never subscribe.
   const mitmProxy = useTcp
     ? createMitmProxy({
         listenPort: 0,
@@ -251,8 +254,7 @@ export async function prepareDockerInfrastructure(
         registries,
         packageValidation,
         controlPort: 0,
-        tokenStreamBus,
-        sessionId: tokenStreamBus ? sessionId : undefined,
+        sessionId,
       })
     : createMitmProxy({
         socketPath: resolve(socketsDir, 'mitm-proxy.sock'),
@@ -261,8 +263,7 @@ export async function prepareDockerInfrastructure(
         registries,
         packageValidation,
         controlSocketPath: resolve(sessionDir, 'mitm-control.sock'),
-        tokenStreamBus,
-        sessionId: tokenStreamBus ? sessionId : undefined,
+        sessionId,
       });
 
   const docker = createDockerManager();
@@ -378,17 +379,8 @@ export async function createDockerInfrastructure(
   sandboxDir: string,
   escalationDir: string,
   sessionId: string,
-  tokenStreamBus?: TokenStreamBus,
 ): Promise<DockerInfrastructure> {
-  const core = await prepareDockerInfrastructure(
-    config,
-    mode,
-    sessionDir,
-    sandboxDir,
-    escalationDir,
-    sessionId,
-    tokenStreamBus,
-  );
+  const core = await prepareDockerInfrastructure(config, mode, sessionDir, sandboxDir, escalationDir, sessionId);
 
   try {
     const containerResources = await createSessionContainers(core, config);

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -32,7 +32,7 @@ import type { RegistryConfig, PackageValidator, AllowedVersionCache } from './pa
 import { DENY_ALL_VALIDATOR } from './package-validator.js';
 import { validateDomain, type DomainListing } from './proxy-tools.js';
 import { PassThrough } from 'node:stream';
-import type { TokenStreamBus } from './token-stream-bus.js';
+import { getTokenStreamBus } from './token-stream-bus.js';
 import type { SseProvider } from './token-stream-types.js';
 import { SseExtractorTransform } from './sse-extractor.js';
 import * as logger from '../logger.js';
@@ -133,17 +133,10 @@ export interface MitmProxyOptions {
    */
   readonly dnsLookup?: http.RequestOptions['lookup'];
   /**
-   * Shared daemon-level token stream bus. When provided together with
-   * `sessionId`, the proxy taps SSE responses from LLM API endpoints
-   * and pushes parsed token events into the bus.
-   *
-   * Both `tokenStreamBus` and `sessionId` must be provided together.
-   * If one is set without the other, `createMitmProxy()` throws.
-   */
-  readonly tokenStreamBus?: TokenStreamBus;
-  /**
-   * Session ID for token stream routing. Required when `tokenStreamBus`
-   * is provided. Used to key events pushed into the bus.
+   * Session ID for token stream routing. When provided, the proxy taps
+   * SSE/JSON responses from LLM API endpoints and pushes parsed token
+   * events into the module-scoped singleton bus (see `getTokenStreamBus`).
+   * When absent, extractor installation is skipped entirely.
    */
   readonly sessionId?: string;
 }
@@ -309,12 +302,14 @@ function extractTrailingToolMessages(messages: unknown[]): unknown[] {
 
 export function extractToolResults(
   parsed: Record<string, unknown>,
-  bus: TokenStreamBus,
   sessionId: import('../session/types.js').SessionId,
 ): void {
   const messages = parsed['messages'];
   if (!Array.isArray(messages)) return;
 
+  // Fetch the singleton bus lazily so `resetTokenStreamBus()` between tests
+  // is honored at call time (not import time).
+  const bus = getTokenStreamBus();
   const now = Date.now();
 
   // Only extract from the LAST user/tool messages to avoid re-emitting
@@ -394,11 +389,7 @@ export function extractToolResults(
  *
  * Emits message_start (model), text_delta (content), and message_end (usage).
  */
-export function extractFromJsonResponse(
-  body: Buffer,
-  bus: TokenStreamBus,
-  sessionId: import('../session/types.js').SessionId,
-): void {
+export function extractFromJsonResponse(body: Buffer, sessionId: import('../session/types.js').SessionId): void {
   let parsed: Record<string, unknown>;
   try {
     parsed = JSON.parse(body.toString()) as Record<string, unknown>;
@@ -406,6 +397,9 @@ export function extractFromJsonResponse(
     return; // Not valid JSON -- nothing to extract
   }
 
+  // Fetch the singleton bus lazily so `resetTokenStreamBus()` between tests
+  // is honored at call time (not import time).
+  const bus = getTokenStreamBus();
   const now = Date.now();
 
   // Anthropic format: { model, content: [{type: 'text', text: '...'}], usage: {input_tokens, output_tokens}, stop_reason }
@@ -478,13 +472,10 @@ export function extractFromJsonResponse(
 }
 
 export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
-  // Validate token stream options: both must be provided together
-  const hasBus = options.tokenStreamBus !== undefined;
-  const hasSessionId = options.sessionId !== undefined;
-  if (hasBus !== hasSessionId) {
-    throw new Error('tokenStreamBus and sessionId must be provided together');
-  }
-  const tokenBus = options.tokenStreamBus;
+  // Token stream extractor installation is gated on `sessionId` alone.
+  // When present, the module-scoped singleton bus is fetched lazily at
+  // each extractor-install point (see below) so `resetTokenStreamBus()`
+  // between tests is honored.
   const tokenSessionId = options.sessionId;
 
   // Parse CA cert and key from PEM
@@ -778,14 +769,17 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
           clientRes.socket?.setNoDelay(true);
 
           const contentType = upstreamRes.headers['content-type'] ?? '';
-          if (tokenBus && tokenSessionId && contentType.includes('text/event-stream')) {
+          if (tokenSessionId && contentType.includes('text/event-stream')) {
+            // Fetch the singleton bus lazily so `resetTokenStreamBus()`
+            // between tests is honored.
+            const tokenBus = getTokenStreamBus();
+            const sid = tokenSessionId as import('../session/types.js').SessionId;
             const sseProvider = resolveSseProvider(targetHost);
             const extractor = new SseExtractorTransform(sseProvider, (event) => {
-              tokenBus.push(tokenSessionId as import('../session/types.js').SessionId, event);
+              tokenBus.push(sid, event);
             });
             upstreamRes.pipe(extractor).pipe(clientRes);
           } else if (
-            tokenBus &&
             tokenSessionId &&
             isLlmMessagesEndpoint(path as string) &&
             contentType.includes('application/json')
@@ -796,6 +790,7 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
             // we stop accumulating chunks (and skip extraction at end-of-stream),
             // but the passthrough listener stays attached so the stream completes
             // normally and the client still sees every byte.
+            const sid = tokenSessionId as import('../session/types.js').SessionId;
             const passthrough = new PassThrough();
             const capture = createBoundedJsonResponseCapture();
             passthrough.on('data', (chunk: Buffer) => capture.onData(chunk));
@@ -803,7 +798,7 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
               capture.onEnd((body) => {
                 if (body === null) return; // overflowed -- skip extraction
                 try {
-                  extractFromJsonResponse(body, tokenBus, tokenSessionId as import('../session/types.js').SessionId);
+                  extractFromJsonResponse(body, sid);
                 } catch {
                   // Extraction errors must never affect the forwarding path
                 }
@@ -902,10 +897,10 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
 
         // Extract tool_result events from the request body for token stream observation.
         // Done before rewriting so we see the original messages array.
-        if (tokenBus && tokenSessionId && isLlmMessagesEndpoint(path as string)) {
+        if (tokenSessionId && isLlmMessagesEndpoint(path as string)) {
           try {
             const bodyParsed = JSON.parse(rawBody.toString()) as Record<string, unknown>;
-            extractToolResults(bodyParsed, tokenBus, tokenSessionId as import('../session/types.js').SessionId);
+            extractToolResults(bodyParsed, tokenSessionId as import('../session/types.js').SessionId);
           } catch {
             // Parse failure is fine -- the rewriter below will also attempt to parse
           }

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -770,8 +770,6 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
 
           const contentType = upstreamRes.headers['content-type'] ?? '';
           if (tokenSessionId && contentType.includes('text/event-stream')) {
-            // Fetch the singleton bus lazily so `resetTokenStreamBus()`
-            // between tests is honored.
             const tokenBus = getTokenStreamBus();
             const sid = tokenSessionId as import('../session/types.js').SessionId;
             const sseProvider = resolveSseProvider(targetHost);

--- a/src/docker/token-stream-bus.ts
+++ b/src/docker/token-stream-bus.ts
@@ -113,3 +113,43 @@ export function createTokenStreamBus(): TokenStreamBus {
     },
   };
 }
+
+/**
+ * Module-scoped singleton instance. Lazily created on first call to
+ * `getTokenStreamBus()`. Cleared by `resetTokenStreamBus()` for tests.
+ */
+let singleton: TokenStreamBus | undefined;
+
+/**
+ * Returns the module-scoped singleton TokenStreamBus, creating it on
+ * first access. Subsequent calls return the same instance.
+ *
+ * Use this from daemon-level producers/consumers (MITM proxy, web UI
+ * bridge, observe CLI) that all need to share a single bus. Tests that
+ * want isolated, stack-local instances should call `createTokenStreamBus()`
+ * directly.
+ */
+export function getTokenStreamBus(): TokenStreamBus {
+  if (!singleton) {
+    singleton = createTokenStreamBus();
+  }
+  return singleton;
+}
+
+/**
+ * Clears the module-scoped singleton so the next `getTokenStreamBus()`
+ * call returns a fresh instance. Intended for test `beforeEach` hooks.
+ *
+ * INVARIANT: do NOT call this while any `TokenStreamBridge` instance has
+ * active subscriptions. The bridge caches bus unsubscribe handles in
+ * `this.subscriptions` / `this.globalUnsubscribe` that are bound to the
+ * old bus; after reset, subsequent `addClient`/`addGlobalClient` calls
+ * will subscribe on the NEW bus, but events pushed on behalf of old
+ * subscriptions still target the stale bus and never reach the new one.
+ * The safe pattern is: construct a fresh `TokenStreamBridge` after every
+ * reset (i.e. build both in the same `beforeEach`). Daemon production
+ * code never resets.
+ */
+export function resetTokenStreamBus(): void {
+  singleton = undefined;
+}

--- a/src/docker/token-stream-bus.ts
+++ b/src/docker/token-stream-bus.ts
@@ -1,10 +1,10 @@
 /**
  * Stateless pub/sub dispatcher for LLM token stream events.
  *
- * A single instance is created at daemon startup and shared across
- * all MITM proxies and consumers. The bus has no internal buffering --
- * events are delivered synchronously to current listeners and discarded
- * if none exist.
+ * A module-scoped singleton (see `getTokenStreamBus()`) is shared
+ * across all publishers and subscribers in-process. No buffering --
+ * events are delivered synchronously to current listeners and
+ * discarded if none exist.
  */
 
 import type { SessionId } from '../session/types.js';

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -202,7 +202,6 @@ async function createDockerSession(
         sessionConfig.sandboxDir,
         sessionConfig.escalationDir,
         sessionId,
-        options.tokenStreamBus,
       );
       builtInfra = true;
     }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -268,15 +268,6 @@ export interface SessionOptions {
   jobId?: string;
 
   /**
-   * Shared daemon-level token stream bus. When provided for Docker
-   * sessions, the MITM proxy taps SSE responses and pushes parsed
-   * token events into this bus for real-time observation.
-   *
-   * Ignored for builtin sessions (no MITM proxy to tap).
-   */
-  tokenStreamBus?: import('../docker/token-stream-bus.js').TokenStreamBus;
-
-  /**
    * Partial overrides for the resolved resource budget config.
    * Applied on top of the global defaults and user config.
    * Used by workflows to set longer per-turn timeouts.

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -22,6 +22,7 @@ import { loadConfig } from '../../config/index.js';
 import { createSession } from '../../session/index.js';
 import { shouldAutoSaveMemory } from '../../memory/auto-save.js';
 import { BudgetExhaustedError } from '../../session/errors.js';
+import { getTokenStreamBus } from '../../docker/token-stream-bus.js';
 import * as logger from '../../logger.js';
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ export async function sessionDispatch(
       const endManaged = ctx.sessionManager.get(label);
       const endSessionId = endManaged?.session.getInfo().id;
       await ctx.sessionManager.end(label);
-      if (endSessionId) ctx.tokenStreamBus?.endSession(endSessionId);
+      if (endSessionId) getTokenStreamBus().endSession(endSessionId);
       cleanupSessionQueue(ctx, label);
       ctx.eventBus.emit('session.ended', { label, reason: 'user_ended' });
       return;
@@ -138,7 +139,6 @@ async function createWebSession(ctx: DispatchContext, persona?: string): Promise
     config,
     mode: ctx.mode,
     persona,
-    tokenStreamBus: ctx.tokenStreamBus,
     onEscalation: transport.createEscalationHandler(),
     onEscalationExpired: transport.createEscalationExpiredHandler(),
     onEscalationResolved: transport.createEscalationResolvedHandler(),
@@ -163,7 +163,7 @@ async function createWebSession(ctx: DispatchContext, persona?: string): Promise
           logger.error(`[WebUI] Failed to clean up session #${label}: ${String(err)}`);
         });
       }
-      ctx.tokenStreamBus?.endSession(sessionId);
+      getTokenStreamBus().endSession(sessionId);
     })
     .catch((err: unknown) => {
       logger.error(`[WebUI] Transport #${label} error: ${String(err)}`);
@@ -211,7 +211,7 @@ function sendToSession(ctx: DispatchContext, label: number, text: string): { acc
         const budgetSessionId = managed.session.getInfo().id;
         ctx.eventBus.emit('session.ended', { label, reason: `Budget exhausted: ${err.message}` });
         await ctx.sessionManager.end(label);
-        ctx.tokenStreamBus?.endSession(budgetSessionId);
+        getTokenStreamBus().endSession(budgetSessionId);
         cleanupSessionQueue(ctx, label);
       } else {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/web-ui/dispatch/types.ts
+++ b/src/web-ui/dispatch/types.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import type { SessionManager, ManagedSession } from '../../session/session-manager.js';
 import type { ControlRequestHandler } from '../../daemon/control-socket.js';
 import type { SessionMode } from '../../session/types.js';
-import type { TokenStreamBus } from '../../docker/token-stream-bus.js';
 import type { TokenStreamBridge } from '../token-stream-bridge.js';
 import type { WebEventBus } from '../web-event-bus.js';
 import { type SessionDto, type BudgetSummaryDto, type DaemonStatusDto, InvalidParamsError } from '../web-ui-types.js';
@@ -33,8 +32,6 @@ export interface DispatchContext {
   readonly maxConcurrentWebSessions: number;
   /** @internal Sequencing queues per session -- managed by dispatch module. */
   readonly sessionQueues: Map<number, Promise<void>>;
-  /** Shared token stream bus for real-time LLM output observation. */
-  readonly tokenStreamBus?: TokenStreamBus;
   /** Bridge for per-client token stream subscriptions. */
   tokenStreamBridge?: TokenStreamBridge;
 }

--- a/src/web-ui/token-stream-bridge.ts
+++ b/src/web-ui/token-stream-bridge.ts
@@ -10,7 +10,7 @@
 import type { WebSocket as WsWebSocket } from 'ws';
 
 import type { SessionId } from '../session/types.js';
-import type { TokenStreamBus } from '../docker/token-stream-bus.js';
+import { getTokenStreamBus } from '../docker/token-stream-bus.js';
 import type { TokenStreamEvent } from '../docker/token-stream-types.js';
 
 // ---------------------------------------------------------------------------
@@ -57,7 +57,6 @@ export class TokenStreamBridge {
 
   constructor(
     private readonly sender: TokenStreamSender,
-    private readonly bus: TokenStreamBus,
     private readonly flushIntervalMs = 50,
   ) {}
 
@@ -72,7 +71,10 @@ export class TokenStreamBridge {
 
     let sub = this.subscriptions.get(label);
     if (!sub) {
-      const unsubscribe = this.bus.subscribe(sessionId, (_sid, event) => {
+      // Resolve the bus lazily via the module-scoped singleton so that
+      // `resetTokenStreamBus()` (in test `beforeEach`) takes effect for
+      // bridges constructed after the reset.
+      const unsubscribe = getTokenStreamBus().subscribe(sessionId, (_sid, event) => {
         this.enqueue(label, event);
       });
       sub = { sessionId, unsubscribe, clients: new Set() };
@@ -118,7 +120,9 @@ export class TokenStreamBridge {
     labels.add(GLOBAL_LABEL);
 
     if (!this.globalUnsubscribe) {
-      this.globalUnsubscribe = this.bus.subscribeAll((sessionId, event) => {
+      // Resolve the bus lazily via the singleton so `resetTokenStreamBus()`
+      // between tests is honored.
+      this.globalUnsubscribe = getTokenStreamBus().subscribeAll((sessionId, event) => {
         const label = this.sessionToLabel.get(sessionId);
         if (label === undefined) return;
         this.enqueueGlobal(label, event);

--- a/src/web-ui/web-ui-server.ts
+++ b/src/web-ui/web-ui-server.ts
@@ -17,7 +17,6 @@ import { WebSocketServer, WebSocket as WsWebSocket } from 'ws';
 import type { SessionManager } from '../session/session-manager.js';
 import type { ControlRequestHandler } from '../daemon/control-socket.js';
 import type { SessionMode } from '../session/types.js';
-import type { TokenStreamBus } from '../docker/token-stream-bus.js';
 import type { TokenStreamBridge } from './token-stream-bridge.js';
 import { WebEventBus } from './web-event-bus.js';
 import { type RequestFrame, type ResponseFrame, type EventFrame, RpcError } from './web-ui-types.js';
@@ -57,8 +56,6 @@ export interface WebUiServerOptions {
   readonly devMode?: boolean;
   /** Optional WorkflowManager for workflow RPC methods. */
   readonly workflowManager?: WorkflowManager;
-  /** Shared token stream bus for real-time LLM output observation. */
-  readonly tokenStreamBus?: TokenStreamBus;
 }
 
 export class WebUiServer {
@@ -98,7 +95,6 @@ export class WebUiServer {
       maxConcurrentWebSessions: options.maxConcurrentWebSessions,
       sessionQueues: new Map(),
       workflowManager: options.workflowManager,
-      tokenStreamBus: options.tokenStreamBus,
     };
 
     // Subscribe to own event bus and broadcast to WS clients

--- a/test/docker/token-stream-bus.test.ts
+++ b/test/docker/token-stream-bus.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTokenStreamBus, resetTokenStreamBus } from '../../src/docker/token-stream-bus.js';
+import type { SessionId } from '../../src/session/types.js';
+import type { TokenStreamEvent } from '../../src/docker/token-stream-types.js';
+
+const sessionId = 'session-smoke' as SessionId;
+
+function makeEvent(text: string): TokenStreamEvent {
+  return { kind: 'text_delta', text, timestamp: 0 };
+}
+
+describe('getTokenStreamBus (singleton)', () => {
+  beforeEach(() => {
+    resetTokenStreamBus();
+  });
+
+  it('returns the same instance on repeated calls', () => {
+    const first = getTokenStreamBus();
+    const second = getTokenStreamBus();
+
+    expect(second).toBe(first);
+
+    // Cross-check: publishing on the second reference reaches a listener
+    // attached via the first. Identity alone would be enough, but this
+    // also confirms the shared instance is actually wired up.
+    const received: TokenStreamEvent[] = [];
+    const unsubscribe = first.subscribe(sessionId, (_sid, event) => {
+      received.push(event);
+    });
+    second.push(sessionId, makeEvent('hello'));
+    unsubscribe();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ kind: 'text_delta', text: 'hello' });
+  });
+
+  it('resetTokenStreamBus() causes the next call to return a fresh instance', () => {
+    const before = getTokenStreamBus();
+    resetTokenStreamBus();
+    const after = getTokenStreamBus();
+
+    expect(after).not.toBe(before);
+
+    // A listener on the stale instance should not receive events pushed
+    // to the fresh instance -- confirms they are genuinely independent.
+    const staleEvents: TokenStreamEvent[] = [];
+    before.subscribe(sessionId, (_sid, event) => {
+      staleEvents.push(event);
+    });
+    after.push(sessionId, makeEvent('after-reset'));
+
+    expect(staleEvents).toHaveLength(0);
+  });
+});

--- a/test/mitm-proxy-extraction.test.ts
+++ b/test/mitm-proxy-extraction.test.ts
@@ -2,8 +2,8 @@
  * Tests for extractToolResults and extractFromJsonResponse in mitm-proxy.ts.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { createTokenStreamBus } from '../src/docker/token-stream-bus.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getTokenStreamBus, resetTokenStreamBus } from '../src/docker/token-stream-bus.js';
 import type { TokenStreamEvent } from '../src/docker/token-stream-types.js';
 import type { SessionId } from '../src/session/types.js';
 import {
@@ -19,15 +19,18 @@ import {
 
 const SESSION_ID = 'test-session' as SessionId;
 
-/** Collect all events pushed to a bus for a given session. */
+/**
+ * Collect events from the singleton bus for the given session.
+ * Requires `resetTokenStreamBus()` to have been called in `beforeEach` so
+ * each test sees a fresh bus. Subscribing after the reset means the listener
+ * is attached to the same singleton instance extractor calls publish into.
+ */
 function collectEvents(sessionId: SessionId): {
   events: TokenStreamEvent[];
-  bus: ReturnType<typeof createTokenStreamBus>;
 } {
-  const bus = createTokenStreamBus();
   const events: TokenStreamEvent[] = [];
-  bus.subscribe(sessionId, (_sid, event) => events.push(event));
-  return { events, bus };
+  getTokenStreamBus().subscribe(sessionId, (_sid, event) => events.push(event));
+  return { events };
 }
 
 /** Type-safe event filter that narrows the union. */
@@ -43,8 +46,12 @@ function eventsOfKind<K extends TokenStreamEvent['kind']>(
 // ---------------------------------------------------------------------------
 
 describe('extractToolResults', () => {
+  beforeEach(() => {
+    resetTokenStreamBus();
+  });
+
   it('extracts Anthropic tool_result blocks from request body', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         {
@@ -60,7 +67,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(1);
     expect(events[0].kind).toBe('tool_result');
@@ -72,7 +79,7 @@ describe('extractToolResults', () => {
   });
 
   it('handles is_error flag', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         {
@@ -89,7 +96,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(1);
     if (events[0].kind === 'tool_result') {
@@ -99,7 +106,7 @@ describe('extractToolResults', () => {
   });
 
   it('handles array content blocks (Anthropic format)', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         {
@@ -118,7 +125,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(1);
     if (events[0].kind === 'tool_result') {
@@ -127,7 +134,7 @@ describe('extractToolResults', () => {
   });
 
   it('truncates very long content', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const longContent = 'x'.repeat(1000);
     const parsed = {
       messages: [
@@ -144,7 +151,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(1);
     if (events[0].kind === 'tool_result') {
@@ -154,7 +161,7 @@ describe('extractToolResults', () => {
   });
 
   it('extracts multiple tool_results from a single message', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         {
@@ -167,7 +174,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(2);
     if (events[0].kind === 'tool_result' && events[1].kind === 'tool_result') {
@@ -177,7 +184,7 @@ describe('extractToolResults', () => {
   });
 
   it('extracts OpenAI tool role messages', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         {
@@ -188,7 +195,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(1);
     if (events[0].kind === 'tool_result') {
@@ -199,7 +206,7 @@ describe('extractToolResults', () => {
   });
 
   it('ignores non-user/non-tool messages', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         { role: 'assistant', content: 'Some text' },
@@ -207,19 +214,19 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(0);
   });
 
   it('handles missing messages array gracefully', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
-    extractToolResults({}, bus, SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
+    extractToolResults({}, SESSION_ID);
     expect(events).toHaveLength(0);
   });
 
   it('ignores non-tool_result content blocks', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const parsed = {
       messages: [
         {
@@ -232,7 +239,7 @@ describe('extractToolResults', () => {
       ],
     };
 
-    extractToolResults(parsed, bus, SESSION_ID);
+    extractToolResults(parsed, SESSION_ID);
 
     expect(events).toHaveLength(1);
     if (events[0].kind === 'tool_result') {
@@ -246,8 +253,12 @@ describe('extractToolResults', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromJsonResponse', () => {
+  beforeEach(() => {
+    resetTokenStreamBus();
+  });
+
   it('extracts Anthropic JSON response (model + text + usage)', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const body = Buffer.from(
       JSON.stringify({
         model: 'claude-sonnet-4-20250514',
@@ -257,7 +268,7 @@ describe('extractFromJsonResponse', () => {
       }),
     );
 
-    extractFromJsonResponse(body, bus, SESSION_ID);
+    extractFromJsonResponse(body, SESSION_ID);
 
     expect(events).toHaveLength(3);
 
@@ -277,7 +288,7 @@ describe('extractFromJsonResponse', () => {
   });
 
   it('extracts OpenAI JSON response format', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const body = Buffer.from(
       JSON.stringify({
         model: 'gpt-4',
@@ -286,7 +297,7 @@ describe('extractFromJsonResponse', () => {
       }),
     );
 
-    extractFromJsonResponse(body, bus, SESSION_ID);
+    extractFromJsonResponse(body, SESSION_ID);
 
     const starts = eventsOfKind(events, 'message_start');
     expect(starts).toHaveLength(1);
@@ -303,13 +314,13 @@ describe('extractFromJsonResponse', () => {
   });
 
   it('handles invalid JSON gracefully', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
-    extractFromJsonResponse(Buffer.from('not json'), bus, SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
+    extractFromJsonResponse(Buffer.from('not json'), SESSION_ID);
     expect(events).toHaveLength(0);
   });
 
   it('handles response without model', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const body = Buffer.from(
       JSON.stringify({
         content: [{ type: 'text', text: 'no model' }],
@@ -317,7 +328,7 @@ describe('extractFromJsonResponse', () => {
       }),
     );
 
-    extractFromJsonResponse(body, bus, SESSION_ID);
+    extractFromJsonResponse(body, SESSION_ID);
 
     // No message_start since no model
     expect(eventsOfKind(events, 'message_start')).toHaveLength(0);
@@ -328,7 +339,7 @@ describe('extractFromJsonResponse', () => {
   });
 
   it('handles response without usage', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const body = Buffer.from(
       JSON.stringify({
         model: 'claude-sonnet-4-20250514',
@@ -336,7 +347,7 @@ describe('extractFromJsonResponse', () => {
       }),
     );
 
-    extractFromJsonResponse(body, bus, SESSION_ID);
+    extractFromJsonResponse(body, SESSION_ID);
 
     const ends = eventsOfKind(events, 'message_end');
     expect(ends).toHaveLength(1);
@@ -345,7 +356,7 @@ describe('extractFromJsonResponse', () => {
   });
 
   it('extracts multiple content blocks', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const body = Buffer.from(
       JSON.stringify({
         model: 'claude-sonnet-4-20250514',
@@ -357,7 +368,7 @@ describe('extractFromJsonResponse', () => {
       }),
     );
 
-    extractFromJsonResponse(body, bus, SESSION_ID);
+    extractFromJsonResponse(body, SESSION_ID);
 
     const deltas = eventsOfKind(events, 'text_delta');
     expect(deltas).toHaveLength(2);
@@ -366,7 +377,7 @@ describe('extractFromJsonResponse', () => {
   });
 
   it('defaults stop_reason to "stop" when missing', () => {
-    const { events, bus } = collectEvents(SESSION_ID);
+    const { events } = collectEvents(SESSION_ID);
     const body = Buffer.from(
       JSON.stringify({
         content: [],
@@ -374,7 +385,7 @@ describe('extractFromJsonResponse', () => {
       }),
     );
 
-    extractFromJsonResponse(body, bus, SESSION_ID);
+    extractFromJsonResponse(body, SESSION_ID);
 
     const ends = eventsOfKind(events, 'message_end');
     expect(ends).toHaveLength(1);

--- a/test/mitm-proxy-token-stream.test.ts
+++ b/test/mitm-proxy-token-stream.test.ts
@@ -12,7 +12,7 @@ import {
   type MitmProxyOptions,
 } from '../src/docker/mitm-proxy.js';
 import type { ProviderConfig } from '../src/docker/provider-config.js';
-import { createTokenStreamBus } from '../src/docker/token-stream-bus.js';
+import { getTokenStreamBus, resetTokenStreamBus } from '../src/docker/token-stream-bus.js';
 import type { TokenStreamEvent } from '../src/docker/token-stream-types.js';
 import type { SessionId } from '../src/session/types.js';
 
@@ -173,6 +173,7 @@ describe('MitmProxy token stream integration', () => {
   let socketPath: string;
 
   beforeEach(() => {
+    resetTokenStreamBus();
     tempDir = mkdtempSync(join(tmpdir(), 'mitm-token-stream-test-'));
     ca = loadOrCreateCA(join(tempDir, 'ca'));
     socketPath = join(tempDir, 'mitm-proxy.sock');
@@ -213,19 +214,7 @@ describe('MitmProxy token stream integration', () => {
     };
   }
 
-  it('throws when tokenStreamBus is provided without sessionId', () => {
-    const bus = createTokenStreamBus();
-    expect(() =>
-      createMitmProxy({
-        socketPath,
-        ca,
-        providers: [],
-        tokenStreamBus: bus,
-      }),
-    ).toThrow('tokenStreamBus and sessionId must be provided together');
-  });
-
-  it('throws when sessionId is provided without tokenStreamBus', () => {
+  it('does not throw when sessionId is provided (bus is fetched from singleton)', () => {
     expect(() =>
       createMitmProxy({
         socketPath,
@@ -233,23 +222,10 @@ describe('MitmProxy token stream integration', () => {
         providers: [],
         sessionId: 'test-session',
       }),
-    ).toThrow('tokenStreamBus and sessionId must be provided together');
-  });
-
-  it('does not throw when both tokenStreamBus and sessionId are provided', () => {
-    const bus = createTokenStreamBus();
-    expect(() =>
-      createMitmProxy({
-        socketPath,
-        ca,
-        providers: [],
-        tokenStreamBus: bus,
-        sessionId: 'test-session',
-      }),
     ).not.toThrow();
   });
 
-  it('does not throw when neither tokenStreamBus nor sessionId are provided', () => {
+  it('does not throw when sessionId is omitted (extractor is skipped)', () => {
     expect(() =>
       createMitmProxy({
         socketPath,
@@ -257,6 +233,58 @@ describe('MitmProxy token stream integration', () => {
         providers: [],
       }),
     ).not.toThrow();
+  });
+
+  it('publishes into the singleton bus when sessionId is provided', async () => {
+    // End-to-end singleton-wiring check: proxy receives only sessionId
+    // (no bus parameter exists), yet subscribers on getTokenStreamBus()
+    // still observe events from the proxy's SSE tap.
+    const ssePayload = [
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Singleton"}}',
+      '',
+    ].join('\n');
+
+    const { server: upstream, port: upstreamPort } = await createSseUpstream(ssePayload);
+
+    try {
+      const sessionId = 'test-session-singleton' as SessionId;
+      const events: TokenStreamEvent[] = [];
+      getTokenStreamBus().subscribe(sessionId, (_sid, event) => {
+        events.push(event);
+      });
+
+      const provider = makeTestProvider(upstreamPort);
+      proxy = createMitmProxy({
+        socketPath,
+        ca,
+        providers: [provider],
+        dnsLookup: localhostDnsLookup,
+        sessionId: sessionId as string,
+      });
+      await proxy.start();
+
+      const { socket } = await sendConnect(socketPath, 'api.anthropic.com', 443);
+      expect(socket).not.toBeNull();
+
+      await makeHttpsRequest(socket!, ca, 'api.anthropic.com', {
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          'x-api-key': provider.fakeKey,
+          'content-type': 'application/json',
+        },
+        body: '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}',
+      });
+
+      const textDelta = events.find((e) => e.kind === 'text_delta');
+      expect(textDelta).toBeDefined();
+      if (textDelta?.kind === 'text_delta') {
+        expect(textDelta.text).toBe('Singleton');
+      }
+    } finally {
+      upstream.close();
+    }
   });
 
   it('taps SSE responses and pushes events to the bus', async () => {
@@ -275,10 +303,11 @@ describe('MitmProxy token stream integration', () => {
     const { server: upstream, port: upstreamPort } = await createSseUpstream(ssePayload);
 
     try {
-      const bus = createTokenStreamBus();
       const sessionId = 'test-session-sse' as SessionId;
       const events: TokenStreamEvent[] = [];
-      bus.subscribe(sessionId, (_sid, event) => {
+      // Subscribe via the singleton bus — this is the same instance the
+      // proxy will publish into.
+      getTokenStreamBus().subscribe(sessionId, (_sid, event) => {
         events.push(event);
       });
 
@@ -288,7 +317,6 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        tokenStreamBus: bus,
         sessionId: sessionId as string,
       });
       await proxy.start();
@@ -333,7 +361,7 @@ describe('MitmProxy token stream integration', () => {
     }
   });
 
-  it('does not tap when tokenStreamBus is not provided', async () => {
+  it('does not tap when sessionId is not provided', async () => {
     const ssePayload = [
       'event: content_block_delta',
       'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
@@ -349,7 +377,7 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        // No tokenStreamBus or sessionId
+        // No sessionId (bus is always fetched from singleton when sessionId is set)
       });
       await proxy.start();
 
@@ -397,10 +425,9 @@ describe('MitmProxy token stream integration', () => {
     });
 
     try {
-      const bus = createTokenStreamBus();
       const sessionId = 'test-session-json' as SessionId;
       const events: TokenStreamEvent[] = [];
-      bus.subscribe(sessionId, (_sid, event) => {
+      getTokenStreamBus().subscribe(sessionId, (_sid, event) => {
         events.push(event);
       });
 
@@ -410,7 +437,6 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        tokenStreamBus: bus,
         sessionId: sessionId as string,
       });
       await proxy.start();
@@ -461,10 +487,9 @@ describe('MitmProxy token stream integration', () => {
     const { server: upstream, port: upstreamPort } = await createSseUpstream(ssePayload);
 
     try {
-      const bus = createTokenStreamBus();
       const sessionId = 'test-session-global' as SessionId;
       const globalEvents: Array<{ sessionId: SessionId; event: TokenStreamEvent }> = [];
-      bus.subscribeAll((sid, event) => {
+      getTokenStreamBus().subscribeAll((sid, event) => {
         globalEvents.push({ sessionId: sid, event });
       });
 
@@ -474,7 +499,6 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        tokenStreamBus: bus,
         sessionId: sessionId as string,
       });
       await proxy.start();

--- a/test/mitm-proxy-token-stream.test.ts
+++ b/test/mitm-proxy-token-stream.test.ts
@@ -377,7 +377,7 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        // No sessionId (bus is always fetched from singleton when sessionId is set)
+        // No sessionId — extractor is skipped
       });
       await proxy.start();
 

--- a/test/token-stream-bridge.test.ts
+++ b/test/token-stream-bridge.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TokenStreamBridge, type TokenStreamSender } from '../src/web-ui/token-stream-bridge.js';
-import { createTokenStreamBus, type TokenStreamBus } from '../src/docker/token-stream-bus.js';
+import { getTokenStreamBus, resetTokenStreamBus, type TokenStreamBus } from '../src/docker/token-stream-bus.js';
 import type { SessionId } from '../src/session/types.js';
 import type { TokenStreamEvent } from '../src/docker/token-stream-types.js';
 import type { WebSocket as WsWebSocket } from 'ws';
@@ -50,7 +50,8 @@ describe('TokenStreamBridge', () => {
   let sender: ReturnType<typeof mockSender>;
 
   beforeEach(() => {
-    bus = createTokenStreamBus();
+    resetTokenStreamBus();
+    bus = getTokenStreamBus();
     sender = mockSender();
     vi.useFakeTimers();
   });
@@ -65,7 +66,7 @@ describe('TokenStreamBridge', () => {
 
   describe('per-session subscription', () => {
     it('delivers batched events to subscribed clients', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -92,7 +93,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('delivers events to multiple clients subscribed to the same session', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -109,7 +110,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('only creates one bus subscription per label', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -128,7 +129,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removing one client keeps the other receiving events', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -146,7 +147,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removing last client unsubscribes from bus', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -161,7 +162,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('hasSubscription reflects current state', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -179,7 +180,7 @@ describe('TokenStreamBridge', () => {
 
   describe('global subscription', () => {
     it('delivers events from any session with a registered label', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid1 = sessionId('sess-1');
       const sid2 = sessionId('sess-2');
@@ -200,7 +201,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('ignores events from sessions without a registered label', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
 
       bridge.addGlobalClient(ws1);
@@ -213,7 +214,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('hasGlobalSubscription reflects current state', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
 
       expect(bridge.hasGlobalSubscription(ws1)).toBe(false);
@@ -224,7 +225,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removing last global client unsubscribes from bus', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -239,7 +240,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('global and per-session clients both receive events without duplication', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const wsGlobal = mockWs();
       const wsSession = mockWs();
       const sid = sessionId('sess-1');
@@ -260,7 +261,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('same client subscribed globally and per-session appears once in recipients', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -276,7 +277,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('delivers events for sessions registered after global subscribe', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('late-session');
 
@@ -305,7 +306,7 @@ describe('TokenStreamBridge', () => {
 
   describe('closeSession', () => {
     it('cancels pending timer and discards buffered events', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -321,7 +322,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('unsubscribes from bus so future events are not received', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -335,7 +336,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('cleans up per-client tracking', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -346,7 +347,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('cleans up register-only sessions (no per-session subscription)', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const wsGlobal = mockWs();
       const sid = sessionId('sess-1');
 
@@ -377,7 +378,7 @@ describe('TokenStreamBridge', () => {
 
   describe('per-session teardown preserves global routing', () => {
     it('global subscribers still receive events after the last per-session client unsubscribes', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const wsSession = mockWs();
       const wsGlobal = mockWs();
       const sid = sessionId('sess-1');
@@ -403,7 +404,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('closeSession still severs global routing for that session', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const wsSession = mockWs();
       const wsGlobal = mockWs();
       const sid = sessionId('sess-1');
@@ -432,7 +433,7 @@ describe('TokenStreamBridge', () => {
 
   describe('removeAllForClient', () => {
     it('removes all per-session subscriptions for a client', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid1 = sessionId('sess-1');
       const sid2 = sessionId('sess-2');
@@ -449,7 +450,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removes global subscription for a client', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -465,7 +466,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('does not affect other clients on the same session', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -483,7 +484,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('is safe to call for an unknown client', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
 
       // Should not throw
@@ -497,7 +498,7 @@ describe('TokenStreamBridge', () => {
 
   describe('batching', () => {
     it('collects multiple events within the flush interval', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 100);
+      const bridge = new TokenStreamBridge(sender, 100);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -517,7 +518,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('schedules a new timer for events arriving after flush', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -533,7 +534,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('does not send empty batches', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -551,7 +552,7 @@ describe('TokenStreamBridge', () => {
 
   describe('close', () => {
     it('cleans up all subscriptions and timers', () => {
-      const bridge = new TokenStreamBridge(sender, bus, 50);
+      const bridge = new TokenStreamBridge(sender, 50);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid1 = sessionId('sess-1');
@@ -574,6 +575,54 @@ describe('TokenStreamBridge', () => {
       bus.push(sid2, textDelta('after-close'));
       vi.advanceTimersByTime(100);
       expect(sender.calls).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // End-to-end regression: the originally-reported bug
+  // -----------------------------------------------------------------------
+
+  describe('observe --all regression (workflow via web UI path)', () => {
+    /**
+     * Regression test for the original defect: workflow sessions launched
+     * via the web UI did not emit tokens to `observe --all --raw`. Root
+     * cause was that the bus was optional on every hop and the
+     * `WorkflowManager -> WorkflowOrchestrator -> createDockerInfrastructure`
+     * path forgot to thread it. With the singleton migration, any MITM
+     * publisher and any `subscribeAll` subscriber share the same bus by
+     * construction.
+     *
+     * This test simulates the full chain end-to-end without Docker:
+     * - A producer (stand-in for MITM SSE extractor) calls
+     *   `getTokenStreamBus().push(sessionId, event)`.
+     * - A `TokenStreamBridge` with a global client (stand-in for the
+     *   `observe --all` WebSocket client) is attached before the push.
+     * - The test asserts the event traverses the full chain to the sender.
+     */
+    it('delivers MITM-produced events to observe --all via the bridge', () => {
+      const bridge = new TokenStreamBridge(sender, 50);
+      const observeClient = mockWs();
+      const sid = sessionId('workflow-session-42');
+
+      // Simulating the web UI dispatch path: label registered before
+      // subscribeAll so the bridge can map SessionId -> label.
+      bridge.registerSession(42, sid);
+      bridge.addGlobalClient(observeClient);
+
+      // The MITM SSE extractor publishes to the singleton.
+      // Previously (pre-migration) a workflow MITM had no bus reference
+      // and silently discarded events. Under the singleton, this push
+      // reaches every subscriber.
+      getTokenStreamBus().push(sid, textDelta('workflow token stream'));
+      vi.advanceTimersByTime(50);
+
+      expect(sender.calls).toHaveLength(1);
+      expect(sender.calls[0].event).toBe('session.token_stream');
+      expect(sender.calls[0].clients.has(observeClient)).toBe(true);
+      const payload = sender.calls[0].payload as { label: number; events: TokenStreamEvent[] };
+      expect(payload.label).toBe(42);
+      expect(payload.events).toHaveLength(1);
+      expect(payload.events[0].kind).toBe('text_delta');
     });
   });
 });

--- a/test/token-stream-bridge.test.ts
+++ b/test/token-stream-bridge.test.ts
@@ -66,7 +66,7 @@ describe('TokenStreamBridge', () => {
 
   describe('per-session subscription', () => {
     it('delivers batched events to subscribed clients', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -93,7 +93,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('delivers events to multiple clients subscribed to the same session', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -110,7 +110,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('only creates one bus subscription per label', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -129,7 +129,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removing one client keeps the other receiving events', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -147,7 +147,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removing last client unsubscribes from bus', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -162,7 +162,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('hasSubscription reflects current state', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -180,7 +180,7 @@ describe('TokenStreamBridge', () => {
 
   describe('global subscription', () => {
     it('delivers events from any session with a registered label', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid1 = sessionId('sess-1');
       const sid2 = sessionId('sess-2');
@@ -201,7 +201,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('ignores events from sessions without a registered label', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
 
       bridge.addGlobalClient(ws1);
@@ -214,7 +214,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('hasGlobalSubscription reflects current state', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
 
       expect(bridge.hasGlobalSubscription(ws1)).toBe(false);
@@ -225,7 +225,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removing last global client unsubscribes from bus', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -240,7 +240,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('global and per-session clients both receive events without duplication', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const wsGlobal = mockWs();
       const wsSession = mockWs();
       const sid = sessionId('sess-1');
@@ -261,7 +261,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('same client subscribed globally and per-session appears once in recipients', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -277,7 +277,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('delivers events for sessions registered after global subscribe', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('late-session');
 
@@ -306,7 +306,7 @@ describe('TokenStreamBridge', () => {
 
   describe('closeSession', () => {
     it('cancels pending timer and discards buffered events', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -322,7 +322,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('unsubscribes from bus so future events are not received', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -336,7 +336,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('cleans up per-client tracking', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -347,7 +347,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('cleans up register-only sessions (no per-session subscription)', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const wsGlobal = mockWs();
       const sid = sessionId('sess-1');
 
@@ -378,7 +378,7 @@ describe('TokenStreamBridge', () => {
 
   describe('per-session teardown preserves global routing', () => {
     it('global subscribers still receive events after the last per-session client unsubscribes', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const wsSession = mockWs();
       const wsGlobal = mockWs();
       const sid = sessionId('sess-1');
@@ -404,7 +404,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('closeSession still severs global routing for that session', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const wsSession = mockWs();
       const wsGlobal = mockWs();
       const sid = sessionId('sess-1');
@@ -433,7 +433,7 @@ describe('TokenStreamBridge', () => {
 
   describe('removeAllForClient', () => {
     it('removes all per-session subscriptions for a client', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid1 = sessionId('sess-1');
       const sid2 = sessionId('sess-2');
@@ -450,7 +450,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('removes global subscription for a client', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -466,7 +466,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('does not affect other clients on the same session', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid = sessionId('sess-1');
@@ -484,7 +484,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('is safe to call for an unknown client', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
 
       // Should not throw
@@ -518,7 +518,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('schedules a new timer for events arriving after flush', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -534,7 +534,7 @@ describe('TokenStreamBridge', () => {
     });
 
     it('does not send empty batches', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const sid = sessionId('sess-1');
 
@@ -552,7 +552,7 @@ describe('TokenStreamBridge', () => {
 
   describe('close', () => {
     it('cleans up all subscriptions and timers', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const ws1 = mockWs();
       const ws2 = mockWs();
       const sid1 = sessionId('sess-1');
@@ -600,7 +600,7 @@ describe('TokenStreamBridge', () => {
      * - The test asserts the event traverses the full chain to the sender.
      */
     it('delivers MITM-produced events to observe --all via the bridge', () => {
-      const bridge = new TokenStreamBridge(sender, 50);
+      const bridge = new TokenStreamBridge(sender);
       const observeClient = mockWs();
       const sid = sessionId('workflow-session-42');
 

--- a/test/token-stream-dispatch.test.ts
+++ b/test/token-stream-dispatch.test.ts
@@ -106,7 +106,7 @@ describe('tokenStreamDispatch', () => {
   beforeEach(() => {
     resetTokenStreamBus();
     const sender = { sendToSubscribers: vi.fn() };
-    bridge = new TokenStreamBridge(sender, 50);
+    bridge = new TokenStreamBridge(sender);
     ctx = makeCtx(bridge);
   });
 

--- a/test/token-stream-dispatch.test.ts
+++ b/test/token-stream-dispatch.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { tokenStreamDispatch } from '../src/web-ui/dispatch/token-stream-dispatch.js';
 import { TokenStreamBridge } from '../src/web-ui/token-stream-bridge.js';
-import { createTokenStreamBus } from '../src/docker/token-stream-bus.js';
+import { resetTokenStreamBus } from '../src/docker/token-stream-bus.js';
 import { SessionManager } from '../src/session/session-manager.js';
 import { WebEventBus } from '../src/web-ui/web-event-bus.js';
 import type { DispatchContext } from '../src/web-ui/dispatch/types.js';
@@ -100,14 +100,13 @@ function makeCtx(bridge: TokenStreamBridge): DispatchContext {
 // ---------------------------------------------------------------------------
 
 describe('tokenStreamDispatch', () => {
-  let bus: ReturnType<typeof createTokenStreamBus>;
   let bridge: TokenStreamBridge;
   let ctx: DispatchContext;
 
   beforeEach(() => {
-    bus = createTokenStreamBus();
+    resetTokenStreamBus();
     const sender = { sendToSubscribers: vi.fn() };
-    bridge = new TokenStreamBridge(sender, bus, 50);
+    bridge = new TokenStreamBridge(sender, 50);
     ctx = makeCtx(bridge);
   });
 


### PR DESCRIPTION
## Summary

- Replace caller-threaded `TokenStreamBus` with a module-level singleton (`getTokenStreamBus()` + `resetTokenStreamBus()`) in `src/docker/token-stream-bus.ts`.
- Publishers (MITM SSE extractor, `extractToolResults`, `extractFromJsonResponse`) and subscribers (`TokenStreamBridge`, `session-dispatch` endSession paths) read the singleton directly instead of receiving a `bus` parameter.
- Removes the `tokenStreamBus` field from `MitmProxyOptions`, `DockerInfrastructure`, `createDockerInfrastructure`, `prepareDockerInfrastructure`, `SessionOptions`, `WebUiServerOptions`, and `DispatchContext`. Drops the both-or-neither guard in `createMitmProxy` — `sessionId` alone now gates extractor installation.

## Fixes the silent-observer bug

The original symptom: `tsx src/cli.ts observe --all --raw` produced no output while a workflow ran via the web UI. Root cause: `WorkflowManager`, `WorkflowOrchestrator.loadDefaultInfrastructureFactory`, and the per-state `createSession` call all dropped the `tokenStreamBus` option, so the MITM proxy's SSE extractor was never installed for workflow sessions.

With the singleton, the bug is **structurally impossible** — there is no bus to forget to thread. Any publisher calling `getTokenStreamBus().push(...)` reaches any subscriber calling `getTokenStreamBus().subscribe*(...)` by construction.

## Design rationale

Full doc at `docs/designs/token-stream-bus-ownership.md` (Option F — process-wide module singleton). Rejected Option E (infrastructure-scoped buses + daemon aggregator) for over-engineering: isolation is provided by distinct `sessionId`s, not distinct bus instances.

## Test plan

- [x] `npm test` — 3955 backend + 256 web-ui tests pass (+1 regression test for the observe-all path through singleton → bridge → subscriber)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npx tsc --noEmit` clean
- [ ] Manual: run `ironcurtain daemon --web-ui`, start a workflow through the web UI, confirm `ironcurtain observe --all --raw` in a separate terminal shows streaming LLM tokens

## Migration steps (all shipped in this PR)

1. Add `getTokenStreamBus()` / `resetTokenStreamBus()` singleton accessors
2. MITM fetches bus internally; remove `MitmProxyOptions.tokenStreamBus` + both-or-neither guard
3. Remove bus threading from `DockerInfrastructure`, `SessionOptions`, `DispatchContext`, `WebUiServerOptions`, daemon field
4. `TokenStreamBridge` reads singleton; `extract*` helpers drop `bus` param
5. Invariant JSDoc on `resetTokenStreamBus()`, design doc status flipped to shipped, regression test added

Each step landed with paired implementer + reviewer agents. Simplify pass followed (commit `1b06c24`) for post-migration comment hygiene and removing 28 redundant default-value test arguments.