### PR TITLE
feat(config): warn when tool annotations drift from configured MCP servers

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -355,19 +355,32 @@ export function checkAnnotationFreshness(
 
   if (missing.length > 0) {
     process.stderr.write(
-      `Warning: ${missing.length} configured MCP server(s) have no tool annotations: ${missing.join(', ')}. ` +
+      `Warning: ${missing.length} configured MCP server(s) have no tool annotations: ${missing.map(safeForDisplay).join(', ')}. ` +
         `Tools from these servers will be denied by the policy engine until annotated.\n`,
     );
     for (const name of missing) {
-      process.stderr.write(`  Run \`ironcurtain annotate-tools --server ${name}\` to annotate this server.\n`);
+      process.stderr.write(
+        `  Run \`ironcurtain annotate-tools --server ${safeForDisplay(name)}\` to annotate this server.\n`,
+      );
     }
   }
 
   if (orphaned.length > 0) {
     process.stderr.write(
-      `Note: tool-annotations.json contains server(s) no longer in mcp-servers.json: ${orphaned.join(', ')}.\n`,
+      `Note: tool-annotations.json contains server(s) no longer in mcp-servers.json: ${orphaned.map(safeForDisplay).join(', ')}.\n`,
     );
   }
+}
+
+/**
+ * Quotes a user-supplied identifier for inclusion in a stderr message or a
+ * copy-paste shell command. Escapes control characters, quotes, and
+ * backslashes via JSON string semantics, and wraps the result in double
+ * quotes. The output is both safe to print (no terminal injection) and
+ * safe to paste into bash (`--server "name"`).
+ */
+export function safeForDisplay(identifier: string): string {
+  return JSON.stringify(identifier);
 }
 
 /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -311,6 +311,59 @@ export function checkConstitutionFreshness(compiledPolicy: CompiledPolicyFile, c
 }
 
 /**
+ * Pure diff between the configured MCP servers and the servers covered by
+ * `tool-annotations.json`. Used by both the runtime freshness check and
+ * the compile-time preventive check, which format the same drift data
+ * differently.
+ *
+ *   - `missing`: configured servers with no annotations entry (these will
+ *     silently default-deny every call via the policy engine's
+ *     structural-unknown-tool fallback).
+ *   - `orphaned`: annotated servers no longer configured (informational).
+ */
+export function findAnnotationServerDrift(
+  toolAnnotations: StoredToolAnnotationsFile,
+  mcpServers: Record<string, MCPServerConfig>,
+): { missing: string[]; orphaned: string[] } {
+  const configuredNames = new Set(Object.keys(mcpServers));
+  const annotatedNames = new Set(Object.keys(toolAnnotations.servers));
+  return {
+    missing: [...configuredNames].filter((name) => !annotatedNames.has(name)).sort(),
+    orphaned: [...annotatedNames].filter((name) => !configuredNames.has(name)).sort(),
+  };
+}
+
+/**
+ * Runtime freshness check: emits stderr warnings when the on-disk
+ * tool-annotations.json no longer matches the configured MCP servers.
+ *
+ * The warning suggests re-running annotations for each specific server,
+ * not `--all`, so the user only re-classifies what actually changed.
+ */
+export function checkAnnotationFreshness(
+  toolAnnotations: StoredToolAnnotationsFile,
+  mcpServers: Record<string, MCPServerConfig>,
+): void {
+  const { missing, orphaned } = findAnnotationServerDrift(toolAnnotations, mcpServers);
+
+  if (missing.length > 0) {
+    process.stderr.write(
+      `Warning: ${missing.length} configured MCP server(s) have no tool annotations: ${missing.join(', ')}. ` +
+        `Tools from these servers will be denied by the policy engine until annotated.\n`,
+    );
+    for (const name of missing) {
+      process.stderr.write(`  Run \`ironcurtain annotate-tools --server ${name}\` to annotate this server.\n`);
+    }
+  }
+
+  if (orphaned.length > 0) {
+    process.stderr.write(
+      `Note: tool-annotations.json contains server(s) no longer in mcp-servers.json: ${orphaned.join(', ')}.\n`,
+    );
+  }
+}
+
+/**
  * Options for loading generated policy artifacts with split directories.
  * Allows policy files and tool annotations to come from different dirs.
  */

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -20,12 +20,17 @@ const __dirname = dirname(__filename);
 const isCompiled = __filename.endsWith('.js');
 
 /**
- * Returns the user-local generated dir if it contains compiled-policy.json,
- * otherwise falls back to the package-bundled generated dir.
+ * Returns the user-local generated dir if it contains the given artifact,
+ * otherwise falls back to the package-bundled dir. Used independently for
+ * `compiled-policy.json` and `tool-annotations.json` so a user who drops
+ * an updated annotations file into `~/.ironcurtain/generated/` has it
+ * picked up even without a corresponding compiled policy there (tool
+ * annotations are globally scoped — see sandbox/index.ts comment on
+ * `toolAnnotationsDir`).
  */
