### PR TITLE
fix: address Copilot feedback on PR #200

### DIFF
--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -1273,7 +1273,7 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
               workflowId: newId,
               stateId: 'plan',
               verdict: 'success',
-              confidence: 0.87,
+              confidence: '0.87',
             });
             wf.currentState = 'plan_review';
             wf.phase = 'waiting_human';
@@ -1371,7 +1371,7 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
                 workflowId: resolveWfId,
                 stateId: nextState,
                 verdict: 'success',
-                confidence: 0.79,
+                confidence: '0.79',
               });
               if (nextState === 'implement') {
                 wf.currentState = 'review';

--- a/packages/web-ui/src/lib/components/ui/table/table-row.svelte
+++ b/packages/web-ui/src/lib/components/ui/table/table-row.svelte
@@ -17,16 +17,18 @@
     children?: Snippet;
   } = $props();
 
-  // When the row is `clickable`, mirror Enter / Space to the same `onclick`
-  // handler so keyboard users can activate it like a button. Space is
+  // When the row is `clickable`, mirror Enter / Space to a real DOM click
+  // dispatch so keyboard users can activate it like a button. Going through
+  // `currentTarget?.click()` produces a genuine MouseEvent — handlers reading
+  // `.button`, `.clientX/Y`, `.detail`, etc. keep working. Space is
   // intercepted with preventDefault() to suppress the browser's default
   // page-scroll behavior.
