### PR TITLE
Pre-flight checks for sandbox viability + Docker/OAuth triage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,23 @@ if (!subcommand || subcommand === 'help') {
   process.exit(0);
 }
 
+// Commands that require the V8 sandbox. We check early to catch Node version
+// mismatches (like Node 25) or stale native module builds before importing heavy dependencies.
+// `compile-policy` is the offline policy pipeline and never instantiates the V8 sandbox.
+const requiresSandbox = ['start', 'daemon', 'bot', 'workflow'];
+if (requiresSandbox.includes(subcommand)) {
+  const { checkSandboxViability } = await import('./utils/preflight-checks.js');
+  const result = await checkSandboxViability();
+  if (!result.ok) {
+    const chalk = (await import('chalk')).default;
+    console.error(`\n${chalk.bold(chalk.red('Fatal Error:'))} ${result.message}`);
+    if (result.details) {
+      console.error(chalk.dim(result.details) + '\n');
+    }
+    process.exit(1);
+  }
+}
+
 switch (subcommand) {
   case 'start': {
     const { main } = await import('./index.js');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,9 +97,12 @@ if (requiresSandbox.includes(subcommand)) {
   const result = await checkSandboxViability();
   if (!result.ok) {
     const chalk = (await import('chalk')).default;
-    console.error(`\n${chalk.bold(chalk.red('Fatal Error:'))} ${result.message}`);
+    // Use process.stderr.write rather than console.error because the logger
+    // (src/logger.ts) monkey-patches console.* to redirect into the session log
+    // file. Writing directly to stderr keeps fatal errors visible on the terminal.
+    process.stderr.write(`\n${chalk.bold(chalk.red('Fatal Error:'))} ${result.message}\n`);
     if (result.details) {
-      console.error(chalk.dim(result.details) + '\n');
+      process.stderr.write(chalk.dim(result.details) + '\n\n');
     }
     process.exit(1);
   }

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -203,16 +203,19 @@ async function resolveAutoDetect(
   credentialSources?: CredentialSources,
 ): Promise<PreflightResult> {
   const defaultAgent = config.userConfig.preferredDockerAgent as AgentId;
-  const [dockerStatus, credKind] = await Promise.all([
+  const [dockerStatus, credKind, authMethod] = await Promise.all([
     isDockerAvailable(),
     detectCredentials(defaultAgent, config, credentialSources),
+    detectAuthMethod(config, credentialSources ?? preflightSources),
   ]);
 
   if (!dockerStatus.available) {
-    // detectCredentials reports 'oauth' whenever OAuth is present, even if an API key
-    // also exists, because detectAuthMethod prefers OAuth. Re-check specifically for an
-    // API key so we only throw when the user genuinely has no fallback to builtin.
-    if (credKind === 'oauth' && resolveApiKeyForProvider('anthropic', config.userConfig).length === 0) {
+    // Check Anthropic OAuth presence directly, independent of the preferred agent.
+    // detectCredentials only probes Anthropic OAuth on the Claude Code path; when the
+    // preferred agent is goose it reports credKind based on the goose provider key and
+    // never looks at Anthropic OAuth. Call detectAuthMethod explicitly so we catch the
+    // OAuth-only-no-Docker failure even for goose-preferred configs.
+    if (authMethod.kind === 'oauth' && resolveApiKeyForProvider('anthropic', config.userConfig).length === 0) {
       throw new PreflightError(
         `Cannot start IronCurtain. You have Claude OAuth credentials, which require Docker mode, ` +
           `but Docker is not available:\n\n${dockerStatus.detailedMessage}\n\n` +

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -3,7 +3,8 @@
  *
  * When --agent is explicit, validates prerequisites and fails fast.
  * When no --agent is given, auto-detects the best mode (Docker preferred,
- * builtin fallback) without ever throwing.
+ * builtin fallback) without ever throwing, EXCEPT when the user has OAuth
+ * credentials but no API key (which strictly requires Docker).
  */
 
 import { execFile as execFileCb } from 'node:child_process';
@@ -26,10 +27,11 @@ import { resolveApiKeyForProvider } from '../config/model-provider.js';
 const execFile = promisify(execFileCb);
 
 const DOCKER_TIMEOUT_MS = 5_000;
+const DOCKER_UNAVAILABLE_REASON = 'Docker not available';
 
 /**
- * Thrown when explicit --agent prerequisites are not met.
- * Never thrown during auto-detect.
+ * Thrown when explicit --agent prerequisites are not met, or when
+ * auto-detect finds an unresolvable constraint (e.g. OAuth-only without Docker).
  */
 export class PreflightError extends Error {
   constructor(message: string) {
@@ -44,27 +46,52 @@ export interface PreflightResult {
   readonly reason: string;
 }
 
+export type DockerAvailability = { available: true } | { available: false; reason: string; detailedMessage: string };
+
 export interface PreflightOptions {
   config: IronCurtainConfig;
   /** The --agent flag value. undefined = auto-detect. */
   requestedAgent?: AgentId;
   /** Dependency injection for tests. Defaults to real Docker check. */
-  isDockerAvailable?: () => Promise<boolean>;
+  isDockerAvailable?: () => Promise<DockerAvailability>;
   /** Dependency injection for tests. Defaults to real credential detection. */
   credentialSources?: CredentialSources;
 }
 
 /**
  * Checks whether the Docker daemon is responsive.
- * Returns false if the binary is missing, the daemon is stopped, or the check times out.
+ * Returns detailed diagnostic information if it fails.
  */
-export async function checkDockerAvailable(): Promise<boolean> {
+export async function checkDockerAvailable(): Promise<DockerAvailability> {
   try {
     await execFile('docker', ['info'], { timeout: DOCKER_TIMEOUT_MS });
-    return true;
-  } catch {
-    return false;
+    return { available: true };
+  } catch (err: unknown) {
+    let detailedMessage = err instanceof Error ? err.message : String(err);
+    const errCode = isObjectWithProp(err, 'code') ? err.code : undefined;
+    const errStderr = isObjectWithProp(err, 'stderr') ? err.stderr : undefined;
+    if (errCode === 'ENOENT') {
+      detailedMessage = 'The "docker" command was not found in your PATH. Is Docker installed?';
+    } else if (typeof errStderr === 'string' && errStderr.length > 0) {
+      const stderr = errStderr.trim();
+      if (stderr.includes('permission denied')) {
+        detailedMessage =
+          'Permission denied while connecting to the Docker daemon socket.\n' + 'Is your user in the "docker" group?';
+      } else if (stderr.includes('Cannot connect to the Docker daemon')) {
+        detailedMessage =
+          'Cannot connect to the Docker daemon.\n' +
+          'Is the Docker service running? On macOS/Windows, ensure Docker Desktop is started.';
+      } else {
+        detailedMessage = stderr;
+      }
+    }
+    return { available: false, reason: DOCKER_UNAVAILABLE_REASON, detailedMessage };
   }
+}
+
+/** Type-narrowing helper for inspecting unknown error shapes. */
+function isObjectWithProp<K extends string>(value: unknown, key: K): value is Record<K, unknown> {
+  return typeof value === 'object' && value !== null && key in value;
 }
 
 /**
@@ -124,7 +151,8 @@ function credentialErrorMessage(agentId: AgentId, config: IronCurtainConfig): st
  * Resolves the session mode based on explicit --agent flag or auto-detection.
  *
  * - Explicit agent: validates prerequisites; throws PreflightError on failure.
- * - Auto-detect: prefers Docker when available; silently falls back to builtin. Never throws.
+ * - Auto-detect: prefers Docker when available; falls back to builtin, but throws if
+ *   OAuth is the only available credential (since builtin requires an API key).
  */
 export async function resolveSessionMode(options: PreflightOptions): Promise<PreflightResult> {
   const { config, requestedAgent, credentialSources } = options;
@@ -140,7 +168,7 @@ export async function resolveSessionMode(options: PreflightOptions): Promise<Pre
 async function resolveExplicit(
   agent: AgentId,
   config: IronCurtainConfig,
-  isDockerAvailable: () => Promise<boolean>,
+  isDockerAvailable: () => Promise<DockerAvailability>,
   credentialSources?: CredentialSources,
 ): Promise<PreflightResult> {
   if (agent === 'builtin') {
@@ -150,10 +178,11 @@ async function resolveExplicit(
     };
   }
 
-  const dockerOk = await isDockerAvailable();
-  if (!dockerOk) {
+  const dockerStatus = await isDockerAvailable();
+  if (!dockerStatus.available) {
     throw new PreflightError(
-      `--agent ${agent} requires Docker, but the Docker daemon is not available. ` + 'Is Docker installed and running?',
+      `--agent ${agent} requires Docker, but it is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
+        'Please fix your Docker installation or use the builtin agent.',
     );
   }
 
@@ -170,19 +199,33 @@ async function resolveExplicit(
 
 async function resolveAutoDetect(
   config: IronCurtainConfig,
-  isDockerAvailable: () => Promise<boolean>,
+  isDockerAvailable: () => Promise<DockerAvailability>,
   credentialSources?: CredentialSources,
 ): Promise<PreflightResult> {
-  const dockerOk = await isDockerAvailable();
-  if (!dockerOk) {
+  const defaultAgent = config.userConfig.preferredDockerAgent as AgentId;
+  const [dockerStatus, credKind] = await Promise.all([
+    isDockerAvailable(),
+    detectCredentials(defaultAgent, config, credentialSources),
+  ]);
+
+  if (!dockerStatus.available) {
+    // detectCredentials reports 'oauth' whenever OAuth is present, even if an API key
+    // also exists, because detectAuthMethod prefers OAuth. Re-check specifically for an
+    // API key so we only throw when the user genuinely has no fallback to builtin.
+    if (credKind === 'oauth' && resolveApiKeyForProvider('anthropic', config.userConfig).length === 0) {
+      throw new PreflightError(
+        `Cannot start IronCurtain. You have Claude OAuth credentials, which require Docker mode, ` +
+          `but Docker is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
+          `To run without Docker, you must provide an ANTHROPIC_API_KEY.`,
+      );
+    }
+
     return {
       mode: { kind: 'builtin' },
-      reason: 'Docker not available',
+      reason: DOCKER_UNAVAILABLE_REASON,
     };
   }
 
-  const defaultAgent = config.userConfig.preferredDockerAgent as AgentId;
-  const credKind = await detectCredentials(defaultAgent, config, credentialSources);
   if (credKind === null) {
     return {
       mode: { kind: 'builtin' },

--- a/src/utils/preflight-checks.ts
+++ b/src/utils/preflight-checks.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { getIronCurtainHome } from '../config/paths.js';
 
@@ -28,24 +29,16 @@ function getCacheMarkerPath(): string {
  * (not the semver range from the root package.json) because the cache is
  * about ABI compatibility — the installed build is what actually runs.
  * Returns null if the package can't be located (treated as a cache miss).
+ *
+ * Uses Node's module resolution (via createRequire) rather than cwd-based
+ * guessing so this works from any invocation directory, including global
+ * installs.
  */
 function resolveUtcpVersion(): string | null {
   try {
-    // require.resolve isn't available in pure ESM; walk up from cwd looking for node_modules.
-    // Because this CLI runs from the project root or a global install, the package.json
-    // path is straightforward to construct — we search a couple of likely roots.
-    const candidates = [
-      resolve(process.cwd(), 'node_modules', '@utcp', 'code-mode', 'package.json'),
-      // Global install: the CLI lives at <prefix>/lib/node_modules/ironcurtain/dist/cli.js,
-      // and @utcp/code-mode sits next to it under <prefix>/lib/node_modules/.
-      resolve(process.cwd(), '..', 'node_modules', '@utcp', 'code-mode', 'package.json'),
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) {
-        const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as { version?: string };
-        if (typeof pkg.version === 'string') return pkg.version;
-      }
-    }
+    const pkgPath = createRequire(import.meta.url).resolve('@utcp/code-mode/package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    if (typeof pkg.version === 'string') return pkg.version;
   } catch {
     // Fall through — caller treats null as "no cache, run real check".
   }

--- a/src/utils/preflight-checks.ts
+++ b/src/utils/preflight-checks.ts
@@ -1,0 +1,191 @@
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getIronCurtainHome } from '../config/paths.js';
+
+export interface PreflightCheckResult {
+  ok: boolean;
+  message: string;
+  details?: string;
+}
+
+/** Hard timeout for the child-process viability check. */
+const SANDBOX_CHECK_TIMEOUT_MS = 10_000;
+
+/** Cache marker — skips the subprocess on repeat runs when the env hasn't changed. */
+interface CacheMarker {
+  nodeVersion: string;
+  utcpVersion: string;
+}
+
+function getCacheMarkerPath(): string {
+  return resolve(getIronCurtainHome(), '.preflight-ok');
+}
+
+/**
+ * Resolves the installed `@utcp/code-mode` version by reading its
+ * `node_modules/@utcp/code-mode/package.json`. We pick the resolved version
+ * (not the semver range from the root package.json) because the cache is
+ * about ABI compatibility — the installed build is what actually runs.
+ * Returns null if the package can't be located (treated as a cache miss).
+ */
+function resolveUtcpVersion(): string | null {
+  try {
+    // require.resolve isn't available in pure ESM; walk up from cwd looking for node_modules.
+    // Because this CLI runs from the project root or a global install, the package.json
+    // path is straightforward to construct — we search a couple of likely roots.
+    const candidates = [
+      resolve(process.cwd(), 'node_modules', '@utcp', 'code-mode', 'package.json'),
+      // Global install: the CLI lives at <prefix>/lib/node_modules/ironcurtain/dist/cli.js,
+      // and @utcp/code-mode sits next to it under <prefix>/lib/node_modules/.
+      resolve(process.cwd(), '..', 'node_modules', '@utcp', 'code-mode', 'package.json'),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf-8')) as { version?: string };
+        if (typeof pkg.version === 'string') return pkg.version;
+      }
+    }
+  } catch {
+    // Fall through — caller treats null as "no cache, run real check".
+  }
+  return null;
+}
+
+function readCacheMarker(): CacheMarker | null {
+  try {
+    const parsed = JSON.parse(readFileSync(getCacheMarkerPath(), 'utf-8')) as Partial<CacheMarker>;
+    if (typeof parsed.nodeVersion !== 'string' || typeof parsed.utcpVersion !== 'string') {
+      return null;
+    }
+    return { nodeVersion: parsed.nodeVersion, utcpVersion: parsed.utcpVersion };
+  } catch {
+    return null;
+  }
+}
+
+function writeCacheMarker(marker: CacheMarker): void {
+  try {
+    mkdirSync(getIronCurtainHome(), { recursive: true });
+    writeFileSync(getCacheMarkerPath(), JSON.stringify(marker), { mode: 0o600 });
+  } catch {
+    // Cache writes are best-effort — failure just means we re-run next time.
+  }
+}
+
+/**
+ * Validates that the V8 sandbox (isolated-vm) can be initialized.
+ * We spawn a separate Node process to prevent native module crashes (like
+ * segfaults on Node 25 or ABI mismatches from stale builds) from killing
+ * the main CLI process.
+ *
+ * On success, writes a cache marker keyed on `{nodeVersion, utcpVersion}`
+ * so subsequent invocations skip the spawn (which otherwise costs hundreds
+ * of ms for the UTCP module load).
+ */
+export async function checkSandboxViability(): Promise<PreflightCheckResult> {
+  const utcpVersion = resolveUtcpVersion();
+  if (utcpVersion) {
+    const cached = readCacheMarker();
+    if (cached && cached.nodeVersion === process.versions.node && cached.utcpVersion === utcpVersion) {
+      return { ok: true, message: 'cached' };
+    }
+  }
+
+  const result = await runSandboxViabilityCheck();
+  if (result.ok && utcpVersion) {
+    writeCacheMarker({ nodeVersion: process.versions.node, utcpVersion });
+  }
+  return result;
+}
+
+function runSandboxViabilityCheck(): Promise<PreflightCheckResult> {
+  return new Promise((resolvePromise) => {
+    // The script simply attempts to import and instantiate the UTCP client.
+    const script = `
+      import('@utcp/code-mode')
+        .then((m) => m.CodeModeUtcpClient.create())
+        .then(() => process.exit(0))
+        .catch((e) => {
+          console.error(e.message || e);
+          process.exit(1);
+        });
+    `;
+
+    const child = spawn(process.execPath, ['--no-warnings', '-e', script], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: process.env,
+    });
+
+    let stderrOutput = '';
+    let settled = false;
+
+    const settle = (result: PreflightCheckResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise(result);
+    };
+
+    const timer = setTimeout(() => {
+      // SIGKILL directly — the child is either hung in native init or stuck
+      // loading UTCP, neither of which respects SIGTERM cleanly.
+      child.kill('SIGKILL');
+      settle({
+        ok: false,
+        message: 'Sandbox viability check timed out.',
+        details:
+          `The V8 sandbox (isolated-vm) did not initialize within ${SANDBOX_CHECK_TIMEOUT_MS}ms. ` +
+          'This usually indicates a hung native module load. ' +
+          'Try `npm rebuild` or `rm -rf node_modules && npm install` to rebuild dependencies.',
+      });
+    }, SANDBOX_CHECK_TIMEOUT_MS);
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      stderrOutput += typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+    });
+
+    child.on('close', (code, signal) => {
+      if (settled) return;
+
+      if (code === 0 && !signal) {
+        settle({ ok: true, message: 'V8 sandbox loaded successfully.' });
+        return;
+      }
+
+      let details = stderrOutput.trim();
+      let message = 'Failed to initialize the V8 sandbox (isolated-vm).';
+
+      if (signal) {
+        message = `V8 sandbox crashed with signal ${signal}.`;
+        if (signal === 'SIGSEGV' || signal === 'SIGILL') {
+          details =
+            'This is often caused by an incompatible Node.js version (e.g., Node 25). ' +
+            'Please use Node.js 22, 23, or 24.';
+        }
+      } else if (details.includes('NODE_MODULE_VERSION')) {
+        message = 'Native module ABI mismatch detected.';
+        details =
+          'You likely changed Node.js versions without rebuilding dependencies. ' +
+          'Run `npm rebuild` or `rm -rf node_modules && npm install` to fix this.';
+      } else if (details.includes('Cannot find package')) {
+        message = 'Missing required dependency: @utcp/code-mode';
+        details = 'Run `npm install` to ensure all dependencies are present.';
+      }
+
+      settle({
+        ok: false,
+        message,
+        details: details || `Process exited with code ${code}`,
+      });
+    });
+
+    child.on('error', (err) => {
+      settle({
+        ok: false,
+        message: 'Failed to spawn sandbox check process.',
+        details: err.message,
+      });
+    });
+  });
+}

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -240,6 +240,25 @@ describe('resolveSessionMode', () => {
         expect(result.mode).toEqual({ kind: 'builtin' });
         expect(result.reason).toBe('Docker not available');
       });
+
+      it('throws PreflightError when preferredDockerAgent is goose but Anthropic OAuth is the only credential', async () => {
+        // Regression: previously, detectCredentials on the goose path only probed the
+        // goose provider's API key and never looked at Anthropic OAuth, so OAuth-only
+        // users with preferredDockerAgent=goose silently fell back to builtin (which
+        // then failed without an API key). authMethod must be checked directly.
+        const config = createTestConfig({ anthropicApiKey: '' });
+        config.userConfig.preferredDockerAgent = 'goose';
+        config.userConfig.gooseProvider = 'anthropic';
+
+        const promise = resolveSessionMode({
+          config,
+          isDockerAvailable: dockerUnavailable,
+          credentialSources: oauthOnlySources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        await expect(promise).rejects.toThrow(/Docker/);
+      });
     });
   });
 });

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSessionMode, PreflightError } from '../src/session/preflight.js';
+import { resolveSessionMode, PreflightError, type DockerAvailability } from '../src/session/preflight.js';
 import type { IronCurtainConfig } from '../src/config/types.js';
 import type { AgentId } from '../src/docker/agent-adapter.js';
 import type { CredentialSources } from '../src/docker/oauth-credentials.js';
@@ -54,8 +54,13 @@ function createTestConfig(overrides: { anthropicApiKey?: string } = {}): IronCur
   };
 }
 
-const dockerAvailable = (): Promise<boolean> => Promise.resolve(true);
-const dockerUnavailable = (): Promise<boolean> => Promise.resolve(false);
+const dockerAvailable = (): Promise<DockerAvailability> => Promise.resolve({ available: true });
+const dockerUnavailable = (): Promise<DockerAvailability> =>
+  Promise.resolve({
+    available: false,
+    reason: 'Docker not available',
+    detailedMessage: 'docker daemon not running (test fixture)',
+  });
 
 describe('resolveSessionMode', () => {
   describe('explicit --agent', () => {
@@ -202,6 +207,39 @@ describe('resolveSessionMode', () => {
       });
 
       expect(result.mode).toEqual({ kind: 'builtin' });
+    });
+
+    describe('OAuth-only without Docker', () => {
+      const oauthOnlySources: CredentialSources = {
+        loadFromFile: () => ({
+          accessToken: 'sk-ant-oat01-test',
+          refreshToken: 'sk-ant-ort01-test',
+          expiresAt: Date.now() + 3_600_000,
+        }),
+        loadFromKeychain: () => null,
+      };
+
+      it('throws PreflightError when Docker is unavailable and only OAuth is configured', async () => {
+        const promise = resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: '' }),
+          isDockerAvailable: dockerUnavailable,
+          credentialSources: oauthOnlySources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        await expect(promise).rejects.toThrow(/Docker/);
+      });
+
+      it('falls back to builtin when Docker is unavailable but an API key is also configured', async () => {
+        const result = await resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: 'sk-ant-test-fallback' }),
+          isDockerAvailable: dockerUnavailable,
+          credentialSources: oauthOnlySources,
+        });
+
+        expect(result.mode).toEqual({ kind: 'builtin' });
+        expect(result.reason).toBe('Docker not available');
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Sandbox viability preflight.** Before running `start`, `daemon`, `bot`, or `workflow`, spawn a child Node process that tries to import `@utcp/code-mode` and create a `CodeModeUtcpClient`. Maps SIGSEGV/SIGILL → "use Node 22–24", `NODE_MODULE_VERSION` → "npm rebuild", and missing-package errors to "npm install". 10s hard timeout; success cached at `~/.ironcurtain/.preflight-ok` keyed on `{nodeVersion, utcpVersion}` so repeat CLI invocations skip the subprocess.
- **Docker availability is now a tagged union.** `checkDockerAvailable` returns `{ available, reason, detailedMessage }` with targeted messages for ENOENT, permission denied, and "Cannot connect to the Docker daemon" so the user learns *why* Docker wasn't detected rather than just "not available."
- **OAuth-only without Docker fails fast.** If auto-detect finds OAuth credentials but no API key and Docker is unavailable, we throw a `PreflightError` pointing at the root cause instead of silently falling back to builtin and later erroring with `invalid x-api-key`.

Addresses feedback items 1, 2, and the Docker-detection/auth chain flagged by Aaron (macOS) and Ben (Kali) during BishopFox testing.

## Test plan

- [ ] `npx vitest run test/preflight.test.ts` — 13 tests (2 new for the OAuth-only-without-Docker throw path; 6 pre-existing fixtures updated to match the new `Promise<DockerAvailability>` signature).
- [ ] Smoke: `ironcurtain start "say hi"` on Node 22 still works.
- [ ] Smoke: run under Node 25 and confirm the preflight produces the "use Node 22–24" message instead of a crash.
- [ ] Smoke: stop Docker daemon, run `ironcurtain start --agent claude-code` — confirm the explicit-agent error now includes "Cannot connect to the Docker daemon" rather than a generic not-available string.
- [ ] Smoke: with only OAuth creds and Docker stopped, confirm auto-detect throws the "you have OAuth credentials, which require Docker mode" message.

## Out of scope

- Windows-specific crash handling — IronCurtain intentionally does not support Windows (users run WSL2).
- Remaining items in `bishop-fox-feedback-fixes.md` (web UI, networking, test isolation, etc.) land in follow-up PRs.