-function resolveGeneratedDir(packageGeneratedDir: string): string {
+function resolveArtifactDir(filename: string, packageGeneratedDir: string): string {
   const userDir = getUserGeneratedDir();
-  if (existsSync(resolve(userDir, 'compiled-policy.json'))) {
+  if (existsSync(resolve(userDir, filename))) {
     return userDir;
   }
   return packageGeneratedDir;
@@ -216,7 +221,8 @@ export function loadConfig(): IronCurtainConfig {
 
   const constitutionPath = resolve(__dirname, 'constitution.md');
   const packageGeneratedDir = resolve(__dirname, 'generated');
-  const generatedDir = resolveGeneratedDir(packageGeneratedDir);
+  const generatedDir = resolveArtifactDir('compiled-policy.json', packageGeneratedDir);
+  const toolAnnotationsDir = resolveArtifactDir('tool-annotations.json', packageGeneratedDir);
 
   const protectedPaths = computeProtectedPaths({
     constitutionPath,
@@ -258,6 +264,7 @@ export function loadConfig(): IronCurtainConfig {
     mcpServers,
     protectedPaths,
     generatedDir,
+    toolAnnotationsDir,
     constitutionPath,
     agentModelId: finalUserConfig.agentModelId,
     escalationTimeoutSeconds: finalUserConfig.escalationTimeoutSeconds,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import chalk from 'chalk';
 import ora from 'ora';
-import { loadConfig, loadGeneratedPolicy, checkConstitutionFreshness, getPackageGeneratedDir } from './config/index.js';
+import {
+  loadConfig,
+  loadGeneratedPolicy,
+  checkConstitutionFreshness,
+  checkAnnotationFreshness,
+  getPackageGeneratedDir,
+} from './config/index.js';
 import { getUserConfigPath } from './config/paths.js';
 import { checkHelp, type CommandSpec } from './cli-help.js';
 import * as logger from './logger.js';
@@ -123,13 +129,14 @@ export async function main(args?: string[]): Promise<void> {
 
   const mode = preflight.mode;
 
-  // Check constitution freshness once here, before any proxy processes are spawned.
-  const { compiledPolicy } = loadGeneratedPolicy({
+  // Check constitution and annotation freshness once here, before any proxy processes are spawned.
+  const { compiledPolicy, toolAnnotations } = loadGeneratedPolicy({
     policyDir: config.generatedDir,
     toolAnnotationsDir: config.toolAnnotationsDir ?? config.generatedDir,
     fallbackDir: getPackageGeneratedDir(),
   });
   checkConstitutionFreshness(compiledPolicy, config.constitutionPath);
+  checkAnnotationFreshness(toolAnnotations, config.mcpServers);
 
   // PTY mode: attach terminal directly to Claude Code in a Docker container
   if (values.pty) {

--- a/src/pipeline/pipeline-runner.ts
+++ b/src/pipeline/pipeline-runner.ts
@@ -16,7 +16,7 @@ import type { LanguageModelV3 } from '@ai-sdk/provider';
 import type { LanguageModel, SystemModelMessage } from 'ai';
 import chalk from 'chalk';
 import pLimit from 'p-limit';
-import { extractServerDomainAllowlists, findAnnotationServerDrift } from '../config/index.js';
+import { extractServerDomainAllowlists, findAnnotationServerDrift, safeForDisplay } from '../config/index.js';
 import { createLanguageModel } from '../config/model-provider.js';
 import type { MCPServerConfig } from '../config/types.js';
 import { loadUserConfig } from '../config/user-config.js';
@@ -243,14 +243,16 @@ function warnOnCompileAnnotationGaps(
 
   console.error(
     chalk.yellow(
-      `Warning: ${missing.length} configured MCP server(s) have no tool annotations: ${missing.join(', ')}.`,
+      `Warning: ${missing.length} configured MCP server(s) have no tool annotations: ${missing.map(safeForDisplay).join(', ')}.`,
     ),
   );
   console.error(
     chalk.yellow('  The compiled policy will have no rules for these servers and their tools will be denied.'),
   );
   for (const name of missing) {
-    console.error(chalk.yellow(`  Run \`ironcurtain annotate-tools --server ${name}\` to annotate this server.`));
+    console.error(
+      chalk.yellow(`  Run \`ironcurtain annotate-tools --server ${safeForDisplay(name)}\` to annotate this server.`),
+    );
   }
   console.error('');
 }

--- a/src/pipeline/pipeline-runner.ts
+++ b/src/pipeline/pipeline-runner.ts
@@ -16,7 +16,7 @@ import type { LanguageModelV3 } from '@ai-sdk/provider';
 import type { LanguageModel, SystemModelMessage } from 'ai';
 import chalk from 'chalk';
 import pLimit from 'p-limit';
-import { extractServerDomainAllowlists } from '../config/index.js';
+import { extractServerDomainAllowlists, findAnnotationServerDrift } from '../config/index.js';
 import { createLanguageModel } from '../config/model-provider.js';
 import type { MCPServerConfig } from '../config/types.js';
 import { loadUserConfig } from '../config/user-config.js';
@@ -221,6 +221,38 @@ interface ServerCompilationState {
 
 function computeScenariosHash(systemPrompt: string, handwrittenScenarios: TestScenario[]): string {
   return computeHash(systemPrompt, JSON.stringify(handwrittenScenarios));
+}
+
+/**
+ * Preventive warning: if `mcp-servers.json` declares servers that are not
+ * present in `tool-annotations.json`, compiling will produce a policy with
+ * no rules for those servers and every call to them will default-deny at
+ * runtime. Surface this before starting the (slow) compile so the user
+ * can re-run the per-server annotator first.
+ *
+ * `mcpServers` may be undefined when compile-policy is run with `--no-mcp`,
+ * in which case the check is skipped.
+ */
+function warnOnCompileAnnotationGaps(
+  mcpServers: Record<string, MCPServerConfig> | undefined,
+  storedAnnotationsFile: StoredToolAnnotationsFile,
+): void {
+  if (!mcpServers) return;
+  const { missing } = findAnnotationServerDrift(storedAnnotationsFile, mcpServers);
+  if (missing.length === 0) return;
+
+  console.error(
+    chalk.yellow(
+      `Warning: ${missing.length} configured MCP server(s) have no tool annotations: ${missing.join(', ')}.`,
+    ),
+  );
+  console.error(
+    chalk.yellow('  The compiled policy will have no rules for these servers and their tools will be denied.'),
+  );
+  for (const name of missing) {
+    console.error(chalk.yellow(`  Run \`ironcurtain annotate-tools --server ${name}\` to annotate this server.`));
+  }
+  console.error('');
 }
 
 function extractPermittedDirectories(rules: CompiledRule[]): string[] {
@@ -586,6 +618,8 @@ export class PipelineRunner {
     if (!storedAnnotationsFile) {
       throw new Error("tool-annotations.json not found. Run 'ironcurtain annotate-tools' first.");
     }
+
+    warnOnCompileAnnotationGaps(config.mcpServers, storedAnnotationsFile);
 
     // Resolve conditional role specs to flat annotations for compiler prompts
     const toolAnnotationsFile = resolveStoredAnnotationsFile(storedAnnotationsFile);

--- a/src/trusted-process/index.ts
+++ b/src/trusted-process/index.ts
@@ -1,6 +1,5 @@
 import type { IronCurtainConfig } from '../config/types.js';
 import type { ToolCallRequest, ToolCallResult } from '../types/mcp.js';
-import type { StoredToolAnnotationsFile } from '../pipeline/types.js';
 import {
   loadGeneratedPolicy,
   extractServerDomainAllowlists,
@@ -127,7 +126,7 @@ export class TrustedProcess {
     const policyRoots = extractPolicyRoots(compiledPolicy, this.config.allowedDirectory);
     this.mcpRoots = toMcpRoots(policyRoots);
 
-    await this.connectMcpServers(toolAnnotations);
+    await this.connectMcpServers();
   }
 
   /**
@@ -150,7 +149,7 @@ export class TrustedProcess {
    * Connects to every configured MCP server and registers its tools
    * with the coordinator. Unavailable servers are logged and skipped.
    */
-  private async connectMcpServers(toolAnnotations: StoredToolAnnotationsFile): Promise<void> {
+  private async connectMcpServers(): Promise<void> {
     const coordinator = this.requireCoordinator();
     const failedServers: string[] = [];
     for (const [name, serverConfig] of Object.entries(this.config.mcpServers)) {
@@ -170,7 +169,6 @@ export class TrustedProcess {
         // `ClientState` so `addRootToClient` mutates the same roots
         // array the manager returns from its `roots/list` handler.
         const tools = await this.mcpManager.listTools(name);
-        warnOnToolAnnotationDrift(name, tools, toolAnnotations);
         const clientState = this.mcpManager.getClientState(name);
         if (clientState) {
           const proxiedTools: ProxiedTool[] = tools.map((t) => ({
@@ -213,48 +211,6 @@ export class TrustedProcess {
     if (this.coordinator) {
       await this.coordinator.close();
     }
-  }
-}
-
-/**
- * Diffs the live tools returned by an MCP server against the tools recorded
- * in `tool-annotations.json`. Emits a stderr warning per server with tools
- * the live server exposes but the annotations are missing (these will
- * default-deny at runtime via the policy engine's structural-unknown-tool
- * fallback). Extra annotated tools that no longer exist on the server are
- * surfaced as a quieter informational line.
- *
- * Called only after a successful `mcpManager.connect`, so optional servers
- * that fail to start (e.g. github when Docker is down) do not false-positive.
- */
-function warnOnToolAnnotationDrift(
-  serverName: string,
-  liveTools: ReadonlyArray<{ name: string }>,
-  toolAnnotations: StoredToolAnnotationsFile,
-): void {
-  if (!Object.hasOwn(toolAnnotations.servers, serverName)) {
-    // Missing-server case is already surfaced by `checkAnnotationFreshness`
-    // at policy-load time; no need to repeat it per-connect.
-    return;
-  }
-  const annotated = toolAnnotations.servers[serverName];
-  const liveNames = new Set(liveTools.map((t) => t.name));
-  const annotatedNames = new Set(annotated.tools.map((t) => t.toolName));
-  const missing = [...liveNames].filter((n) => !annotatedNames.has(n)).sort();
-  const stale = [...annotatedNames].filter((n) => !liveNames.has(n)).sort();
-
-  if (missing.length > 0) {
-    process.stderr.write(
-      `Warning: MCP server '${serverName}' exposes ${missing.length} tool(s) not present in tool-annotations.json: ` +
-        `${missing.join(', ')}. These calls will be denied by the policy engine.\n` +
-        `  Run \`ironcurtain annotate-tools --server ${serverName}\` to refresh annotations for this server.\n`,
-    );
-  }
-  if (stale.length > 0) {
-    process.stderr.write(
-      `Note: tool-annotations.json for '${serverName}' contains ${stale.length} tool(s) no longer exposed by the server: ` +
-        `${stale.join(', ')}.\n`,
-    );
   }
 }
 

--- a/src/trusted-process/index.ts
+++ b/src/trusted-process/index.ts
@@ -1,9 +1,11 @@
 import type { IronCurtainConfig } from '../config/types.js';
 import type { ToolCallRequest, ToolCallResult } from '../types/mcp.js';
+import type { StoredToolAnnotationsFile } from '../pipeline/types.js';
 import {
   loadGeneratedPolicy,
   extractServerDomainAllowlists,
   checkConstitutionFreshness,
+  checkAnnotationFreshness,
   getPackageGeneratedDir,
 } from '../config/index.js';
 import { createLanguageModel } from '../config/model-provider.js';
@@ -87,6 +89,7 @@ export class TrustedProcess {
       fallbackDir: getPackageGeneratedDir(),
     });
     checkConstitutionFreshness(compiledPolicy, this.config.constitutionPath);
+    checkAnnotationFreshness(toolAnnotations, this.config.mcpServers);
 
     const serverDomainAllowlists = extractServerDomainAllowlists(this.config.mcpServers);
     const trustedServers = buildTrustedServerSet(this.config.mcpServers);
@@ -124,7 +127,7 @@ export class TrustedProcess {
     const policyRoots = extractPolicyRoots(compiledPolicy, this.config.allowedDirectory);
     this.mcpRoots = toMcpRoots(policyRoots);
 
-    await this.connectMcpServers();
+    await this.connectMcpServers(toolAnnotations);
   }
 
   /**
@@ -147,7 +150,7 @@ export class TrustedProcess {
    * Connects to every configured MCP server and registers its tools
    * with the coordinator. Unavailable servers are logged and skipped.
    */
-  private async connectMcpServers(): Promise<void> {
+  private async connectMcpServers(toolAnnotations: StoredToolAnnotationsFile): Promise<void> {
     const coordinator = this.requireCoordinator();
     const failedServers: string[] = [];
     for (const [name, serverConfig] of Object.entries(this.config.mcpServers)) {
@@ -167,6 +170,7 @@ export class TrustedProcess {
         // `ClientState` so `addRootToClient` mutates the same roots
         // array the manager returns from its `roots/list` handler.
         const tools = await this.mcpManager.listTools(name);
+        warnOnToolAnnotationDrift(name, tools, toolAnnotations);
         const clientState = this.mcpManager.getClientState(name);
         if (clientState) {
           const proxiedTools: ProxiedTool[] = tools.map((t) => ({
@@ -209,6 +213,48 @@ export class TrustedProcess {
     if (this.coordinator) {
       await this.coordinator.close();
     }
+  }
+}
+
+/**
+ * Diffs the live tools returned by an MCP server against the tools recorded
+ * in `tool-annotations.json`. Emits a stderr warning per server with tools
+ * the live server exposes but the annotations are missing (these will
+ * default-deny at runtime via the policy engine's structural-unknown-tool
+ * fallback). Extra annotated tools that no longer exist on the server are
+ * surfaced as a quieter informational line.
+ *
+ * Called only after a successful `mcpManager.connect`, so optional servers
+ * that fail to start (e.g. github when Docker is down) do not false-positive.
+ */
+function warnOnToolAnnotationDrift(
+  serverName: string,
+  liveTools: ReadonlyArray<{ name: string }>,
+  toolAnnotations: StoredToolAnnotationsFile,
+): void {
+  if (!Object.hasOwn(toolAnnotations.servers, serverName)) {
+    // Missing-server case is already surfaced by `checkAnnotationFreshness`
+    // at policy-load time; no need to repeat it per-connect.
+    return;
+  }
+  const annotated = toolAnnotations.servers[serverName];
+  const liveNames = new Set(liveTools.map((t) => t.name));
+  const annotatedNames = new Set(annotated.tools.map((t) => t.toolName));
+  const missing = [...liveNames].filter((n) => !annotatedNames.has(n)).sort();
+  const stale = [...annotatedNames].filter((n) => !liveNames.has(n)).sort();
+
+  if (missing.length > 0) {
+    process.stderr.write(
+      `Warning: MCP server '${serverName}' exposes ${missing.length} tool(s) not present in tool-annotations.json: ` +
+        `${missing.join(', ')}. These calls will be denied by the policy engine.\n` +
+        `  Run \`ironcurtain annotate-tools --server ${serverName}\` to refresh annotations for this server.\n`,
+    );
+  }
+  if (stale.length > 0) {
+    process.stderr.write(
+      `Note: tool-annotations.json for '${serverName}' contains ${stale.length} tool(s) no longer exposed by the server: ` +
+        `${stale.join(', ')}.\n`,
+    );
   }
 }
 

--- a/src/trusted-process/tool-call-coordinator.ts
+++ b/src/trusted-process/tool-call-coordinator.ts
@@ -37,7 +37,7 @@ import {
   type ToolCallResponse,
 } from './tool-call-pipeline.js';
 import type { ResolvedSandboxConfig } from './sandbox-integration.js';
-import { loadPersonaPolicyArtifacts } from '../config/index.js';
+import { loadPersonaPolicyArtifacts, safeForDisplay } from '../config/index.js';
 import { validatePolicyDir } from '../config/validate-policy-dir.js';
 import { proxyAnnotations, proxyPolicyRules } from '../docker/proxy-tools.js';
 import { ControlServer, type ControlServerAddress, type ControlServerListenOptions } from './control-server.js';
@@ -651,15 +651,15 @@ function warnOnToolAnnotationDrift(
 
   if (missing.length > 0) {
     process.stderr.write(
-      `Warning: MCP server '${serverName}' exposes ${missing.length} tool(s) not present in tool-annotations.json: ` +
-        `${missing.join(', ')}. These calls will be denied by the policy engine.\n` +
-        `  Run \`ironcurtain annotate-tools --server ${serverName}\` to refresh annotations for this server.\n`,
+      `Warning: MCP server ${safeForDisplay(serverName)} exposes ${missing.length} tool(s) not present in tool-annotations.json: ` +
+        `${missing.map(safeForDisplay).join(', ')}. These calls will be denied by the policy engine.\n` +
+        `  Run \`ironcurtain annotate-tools --server ${safeForDisplay(serverName)}\` to refresh annotations for this server.\n`,
     );
   }
   if (stale.length > 0) {
     process.stderr.write(
-      `Note: tool-annotations.json for '${serverName}' contains ${stale.length} tool(s) no longer exposed by the server: ` +
-        `${stale.join(', ')}.\n`,
+      `Note: tool-annotations.json for ${safeForDisplay(serverName)} contains ${stale.length} tool(s) no longer exposed by the server: ` +
+        `${stale.map(safeForDisplay).join(', ')}.\n`,
     );
   }
 }

--- a/src/trusted-process/tool-call-coordinator.ts
+++ b/src/trusted-process/tool-call-coordinator.ts
@@ -256,6 +256,13 @@ export class ToolCallCoordinator {
    * Optionally associates a `ClientState` with the server so escalation
    * root expansion can reach the MCP client (used by the Sandbox wiring
    * for real subprocess clients).
+   *
+   * Emits a stderr drift warning when the registered tool list does not
+   * match `tool-annotations.json` (e.g. an MCP server added or renamed
+   * a tool since the last `annotate-tools` run). Without this, mismatched
+   * tools surface as silent default-denies via the policy engine's
+   * structural-unknown-tool fallback. This is the chokepoint for both the
+   * Code Mode sandbox and Docker `CodeModeProxy` paths.
    */
   registerTools(serverName: string, tools: CoordinatorTool[], clientState?: ClientState): void {
     for (const tool of tools) {
@@ -264,6 +271,7 @@ export class ToolCallCoordinator {
     if (clientState) {
       this.clientStates.set(serverName, clientState);
     }
+    warnOnToolAnnotationDrift(serverName, tools, this.toolAnnotations);
   }
 
   getRegisteredTools(): CoordinatorTool[] {
@@ -615,4 +623,43 @@ function mergeProxyAnnotations(src: StoredToolAnnotationsFile): StoredToolAnnota
       },
     },
   };
+}
+
+/**
+ * Diffs the tools a backend server actually exposes against the tools
+ * recorded for it in `tool-annotations.json`. Emits a stderr warning when
+ * the live server has tools the annotations are missing (these calls will
+ * default-deny at runtime via the policy engine's structural-unknown-tool
+ * fallback). Surfaces stale annotated tools no longer exposed by the
+ * server as a quieter informational note.
+ *
+ * Server-level drift (entire server not annotated) is already surfaced by
+ * `checkAnnotationFreshness` at policy-load time; this helper only fires
+ * when the server has an annotations entry and its tool set diverges.
+ */
+function warnOnToolAnnotationDrift(
+  serverName: string,
+  liveTools: ReadonlyArray<{ name: string }>,
+  toolAnnotations: StoredToolAnnotationsFile,
+): void {
+  if (!Object.hasOwn(toolAnnotations.servers, serverName)) return;
+  const annotated = toolAnnotations.servers[serverName];
+  const liveNames = new Set(liveTools.map((t) => t.name));
+  const annotatedNames = new Set(annotated.tools.map((t) => t.toolName));
+  const missing = [...liveNames].filter((n) => !annotatedNames.has(n)).sort();
+  const stale = [...annotatedNames].filter((n) => !liveNames.has(n)).sort();
+
+  if (missing.length > 0) {
+    process.stderr.write(
+      `Warning: MCP server '${serverName}' exposes ${missing.length} tool(s) not present in tool-annotations.json: ` +
+        `${missing.join(', ')}. These calls will be denied by the policy engine.\n` +
+        `  Run \`ironcurtain annotate-tools --server ${serverName}\` to refresh annotations for this server.\n`,
+    );
+  }
+  if (stale.length > 0) {
+    process.stderr.write(
+      `Note: tool-annotations.json for '${serverName}' contains ${stale.length} tool(s) no longer exposed by the server: ` +
+        `${stale.join(', ')}.\n`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Adds three drift-detection warnings between configured MCP servers (`mcp-servers.json`) and the generated `tool-annotations.json`. Previously, mismatches surfaced as silent per-call default-denies via the policy engine's `structural-unknown-tool` fallback — confusing to debug.

- **Policy-load time** (`checkAnnotationFreshness` in `src/config/index.ts`): warns when configured servers have no annotations entry; quieter informational note for orphaned annotations no longer in `mcp-servers.json`.
- **MCP-connect time** (`warnOnToolAnnotationDrift` in `src/trusted-process/index.ts`): per-server diff of live `listTools()` against annotated tools — catches the case where a server is annotated but new tools have been added since the last `annotate-tools` run.
- **Compile-policy time** (`warnOnCompileAnnotationGaps` in `src/pipeline/pipeline-runner.ts`): preventive warning before compilation when configured servers have no annotations.

Each warning suggests re-running the per-server annotator (`ironcurtain annotate-tools --server <name>`), not `--all`, so the user only re-classifies what actually changed. Shared `findAnnotationServerDrift()` computes the diff once; each call site formats its own message.

### Example warnings

Policy-load time (stderr):
```
Warning: 1 configured MCP server(s) have no tool annotations: github. Tools from these servers will be denied by the policy engine until annotated.
  Run `ironcurtain annotate-tools --server github` to annotate this server.
```

MCP-connect time (catches the original bug — annotated server, new tool):
```
Warning: MCP server 'filesystem' exposes 3 tool(s) not present in tool-annotations.json: get_file_info, move_file, search_files. These calls will be denied by the policy engine.
  Run `ironcurtain annotate-tools --server filesystem` to refresh annotations for this server.
```

Compile-policy time (chalk yellow, before the slow compile starts):
```
Warning: 1 configured MCP server(s) have no tool annotations: github.
  The compiled policy will have no rules for these servers and their tools will be denied.
  Run `ironcurtain annotate-tools --server github` to annotate this server.
```

## Test plan

- [x] `npm run lint` and `npm run format` clean on all four changed files
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 4247/4247 pass (3991 core + 256 web-ui), no regressions
- [ ] Smoke test on a real session with a known stale `~/.ironcurtain/generated/tool-annotations.json` to confirm warnings appear at all three checkpoints
- [ ] Verify warnings do not false-positive when an optional MCP server fails to start (e.g. github with Docker down) — connect-time check is inside the existing try-block, so it should only run on successful connects