### PR TITLE
feat(workflow): accept Ollama-style model IDs in workflow YAML

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -290,7 +290,7 @@ my_state:
 
 ### Model selection
 
-Workflows can pin a specific LLM at two levels. Both use a qualified model ID (`provider:model-name`). A bare model name with no prefix defaults to Anthropic. Ollama-style `name:tag` identifiers (e.g. `glm-5.1:cloud`, `qwen3.5-uncensored:35b`) are also accepted and passed through opaquely — the leading segment is not a known provider, so the whole string is forwarded verbatim.
+Workflows can pin a specific LLM at two levels. The `model` field accepts three forms: a `provider:model-name` qualified ID (provider ∈ anthropic, google, openai), a bare model name (treated as Anthropic), or an Ollama-style `name:tag` identifier (e.g. `glm-5.1:cloud`, `qwen3.5-uncensored:35b`) forwarded verbatim to an upstream gateway such as `ANTHROPIC_BASE_URL`.
 
 Valid IDs depend on which agent is running the workflow:
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -290,7 +290,7 @@ my_state:
 
 ### Model selection
 
-Workflows can pin a specific LLM at two levels. Both use a qualified model ID (`provider:model-name`). A bare model name with no prefix defaults to Anthropic.
+Workflows can pin a specific LLM at two levels. Both use a qualified model ID (`provider:model-name`). A bare model name with no prefix defaults to Anthropic. Ollama-style `name:tag` identifiers (e.g. `glm-5.1:cloud`, `qwen3.5-uncensored:35b`) are also accepted and passed through opaquely — the leading segment is not a known provider, so the whole string is forwarded verbatim.
 
 Valid IDs depend on which agent is running the workflow:
 

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -66,6 +66,9 @@ function createModelIdSchema(options: { readonly strict: boolean; readonly messa
     .min(1)
     .refine(
       (val) => {
+        // Reject malformed colon shapes ":tag" and "name:" — these otherwise
+        // slip through parseModelId's unknown-prefix fallthrough as opaque IDs.
+        if (val.startsWith(':') || val.endsWith(':')) return false;
         try {
           const { modelId } = parseModelId(val);
           if (options.strict && val.includes(':') && val === modelId) return false;

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -55,35 +55,50 @@ const resourceBudgetSchema = z
   .optional();
 
 /**
- * Validates a qualified model ID string for config files: either a bare model
- * name (no colons) or "provider:model-name" where provider is a known provider.
- *
- * Stricter than parseModelId() which also accepts Ollama-style "name:tag" via
- * the --model CLI flag. Config values should use explicit provider prefixes
- * when colons are present to avoid ambiguity.
+ * Shared scaffold for the two model-ID validators below. Both accept strings
+ * that `parseModelId()` handles. Strict mode additionally rejects values where
+ * a colon is present but the prefix is not a known provider — that catches
+ * typos like "anthropc:claude-sonnet" in `~/.ironcurtain/config.json`.
  */
-export const qualifiedModelId = z
-  .string()
-  .min(1)
-  .refine(
-    (val) => {
-      try {
-        const { provider, modelId } = parseModelId(val);
-        // If the original value contains a colon, it must have resolved to
-        // a known provider prefix (not fallen through to the default).
-        // This catches ambiguous strings like "unknown:model" in config files.
-        if (val.includes(':') && val === modelId) return false;
-        return !!provider;
-      } catch {
-        return false;
-      }
-    },
-    {
-      message:
-        'Model ID must be "model-name" or "provider:model-name" ' +
-        'where provider is one of: anthropic, google, openai',
-    },
-  );
+function createModelIdSchema(options: { readonly strict: boolean; readonly message: string }): z.ZodType<string> {
+  return z
+    .string()
+    .min(1)
+    .refine(
+      (val) => {
+        try {
+          const { modelId } = parseModelId(val);
+          if (options.strict && val.includes(':') && val === modelId) return false;
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: options.message },
+    );
+}
+
+/**
+ * Strict model ID validator for `~/.ironcurtain/config.json`. A colon-prefixed
+ * value must name a known provider; bare names are accepted.
+ */
+export const qualifiedModelId = createModelIdSchema({
+  strict: true,
+  message:
+    'Model ID must be "model-name" or "provider:model-name" ' + 'where provider is one of: anthropic, google, openai',
+});
+
+/**
+ * Looser model ID validator for workflow YAML. Additionally accepts
+ * Ollama-style "name:tag" identifiers (e.g. `glm-5.1:cloud`) reached via
+ * an upstream gateway like ANTHROPIC_BASE_URL.
+ */
+export const looseModelId = createModelIdSchema({
+  strict: false,
+  message:
+    'Model ID must be "model-name", "provider:model-name" ' +
+    '(provider: anthropic, google, openai), or an Ollama-style "name:tag" bare model ID',
+});
 
 const autoCompactSchema = z
   .object({

--- a/src/workflow/validate.ts
+++ b/src/workflow/validate.ts
@@ -9,7 +9,7 @@ import type {
 } from './types.js';
 import { AGENT_OUTPUT_FIELDS, CONFIDENCE_VALUES } from './types.js';
 import { REGISTERED_GUARDS } from './guards.js';
-import { qualifiedModelId } from '../config/user-config.js';
+import { looseModelId } from '../config/user-config.js';
 import { isPlainObject } from '../utils/is-plain-object.js';
 
 // ---------------------------------------------------------------------------
@@ -57,7 +57,7 @@ const agentStateSchema = z.object({
   transitions: z.array(agentTransitionSchema).min(1),
   worktree: z.boolean().optional(),
   freshSession: z.boolean().optional(),
-  model: qualifiedModelId.optional(),
+  model: looseModelId.optional(),
   maxVisits: z.number().int().positive().optional(),
   containerScope: z.string().regex(CONTAINER_SCOPE_PATTERN).optional(),
 });
@@ -101,7 +101,7 @@ const workflowSettingsSchema = z
     systemPrompt: z.string().optional(),
     maxSessionSeconds: z.number().positive().optional(),
     unversionedArtifacts: z.array(z.string()).optional(),
-    model: qualifiedModelId.optional(),
+    model: looseModelId.optional(),
     sharedContainer: z.boolean().optional(),
   })
   .optional();

--- a/test/workflow/model-selection.test.ts
+++ b/test/workflow/model-selection.test.ts
@@ -117,6 +117,18 @@ describe('workflow model validation', () => {
     expect(() => validateDefinition(def)).not.toThrow();
   });
 
+  it('rejects a model ID with an empty name before the colon', () => {
+    const def = baseWorkflow();
+    def.settings = { model: ':tag' };
+    expect(() => validateDefinition(def)).toThrow(WorkflowValidationError);
+  });
+
+  it('rejects a model ID with an empty tag after the colon', () => {
+    const def = baseWorkflow();
+    def.settings = { model: 'name:' };
+    expect(() => validateDefinition(def)).toThrow(WorkflowValidationError);
+  });
+
   it('rejects an empty-string model at workflow level', () => {
     const def = baseWorkflow();
     def.settings = { model: '' };

--- a/test/workflow/model-selection.test.ts
+++ b/test/workflow/model-selection.test.ts
@@ -103,6 +103,20 @@ describe('workflow model validation', () => {
     expect(() => validateDefinition(def)).not.toThrow();
   });
 
+  it('accepts an Ollama-style "name:tag" model ID at workflow level', () => {
+    // Forwarded verbatim to an upstream gateway via ANTHROPIC_BASE_URL.
+    const def = baseWorkflow();
+    def.settings = { model: 'glm-5.1:cloud' };
+    expect(() => validateDefinition(def)).not.toThrow();
+  });
+
+  it('accepts an Ollama-style "name:tag" model ID at state level', () => {
+    const def = baseWorkflow();
+    const states = def.states as Record<string, Record<string, unknown>>;
+    states.plan.model = 'qwen3.5-uncensored:35b';
+    expect(() => validateDefinition(def)).not.toThrow();
+  });
+
   it('rejects an empty-string model at workflow level', () => {
     const def = baseWorkflow();
     def.settings = { model: '' };


### PR DESCRIPTION
## Summary
- Workflow YAML now accepts `glm-5.1:cloud` and other Ollama-style `name:tag` identifiers in `settings.model` and per-state `model` fields. Previously rejected by the strict `qualifiedModelId` validator even though downstream routing (claude-code + `ANTHROPIC_BASE_URL` → Ollama) already handled them.
- Factored the shared `try/parseModelId` scaffold into a `createModelIdSchema()` helper and added a `looseModelId` variant that permits opaque `name:tag` forms. `~/.ironcurtain/config.json` slots stay on strict `qualifiedModelId` where typos like `anthropc:model` are more costly than flexibility.

## Test plan
- [x] `npm test -- test/workflow/model-selection.test.ts` — 22 tests pass, including 2 new Ollama-style cases at workflow and state level
- [x] `npm test -- test/user-config.test.ts test/model-provider.test.ts test/config-command.test.ts` — strict validator unchanged (129 tests pass in aggregate)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` and `prettier --check` clean