### PR TITLE
feat(workflow): detect provider 429s and make runs resilient to quota exhaustion

### DIFF
--- a/src/docker/CLAUDE.md
+++ b/src/docker/CLAUDE.md
@@ -53,6 +53,8 @@ The `proxy` virtual MCP server (`proxy-tools.ts`) exposes `add_proxy_domain`, `r
 - `adapters/shared-scripts.ts` - Shared shell script generators (e.g., `resize-pty.sh`) and prompt sections used by both adapters.
 - `claude-md-seed.ts` - Builds `CLAUDE.md` content seeded into the container's `~/.claude/` for Claude Code sessions. Contains memory behavioral rules (pre-response MCP tool call protocol).
 
+**Quota exhaustion contract:** adapters MUST populate `AgentResponse.quotaExhausted` when the underlying CLI surfaces a 429-class envelope; the workflow orchestrator short-circuits on this signal instead of retrying. See `adapters/claude-code.ts` for the canonical implementation.
+
 ## Dual session modes: keep in sync
 
 `docker-agent-session.ts` (batch mode) and `pty-session.ts` (PTY mode) have parallel initialization paths that share adapter infrastructure but assemble container configs independently. When adding a mount, env var, or container lifecycle feature to one mode, always check the other mode and apply the same change if applicable. Past bug: conversation state mount was added to PTY mode but missed in batch mode, breaking `claude --continue` across container recreations.

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -245,6 +245,15 @@ exit $STATUS
 
     extractResponse(exitCode: number, stdout: string): AgentResponse {
       if (exitCode !== 0) {
+        // Before falling back to the generic "exited non-zero" wrapper,
+        // look inside Claude Code's JSON envelope for a structured
+        // quota-exhaustion signal. Claude Code exits non-zero on 429
+        // but still prints its result envelope on stdout — we would
+        // otherwise throw that signal away.
+        const quotaExhausted = extractClaudeCodeQuotaSignal(stdout);
+        if (quotaExhausted) {
+          return { text: quotaExhausted.rawMessage, quotaExhausted };
+        }
         // Zero output on non-zero exit indicates the claude process was
         // killed (SIGTERM) or crashed before producing any assistant text —
         // typically an upstream provider stall. The session id has been
@@ -283,6 +292,50 @@ exit $STATUS
       };
     },
   };
+}
+
+/**
+ * Matches the human-readable reset timestamp that litellm / Anthropic
+ * surface in the 429 error `result` string, e.g.
+ *   "Usage limit reached for 5 hour. Your limit will reset at 2026-04-22 18:27:36"
+ * The timestamp has no timezone suffix in practice; we treat it as UTC.
+ */
+const QUOTA_RESET_REGEX = /Your limit will reset at (\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/;
+
+/**
+ * Extracts a quota-exhaustion signal from Claude Code's JSON error
+ * envelope. Returns undefined when the envelope is missing, malformed,
+ * or carries a different error class. When present, `rawMessage` is
+ * always set (from the envelope's `result` string or a stringified
+ * fallback) and `resetAt` is populated only when the human-readable
+ * reset timestamp can be parsed.
+ *
+ * Contract: this helper populates `AgentResponse.quotaExhausted`,
+ * which the workflow orchestrator treats as a terminal "pause and
+ * resume later" signal — do not fold unrelated errors into this path.
+ */
+function extractClaudeCodeQuotaSignal(stdout: string): AgentResponse['quotaExhausted'] | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.api_error_status !== 429) return undefined;
+
+  const resultText = typeof obj.result === 'string' ? obj.result : undefined;
+  const rawMessage = resultText ?? stdout.trim();
+  const match = resultText ? QUOTA_RESET_REGEX.exec(resultText) : null;
+  if (match) {
+    const [, date, time] = match;
+    const resetAt = new Date(`${date}T${time}Z`);
+    if (!Number.isNaN(resetAt.getTime())) {
+      return { resetAt, rawMessage };
+    }
+  }
+  return { rawMessage };
 }
 
 /**

--- a/src/docker/adapters/goose.ts
+++ b/src/docker/adapters/goose.ts
@@ -286,6 +286,24 @@ export function createGooseAdapter(userConfig?: ResolvedUserConfig): AgentAdapte
       return env;
     },
 
+    /**
+     * NOTE: this adapter does NOT currently populate
+     * `AgentResponse.quotaExhausted`. Goose runs without a JSON output
+     * mode (see the module header above), so on quota exhaustion its
+     * stdout is unstructured provider text with no machine-readable
+     * `api_error_status` field to key off of. A workflow run that hits
+     * a 429 under Goose will therefore take the generic abort path
+     * instead of pausing cleanly.
+     *
+     * Closing this gap requires either (a) adopting a Goose structured
+     * output mode when one becomes available, or (b) a fragile stderr
+     * regex against known provider messages ("Usage limit reached",
+     * "429", "rate_limit_exceeded"); (b) is deliberately not attempted
+     * without broader testing across providers. See the Claude Code
+     * adapter (`adapters/claude-code.ts`) for the target contract and
+     * `AgentResponse.quotaExhausted` in `../agent-adapter.ts` for the
+     * interface-level requirement on adapters.
+     */
     extractResponse(exitCode: number, stdout: string): AgentResponse {
       const clean = stripAnsi(stdout);
 

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -35,6 +35,31 @@ export interface AgentResponse {
    * agent CLI considers the id consumed.
    */
   readonly hardFailure?: boolean;
+  /**
+   * Set when the adapter detected that the agent aborted because of
+   * upstream quota exhaustion — the kind the agent CLI's own retry loop
+   * cannot recover from within a reasonable window (e.g. a multi-hour
+   * provider usage-limit reset, surfaced by Claude Code as an
+   * `api_error_status: 429` JSON envelope with a human-readable
+   * "limit will reset at ..." message).
+   *
+   * Adapters MUST populate this whenever their CLI surfaces such a
+   * signal. The orchestrator will neither retry nor spend further
+   * budget on a turn that sets it — it throws a dedicated error class
+   * so the workflow can be paused and resumed once the quota window
+   * opens instead of aborting. Leaving this undefined causes the
+   * orchestrator to fall through to the generic abort path — acceptable
+   * only when the adapter's CLI has no machine-readable quota signal.
+   *
+   * `rawMessage` is the original provider/CLI text, preserved for
+   * diagnostics and CLI output. `resetAt` is optional because not every
+   * provider emits a parseable timestamp; when absent the caller picks
+   * a conservative default pause.
+   */
+  readonly quotaExhausted?: {
+    readonly resetAt?: Date;
+    readonly rawMessage: string;
+  };
 }
 
 /**
@@ -197,6 +222,16 @@ export interface AgentAdapter {
 
   /**
    * Parses the agent's output to extract the response and optional cost.
+   *
+   * IMPORTANT: adapters are the sole place where CLI-specific error
+   * envelopes are translated into structured signals for the workflow
+   * engine. In particular, when the underlying CLI exposes a
+   * quota-exhaustion / rate-limit-exceeded signal (e.g. Claude Code's
+   * `api_error_status: 429` JSON envelope), the adapter MUST surface
+   * it via `AgentResponse.quotaExhausted`. See the Claude Code adapter
+   * (`adapters/claude-code.ts`) for the canonical implementation.
+   * Failing to surface this signal causes the orchestrator to treat
+   * quota exhaustion as a generic abort, wasting the workflow run.
    *
    * @param exitCode - the container's exit code
    * @param stdout - captured stdout from the container

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -311,7 +311,11 @@ export class DockerAgentSession implements Session {
         this.firstTurnComplete = true;
       }
 
-      return { text: response.text, hardFailure: response.hardFailure ?? false };
+      return {
+        text: response.text,
+        hardFailure: response.hardFailure ?? false,
+        quotaExhausted: response.quotaExhausted,
+      };
     } finally {
       // Restore to 'ready' on both success and exception so a failed
       // turn (docker.exec timeout, adapter parse error, etc.) doesn't

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -467,6 +467,19 @@ export interface AgentTurnResult {
    * should consult this flag rather than parsing `text`.
    */
   readonly hardFailure: boolean;
+  /**
+   * Set when the adapter detected upstream quota exhaustion. When
+   * present, the caller MUST NOT retry the turn — the provider's
+   * rate-limit window is the bottleneck, not the agent. Workflow
+   * callers halt the run and surface `resetAt` (if any) to the user;
+   * interactive callers print and exit. See `AgentResponse.quotaExhausted`
+   * in `src/docker/agent-adapter.ts` for the adapter-side contract this
+   * field is populated from.
+   */
+  readonly quotaExhausted?: {
+    readonly resetAt?: Date;
+    readonly rawMessage: string;
+  };
 }
 
 export interface Session {

--- a/src/workflow/errors.ts
+++ b/src/workflow/errors.ts
@@ -34,3 +34,37 @@ export class AgentInvocationError extends Error {
 export function isAgentInvocationError(err: unknown): err is AgentInvocationError {
   return err instanceof AgentInvocationError;
 }
+
+/**
+ * Thrown when the agent adapter reports upstream quota exhaustion for a
+ * state's turn. Distinct from a generic `Error` so M4's paused-phase
+ * handling (follow-up work) can intercept it cleanly and drive a
+ * `paused` terminal instead of the current `aborted` terminal.
+ *
+ * `resetAt` is the provider-advertised reset time when the adapter
+ * could parse one; `rawMessage` is the original provider/CLI text.
+ */
+export interface WorkflowQuotaExhaustedOptions {
+  readonly stateId: string;
+  readonly resetAt?: Date;
+  readonly rawMessage: string;
+}
+
+export class WorkflowQuotaExhaustedError extends Error {
+  readonly stateId: string;
+  readonly resetAt?: Date;
+  readonly rawMessage: string;
+
+  constructor(options: WorkflowQuotaExhaustedOptions) {
+    const resetHint = options.resetAt ? ` (resets at ${options.resetAt.toISOString()})` : '';
+    super(`Agent turn aborted: upstream quota exhausted${resetHint}`);
+    this.name = 'WorkflowQuotaExhaustedError';
+    this.stateId = options.stateId;
+    this.resetAt = options.resetAt;
+    this.rawMessage = options.rawMessage;
+  }
+}
+
+export function isWorkflowQuotaExhaustedError(err: unknown): err is WorkflowQuotaExhaustedError {
+  return err instanceof WorkflowQuotaExhaustedError;
+}

--- a/src/workflow/message-log.ts
+++ b/src/workflow/message-log.ts
@@ -63,6 +63,21 @@ export interface StateTransitionEntry extends BaseEntry {
   readonly event: string;
 }
 
+/**
+ * Emitted when the adapter detected upstream quota exhaustion and the
+ * orchestrator halted the run instead of retrying. `resetAt` is the
+ * ISO-formatted provider-advertised reset time when the adapter could
+ * parse one; absent when the provider did not supply a machine-readable
+ * timestamp. `rawMessage` preserves the original provider/CLI text for
+ * humans inspecting the log.
+ */
+export interface QuotaExhaustedEntry extends BaseEntry {
+  readonly type: 'quota_exhausted';
+  readonly role: string;
+  readonly resetAt?: string;
+  readonly rawMessage: string;
+}
+
 /** Discriminated union of all log entry types. */
 export type MessageLogEntry =
   | AgentSentEntry
@@ -71,7 +86,8 @@ export type MessageLogEntry =
   | GateRaisedEntry
   | GateResolvedEntry
   | ErrorEntry
-  | StateTransitionEntry;
+  | StateTransitionEntry
+  | QuotaExhaustedEntry;
 
 // ---------------------------------------------------------------------------
 // MessageLog

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -73,7 +73,7 @@ import { buildAgentCommand, buildArtifactReprompt, buildStatusInstructions } fro
 import { collectFilesRecursive, hasAnyFiles, snapshotArtifacts } from './artifacts.js';
 import { validateDefinition } from './validate.js';
 import { parseDefinitionFile } from './discovery.js';
-import { AgentInvocationError, WorkflowQuotaExhaustedError } from './errors.js';
+import { AgentInvocationError, WorkflowQuotaExhaustedError, isWorkflowQuotaExhaustedError } from './errors.js';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -407,6 +407,16 @@ interface WorkflowInstance {
    * post-teardown leak assertion.
    */
   aborted: boolean;
+  /**
+   * Stamped by `throwIfQuotaExhausted` when an agent turn reports
+   * upstream quota exhaustion. `handleWorkflowComplete` consults this
+   * to force an abort-like terminal phase and preserve the checkpoint,
+   * regardless of which state the error target resolved to — so resume
+   * still works for workflow definitions whose error target happens to
+   * be a normal terminal (e.g. `done`) rather than `aborted`/`failed`.
+   * Survives only in-process; the checkpoint itself does not record it.
+   */
+  quotaExhausted?: { readonly resetAt?: Date; readonly rawMessage: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -1533,6 +1543,12 @@ export class WorkflowOrchestrator implements WorkflowController {
             resetAt: resetAt?.toISOString(),
             rawMessage,
           });
+          // Stamp the instance before throwing so `handleWorkflowComplete`
+          // can force an abort-preserving terminal regardless of which
+          // state the onError target resolves to — protects checkpoint
+          // retention for workflow definitions whose error target happens
+          // to be a normal terminal (e.g. `done`).
+          instance.quotaExhausted = { resetAt, rawMessage };
           throw new WorkflowQuotaExhaustedError({ stateId, resetAt, rawMessage });
         }
         return result;
@@ -1693,12 +1709,20 @@ export class WorkflowOrchestrator implements WorkflowController {
         responseText,
       };
     } catch (err) {
-      instance.messageLog.append({
-        ...this.logBase(instance),
-        type: 'error',
-        error: toErrorMessage(err),
-        context: `agent "${stateId}" (persona: ${stateConfig.persona})`,
-      });
+      // Quota exhaustion already produced its own structured
+      // `quota_exhausted` log entry inside `sendAgentTurn`; appending a
+      // generic `error` entry here would double-log the same event and
+      // make `workflow inspect` surface both a yellow quota line and a
+      // red error line for the same failure. Suppress the generic entry
+      // when the cause is a `WorkflowQuotaExhaustedError`.
+      if (!isWorkflowQuotaExhaustedError(err)) {
+        instance.messageLog.append({
+          ...this.logBase(instance),
+          type: 'error',
+          error: toErrorMessage(err),
+          context: `agent "${stateId}" (persona: ${stateConfig.persona})`,
+        });
+      }
       throw new AgentInvocationError({ stateId, agentConversationId: currentConversationId, cause: err });
     } finally {
       instance.activeSessions.delete(session);
@@ -1812,9 +1836,23 @@ export class WorkflowOrchestrator implements WorkflowController {
     // are noisy).
     if (instance.finalStatus) return;
 
-    // Check if this is a normal completion or an aborted terminal
+    // Check if this is a normal completion or an aborted terminal.
+    // Quota exhaustion takes precedence: the error target may have
+    // resolved to any terminal (including `done`-like ones), but a run
+    // that died on upstream quota MUST be treated as aborted so the
+    // checkpoint is preserved and the user can resume once the provider
+    // window reopens. (M4 will upgrade this to a dedicated `paused`
+    // phase; for now `aborted` gives us the same checkpoint retention.)
     const stateValue = instance.currentState;
-    if (stateValue === 'aborted' || stateValue.includes('abort')) {
+    if (instance.quotaExhausted) {
+      const resetHint = instance.quotaExhausted.resetAt
+        ? ` (resets at ${instance.quotaExhausted.resetAt.toISOString()})`
+        : '';
+      instance.finalStatus = {
+        phase: 'aborted',
+        reason: `Upstream quota exhausted${resetHint}`,
+      };
+    } else if (stateValue === 'aborted' || stateValue.includes('abort')) {
       instance.finalStatus = {
         phase: 'aborted',
         reason: 'Workflow reached aborted state',

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -43,7 +43,14 @@ import { POLICY_LOAD_PATH } from '../trusted-process/control-server.js';
 import { loadConfig } from '../config/index.js';
 import { getPersonaDefinitionPath, resolvePersona } from '../persona/resolve.js';
 import { createPersonaName } from '../persona/types.js';
-import type { AgentConversationId, BundleId, Session, SessionOptions, SessionMode } from '../session/types.js';
+import type {
+  AgentConversationId,
+  AgentTurnResult,
+  BundleId,
+  Session,
+  SessionOptions,
+  SessionMode,
+} from '../session/types.js';
 import { createAgentConversationId, createBundleId } from '../session/types.js';
 import type { AgentId } from '../docker/agent-adapter.js';
 import { ensureSecureBundleDir, type DockerInfrastructure } from '../docker/docker-infrastructure.js';
@@ -66,7 +73,7 @@ import { buildAgentCommand, buildArtifactReprompt, buildStatusInstructions } fro
 import { collectFilesRecursive, hasAnyFiles, snapshotArtifacts } from './artifacts.js';
 import { validateDefinition } from './validate.js';
 import { parseDefinitionFile } from './discovery.js';
-import { AgentInvocationError } from './errors.js';
+import { AgentInvocationError, WorkflowQuotaExhaustedError } from './errors.js';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -1313,6 +1320,24 @@ export class WorkflowOrchestrator implements WorkflowController {
   // Agent state execution
   // -----------------------------------------------------------------------
 
+  // TODO(refactor): this method is ~230 lines and carries three
+  // invocation-scoped closures (`logReceived`, `logAgentRetry`,
+  // `sendAgentTurn`) that all capture the same bundle of state —
+  // `session`, `instance`, `stateConfig`, `stateId`, `messageLog`, and
+  // `this`. The closure pattern is idiomatic here only because every
+  // alternative (methods, helpers) would propagate that bundle through
+  // 5–6 parameters per site.
+  //
+  // The right fix is to extract the whole turn-handling pipeline
+  // (send/parse/retry/reprompt + the three log helpers) into a
+  // dedicated class — e.g. `AgentTurnRunner` — constructed once per
+  // invocation with the shared state injected. That shrinks this
+  // method from ~230 lines to ~80, and makes turn handling
+  // unit-testable in isolation (today it is reachable only through
+  // end-to-end workflow tests). Pair the extraction with a review of
+  // `AgentInvocationError` wrapping so the conversation-id recovery
+  // semantics survive the move. Worth doing as its own PR; do NOT
+  // fold it into a feature change.
   private async executeAgentState(
     workflowId: WorkflowId,
     input: AgentInvokeInput,
@@ -1482,6 +1507,37 @@ export class WorkflowOrchestrator implements WorkflowController {
         });
       };
 
+      // Uniform agent-turn entrypoint: every prompt and reprompt must flow
+      // through here so the quota-exhaustion short-circuit applies to ALL
+      // of them. Retrying or reprompting a turn whose adapter reported
+      // quota exhaustion would only burn more of the already-exhausted
+      // budget — instead we log a `quota_exhausted` event once and throw
+      // a dedicated error so higher layers can distinguish "paused by
+      // provider" from "aborted by bug" (today both abort; M4 turns this
+      // into a `paused` terminal phase without touching here).
+      //
+      // Sessions without `sendMessageDetailed` (e.g., built-in in-process
+      // sessions) degrade cleanly to `sendMessage`, which cannot produce
+      // a quota signal — the short-circuit simply never fires for them.
+      const sendAgentTurn = async (msg: string): Promise<AgentTurnResult> => {
+        const result = session.sendMessageDetailed
+          ? await session.sendMessageDetailed(msg)
+          : { text: await session.sendMessage(msg), hardFailure: false };
+        if (result.quotaExhausted) {
+          const { resetAt, rawMessage } = result.quotaExhausted;
+          logReceived(result.text, undefined);
+          messageLog.append({
+            ...this.logBase(instance),
+            type: 'quota_exhausted',
+            role: stateConfig.persona,
+            resetAt: resetAt?.toISOString(),
+            rawMessage,
+          });
+          throw new WorkflowQuotaExhaustedError({ stateId, resetAt, rawMessage });
+        }
+        return result;
+      };
+
       messageLog.append({
         ...this.logBase(instance),
         type: 'agent_sent',
@@ -1509,13 +1565,7 @@ export class WorkflowOrchestrator implements WorkflowController {
       const MAX_HARD_RETRIES = 2;
       let responseText = '';
       for (let attempt = 0; attempt <= MAX_HARD_RETRIES; attempt++) {
-        // `sendMessageDetailed` is optional on the Session interface.
-        // Sessions that can't produce hard failures (e.g., built-in
-        // in-process sessions) don't implement it — fall back to
-        // `sendMessage` and surface `hardFailure: false`.
-        const result = session.sendMessageDetailed
-          ? await session.sendMessageDetailed(command)
-          : { text: await session.sendMessage(command), hardFailure: false };
+        const result = await sendAgentTurn(command);
         responseText = result.text;
         if (!result.hardFailure) break;
 
@@ -1550,7 +1600,7 @@ export class WorkflowOrchestrator implements WorkflowController {
           retryMsg,
         );
 
-        responseText = await session.sendMessage(retryMsg);
+        responseText = (await sendAgentTurn(retryMsg)).text;
         parseResult = tryParseAgentStatus(responseText);
         logReceived(responseText, parseResult.kind === 'ok' ? parseResult.output : undefined);
 
@@ -1576,7 +1626,7 @@ export class WorkflowOrchestrator implements WorkflowController {
           retryMsg,
         );
 
-        responseText = await session.sendMessage(retryMsg);
+        responseText = (await sendAgentTurn(retryMsg)).text;
         const retryParse = tryParseAgentStatus(responseText);
         logReceived(responseText, retryParse.kind === 'ok' ? retryParse.output : undefined);
 
@@ -1606,7 +1656,7 @@ export class WorkflowOrchestrator implements WorkflowController {
         const artifactRetryMsg = buildArtifactReprompt(missingArtifacts, stateConfig.transitions);
         logAgentRetry('missing_artifacts', `Missing: ${missingArtifacts.join(', ')}`, artifactRetryMsg);
 
-        const retryResponse = await session.sendMessage(artifactRetryMsg);
+        const retryResponse = (await sendAgentTurn(artifactRetryMsg)).text;
         const retryParse = tryParseAgentStatus(retryResponse);
         if (retryParse.kind === 'ok') {
           logReceived(retryResponse, retryParse.output);

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -1114,11 +1114,9 @@ export class WorkflowOrchestrator implements WorkflowController {
     // are closed. Error-tolerant (see destroyWorkflowInfrastructure).
     await this.destroyWorkflowInfrastructure(instance);
 
-    try {
-      this.deps.checkpointStore.remove(id);
-    } catch (err) {
-      writeStderr(`[workflow] Failed to remove checkpoint on abort for ${id}: ${toErrorMessage(err)}`);
-    }
+    // Intentionally leave the checkpoint in place: a user-triggered abort
+    // should remain resumable via `workflow resume`. The checkpoint is only
+    // removed on successful completion (see handleWorkflowComplete).
 
     instance.tab.write('[aborted]');
     instance.tab.close();
@@ -1222,7 +1220,14 @@ export class WorkflowOrchestrator implements WorkflowController {
           agentMessage,
         });
         instance.stateEnteredAt = now;
-        this.saveCheckpoint(instance, snapshot);
+
+        // Skip checkpointing transitions into terminal states. On successful
+        // completion `handleWorkflowComplete` removes the checkpoint anyway;
+        // on abort we want the surviving checkpoint to point at the last
+        // non-terminal state so `resume()` can restart the run meaningfully.
+        if (!this.isTerminalStateValue(definition, stateValue)) {
+          this.saveCheckpoint(instance, snapshot);
+        }
 
         instance.messageLog.append({
           ...this.logBase(instance),
@@ -1276,6 +1281,17 @@ export class WorkflowOrchestrator implements WorkflowController {
   // -----------------------------------------------------------------------
   // Checkpointing
   // -----------------------------------------------------------------------
+
+  /**
+   * Returns true if `stateValue` names a terminal state in the workflow
+   * definition. Used to skip checkpointing on the final transition so the
+   * last on-disk checkpoint points at the last non-terminal state (important
+   * for resume-after-abort, which would otherwise reload an `aborted`
+   * snapshot and immediately re-terminate).
+   */
+  private isTerminalStateValue(definition: WorkflowDefinition, stateValue: string): boolean {
+    return definition.states[stateValue].type === 'terminal';
+  }
 
   private saveCheckpoint(instance: WorkflowInstance, snapshot: { value: unknown; context: unknown }): void {
     const checkpoint: WorkflowCheckpoint = {
@@ -1761,10 +1777,15 @@ export class WorkflowOrchestrator implements WorkflowController {
       };
     }
 
-    try {
-      this.deps.checkpointStore.remove(workflowId);
-    } catch (err) {
-      writeStderr(`[workflow] Failed to remove checkpoint for ${workflowId}: ${toErrorMessage(err)}`);
+    // Only remove the checkpoint when the workflow completes successfully.
+    // Aborted runs keep their checkpoint on disk so `workflow resume` can
+    // restart them from the last saved state.
+    if (instance.finalStatus.phase === 'completed') {
+      try {
+        this.deps.checkpointStore.remove(workflowId);
+      } catch (err) {
+        writeStderr(`[workflow] Failed to remove checkpoint for ${workflowId}: ${toErrorMessage(err)}`);
+      }
     }
 
     instance.tab.write(`[done] ${instance.finalStatus.phase}`);

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -40,6 +40,7 @@ import {
   DIM,
   MAGENTA,
   CYAN,
+  YELLOW,
   RESET,
 } from './cli-support.js';
 
@@ -520,6 +521,11 @@ function runInspect(args: string[]): void {
             break;
           case 'error':
             writeStdout(`${prefix} ${RED}[error]${RESET} ${entry.error}`);
+            break;
+          case 'quota_exhausted':
+            writeStdout(
+              `${prefix} ${YELLOW}[quota/${entry.role}]${RESET} resets=${entry.resetAt ?? 'unknown'} — ${truncate(entry.rawMessage, 80)}`,
+            );
             break;
           case 'state_transition': {
             const toDesc = stateDescriptions?.get(entry.event);

--- a/src/workflow/workflows/vuln-discovery.yaml
+++ b/src/workflow/workflows/vuln-discovery.yaml
@@ -141,34 +141,65 @@ states:
 
       On each invocation: update the status header in-place, then APPEND a new round section at the end. Never edit or delete previous round sections — they are the investigation's permanent record.
 
-      After updating the journal, decide the next action by setting your verdict to one of these routing values:
-
-      | Verdict | Destination | When to use |
-      |---------|-------------|-------------|
-      | harness_design | harness_design | Build or upgrade a harness. Your directive MUST specify the tier (see below). |
-      | discover | discover | Run hypothesis-driven research using an existing working harness. |
-      | differential_validate | differential_validate | Harness test diverges from expected behavior. |
-      | escalate | human_escalation | Investigation is stuck. Describe what was tried and what you need. |
-      | triage | triage | Enough evidence collected for independent validation. |
-      | complete | conclude | Investigation finished — vulnerability confirmed and triaged, OR thorough search completed with no findings. |
-      | reanalyze | analyze | Need the structural analysis expanded. Your directive tells analyze what to focus on. |
-
-      ## State responsibilities — scope, don't duplicate
+      After updating the journal, decide the next action by setting your verdict. The sections below describe every state the orchestrator can dispatch to, one section each.
 
       Every downstream state has its OWN detailed prompt covering the methodology it uses. Your directive must NOT re-specify that methodology — the state's prompt already covers it, and duplicating it creates tension and wastes tokens. Your directive should supply what is SPECIFIC to this invocation: the target, the hypothesis, the focus area, any human feedback, and WHY this state is being routed to now.
 
-      Phase dictionary — what each state already handles per its own prompt:
+      ## Routing decisions
 
-      | State | Handles per its own prompt | Your directive should supply |
-      |-------|----------------------------|-----------------------------|
-      | analyze | Function catalog, cross-cutting data flow, call graphs, type narrowing, sentinel reachability, check-use separation, assumption inventory | Target code path, any specific focus (e.g., "the initial analysis missed X, look deeper at Y") |
-      | harness_design | Tier structure (1/2/3), fuzzing requirements, systematic input sweeping, design-only scope (separate from build) | Hypothesis, tier, component scope, WHY this tier |
-      | harness_build | Installing dependencies, building with sanitizers, implementing the design | Nothing extra — it reads the design doc |
-      | harness_validate | Reachability checks, coverage verification, baseline testing | Nothing extra — it reads the build output |
-      | discover | Hypothesis-driven experimentation, running harness, reading coverage, iterating inputs | The hypothesis to test and any specific trigger conditions from prior rounds |
-      | differential_validate | Diagnosing divergences between tiers or live system behavior | What diverged and what hypothesis to test |
-      | triage | Independent reproduction, severity, exploitability, duplicate checking | Nothing extra — reads findings |
-      | conclude | Writing the final report from artifacts | Nothing extra — reads all artifacts |
+      One subsection per state the orchestrator can dispatch to. `harness_build` and `harness_validate` are NOT listed — the orchestrator does not route to them directly; they run inside the harness pipeline and hand control back to the orchestrator only after `harness_validate` approves.
+
+      ### `analyze` — verdict: `reanalyze`
+
+      - **When:** Need the structural analysis expanded.
+      - **Directive must supply:** Target code path, any specific focus (e.g., "the initial analysis missed X, look deeper at Y").
+
+      ### `harness_design` — verdict: `harness_design`
+
+      - **When:** Build or upgrade a harness. Directive MUST specify the tier (see Tiered harness strategy below).
+      - **Directive must supply:** Hypothesis, tier, component scope, WHY this tier. Do NOT prescribe specific test cases, fixed input values, or enumerated scenarios (T1, T2, T3...) — that is `harness_design`'s job. Trust the downstream agent to pick the sweep strategy given the hypothesis you describe.
+      - **Audit on return** (after `harness_validate` approves and control comes back to the orchestrator): confirm validation showed the target function reached with non-zero coverage.
+
+      ### `discover` — verdict: `discover`
+
+      - **When:** Run hypothesis-driven research using an existing working harness.
+      - **Directive must supply:** The hypothesis to test and any specific trigger conditions from prior rounds.
+      - **Audit on return** depends on the verdict discover produced:
+
+        **If discover returned `approved` (confirmed):** route to `triage` if the evidence is solid, or back to `discover` for more evidence if it is thin.
+
+        **If discover returned `blocked` (mitigated or exhausted):** the "mitigated" claim is only authoritative when BOTH of these hold:
+        - The tier matched the hypothesis scope — cross-component hypotheses require Tier 2+.
+        - Evidence shows execution, not reasoning: coverage of the mitigation code AND a completed input sweep over the hypothesis's value range (fuzzing for value-dependent claims, bounded enumeration for discrete claims).
+
+        Textual reasoning about why the code looks safe is NOT sufficient evidence. If the evidence is text-only, re-route to `discover` with a directive to exercise the mitigation, or to `harness_design` at a higher tier if the harness cannot exercise it.
+
+        **If discover returned `rejected` (couldn't run):**
+        - Coverage shows the target function IS reached but the condition doesn't fire → `differential_validate` (values need adjustment for the live context: protocol encoding, byte order, framing).
+        - Coverage shows the target function is NOT reached → `harness_design` at a higher tier (reachability problem).
+        - Discover agent couldn't run the harness at all → `harness_design` (infrastructure problem).
+
+      ### `differential_validate` — verdict: `differential_validate`
+
+      - **When:** Harness test diverges from expected behavior.
+      - **Directive must supply:** What diverged and what hypothesis to test.
+
+      ### `human_escalation` — verdict: `escalate`
+
+      - **When:** Investigation is stuck.
+      - **Directive must supply:** Describe what was tried and what you need from the human.
+      - **Return:** via human events (APPROVE / FORCE_REVISION / ABORT), not verdicts.
+
+      ### `triage` — verdict: `triage`
+
+      - **When:** Enough evidence collected for independent validation.
+      - **Directive must supply:** Nothing extra — reads findings.
+
+      ### `conclude` — verdict: `complete`
+
+      - **When:** Investigation finished — vulnerability confirmed and triaged, OR thorough search completed with no findings.
+      - **Directive must supply:** Nothing extra — reads all artifacts.
+      - **Return:** terminal, no return.
 
       **Feedback-driven directives.** When human feedback or prior-round evidence changes the focus, your directive should point the next agent AT the specific thing to investigate, not prescribe how to investigate it. Example shape: "Re-analyze focusing on the interaction between [function A] and [data structure B] — prior round missed [the specific case]." Let the agent's prompt drive HOW.
 
@@ -188,20 +219,7 @@ states:
       - Hypothesis requires real initialization, protocol framing, or global state → Tier 3
       Never use Tier 1 for a cross-component hypothesis. If in doubt, go higher.
 
-      **Accepting a "mitigated" verdict.** A downstream agent's "mitigated" is only authoritative if two conditions both hold:
-      - The tier matched the hypothesis scope (Tier 2+ for cross-component, etc.). If the tier was too low, re-route to harness_design at the next tier — don't judge the test, just compare tier to scope.
-      - The evidence shows execution: coverage of the mitigation code AND a completed input sweep over the hypothesis's value range (fuzzing for value-dependent claims, bounded enumeration for discrete claims). Textual reasoning about why the code looks safe is NOT sufficient evidence. If the evidence is text-only, re-route to discover with a directive to exercise the mitigation, or to harness_design if the harness cannot exercise it.
-
-      A "confirmed" verdict at any tier → discover or triage depending on evidence strength.
-
-      **The orchestrator scopes, harness_design designs.** When routing to harness_design, specify the hypothesis, the tier, the component scope, and WHY this tier was chosen. Do NOT prescribe specific test cases, fixed input values, or enumerated scenarios (T1, T2, T3...) — that is harness_design's job. The designer is instructed to fuzz the input space; your prescriptive test list would defeat that. Trust the downstream agent to pick the right sweep strategy given the hypothesis you describe.
-
       ## Strategic principles
-
-      **Diagnosing failures.** When the discover agent reports that trigger values don't work through the live harness:
-      - If coverage shows the target function IS reached but the condition doesn't fire → the values need adjustment for the live context (protocol encoding, byte order, framing). Route to differential_validate.
-      - If coverage shows the target function is NOT reached → the harness has a reachability problem. Route to harness_design for redesign at a higher tier.
-      - If the discover agent couldn't run the harness at all → infrastructure problem. Route to harness_design.
 
       IMPORTANT: Always update `.workflow/journal/journal.md` before setting your verdict. The journal is the persistent memory of this investigation — your conversation history may be long but the journal is the structured summary.
 
@@ -574,11 +592,12 @@ states:
       - **rejected**: The harness is insufficient — can't reach the target, missing protocol feature, broken infrastructure.
       - **blocked**: Hypothesis did not fire despite a completed search. You may only return `blocked` if (a) coverage shows the target code was executed, AND (b) you swept the input range relevant to the hypothesis — fuzzing for value-dependent claims (sizes, offsets, indices, counters), bounded enumeration for discrete claims (protocol states, flag combinations, auth paths). "I read the code and it looks mitigated" is not `blocked` — it's `rejected` with a request to redesign the harness. If neither fuzzing nor enumeration applies to this hypothesis, name the reason explicitly in your findings doc.
 
-      Write findings to `.workflow/discoveries/findings.md`.
+      Write findings to `.workflow/discoveries/findings.md`. Append after each experiment (hypothesis, input, harness command, result) before starting the next one — do not batch writes to the end, so a crash or rate-limit preserves the round's work. If the file already exists from a prior run, read it first and skip experiments whose results are already recorded.
     inputs:
       - analysis
       - harness_build
       - journal
+      - discoveries?
     outputs:
       - discoveries
     transitions:

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -197,6 +197,57 @@ describe('Claude Code Adapter', () => {
     expect(response.costUsd).toBeUndefined();
   });
 
+  it('surfaces quotaExhausted with resetAt from Claude Code 429 envelope', () => {
+    // Mirrors the envelope observed in the failed workflow run
+    // e82b98ea-3195-412c-a6f7-669004f059ff that motivated this code path.
+    const envelope = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      api_error_status: 429,
+      result:
+        'API Error: Server is temporarily limiting requests (not your usage limit) · ' +
+        '{"error":{"code":"1308","message":"Usage limit reached for 5 hour. Your limit will reset at 2026-04-22 18:27:36"}}',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.quotaExhausted).toBeDefined();
+    expect(response.quotaExhausted!.rawMessage).toContain('Usage limit reached');
+    expect(response.quotaExhausted!.resetAt).toEqual(new Date('2026-04-22T18:27:36Z'));
+    // The turn's `text` surfaces the raw message so CLI output stays readable.
+    expect(response.text).toContain('Usage limit reached');
+    // Quota exhaustion must NOT route through the hardFailure retry path.
+    expect(response.hardFailure).toBeUndefined();
+  });
+
+  it('surfaces quotaExhausted without resetAt when timestamp is unparseable', () => {
+    const envelope = JSON.stringify({
+      is_error: true,
+      api_error_status: 429,
+      result: 'Rate limit exceeded. Try again later.',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.quotaExhausted).toBeDefined();
+    expect(response.quotaExhausted!.rawMessage).toBe('Rate limit exceeded. Try again later.');
+    expect(response.quotaExhausted!.resetAt).toBeUndefined();
+  });
+
+  it('does not flag quotaExhausted when is_error is set without api_error_status 429', () => {
+    // Guards against false positives: other error classes (500s, auth
+    // failures) must NOT route to the quota-pause path.
+    const envelope = JSON.stringify({
+      is_error: true,
+      api_error_status: 500,
+      result: 'Internal error',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.quotaExhausted).toBeUndefined();
+  });
+
+  it('does not flag quotaExhausted when non-zero exit stdout is not JSON', () => {
+    const response = claudeCodeAdapter.extractResponse(1, 'plain text crash output');
+    expect(response.quotaExhausted).toBeUndefined();
+  });
+
   it('returns conversation state config for session resume', () => {
     const config = claudeCodeAdapter.getConversationStateConfig!();
     expect(config.hostDirName).toBe('claude-state');

--- a/test/workflow/orchestrator-quota.test.ts
+++ b/test/workflow/orchestrator-quota.test.ts
@@ -34,6 +34,7 @@ import {
   findWorkflowDir,
   writeDefinitionFile,
   createDeps,
+  createCheckpointStore,
   waitForCompletion,
   stubPersonasForTest,
 } from './test-helpers.js';
@@ -89,7 +90,7 @@ describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
     rmSync(ckptDir, { recursive: true, force: true });
   });
 
-  it('halts immediately when the primary turn reports quotaExhausted', async () => {
+  it('halts immediately when the primary turn reports quotaExhausted, preserves checkpoint, and does not double-log', async () => {
     const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
     const allSessions: MockSession[] = [];
 
@@ -107,16 +108,33 @@ describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
       return session;
     });
 
-    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    // Share the checkpoint store with the orchestrator so we can verify
+    // it was NOT cleared after quota exhaustion.
+    const checkpointStore = createCheckpointStore(tmpDir);
+    const deps = createDeps(tmpDir, { createSession: sessionFactory, checkpointStore });
     const orchestrator = new WorkflowOrchestrator(deps);
     activeOrchestrator = orchestrator;
 
     const workflowId = await orchestrator.start(defPath, 'write code');
     await waitForCompletion(orchestrator, workflowId);
 
-    // The workflow routes to onError's fallback terminal (see
-    // orchestrator-retry.test.ts for why this lands on 'completed').
-    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+    // Quota exhaustion must force an abort-like phase regardless of which
+    // terminal the state's `onError` target resolved to. This simple
+    // workflow has no `aborted`/`failed` terminal, so `findErrorTarget`
+    // would otherwise route to `done` and `handleWorkflowComplete` would
+    // mark the run as `completed` and delete the checkpoint — breaking
+    // resume. The `instance.quotaExhausted` check in
+    // `handleWorkflowComplete` is what keeps this from happening.
+    const status = orchestrator.getStatus(workflowId);
+    expect(status?.phase).toBe('aborted');
+    if (status?.phase === 'aborted') {
+      expect(status.reason).toContain('quota');
+      expect(status.reason).toContain(RESET_AT.toISOString());
+    }
+
+    // Checkpoint MUST be preserved so `workflow resume` works once the
+    // provider window reopens.
+    expect(checkpointStore.load(workflowId)).not.toBeNull();
 
     // Exactly ONE turn — no hard-retry rotation, no missing-status-block
     // reprompt. Any further sends would burn the exhausted budget.
@@ -131,6 +149,13 @@ describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
     expect(quotaEntries[0].role).toBe('coder');
     expect(quotaEntries[0].rawMessage).toBe(RAW_MESSAGE);
     expect(quotaEntries[0].resetAt).toBe(RESET_AT.toISOString());
+
+    // Concern #2 regression guard: no generic `error` entry should be
+    // appended alongside the quota_exhausted entry. `workflow inspect`
+    // must show a single structured quota line, not a duplicate red
+    // error line for the same event.
+    const errorEntries = log.filter((e) => e.type === 'error');
+    expect(errorEntries).toHaveLength(0);
   });
 
   it('prefers the quota short-circuit over the hard-retry loop when both signals are set', async () => {
@@ -161,7 +186,7 @@ describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
     const workflowId = await orchestrator.start(defPath, 'write code');
     await waitForCompletion(orchestrator, workflowId);
 
-    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
 
     const session = allSessions[0];
     // The quota check runs BEFORE the hard-retry loop, so only one turn
@@ -216,7 +241,7 @@ describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
     const workflowId = await orchestrator.start(defPath, 'write code');
     await waitForCompletion(orchestrator, workflowId);
 
-    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
 
     const session = allSessions[0];
     // Exactly two turns: the primary + the reprompt that quota-exhausted.
@@ -255,7 +280,7 @@ describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
     const workflowId = await orchestrator.start(defPath, 'write code');
     await waitForCompletion(orchestrator, workflowId);
 
-    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
 
     const log = readMessageLog(tmpDir);
     const quotaEntries = log.filter((e): e is QuotaExhaustedEntry => e.type === 'quota_exhausted');

--- a/test/workflow/orchestrator-quota.test.ts
+++ b/test/workflow/orchestrator-quota.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Orchestrator quota-exhaustion short-circuit tests.
+ *
+ * Paired with `test/docker-agent-adapter.test.ts` which covers the
+ * adapter-level 429 envelope detection. These tests exercise the
+ * orchestrator-side contract:
+ *
+ *  - When `sendMessageDetailed()` returns `quotaExhausted`, the
+ *    orchestrator MUST halt the run immediately — no missing-status-block
+ *    reprompt, no hard-retry rotation. Retrying would only burn more of
+ *    the already-exhausted provider budget.
+ *  - The quota check runs before the hard-retry loop, so a response that
+ *    also sets `hardFailure: true` must NOT enter the retry loop.
+ *  - The short-circuit applies to every agent-turn site: the initial
+ *    command AND every reprompt (missing-status-block, invalid-verdict,
+ *    missing-artifacts). We spot-check the initial-command site and the
+ *    missing-status-block reprompt site; the four sites share the same
+ *    `sendAgentTurn` closure, so coverage of two is sufficient.
+ *  - A `quota_exhausted` entry lands in the message log with the
+ *    expected fields.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { WorkflowDefinition } from '../../src/workflow/types.js';
+import { WorkflowOrchestrator } from '../../src/workflow/orchestrator.js';
+import type { MessageLogEntry, QuotaExhaustedEntry } from '../../src/workflow/message-log.js';
+import {
+  MockSession,
+  noStatusResponse,
+  simulateArtifacts,
+  findWorkflowDir,
+  writeDefinitionFile,
+  createDeps,
+  waitForCompletion,
+  stubPersonasForTest,
+} from './test-helpers.js';
+
+const simpleAgentDef: WorkflowDefinition = {
+  name: 'simple-agent',
+  description: 'Single agent to done',
+  initial: 'implement',
+  settings: { mode: 'builtin' },
+  states: {
+    implement: {
+      type: 'agent',
+      description: 'Writes code',
+      persona: 'coder',
+      prompt: 'You are a coder.',
+      inputs: [],
+      outputs: ['code'],
+      transitions: [{ to: 'done' }],
+    },
+    done: { type: 'terminal', description: 'Done' },
+  },
+};
+
+const RESET_AT = new Date('2026-04-22T18:27:36Z');
+const RAW_MESSAGE = 'Usage limit reached. Resets at 18:27 UTC.';
+
+function readMessageLog(baseDir: string): MessageLogEntry[] {
+  const logPath = resolve(findWorkflowDir(baseDir), 'messages.jsonl');
+  if (!existsSync(logPath)) return [];
+  const lines = readFileSync(logPath, 'utf-8').split('\n').filter(Boolean);
+  return lines.map((l) => JSON.parse(l) as MessageLogEntry);
+}
+
+describe('WorkflowOrchestrator quota-exhaustion short-circuit', () => {
+  let tmpDir: string;
+  let activeOrchestrator: WorkflowOrchestrator | undefined;
+  let cleanupPersonas: (() => void) | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'orchestrator-quota-test-'));
+    activeOrchestrator = undefined;
+    cleanupPersonas = stubPersonasForTest(tmpDir, simpleAgentDef);
+  });
+
+  afterEach(async () => {
+    if (activeOrchestrator) {
+      await activeOrchestrator.shutdownAll();
+    }
+    cleanupPersonas?.();
+    rmSync(tmpDir, { recursive: true, force: true });
+    const baseName = resolve(tmpDir).split('/').pop()!;
+    const ckptDir = resolve(tmpDir, '..', `${baseName}-ckpt`);
+    rmSync(ckptDir, { recursive: true, force: true });
+  });
+
+  it('halts immediately when the primary turn reports quotaExhausted', async () => {
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const allSessions: MockSession[] = [];
+
+    const sessionFactory = vi.fn(async () => {
+      const session = new MockSession({
+        responses: [
+          {
+            text: 'Agent stopped mid-stream.',
+            hardFailure: false,
+            quotaExhausted: { resetAt: RESET_AT, rawMessage: RAW_MESSAGE },
+          },
+        ],
+      });
+      allSessions.push(session);
+      return session;
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = new WorkflowOrchestrator(deps);
+    activeOrchestrator = orchestrator;
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    // The workflow routes to onError's fallback terminal (see
+    // orchestrator-retry.test.ts for why this lands on 'completed').
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+
+    // Exactly ONE turn — no hard-retry rotation, no missing-status-block
+    // reprompt. Any further sends would burn the exhausted budget.
+    const session = allSessions[0];
+    expect(session.sentMessages).toHaveLength(1);
+    expect(session.rotateCalls).toEqual([]);
+
+    // A quota_exhausted entry lands in the message log with the expected fields.
+    const log = readMessageLog(tmpDir);
+    const quotaEntries = log.filter((e): e is QuotaExhaustedEntry => e.type === 'quota_exhausted');
+    expect(quotaEntries).toHaveLength(1);
+    expect(quotaEntries[0].role).toBe('coder');
+    expect(quotaEntries[0].rawMessage).toBe(RAW_MESSAGE);
+    expect(quotaEntries[0].resetAt).toBe(RESET_AT.toISOString());
+  });
+
+  it('prefers the quota short-circuit over the hard-retry loop when both signals are set', async () => {
+    // Regression guard: if the orchestrator checked `hardFailure` before
+    // `quotaExhausted`, a concurrent hard-failure would drive the retry
+    // loop and burn 2 more turns of exhausted quota.
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const allSessions: MockSession[] = [];
+
+    const sessionFactory = vi.fn(async () => {
+      const session = new MockSession({
+        responses: [
+          {
+            text: '',
+            hardFailure: true,
+            quotaExhausted: { resetAt: RESET_AT, rawMessage: RAW_MESSAGE },
+          },
+        ],
+      });
+      allSessions.push(session);
+      return session;
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = new WorkflowOrchestrator(deps);
+    activeOrchestrator = orchestrator;
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+
+    const session = allSessions[0];
+    // The quota check runs BEFORE the hard-retry loop, so only one turn
+    // is sent and no rotation occurs — despite hardFailure=true.
+    expect(session.sentMessages).toHaveLength(1);
+    expect(session.rotateCalls).toEqual([]);
+
+    const log = readMessageLog(tmpDir);
+    const quotaEntries = log.filter((e): e is QuotaExhaustedEntry => e.type === 'quota_exhausted');
+    expect(quotaEntries).toHaveLength(1);
+  });
+
+  it('halts when quotaExhausted surfaces on the missing-status-block reprompt', async () => {
+    // The missing-status-block reprompt site is one of four `sendAgentTurn`
+    // call sites. A quota signal surfacing on the reprompt (not the
+    // primary turn) must also short-circuit — otherwise we'd fall through
+    // to the "no status block after retry" error path and lose the
+    // structured signal.
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const allSessions: MockSession[] = [];
+
+    const sessionFactory = vi.fn(async () => {
+      let callCount = 0;
+      const session = new MockSession({
+        responses: () => {
+          callCount++;
+          if (callCount === 1) {
+            // Primary turn: produces text but no agent_status block,
+            // triggering the missing-status-block reprompt.
+            simulateArtifacts(findWorkflowDir(tmpDir), ['code']);
+            return noStatusResponse();
+          }
+          if (callCount === 2) {
+            // Reprompt turn: adapter reports quota exhaustion.
+            return {
+              text: 'Agent stopped mid-stream.',
+              hardFailure: false,
+              quotaExhausted: { resetAt: RESET_AT, rawMessage: RAW_MESSAGE },
+            };
+          }
+          throw new Error(`Unexpected call ${callCount} — reprompt should have short-circuited`);
+        },
+      });
+      allSessions.push(session);
+      return session;
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = new WorkflowOrchestrator(deps);
+    activeOrchestrator = orchestrator;
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+
+    const session = allSessions[0];
+    // Exactly two turns: the primary + the reprompt that quota-exhausted.
+    // No further sends (no third reprompt, no rotation).
+    expect(session.sentMessages).toHaveLength(2);
+    expect(session.rotateCalls).toEqual([]);
+
+    const log = readMessageLog(tmpDir);
+    const quotaEntries = log.filter((e): e is QuotaExhaustedEntry => e.type === 'quota_exhausted');
+    expect(quotaEntries).toHaveLength(1);
+    expect(quotaEntries[0].rawMessage).toBe(RAW_MESSAGE);
+  });
+
+  it('omits resetAt in the log entry when the adapter could not parse one', async () => {
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const allSessions: MockSession[] = [];
+
+    const sessionFactory = vi.fn(async () => {
+      const session = new MockSession({
+        responses: [
+          {
+            text: 'Agent stopped mid-stream.',
+            hardFailure: false,
+            quotaExhausted: { rawMessage: 'Rate limit exceeded. Try again later.' },
+          },
+        ],
+      });
+      allSessions.push(session);
+      return session;
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = new WorkflowOrchestrator(deps);
+    activeOrchestrator = orchestrator;
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+
+    const log = readMessageLog(tmpDir);
+    const quotaEntries = log.filter((e): e is QuotaExhaustedEntry => e.type === 'quota_exhausted');
+    expect(quotaEntries).toHaveLength(1);
+    expect(quotaEntries[0].resetAt).toBeUndefined();
+    expect(quotaEntries[0].rawMessage).toBe('Rate limit exceeded. Try again later.');
+  });
+});

--- a/test/workflow/orchestrator-resume.test.ts
+++ b/test/workflow/orchestrator-resume.test.ts
@@ -304,6 +304,79 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Test 2b: Aborted workflows keep their checkpoint so resume can restart them
+  // -----------------------------------------------------------------------
+
+  it('preserves checkpoint on user-invoked abort so resume can restart it', async () => {
+    const defPath = writeDefinitionFile(tmpDir, linearWorkflowDef);
+    const checkpointStore = createCheckpointStore(tmpDir);
+
+    const sessionFactory = vi.fn(async () => {
+      return createArtifactAwareSession([{ text: approvedResponse('plan done'), artifacts: ['plan'] }], tmpDir);
+    });
+
+    const raiseGate = vi.fn();
+    const deps = createDeps(tmpDir, {
+      createSession: sessionFactory,
+      raiseGate,
+      checkpointStore,
+    });
+
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+    const workflowId = await orchestrator.start(defPath, 'build a thing');
+
+    // Wait for plan_gate so a checkpoint is persisted.
+    await waitForGate(raiseGate, 1);
+    expect(checkpointStore.load(workflowId)).toBeDefined();
+
+    // User-invoked abort: should leave the checkpoint on disk.
+    await orchestrator.abort(workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
+    const surviving = checkpointStore.load(workflowId);
+    expect(surviving).toBeDefined();
+    expect(surviving!.machineState).toBe('plan_gate');
+  });
+
+  it('preserves checkpoint when workflow reaches aborted state via ABORT event', async () => {
+    const defPath = writeDefinitionFile(tmpDir, linearWorkflowDef);
+    const checkpointStore = createCheckpointStore(tmpDir);
+
+    const sessionFactory = vi.fn(async () => {
+      return createArtifactAwareSession([{ text: approvedResponse('plan done'), artifacts: ['plan'] }], tmpDir);
+    });
+
+    const raiseGate = vi.fn();
+    const deps = createDeps(tmpDir, {
+      createSession: sessionFactory,
+      raiseGate,
+      checkpointStore,
+    });
+
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+    const workflowId = await orchestrator.start(defPath, 'build a thing');
+
+    // Wait for plan_gate so a checkpoint is persisted.
+    await waitForGate(raiseGate, 1);
+    expect(checkpointStore.load(workflowId)).toBeDefined();
+
+    // Resolve the gate with ABORT, which drives the machine into the
+    // `aborted` terminal state via handleWorkflowComplete.
+    orchestrator.resolveGate(workflowId, { type: 'ABORT' });
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
+    // handleWorkflowComplete must not remove the checkpoint on abort, and
+    // the transition into the terminal `aborted` state must not overwrite
+    // the last checkpoint. The surviving checkpoint should therefore point
+    // at the pre-abort state (`plan_gate`) so `resume()` can restart the
+    // run meaningfully instead of reloading the terminal state.
+    const surviving = checkpointStore.load(workflowId);
+    expect(surviving).toBeDefined();
+    expect(surviving!.machineState).toBe('plan_gate');
+  });
+
+  // -----------------------------------------------------------------------
   // Test 3: Resume a failed workflow from checkpoint
   // -----------------------------------------------------------------------
 
@@ -340,12 +413,13 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
     expect(checkpoint).toBeDefined();
     expect(checkpoint!.machineState).toBe('error_gate');
 
-    // Simulate orchestrator crash by shutting down (which removes checkpoint via abort)
-    // Save checkpoint state before shutdown
+    // Simulate an orchestrator crash by shutting down. Clean abort now
+    // preserves the checkpoint, but we still re-save the snapshot to be
+    // explicit about the state under test (a real crash where the process
+    // died without even running the abort path).
     const savedCheckpoint = { ...checkpoint! };
     await orchestrator1.shutdownAll();
 
-    // Re-save checkpoint to simulate a real crash (process died, no clean abort)
     checkpointStore.save(workflowId, savedCheckpoint);
 
     // Resume with a new orchestrator that has working sessions


### PR DESCRIPTION
## Summary

- Makes workflow runs resilient to upstream LLM provider quota exhaustion: a 429 from the provider (e.g. a multi-hour usage-limit reset) now short-circuits agent retries instead of burning what little quota remains on doomed reprompts.
- Preserves the workflow checkpoint on abort so the run can be resumed with `ironcurtain workflow resume` once the quota window reopens.
- Incrementalizes the `discover` state's findings writes so partial progress survives mid-state crashes and rate-limit interruptions.

## Motivating failure

A recent `vuln-discovery` run (`~/.ironcurtain/workflow-runs/e82b98ea-3195-412c-a6f7-669004f059ff`) aborted because the upstream provider returned HTTP 429 with a 5-hour reset. Claude Code inside the container retried internally for ~15 minutes, then exited non-zero with a structured JSON envelope (`is_error: true`, `api_error_status: 429`, reset timestamp in `result`). The adapter's `extractResponse` threw that envelope away, the workflow engine retried on the "missing agent_status block" branch — burning the rest of the quota — and the entire run aborted.

## Changes

### Checkpoint-on-abort (`3bc3b79`)
Preserves `checkpoint.json` when a workflow enters the `aborted` terminal, so `workflow resume <baseDir>` can pick up after the operator fixes the upstream issue. Tests extended in `test/workflow/orchestrator-resume.test.ts`.

### vuln-discovery prompt sharpening (`30e9c02`)
- Orchestrator state: replace verdict/destination table with per-state sections so each downstream state's routing contract lives next to its audit rules.
- Discover state: append findings after each experiment (not at end of round), and read any existing `discoveries/` artifacts on re-invocation to skip already-completed experiments. `discoveries?` added as an optional input.

### Provider 429 detection pipeline (`bd080d0`)
- `AgentResponse.quotaExhausted` and `AgentTurnResult.quotaExhausted` carry an optional reset `Date` and raw provider message. JSDoc on both types states the adapter contract: every adapter whose CLI surfaces a 429-class envelope MUST populate this, or the orchestrator falls through to the generic abort path.
- Claude Code adapter now parses its JSON envelope on non-zero exit (previously thrown away), extracts the reset timestamp, and surfaces it.
- Goose adapter carries a doc block explaining why it does not populate the field today and what would close the gap.
- `executeAgentState` wraps every prompt and reprompt through a single `sendAgentTurn` helper plus a `throwIfQuotaExhausted` helper, so the short-circuit applies uniformly to the hardFailure retry loop, the missing/malformed status-block reprompt, the invalid-verdict reprompt, and the missing-artifacts reprompt.
- On detection, a new `quota_exhausted` message-log event is appended (ISO `resetAt` + `rawMessage`) and a dedicated `WorkflowQuotaExhaustedError` throws. Follow-up work can distinguish this error to drive a `paused` terminal phase without touching the detection pipeline again.

### Inspect rendering + tests + docs (`1a25783`)
- `workflow inspect` now renders `quota_exhausted` entries in YELLOW (matching the house "attention/pause" vocabulary used for human gates and resumable-workflow notices).
- New `test/workflow/orchestrator-quota.test.ts` with 4 end-to-end tests driving the real `WorkflowOrchestrator` with `MockSession`: primary-turn halt, quota-before-hardFailure ordering, reprompt-site halt, missing-`resetAt` case.
- `src/docker/CLAUDE.md` carries a one-sentence adapter-contract note pointing at `adapters/claude-code.ts` as canonical.

## Deliberately out of scope (follow-up PRs)

- Dedicated `quota-parser` module — only worth extracting when a second adapter needs quota parsing.
- New `paused` terminal phase in `WorkflowStatus`, `--wait` flag on `workflow resume`, daemon-mode auto-resume timer. Consumes `WorkflowQuotaExhaustedError` via its `AgentInvocationError.cause`, no detection-pipeline changes.
- Goose quota detection — gap is documented in the adapter.
- MITM-side 429 short-horizon retries — explicit non-goal; Claude Code's internal backoff already handles bursts.
- Extracting `executeAgentState` into an `AgentTurnRunner` (existing `TODO(refactor)` at `orchestrator.ts:1323`) so turn-level helpers can be unit-tested without XState.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run format` — applied
- [x] `npx vitest run test/docker-agent-adapter.test.ts` — 26/26 pass (4 new quota-detection tests)
- [x] `npx vitest run test/workflow/orchestrator-quota.test.ts` — 4/4 pass
- [x] `npm test` — full suite 4017 passed / 53 skipped (was 4013 before this PR)
- [ ] Manual: re-run the failed `vuln-discovery` workflow after the reset window and confirm the abort path logs `quota_exhausted` with parsed `resetAt`, does NOT attempt a retry, and leaves a resumable checkpoint.
- [ ] Manual: confirm `ironcurtain workflow inspect <baseDir>` renders the yellow `[quota/<role>]` line for a run that hit the new code path.