### PR TITLE
test(signal): raise waitFor default to 15s for CI stability

### DIFF
--- a/test/signal/signal-bot-daemon.test.ts
+++ b/test/signal/signal-bot-daemon.test.ts
@@ -151,9 +151,18 @@ function wait(ms: number): Promise<void> {
 
 /**
  * Polls a predicate every 5ms and resolves as soon as it returns true.
- * Falls back to a timeout (default 5s) to avoid hanging forever.
+ * Falls back to a timeout to avoid hanging forever.
+ *
+ * The default is 15s — NOT a time budget for expected behavior, but a
+ * safety net against a truly wedged bot. Ubuntu/Node CI runners
+ * occasionally stall for hundreds of ms on GC or scheduler contention
+ * between `simulateIncomingMessage` and the bot's POST response, and
+ * the original 5s default flaked on those runs. Individual vitest
+ * `it(...)` tests still have their own 30s timeout, so a real
+ * correctness bug (bot never sends the awaited message) still fails
+ * loudly within the test runner, not within this poll loop.
  */
-async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+async function waitFor(predicate: () => boolean, timeoutMs = 15_000): Promise<void> {
   const start = Date.now();
   while (!predicate()) {
     if (Date.now() - start > timeoutMs) {
@@ -164,17 +173,21 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
 }
 
 /** Waits until mockApi.sentMessages has at least `count` entries. */
-function waitForMessages(mockApi: MockSignalApi, count: number, timeoutMs = 5000): Promise<void> {
+function waitForMessages(mockApi: MockSignalApi, count: number, timeoutMs = 15_000): Promise<void> {
   return waitFor(() => mockApi.sentMessages.length >= count, timeoutMs);
 }
 
 /** Waits until mockApi.messageTexts contains a message matching the predicate. */
-function waitForMessage(mockApi: MockSignalApi, predicate: (text: string) => boolean, timeoutMs = 5000): Promise<void> {
+function waitForMessage(
+  mockApi: MockSignalApi,
+  predicate: (text: string) => boolean,
+  timeoutMs = 15_000,
+): Promise<void> {
   return waitFor(() => mockApi.messageTexts.some(predicate), timeoutMs);
 }
 
 /** Waits until the given mock function has been called at least `count` times. */
-function waitForCalls(fn: ReturnType<typeof vi.fn>, count: number, timeoutMs = 5000): Promise<void> {
+function waitForCalls(fn: ReturnType<typeof vi.fn>, count: number, timeoutMs = 15_000): Promise<void> {
   return waitFor(() => fn.mock.calls.length >= count, timeoutMs);
 }
 


### PR DESCRIPTION
## Summary

CI failed on master (`ca66fd5`) on the **Ubuntu 24 / Node 24** runner:

> `Error: waitFor timed out after 5000ms` at `test/signal/signal-bot-daemon.test.ts:160`
> in `reproduces production scenario: session #1 escalation resolved, /new, message to #2 escalates with correct label`

The commit that triggered the failure doesn't touch signal-bot code — the flake is scheduler-lag on the CI runner, not a regression. The test passes locally 3/3 in 1.5s, prior master runs passed.

## Root cause

The signal-bot test suite uses a custom `waitFor` helper that polls every 5ms with a **5 second** default timeout. The 5s was acting as a time budget for expected behavior (messages arriving + bot state settling), but Ubuntu CI runners occasionally stall 5+ seconds between `simulateIncomingMessage` and the bot's POST response due to GC or scheduler contention.

## Fix

Bump the default `waitFor` timeout from **5s → 15s**, applied to `waitFor`, `waitForMessages`, `waitForMessage`, `waitForCalls`.

**Why this is the right size:**
- 3x the current budget, headroom for CI scheduler stalls.
- Does NOT mask real hangs — vitest's per-`it` test timeout is 30s, so a genuinely wedged bot still fails loudly within the test runner.
- No semantic change to passing tests — they still resolve in milliseconds on normal runners (local suite still 1.48s).

## Why not event-driven mock?

Considered and prototyped an event-driven version of `waitForMessage` (mock emits on send, helper listens). It's structurally cleaner but hit a real synchronization problem: the bot has internal state that settles AFTER the send POST, and the mock is upstream of that settling. Polling's 5ms interval was inadvertently acting as a barrier waiting for the bot to finish. Without bot-side hooks (`waitForIdle()` etc.), no amount of `setImmediate`/microtask deferral reliably replaces the barrier. Out of scope for a CI-flake fix — reverted.

## Test plan

- [x] Local `npm test` for the signal-bot file: 63/63 passing in 1.48s
- [x] Typecheck / lint / format clean