-  function handleKeydown(event: KeyboardEvent): void {
-    if (clickable && onclick && (event.key === 'Enter' || event.key === ' ')) {
+  function handleKeydown(event: KeyboardEvent & { currentTarget: EventTarget & HTMLTableRowElement }): void {
+    if (clickable && (event.key === 'Enter' || event.key === ' ')) {
       if (event.key === ' ') event.preventDefault();
-      onclick(event as unknown as MouseEvent & { currentTarget: EventTarget & HTMLTableRowElement });
+      event.currentTarget.click();
     }
-    onkeydown?.(event as KeyboardEvent & { currentTarget: EventTarget & HTMLTableRowElement });
+    onkeydown?.(event);
   }
 </script>
 

--- a/packages/web-ui/src/lib/components/ui/table/table-row.svelte
+++ b/packages/web-ui/src/lib/components/ui/table/table-row.svelte
@@ -19,10 +19,11 @@
 
   // When the row is `clickable`, mirror Enter / Space to a real DOM click
   // dispatch so keyboard users can activate it like a button. Going through
-  // `currentTarget?.click()` produces a genuine MouseEvent — handlers reading
-  // `.button`, `.clientX/Y`, `.detail`, etc. keep working. Space is
-  // intercepted with preventDefault() to suppress the browser's default
-  // page-scroll behavior.
+  // `currentTarget.click()` produces a genuine MouseEvent — handlers reading
+  // `.button`, `.clientX/Y`, `.detail`, etc. keep working. The narrowed
+  // event type guarantees `currentTarget` is non-null at this call site.
+  // Space is intercepted with preventDefault() to suppress the browser's
+  // default page-scroll behavior.
   function handleKeydown(event: KeyboardEvent & { currentTarget: EventTarget & HTMLTableRowElement }): void {
     if (clickable && (event.key === 'Enter' || event.key === ' ')) {
       if (event.key === ' ') event.preventDefault();

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -1012,7 +1012,19 @@ export class WorkflowOrchestrator implements WorkflowController {
     const resumable: WorkflowId[] = [];
     for (const run of runs) {
       if (!run.hasCheckpoint || activeIds.has(run.workflowId)) continue;
-      const cp = this.deps.checkpointStore.load(run.workflowId);
+      // FileCheckpointStore.load() re-throws on JSON.parse failure (it only
+      // swallows ENOENT). A single corrupt checkpoint.json would otherwise
+      // poison the whole list and break `workflow inspect` discovery + the
+      // web UI past-runs panel. Skip and log instead.
+      let cp;
+      try {
+        cp = this.deps.checkpointStore.load(run.workflowId);
+      } catch (err) {
+        writeStderr(
+          `[workflow] Failed to load checkpoint for ${run.workflowId}: ${toErrorMessage(err)}; skipping in resumable list`,
+        );
+        continue;
+      }
       if (cp !== undefined && isCheckpointResumable(cp)) {
         resumable.push(run.workflowId);
       }
@@ -1888,10 +1900,22 @@ export class WorkflowOrchestrator implements WorkflowController {
     }
 
     // Persist finalStatus so isCheckpointResumable can later distinguish
-    // completed (excluded) from aborted/failed (still resumable).
+    // completed (excluded) from aborted/failed (still resumable). Preserve
+    // the existing on-disk machineState/context (which points at the last
+    // non-terminal state) so resume-after-abort can re-enter that state
+    // instead of immediately re-completing on a terminal snapshot. The
+    // fallback path covers the unusual case where no prior checkpoint
+    // exists (e.g. a workflow that transitioned straight to terminal
+    // without ever passing through a non-terminal save point).
     try {
-      const snapshot = instance.actor.getSnapshot() as { value: unknown; context: unknown };
-      const checkpoint = this.buildCheckpoint(instance, snapshot, instance.finalStatus);
+      const existing = this.deps.checkpointStore.load(workflowId);
+      const checkpoint = existing
+        ? { ...existing, finalStatus: instance.finalStatus }
+        : this.buildCheckpoint(
+            instance,
+            instance.actor.getSnapshot() as { value: unknown; context: unknown },
+            instance.finalStatus,
+          );
       this.deps.checkpointStore.save(workflowId, checkpoint);
     } catch (err) {
       writeStderr(`[workflow] Failed to save terminal checkpoint for ${workflowId}: ${toErrorMessage(err)}`);

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -1909,13 +1909,18 @@ export class WorkflowOrchestrator implements WorkflowController {
     // without ever passing through a non-terminal save point).
     try {
       const existing = this.deps.checkpointStore.load(workflowId);
+      const terminalCheckpoint = this.buildCheckpoint(
+        instance,
+        instance.actor.getSnapshot() as { value: unknown; context: unknown },
+        instance.finalStatus,
+      );
       const checkpoint = existing
-        ? { ...existing, finalStatus: instance.finalStatus }
-        : this.buildCheckpoint(
-            instance,
-            instance.actor.getSnapshot() as { value: unknown; context: unknown },
-            instance.finalStatus,
-          );
+        ? {
+            ...terminalCheckpoint,
+            machineState: existing.machineState,
+            context: existing.context,
+          }
+        : terminalCheckpoint;
       this.deps.checkpointStore.save(workflowId, checkpoint);
     } catch (err) {
       writeStderr(`[workflow] Failed to save terminal checkpoint for ${workflowId}: ${toErrorMessage(err)}`);

--- a/test/workflow/orchestrator-resume.test.ts
+++ b/test/workflow/orchestrator-resume.test.ts
@@ -456,6 +456,47 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Regression: aborted-state checkpoint must keep the LAST non-terminal
+  // machineState so resume() can re-enter a meaningful state.
+  // -----------------------------------------------------------------------
+
+  it('keeps last non-terminal machineState on disk when terminating via ABORT', async () => {
+    const defPath = writeDefinitionFile(tmpDir, linearWorkflowDef);
+    const checkpointStore = createCheckpointStore(tmpDir);
+
+    const sessionFactory = vi.fn(async () => {
+      return createArtifactAwareSession([{ text: approvedResponse('plan done'), artifacts: ['plan'] }], tmpDir);
+    });
+
+    const raiseGate = vi.fn();
+    const deps = createDeps(tmpDir, {
+      createSession: sessionFactory,
+      raiseGate,
+      checkpointStore,
+    });
+
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+    const workflowId = await orchestrator.start(defPath, 'build a thing');
+
+    // Wait for plan_gate so a non-terminal checkpoint is persisted.
+    await waitForGate(raiseGate, 1);
+    const preAbort = checkpointStore.load(workflowId);
+    expect(preAbort?.machineState).toBe('plan_gate');
+
+    // Drive into the `aborted` terminal via ABORT.
+    orchestrator.resolveGate(workflowId, { type: 'ABORT' });
+    await waitForCompletion(orchestrator, workflowId);
+
+    const surviving = checkpointStore.load(workflowId);
+    expect(surviving).toBeDefined();
+    expect(surviving?.finalStatus?.phase).toBe('aborted');
+    // The on-disk machineState must still be the last non-terminal state.
+    // Persisting the terminal `aborted` snapshot would cause `resume()` to
+    // re-enter the terminal and immediately re-complete.
+    expect(surviving?.machineState).toBe('plan_gate');
+  });
+
+  // -----------------------------------------------------------------------
   // Test 3: Resume a failed workflow from checkpoint
   // -----------------------------------------------------------------------
 
@@ -814,6 +855,54 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
     const resumable = orchestrator.listResumable();
     expect(resumable).toContain(failedId);
     expect(resumable).not.toContain(completedId);
+  });
+
+  it('listResumable skips corrupt checkpoints instead of throwing', async () => {
+    // Place a valid + a corrupt checkpoint side by side. A single corrupt
+    // file must not break enumeration of all other resumable runs.
+    const checkpointStore = new FileCheckpointStore(tmpDir);
+
+    const validId = 'valid-run' as WorkflowId;
+    const corruptId = 'corrupt-run' as WorkflowId;
+
+    checkpointStore.save(validId, {
+      machineState: 'implement',
+      context: {
+        taskDescription: 'still resumable',
+        artifacts: {},
+        round: 0,
+        maxRounds: 4,
+        previousOutputHashes: {},
+        previousTestCount: null,
+        humanPrompt: null,
+        reviewHistory: [],
+        parallelResults: {},
+        worktreeBranches: [],
+        totalTokens: 0,
+        lastError: null,
+        agentConversationsByState: {},
+        previousAgentOutput: null,
+        previousAgentNotes: null,
+        previousStateName: null,
+        visitCounts: {},
+      },
+      timestamp: new Date().toISOString(),
+      transitionHistory: [],
+      definitionPath: writeDefinitionFile(tmpDir, simpleAgentDef),
+      workspacePath: resolve(tmpDir, validId, 'workspace'),
+    });
+
+    // Write raw bytes that won't parse as JSON.
+    const corruptDir = resolve(tmpDir, corruptId);
+    mkdirSync(corruptDir, { recursive: true });
+    writeFileSync(resolve(corruptDir, 'checkpoint.json'), 'not json');
+
+    const deps = createDeps(tmpDir, { checkpointStore });
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+
+    const resumable = orchestrator.listResumable();
+    expect(resumable).toContain(validId);
+    expect(resumable).not.toContain(corruptId);
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Post-merge fixes for four issues Copilot flagged on #200 after squash-merge.

- **workflow checkpoint regression** — `handleWorkflowComplete` now preserves the last non-terminal `machineState` when stamping `finalStatus`, instead of overwriting the on-disk checkpoint with the terminal snapshot. The previous behavior caused `resume()` of aborted or quota-exhausted runs to immediately re-complete instead of restarting from the last meaningful state. This regressed an explicit invariant documented at `orchestrator.ts:1251-1257`.
- **`listResumable` robustness** — `FileCheckpointStore.load()` re-throws on JSON parse errors; a single corrupt `checkpoint.json` previously took the whole list down, breaking `workflow inspect` and the web UI past-runs view. Each load is now wrapped in try/catch with a stderr log; bad runs are skipped.
- **mock WS confidence type** — `mock-ws-server.ts` was emitting `workflow.agent_completed.confidence` as a number, but the wire contract (`web-event-bus.ts:53`) and the frontend parser both expect a string. Switched to string literals to match the protocol. `latestVerdict.confidence` (a separate, numeric field per the DTO) was correctly left alone.
- **TableRow keyboard activation** — Enter/Space now dispatches a real DOM click via `event.currentTarget?.click()` instead of casting `KeyboardEvent` to `MouseEvent`. The cast was unsound and would silently break any handler reading mouse-only fields.

Two new orchestrator tests cover the first two issues. The checkpoint-preservation test was confirmed to fail on master before the fix (asserted `plan_gate`, observed `aborted`).

## Test plan

- [x] `npm test` — 4159 passed, 53 skipped, 0 failed
- [x] `npm test -w packages/web-ui` — 338 passed, 0 failed (includes 7 table-row keyboard tests)
- [x] `npm run lint` clean
- [x] `npm run format` clean
- [x] New regression test fails on master, passes on this branch
- [x] Copilot review