### PR TITLE
feat(workflow): support `actions:` on human gate transitions

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -437,7 +437,7 @@ Use `guard` for conditions that depend on workflow context (round limits, stall 
 
 ### Transition actions
 
-A transition may declare an ordered list of side-effects via `actions:`, in addition to the default context update performed on every transition. Each entry is an object discriminated on `type`:
+A transition may declare an ordered list of side-effects via `actions:`, in addition to the default context update performed on every transition. This is valid on agent, deterministic, and human gate transitions alike. Each entry is an object discriminated on `type`:
 
 ```yaml
 transitions:
@@ -452,7 +452,23 @@ transitions:
 | ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------- |
 | `resetVisitCounts` | `stateIds: [string, ...]` | Zeroes the visit counter for each listed state. All listed IDs must reference existing states. |
 
-Actions run in the order listed. The orchestrator's default context-update action always runs first.
+Actions run in the order listed. The default action always runs first: the context-update action for agent/deterministic transitions, or `storeHumanPrompt` + `clearError` for human gate transitions.
+
+**Human gate reset pattern.** When a bounded loop escalates to a human gate on cap-reached, the gate's APPROVE transition typically routes back into the loop. Without a reset action, the visit counter is still at the cap and the next `isStateVisitLimitReached` check fires immediately, re-escalating to the gate. Declare `resetVisitCounts` on the APPROVE transition so the human's approval actually restarts the loop:
+
+```yaml
+escalate_gate:
+  type: human_gate
+  acceptedEvents: [APPROVE, ABORT]
+  transitions:
+    - to: build_state
+      event: APPROVE
+      actions:
+        - type: resetVisitCounts
+          stateIds: [review_state, build_state]
+    - to: aborted
+      event: ABORT
+```
 
 **Bounded-loop pattern.** `maxVisits` + `isStateVisitLimitReached` + `resetVisitCounts` compose to bound a review/rework loop and reset the cap when the loop is re-entered from outside:
 

--- a/src/workflow/machine-builder.ts
+++ b/src/workflow/machine-builder.ts
@@ -267,9 +267,17 @@ function buildHumanGateState(_stateId: string, config: HumanGateStateDefinition)
 
   for (const t of config.transitions) {
     const eventName = `HUMAN_${t.event}`;
+    // Order: the hardcoded gate actions (storeHumanPrompt, clearError) run
+    // first so they set up context (prompt, error state) before any
+    // user-declared actions observe or modify it. User-declared actions
+    // (e.g., resetVisitCounts) run afterward.
+    const actions: XStateActionEntry[] = ['storeHumanPrompt', 'clearError'];
+    for (const action of t.actions ?? []) {
+      actions.push(compileAction(action));
+    }
     on[eventName] = {
       target: t.to,
-      actions: ['storeHumanPrompt', 'clearError'],
+      actions,
     };
   }
 

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -258,6 +258,12 @@ export interface HumanGateTransitionDefinition {
   readonly to: string;
   /** The accepted event type that triggers this transition. */
   readonly event: HumanGateEventType;
+  /**
+   * Optional ordered list of actions to run on this transition, in
+   * addition to the default gate context-update actions (storeHumanPrompt,
+   * clearError). Actions execute in the order listed.
+   */
+  readonly actions?: readonly WorkflowTransitionAction[];
 }
 
 export type HumanGateEventType = 'APPROVE' | 'FORCE_REVISION' | 'REPLAN' | 'ABORT';

--- a/src/workflow/validate.ts
+++ b/src/workflow/validate.ts
@@ -5,6 +5,7 @@ import type {
   HumanGateStateDefinition,
   AgentOutput,
   AgentTransitionDefinition,
+  HumanGateTransitionDefinition,
 } from './types.js';
 import { AGENT_OUTPUT_FIELDS, CONFIDENCE_VALUES } from './types.js';
 import { REGISTERED_GUARDS } from './guards.js';
@@ -35,6 +36,7 @@ const agentTransitionSchema = z.object({
 const humanGateTransitionSchema = z.object({
   to: z.string(),
   event: z.enum(['APPROVE', 'FORCE_REVISION', 'REPLAN', 'ABORT']),
+  actions: z.array(transitionActionSchema).optional(),
 });
 
 const agentStateSchema = z.object({
@@ -255,8 +257,19 @@ function describeRuntimeType(value: unknown): string {
   return typeof value;
 }
 
-function collectTransitionsWithActions(state: WorkflowStateDefinition): readonly AgentTransitionDefinition[] {
+/**
+ * Returns all transitions on a state that may carry an `actions` array,
+ * regardless of transition type. The validator only reads `to` and
+ * `actions`, so narrowing the element type to the common fields lets us
+ * treat agent, deterministic, and human-gate transitions uniformly.
+ */
+function collectTransitionsWithActions(
+  state: WorkflowStateDefinition,
+): readonly (AgentTransitionDefinition | HumanGateTransitionDefinition)[] {
   if (state.type === 'agent' || state.type === 'deterministic') {
+    return state.transitions;
+  }
+  if (state.type === 'human_gate') {
     return state.transitions;
   }
   return [];

--- a/src/workflow/workflows/vuln-discovery.yaml
+++ b/src/workflow/workflows/vuln-discovery.yaml
@@ -424,6 +424,12 @@ states:
     transitions:
       - to: harness_build
         event: APPROVE
+        # The human's approval resets the harness loop counters so
+        # harness_validate (which reached its cap and escalated here)
+        # does not immediately re-escalate on the next pass.
+        actions:
+          - type: resetVisitCounts
+            stateIds: [harness_design, harness_design_review, harness_build, harness_validate]
       - to: orchestrator
         event: FORCE_REVISION
       - to: aborted

--- a/test/workflow/transition-actions.test.ts
+++ b/test/workflow/transition-actions.test.ts
@@ -410,6 +410,133 @@ describe('transition actions: resetVisitCounts', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Feature 3: transition actions on human gate transitions
+// ---------------------------------------------------------------------------
+
+describe('human gate transition actions: resetVisitCounts', () => {
+  /**
+   * Mirrors the vuln-discovery shape: a bounded agent loop escalates to
+   * a human gate on cap-reached; APPROVE routes back into the loop and
+   * carries a resetVisitCounts action so the loop does not immediately
+   * re-escalate. Also asserts the hardcoded gate actions (storeHumanPrompt,
+   * clearError) still run alongside the user-declared action.
+   */
+  const gateResetDef: WorkflowDefinition = {
+    name: 'gate-reset-test',
+    description: 'Human gate APPROVE resets loop counters',
+    initial: 'build',
+    settings: { maxRounds: 99 },
+    states: {
+      build: {
+        type: 'agent',
+        description: 'Builds',
+        persona: 'builder',
+        prompt: 'Build.',
+        inputs: [],
+        outputs: ['build'],
+        transitions: [{ to: 'validate' }],
+      },
+      validate: {
+        type: 'agent',
+        description: 'Validates',
+        persona: 'validator',
+        prompt: 'Validate.',
+        inputs: ['build'],
+        outputs: ['validate'],
+        maxVisits: 2,
+        transitions: [
+          { to: 'done', when: { verdict: 'approved' } },
+          { to: 'review_gate', guard: 'isStateVisitLimitReached' },
+          { to: 'build', when: { verdict: 'rejected' } },
+        ],
+      },
+      review_gate: {
+        type: 'human_gate',
+        description: 'Human review after cap',
+        acceptedEvents: ['APPROVE', 'ABORT'],
+        transitions: [
+          {
+            to: 'build',
+            event: 'APPROVE',
+            actions: [{ type: 'resetVisitCounts', stateIds: ['build', 'validate'] }],
+          },
+          { to: 'aborted', event: 'ABORT' },
+        ],
+      },
+      done: { type: 'terminal', description: 'Done' },
+      aborted: { type: 'terminal', description: 'Aborted' },
+    },
+  };
+
+  it('clears named visit counts on HUMAN_APPROVE while preserving hardcoded gate actions', async () => {
+    const { machine } = buildWorkflowMachine(gateResetDef, 'task');
+
+    // A gate holds a promise we control so we can assert the context
+    // immediately after the HUMAN_APPROVE transition fires — before the
+    // next agent invocation runs and overwrites humanPrompt via
+    // updateContextFromAgentResult.
+    let resolveBuild: (v: ReturnType<typeof makeAgentResult>) => void = () => {};
+    const buildGate = new Promise<ReturnType<typeof makeAgentResult>>((resolve) => {
+      resolveBuild = resolve;
+    });
+
+    let buildCalls = 0;
+    const testMachine = machine.provide({
+      actors: {
+        agentService: fromPromise(async ({ input }: { input: AgentInvokeInput }) => {
+          if (input.stateId === 'build') {
+            buildCalls++;
+            // First two build calls resolve normally (feed the loop into the
+            // gate). The third (post-APPROVE) waits on the gate so the test
+            // can assert the context right after the APPROVE transition.
+            if (buildCalls < 3) return makeAgentResult();
+            return buildGate;
+          }
+          if (input.stateId === 'validate') {
+            // Always reject on the first pass to hit the cap; after the
+            // reset, approve so the run ends cleanly.
+            return buildCalls <= 2 ? makeRejectedResult() : makeAgentResult();
+          }
+          return makeAgentResult();
+        }),
+      },
+    });
+
+    const actor = createActor(testMachine);
+    actor.start();
+    await settle(200);
+
+    expect(actor.getSnapshot().matches('review_gate')).toBe(true);
+    expect(actor.getSnapshot().context.visitCounts['validate']).toBe(2);
+    expect(actor.getSnapshot().context.visitCounts['build']).toBe(2);
+
+    actor.send({ type: 'HUMAN_APPROVE', prompt: 'Reset and continue' });
+    // Let the transition fire and the third `build` invocation start, but
+    // it's now pending on `buildGate` — so updateContextFromAgentResult
+    // hasn't fired yet and we can see the gate's action side-effects.
+    await settle(50);
+
+    const gateCtx = actor.getSnapshot().context;
+    // Hardcoded gate action storeHumanPrompt still ran.
+    expect(gateCtx.humanPrompt).toBe('Reset and continue');
+    // Hardcoded clearError ran (observable as null).
+    expect(gateCtx.lastError).toBeNull();
+    // User-declared resetVisitCounts cleared the two named states BEFORE
+    // the third build entry incremented build's counter.
+    expect(gateCtx.visitCounts['validate']).toBe(0);
+    // build was re-entered once on the post-reset pass.
+    expect(gateCtx.visitCounts['build']).toBe(1);
+
+    // Let the workflow finish.
+    resolveBuild(makeAgentResult());
+    await settle(200);
+
+    expect(actor.getSnapshot().status).toBe('done');
+    expect(String(actor.getSnapshot().value)).toBe('done');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Validation tests for the new fields
 // ---------------------------------------------------------------------------
 
@@ -506,6 +633,73 @@ describe('validateDefinition: maxVisits and actions', () => {
     states.a.maxVisits = 2;
     states.a.transitions = [{ to: 'done', guard: 'isStateVisitLimitReached' }, { to: 'done' }];
     expect(() => validateDefinition(def)).not.toThrow();
+  });
+
+  // ---- human gate transition actions ---------------------------------------
+
+  function baseWithHumanGate(): Record<string, unknown> {
+    return {
+      name: 'gate-base',
+      description: 'gate-base',
+      initial: 'a',
+      states: {
+        a: {
+          type: 'agent',
+          description: 'A',
+          persona: 'a',
+          prompt: 'A.',
+          inputs: [],
+          outputs: ['a'],
+          transitions: [{ to: 'gate' }],
+        },
+        gate: {
+          type: 'human_gate',
+          description: 'Gate',
+          acceptedEvents: ['APPROVE'],
+          transitions: [{ to: 'done', event: 'APPROVE' }],
+        },
+        done: { type: 'terminal', description: 'Done' },
+      },
+    };
+  }
+
+  it('accepts actions on a human gate transition', () => {
+    const def = baseWithHumanGate();
+    const states = def.states as Record<string, Record<string, unknown>>;
+    (states.gate.transitions as Array<Record<string, unknown>>)[0].actions = [
+      { type: 'resetVisitCounts', stateIds: ['a'] },
+    ];
+    expect(() => validateDefinition(def)).not.toThrow();
+  });
+
+  it('rejects an unknown action type on a human gate transition', () => {
+    const def = baseWithHumanGate();
+    const states = def.states as Record<string, Record<string, unknown>>;
+    (states.gate.transitions as Array<Record<string, unknown>>)[0].actions = [{ type: 'nukeWorld' }];
+    try {
+      validateDefinition(def);
+      expect.fail('should have thrown');
+    } catch (e) {
+      const err = e as WorkflowValidationError;
+      // Zod's discriminated-union error names the offending type.
+      expect(err.issues.join('\n')).toMatch(/type|discriminat|invalid/i);
+    }
+  });
+
+  it('rejects resetVisitCounts referencing an unknown state on a human gate transition', () => {
+    const def = baseWithHumanGate();
+    const states = def.states as Record<string, Record<string, unknown>>;
+    (states.gate.transitions as Array<Record<string, unknown>>)[0].actions = [
+      { type: 'resetVisitCounts', stateIds: ['ghost'] },
+    ];
+    try {
+      validateDefinition(def);
+      expect.fail('should have thrown');
+    } catch (e) {
+      const err = e as WorkflowValidationError;
+      expect(err.issues).toEqual(expect.arrayContaining([expect.stringContaining('ghost')]));
+      expect(err.issues).toEqual(expect.arrayContaining([expect.stringContaining('resetVisitCounts')]));
+    }
   });
 
   // ---- Fix 1: maxVisits is rejected on non-agent states ---------------------


### PR DESCRIPTION
## Summary

- Extend `HumanGateTransitionDefinition` with an optional `actions?: readonly WorkflowTransitionAction[]` field — same discriminated union that already works on agent transitions.
- `buildHumanGateState` compiles user-declared actions via the existing `compileAction` helper and appends them AFTER the hardcoded `storeHumanPrompt` + `clearError` actions.
- `validateDefinition`'s semantic validator now covers human gate transitions too, so `resetVisitCounts.stateIds` references are checked there.
- Use the new capability on `harness_review`'s APPROVE transition in `vuln-discovery.yaml`.

## Motivation

`harness_validate` has `maxVisits: 4` and escalates to `harness_review` (human gate) when the cap is hit. Previously, the APPROVE path looped straight back to `harness_build` → `harness_validate`, but the visit counter was still at 4, so `isStateVisitLimitReached` fired immediately and bounced back to the human with no progress made.

With this change, APPROVE on `harness_review` carries:

```yaml
actions:
  - type: resetVisitCounts
    stateIds: [harness_design, harness_design_review, harness_build, harness_validate]
```

The human's approval clears the accumulated counters, so the next cycle gets a fresh allocation. Same fix protects the `harness_design_review` cap-escalation path.

## Design notes

- **Action order**: hardcoded `storeHumanPrompt` + `clearError` run first, user-declared actions second. Matches the "default context update first, then user actions" convention used for agent transitions. Inline comment explains the choice.
- **Validator reuse**: `collectTransitionsWithActions` broadened to return `AgentTransitionDefinition | HumanGateTransitionDefinition`. The existing `validateTransitionActions` reads only `.to` and `.actions`, which are shape-compatible across both types — no code duplication.
- **Schema**: `humanGateTransitionSchema` now accepts `actions` via the existing `transitionActionSchema`. Today the only variant is `resetVisitCounts` (gate-agnostic); a future action variant may need gate-specific gating.

## Test plan

- [x] `npm test` — 3959 backend + 256 web-ui tests pass (+4 new tests)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npx tsc --noEmit` clean

New tests:
1. Integration: `HUMAN_APPROVE` clears named visit counts while preserving `storeHumanPrompt` + `clearError` side-effects.
2. Validation positive: `actions` on human gate transitions is accepted.
3. Validation negative: unknown action `type` on a human gate transition is rejected.
4. Validation negative: `resetVisitCounts.stateIds` referencing an unknown state on a human gate transition is rejected.

## Follow-ups (not blocking)

- Consider a TODO near `humanGateTransitionSchema` flagging that if a future action variant becomes gate-inappropriate, schema-level discrimination will be needed.
- Integration test proves both hardcoded and user actions ran but doesn't lock in ordering. Today no action set overlaps, so ordering is semantically inert.