### PR TITLE
Add `ironcurtain doctor` for on-demand setup diagnostics

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,8 +103,9 @@ if (requiresSandbox.includes(subcommand)) {
     // file. Writing directly to stderr keeps fatal errors visible on the terminal.
     process.stderr.write(`\n${chalk.bold(chalk.red('Fatal Error:'))} ${result.message}\n`);
     if (result.details) {
-      process.stderr.write(chalk.dim(result.details) + '\n\n');
+      process.stderr.write(chalk.dim(result.details) + '\n');
     }
+    process.stderr.write(chalk.dim('Run `ironcurtain doctor` for a full diagnostic.\n\n'));
     process.exit(1);
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ const topLevelSpec: CommandSpec = {
     { name: 'config', description: 'Edit configuration interactively' },
     { name: 'workflow', description: 'Run multi-agent workflows (start, resume, inspect)' },
     { name: 'observe', description: 'Watch live LLM token output for running sessions' },
+    { name: 'doctor', description: 'Diagnose installation, credentials, and MCP server health' },
     { name: 'help', description: 'Show this help message' },
   ],
   options: [
@@ -197,6 +198,11 @@ switch (subcommand) {
   case 'observe': {
     const { runObserveCommand } = await import('./observe/observe-command.js');
     await runObserveCommand(process.argv.slice(3));
+    break;
+  }
+  case 'doctor': {
+    const { runDoctorCommand } = await import('./doctor/doctor-command.js');
+    await runDoctorCommand(process.argv.slice(3));
     break;
   }
   case 'setup-signal': {

--- a/src/docker/oauth-credentials.ts
+++ b/src/docker/oauth-credentials.ts
@@ -223,10 +223,10 @@ export function writeToKeychain(credentials: OAuthCredentials, serviceName: stri
 }
 
 /** Claude Code's public OAuth client ID. */
-const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+export const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
 /** Anthropic's OAuth token endpoint (platform.claude.com since mid-2025). */
-const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+export const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
 
 /**
  * Refreshes an OAuth access token using a refresh token grant.

--- a/src/docker/oauth-credentials.ts
+++ b/src/docker/oauth-credentials.ts
@@ -223,18 +223,33 @@ export function writeToKeychain(credentials: OAuthCredentials, serviceName: stri
 }
 
 /** Claude Code's public OAuth client ID. */
-export const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
 /** Anthropic's OAuth token endpoint (platform.claude.com since mid-2025). */
-export const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+
+/**
+ * Discriminated result of a refresh attempt.
+ *
+ * Doctor needs the failure mode (HTTP status vs network error vs malformed
+ * response) so it can render an actionable hint. Production callers only
+ * care about ok-vs-not, so they map non-`ok` to null via `refreshResultToCreds`.
+ */
+export type RefreshResult =
+  | { kind: 'ok'; credentials: OAuthCredentials }
+  | { kind: 'http-error'; status: number }
+  | { kind: 'parse-error'; detail: string }
+  | { kind: 'network-error'; message: string };
 
 /**
  * Refreshes an OAuth access token using a refresh token grant.
  *
- * Returns new credentials on success, or null on failure (expired refresh
- * token, network error, etc.).
+ * Returns a discriminated result so callers can distinguish HTTP failures
+ * (refresh token invalidated) from network failures (transient) from
+ * malformed responses (server bug). Production callers that only need
+ * pass/fail should use `refreshResultToCreds` to flatten to OAuthCredentials | null.
  */
-export async function refreshOAuthToken(refreshToken: string): Promise<OAuthCredentials | null> {
+export async function refreshOAuthToken(refreshToken: string): Promise<RefreshResult> {
   const REFRESH_TIMEOUT_MS = 30_000;
   try {
     const body = new URLSearchParams({
@@ -252,33 +267,49 @@ export async function refreshOAuthToken(refreshToken: string): Promise<OAuthCred
 
     if (!response.ok) {
       logger.warn(`OAuth token refresh failed: HTTP ${response.status}`);
-      return null;
+      return { kind: 'http-error', status: response.status };
     }
 
     const data = (await response.json()) as Record<string, unknown>;
     return parseTokenResponse(data, refreshToken);
   } catch (err) {
-    logger.warn(`OAuth token refresh error: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(`OAuth token refresh error: ${message}`);
+    return { kind: 'network-error', message };
   }
 }
 
 /**
+ * Flattens a RefreshResult into the legacy `OAuthCredentials | null` shape
+ * for callers that don't need the failure detail (token-manager, preflight).
+ */
+export function refreshResultToCreds(result: RefreshResult): OAuthCredentials | null {
+  return result.kind === 'ok' ? result.credentials : null;
+}
+
+/**
  * Validates and extracts credentials from an OAuth token endpoint response.
- * Returns null if access_token or expires_in are missing/invalid.
+ * Returns parse-error if access_token or expires_in are missing/invalid.
  * Preserves the original refresh token when the response omits refresh_token
  * (not all providers rotate refresh tokens on every grant).
  */
-function parseTokenResponse(data: Record<string, unknown>, fallbackRefreshToken: string): OAuthCredentials | null {
+function parseTokenResponse(data: Record<string, unknown>, fallbackRefreshToken: string): RefreshResult {
   const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } = data;
 
-  if (!isNonEmptyString(accessToken)) return null;
-  if (!isPositiveFiniteNumber(expiresIn)) return null;
+  if (!isNonEmptyString(accessToken)) {
+    return { kind: 'parse-error', detail: 'response missing access_token' };
+  }
+  if (!isPositiveFiniteNumber(expiresIn)) {
+    return { kind: 'parse-error', detail: 'response missing or invalid expires_in' };
+  }
 
   return {
-    accessToken,
-    refreshToken: isNonEmptyString(refreshToken) ? refreshToken : fallbackRefreshToken,
-    expiresAt: Date.now() + expiresIn * 1000,
+    kind: 'ok',
+    credentials: {
+      accessToken,
+      refreshToken: isNonEmptyString(refreshToken) ? refreshToken : fallbackRefreshToken,
+      expiresAt: Date.now() + expiresIn * 1000,
+    },
   };
 }
 
@@ -336,10 +367,39 @@ export interface CredentialSources {
 const defaultSources: CredentialSources = {
   loadFromFile: loadOAuthCredentials,
   loadFromKeychain: extractFromKeychain,
-  refreshToken: refreshOAuthToken,
+  refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
   saveToFile: saveOAuthCredentials,
   loadFromKeychainWithService: extractFromKeychainWithService,
   writeToKeychain,
+};
+
+/**
+ * Pre-built CredentialSources for active credential detection at startup.
+ * Includes Keychain lookup (~19ms on macOS) and proactive token refresh,
+ * so an expired token is rotated before the first MCP call.
+ *
+ * Shared between session/preflight.ts and doctor's OAuth checks so both
+ * code paths exercise the same detection behavior.
+ */
+export const preflightCredentialSources: CredentialSources = {
+  loadFromFile: loadOAuthCredentials,
+  loadFromKeychain: extractFromKeychain,
+  refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
+  saveToFile: saveOAuthCredentials,
+  loadFromKeychainWithService: extractFromKeychainWithService,
+  writeToKeychain,
+};
+
+/**
+ * Pre-built CredentialSources for read-only detection (used by `ironcurtain doctor`).
+ * Omits refresh/save so passive diagnostics never mutate credential storage.
+ * The user can still validate refresh under `--check-api`, which makes its
+ * own write decisions based on the detected auth source.
+ */
+export const readOnlyCredentialSources: CredentialSources = {
+  loadFromFile: loadOAuthCredentials,
+  loadFromKeychain: extractFromKeychain,
+  loadFromKeychainWithService: extractFromKeychainWithService,
 };
 
 /**

--- a/src/docker/oauth-token-manager.ts
+++ b/src/docker/oauth-token-manager.ts
@@ -19,6 +19,7 @@ import {
   isTokenExpired,
   loadCredentialsFromFile,
   refreshOAuthToken,
+  refreshResultToCreds,
   saveOAuthCredentials,
   getCredentialsFilePath,
   extractFromKeychain,
@@ -43,7 +44,7 @@ export interface TokenManagerDeps {
 const defaultDeps: TokenManagerDeps = {
   loadCredentials: loadCredentialsFromFile,
   loadFromKeychain: extractFromKeychain,
-  refreshToken: refreshOAuthToken,
+  refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
   saveCredentials: saveOAuthCredentials,
   credentialsFilePath: getCredentialsFilePath(),
 };

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -18,7 +18,12 @@ import {
   extractFromKeychainWithService,
   type AuthMethod,
 } from '../docker/oauth-credentials.js';
-import { resolveApiKeyForProvider, createLanguageModel } from '../config/model-provider.js';
+import {
+  resolveApiKeyForProvider,
+  createLanguageModel,
+  parseModelId,
+  type ProviderId,
+} from '../config/model-provider.js';
 import { loadGeneratedPolicy, getPackageGeneratedDir, findAnnotationServerDrift, loadConfig } from '../config/index.js';
 import { computeConstitutionHash } from '../config/paths.js';
 import type { IronCurtainConfig, MCPServerConfig } from '../config/types.js';
@@ -86,6 +91,12 @@ export async function checkSandbox(): Promise<CheckResult> {
   };
 }
 
+/**
+ * Reports Docker daemon status. Returns `warn` (not `fail`) on unavailability
+ * because the builtin agent runs without Docker — doctor doesn't know whether
+ * the user intends to run Docker mode, so it surfaces the issue without
+ * forcing a non-zero exit.
+ */
 export async function checkDocker(
   probe: () => Promise<DockerAvailability> = checkDockerAvailable,
 ): Promise<CheckResult> {
@@ -199,7 +210,7 @@ export function checkConstitutionDrift(
     currentHash = computeConstitutionHash(config.constitutionPath);
   } catch (err) {
     return {
-      name: 'Constitution',
+      name: 'Compiled policy',
       status: 'fail',
       message: err instanceof Error ? err.message : String(err),
       hint: 'Verify that constitution.md exists at the configured location.',
@@ -452,17 +463,20 @@ function formatElapsed(ms: number): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Runs a 1-token generateText call against the configured Anthropic
- * agent model. Surfaces network/auth failures that won't show up until
- * the agent actually starts.
+ * Runs a 1-token generateText call against the configured agent model,
+ * checking the API key for that model's provider (which may not be
+ * Anthropic — IronCurtain supports OpenAI and Google too).
  */
-export async function checkAnthropicApi(config: IronCurtainConfig): Promise<CheckResult> {
-  const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
+export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise<CheckResult> {
+  const { provider } = parseModelId(config.agentModelId);
+  const label = formatProviderLabel(provider);
+  const name = `${label} API round-trip`;
+  const apiKey = resolveApiKeyForProvider(provider, config.userConfig);
   if (apiKey.length === 0) {
     return {
-      name: 'Anthropic API round-trip',
+      name,
       status: 'skip',
-      message: 'no API key — round-trip uses API key auth only',
+      message: `no ${label} API key — round-trip uses API key auth only`,
     };
   }
   try {
@@ -476,15 +490,25 @@ export async function checkAnthropicApi(config: IronCurtainConfig): Promise<Chec
       maxOutputTokens: 1,
     });
     const elapsed = formatElapsed(Date.now() - start);
-    return { name: 'Anthropic API round-trip', status: 'ok', message: `responded in ${elapsed}` };
+    return { name, status: 'ok', message: `responded in ${elapsed}` };
   } catch (err) {
     return {
-      name: 'Anthropic API round-trip',
+      name,
       status: 'fail',
       message: err instanceof Error ? err.message : String(err),
-      hint: 'Verify ANTHROPIC_API_KEY is valid and the configured agentModelId exists.',
+      hint: `Verify the ${label} API key is valid and the configured agentModelId exists.`,
     };
   }
+}
+
+const PROVIDER_LABELS: Record<ProviderId, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  google: 'Google',
+};
+
+function formatProviderLabel(provider: ProviderId): string {
+  return PROVIDER_LABELS[provider];
 }
 
 /**

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -13,11 +13,13 @@ import {
   detectAuthMethod,
   loadOAuthCredentials,
   isTokenExpired,
-  refreshOAuthToken,
   saveOAuthCredentials,
   extractFromKeychain,
   extractFromKeychainWithService,
+  OAUTH_CLIENT_ID,
+  OAUTH_TOKEN_URL,
   type AuthMethod,
+  type OAuthCredentials,
 } from '../docker/oauth-credentials.js';
 import {
   resolveApiKeyForProvider,
@@ -503,10 +505,38 @@ export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise
     return {
       name,
       status: 'fail',
-      message: err instanceof Error ? err.message : String(err),
+      message: describeApiError(err),
       hint: `Verify the ${label} API key is valid and the configured agentModelId exists.`,
     };
   }
+}
+
+/**
+ * Renders an AI SDK error with as much diagnostic info as we can extract.
+ * The SDK's APICallError frequently has an empty .message but a useful
+ * .url and .cause (the underlying fetch error). Surface all of them so
+ * "Cannot connect to API:" doesn't lose the actual reason.
+ */
+function describeApiError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const parts: string[] = [];
+  if (err.message) parts.push(err.message);
+  // AI SDK APICallError surfaces the URL it tried to hit.
+  const url = (err as { url?: unknown }).url;
+  if (typeof url === 'string' && url.length > 0) parts.push(`url=${url}`);
+  // Status code from APICallError.
+  const status = (err as { statusCode?: unknown }).statusCode;
+  if (typeof status === 'number') parts.push(`status=${status}`);
+  // Underlying cause (e.g., fetch's TypeError with the system error code).
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof Error && cause.message) {
+    parts.push(`cause=${cause.message}`);
+    const code = (cause as { code?: unknown }).code;
+    if (typeof code === 'string') parts.push(`code=${code}`);
+  } else if (typeof cause === 'string') {
+    parts.push(`cause=${cause}`);
+  }
+  return parts.join(' | ');
 }
 
 const PROVIDER_LABELS: Record<ProviderId, string> = {
@@ -524,7 +554,11 @@ function formatProviderLabel(provider: ProviderId): string {
  * for new credentials. Anthropic rotates refresh tokens, so the new
  * credentials MUST be persisted — otherwise the next refresh attempt
  * (whether by doctor or by the running agent) fails because the local
- * refresh token has been invalidated server-side. Used only under --check-api.
+ * refresh token has been invalidated server-side.
+ *
+ * Calls the token endpoint directly (rather than via refreshOAuthToken)
+ * so failures surface the HTTP status code — a generic "refresh failed"
+ * isn't actionable. Used only under --check-api.
  */
 export async function checkOAuthRefresh(): Promise<CheckResult> {
   const creds = loadOAuthCredentials();
@@ -537,23 +571,75 @@ export async function checkOAuthRefresh(): Promise<CheckResult> {
   }
   try {
     const start = Date.now();
-    const refreshed = await refreshOAuthToken(creds.refreshToken);
+    const result = await probeOAuthRefresh(creds.refreshToken);
     const elapsed = formatElapsed(Date.now() - start);
-    if (!refreshed) {
+    if (result.kind === 'http-error') {
       return {
         name: 'OAuth refresh',
         status: 'fail',
-        message: `refresh failed (${elapsed})`,
-        hint: 'Run `claude login` to obtain a new refresh token.',
+        message: `refresh rejected (HTTP ${result.status}, ${elapsed})`,
+        hint:
+          result.status === 400 || result.status === 401
+            ? 'Refresh token has been invalidated (likely consumed by an earlier refresh). Run `claude login` to issue a new one.'
+            : 'Run `claude login` to obtain a new refresh token.',
       };
     }
-    saveOAuthCredentials(refreshed);
+    if (result.kind === 'parse-error') {
+      return {
+        name: 'OAuth refresh',
+        status: 'fail',
+        message: `refresh response unparseable (${elapsed})`,
+        hint: result.detail,
+      };
+    }
+    saveOAuthCredentials(result.credentials);
     return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed})` };
   } catch (err) {
+    const cause = err instanceof Error && err.cause instanceof Error ? ` (${err.cause.message})` : '';
     return {
       name: 'OAuth refresh',
       status: 'fail',
-      message: err instanceof Error ? err.message : String(err),
+      message: (err instanceof Error ? err.message : String(err)) + cause,
     };
   }
+}
+
+type RefreshProbeResult =
+  | { kind: 'ok'; credentials: OAuthCredentials }
+  | { kind: 'http-error'; status: number }
+  | { kind: 'parse-error'; detail: string };
+
+async function probeOAuthRefresh(refreshToken: string): Promise<RefreshProbeResult> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: OAUTH_CLIENT_ID,
+  });
+  const response = await fetch(OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    return { kind: 'http-error', status: response.status };
+  }
+  const data = (await response.json()) as Record<string, unknown>;
+  const accessToken = data.access_token;
+  const expiresIn = data.expires_in;
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    return { kind: 'parse-error', detail: 'response missing access_token' };
+  }
+  if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    return { kind: 'parse-error', detail: 'response missing or invalid expires_in' };
+  }
+  const newRefresh = data.refresh_token;
+  return {
+    kind: 'ok',
+    credentials: {
+      accessToken,
+      refreshToken: typeof newRefresh === 'string' && newRefresh.length > 0 ? newRefresh : refreshToken,
+      expiresAt: Date.now() + expiresIn * 1000,
+    },
+  };
 }

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -7,7 +7,6 @@
  * can call check functions directly without short-circuits.
  */
 
-import { generateText } from 'ai';
 import { checkSandboxViability } from '../utils/preflight-checks.js';
 import { checkDockerAvailable, type DockerAvailability } from '../session/preflight.js';
 import {
@@ -420,7 +419,7 @@ export async function checkMcpServerLiveness(
   }
 
   const tasks = entries.map(async ([name, serverConfig]): Promise<CheckResult> => {
-    if (hasUnsetCredentials(serverConfig, config)) {
+    if (checkServerCredentials(name, serverConfig, config).status === 'warn') {
       return { name, status: 'skip', message: 'skipped — missing creds' };
     }
     const result = await probe(name, serverConfig);
@@ -428,34 +427,6 @@ export async function checkMcpServerLiveness(
   });
 
   return Promise.all(tasks);
-}
-
-function hasUnsetCredentials(serverConfig: MCPServerConfig, config: IronCurtainConfig): boolean {
-  const required = collectDeclaredEnvVars(serverConfig);
-  if (required.length === 0) return false;
-  for (const varName of required) {
-    const fromEnv = process.env[varName];
-    if (typeof fromEnv === 'string' && fromEnv.length > 0) continue;
-    // serverCredentials lookup — keyed by server name in user config, but
-    // we don't have the server name here. The caller passes the resolved
-    // config; we look it up via reverse-lookup on mcpServers.
-    const serverName = findServerName(serverConfig, config.mcpServers);
-    const credBag = serverName ? config.userConfig.serverCredentials[serverName] : undefined;
-    const fromCfg: string | undefined = credBag ? credBag[varName] : undefined;
-    if (typeof fromCfg === 'string' && fromCfg.length > 0) continue;
-    return true;
-  }
-  return false;
-}
-
-function findServerName(
-  serverConfig: MCPServerConfig,
-  mcpServers: Record<string, MCPServerConfig>,
-): string | undefined {
-  for (const [name, candidate] of Object.entries(mcpServers)) {
-    if (candidate === serverConfig) return name;
-  }
-  return undefined;
 }
 
 function formatProbeResult(name: string, result: ProbeResult): CheckResult {
@@ -496,6 +467,8 @@ export async function checkAnthropicApi(config: IronCurtainConfig): Promise<Chec
   }
   try {
     const start = Date.now();
+    // Lazy-import the AI SDK so the default doctor run doesn't pay the load cost.
+    const { generateText } = await import('ai');
     const model = await createLanguageModel(config.agentModelId, config.userConfig);
     await generateText({
       model,

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,0 +1,551 @@
+/**
+ * Diagnostic check functions for `ironcurtain doctor`.
+ *
+ * Each check is a thin wrapper around an existing helper. Functions in
+ * this module MUST NOT call process.exit — the entry point alone is
+ * responsible for translating results into an exit code so unit tests
+ * can call check functions directly without short-circuits.
+ */
+
+import { generateText } from 'ai';
+import { checkSandboxViability } from '../utils/preflight-checks.js';
+import { checkDockerAvailable, type DockerAvailability } from '../session/preflight.js';
+import {
+  detectAuthMethod,
+  loadOAuthCredentials,
+  isTokenExpired,
+  refreshOAuthToken,
+  extractFromKeychain,
+  extractFromKeychainWithService,
+  type AuthMethod,
+} from '../docker/oauth-credentials.js';
+import { resolveApiKeyForProvider, createLanguageModel } from '../config/model-provider.js';
+import { loadGeneratedPolicy, getPackageGeneratedDir, findAnnotationServerDrift, loadConfig } from '../config/index.js';
+import { computeConstitutionHash } from '../config/paths.js';
+import type { IronCurtainConfig, MCPServerConfig } from '../config/types.js';
+import { probeServer, type ProbeResult } from './mcp-liveness.js';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type CheckStatus = 'ok' | 'warn' | 'fail' | 'skip';
+
+export interface CheckResult {
+  readonly name: string;
+  readonly status: CheckStatus;
+  readonly message: string;
+  /** Optional remediation suggestion shown indented under the result. */
+  readonly hint?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Environment checks
+// ---------------------------------------------------------------------------
+
+/** Minimum and maximum supported Node.js major versions. */
+const NODE_MIN_MAJOR = 22;
+const NODE_MAX_MAJOR = 24;
+
+export function checkNodeVersion(versionString: string = process.versions.node): CheckResult {
+  const match = /^(\d+)\./.exec(versionString);
+  const major = match ? Number(match[1]) : NaN;
+  if (!Number.isFinite(major)) {
+    return {
+      name: 'Node.js',
+      status: 'fail',
+      message: `unrecognized version "${versionString}"`,
+      hint: `Install Node.js ${NODE_MIN_MAJOR}.x – ${NODE_MAX_MAJOR}.x from https://nodejs.org/`,
+    };
+  }
+  if (major < NODE_MIN_MAJOR || major > NODE_MAX_MAJOR) {
+    return {
+      name: 'Node.js',
+      status: 'fail',
+      message: `${versionString} (unsupported)`,
+      hint: `IronCurtain requires Node.js ${NODE_MIN_MAJOR}.x – ${NODE_MAX_MAJOR}.x.`,
+    };
+  }
+  return {
+    name: 'Node.js',
+    status: 'ok',
+    message: versionString,
+  };
+}
+
+export async function checkSandbox(): Promise<CheckResult> {
+  const result = await checkSandboxViability();
+  if (result.ok) {
+    const note = result.message === 'cached' ? 'OK (cached)' : 'OK';
+    return { name: 'V8 sandbox', status: 'ok', message: note };
+  }
+  return {
+    name: 'V8 sandbox',
+    status: 'fail',
+    message: result.message,
+    hint: result.details,
+  };
+}
+
+export async function checkDocker(
+  probe: () => Promise<DockerAvailability> = checkDockerAvailable,
+): Promise<CheckResult> {
+  const status = await probe();
+  if (status.available) {
+    return { name: 'Docker', status: 'ok', message: 'running' };
+  }
+  return {
+    name: 'Docker',
+    status: 'warn',
+    message: 'unavailable',
+    hint: status.detailedMessage,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Configuration / policy checks
+// ---------------------------------------------------------------------------
+
+export interface ConfigLoadOk {
+  readonly result: CheckResult;
+  readonly config: IronCurtainConfig;
+}
+
+export interface ConfigLoadFail {
+  readonly result: CheckResult;
+  readonly config: undefined;
+}
+
+/**
+ * Loads ~/.ironcurtain/config.json and reports the outcome. Returns the
+ * resolved config alongside the CheckResult so subsequent checks can
+ * reuse it without re-loading.
+ */
+export function checkConfigLoad(): ConfigLoadOk | ConfigLoadFail {
+  try {
+    const config = loadConfig();
+    return {
+      result: { name: 'User config', status: 'ok', message: 'parsed cleanly' },
+      config,
+    };
+  } catch (err) {
+    return {
+      result: {
+        name: 'User config',
+        status: 'fail',
+        message: err instanceof Error ? err.message : String(err),
+        hint: 'Run `ironcurtain config` to fix configuration issues.',
+      },
+      config: undefined,
+    };
+  }
+}
+
+export interface PolicyLoadOk {
+  readonly results: CheckResult[];
+  readonly compiledPolicy: ReturnType<typeof loadGeneratedPolicy>['compiledPolicy'];
+  readonly toolAnnotations: ReturnType<typeof loadGeneratedPolicy>['toolAnnotations'];
+}
+
+export interface PolicyLoadFail {
+  readonly results: CheckResult[];
+  readonly compiledPolicy: undefined;
+  readonly toolAnnotations: undefined;
+}
+
+/**
+ * Loads compiled-policy.json and tool-annotations.json. On success the
+ * caller can run drift checks against the result; on failure both
+ * artifacts are reported as missing/unparseable in a single CheckResult.
+ */
+export function checkPolicyArtifacts(config: IronCurtainConfig): PolicyLoadOk | PolicyLoadFail {
+  try {
+    const loaded = loadGeneratedPolicy({
+      policyDir: config.generatedDir,
+      toolAnnotationsDir: config.toolAnnotationsDir ?? config.generatedDir,
+      fallbackDir: getPackageGeneratedDir(),
+    });
+    return {
+      results: [{ name: 'Policy artifacts', status: 'ok', message: 'present and parseable' }],
+      compiledPolicy: loaded.compiledPolicy,
+      toolAnnotations: loaded.toolAnnotations,
+    };
+  } catch (err) {
+    return {
+      results: [
+        {
+          name: 'Policy artifacts',
+          status: 'fail',
+          message: err instanceof Error ? err.message : String(err),
+          hint: 'Run `ironcurtain compile-policy` to (re)generate compiled-policy.json and tool-annotations.json.',
+        },
+      ],
+      compiledPolicy: undefined,
+      toolAnnotations: undefined,
+    };
+  }
+}
+
+/**
+ * Compares the active constitution hash to the value baked into the
+ * compiled policy. A mismatch means the constitution was edited without
+ * recompiling.
+ */
+export function checkConstitutionDrift(
+  config: IronCurtainConfig,
+  compiledPolicy: { constitutionHash: string },
+): CheckResult {
+  let currentHash: string;
+  try {
+    currentHash = computeConstitutionHash(config.constitutionPath);
+  } catch (err) {
+    return {
+      name: 'Constitution',
+      status: 'fail',
+      message: err instanceof Error ? err.message : String(err),
+      hint: 'Verify that constitution.md exists at the configured location.',
+    };
+  }
+  if (currentHash === compiledPolicy.constitutionHash) {
+    return { name: 'Compiled policy', status: 'ok', message: 'fresh' };
+  }
+  return {
+    name: 'Compiled policy',
+    status: 'warn',
+    message: 'constitution has changed since last compile',
+    hint: 'Run `ironcurtain compile-policy` to update compiled-policy.json.',
+  };
+}
+
+/**
+ * Reports drift between configured MCP servers and tool-annotations.json.
+ * Uses the pure helper findAnnotationServerDrift so output goes through
+ * the doctor renderer rather than stderr.
+ */
+export function checkAnnotationDrift(
+  toolAnnotations: Parameters<typeof findAnnotationServerDrift>[0],
+  mcpServers: Record<string, MCPServerConfig>,
+): CheckResult {
+  const { missing, orphaned } = findAnnotationServerDrift(toolAnnotations, mcpServers);
+  if (missing.length === 0 && orphaned.length === 0) {
+    return { name: 'Tool annotations', status: 'ok', message: 'in sync with mcp-servers.json' };
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing: ${missing.join(', ')}`);
+  if (orphaned.length > 0) parts.push(`orphaned: ${orphaned.join(', ')}`);
+  const hint =
+    missing.length > 0
+      ? `Run \`ironcurtain annotate-tools --server ${missing[0]}\` for each missing server.`
+      : 'Re-run `ironcurtain annotate-tools --all` to drop orphaned entries.';
+  return {
+    name: 'Tool annotations',
+    status: 'warn',
+    message: parts.join('; '),
+    hint,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Credential checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes a human-readable description for an OAuth-typed AuthMethod,
+ * including expiry information.
+ */
+function describeOAuthExpiry(auth: Extract<AuthMethod, { kind: 'oauth' }>): {
+  message: string;
+  status: CheckStatus;
+  hint?: string;
+} {
+  const remainingMs = auth.credentials.expiresAt - Date.now();
+  if (remainingMs <= 0) {
+    return {
+      message: 'OAuth (expired)',
+      status: 'warn',
+      hint: 'Token will be refreshed automatically on next use, or run `claude login` to re-authenticate.',
+    };
+  }
+  const remainingDays = Math.floor(remainingMs / (24 * 60 * 60 * 1000));
+  if (remainingDays >= 1) {
+    return {
+      message: `OAuth (expires in ${remainingDays} day${remainingDays === 1 ? '' : 's'})`,
+      status: 'ok',
+    };
+  }
+  const remainingHours = Math.max(1, Math.floor(remainingMs / (60 * 60 * 1000)));
+  if (isTokenExpired(auth.credentials)) {
+    return {
+      message: `OAuth (expires in ${remainingHours}h, will auto-refresh)`,
+      status: 'ok',
+    };
+  }
+  return {
+    message: `OAuth (expires in ${remainingHours}h)`,
+    status: 'ok',
+  };
+}
+
+/**
+ * Checks Anthropic credential availability. Uses the production
+ * detectAuthMethod by default, but injects no-op refresh/save so doctor
+ * doesn't accidentally rewrite credential files when invoked.
+ */
+export async function checkAnthropicCredentials(config: IronCurtainConfig): Promise<CheckResult> {
+  const auth = await detectAuthMethod(config, {
+    loadFromFile: loadOAuthCredentials,
+    loadFromKeychain: extractFromKeychain,
+    // No refresh/save during diagnostics: the user did not opt into
+    // mutating their credential store. --check-api can verify the
+    // refresh token works without persisting the result.
+    loadFromKeychainWithService: extractFromKeychainWithService,
+  });
+
+  if (auth.kind === 'oauth') {
+    const desc = describeOAuthExpiry(auth);
+    return { name: 'Anthropic', status: desc.status, message: desc.message, hint: desc.hint };
+  }
+  if (auth.kind === 'apikey') {
+    return { name: 'Anthropic', status: 'ok', message: 'API key set' };
+  }
+  return {
+    name: 'Anthropic',
+    status: 'warn',
+    message: 'no credentials detected',
+    hint: 'Set ANTHROPIC_API_KEY or run `claude login` to obtain OAuth credentials.',
+  };
+}
+
+/**
+ * Reports per-MCP-server credential presence. Looks at:
+ *   - `-e <VAR>` arguments (Docker convention used by mcp-servers.json)
+ *   - keys of `config.env`
+ * For each declared env var, the check passes if the value is set in
+ * process.env or in serverCredentials[serverName].
+ */
+export function checkServerCredentials(
+  serverName: string,
+  serverConfig: MCPServerConfig,
+  config: IronCurtainConfig,
+): CheckResult {
+  const required = collectDeclaredEnvVars(serverConfig);
+  if (required.length === 0) {
+    return { name: serverName, status: 'ok', message: 'no credentials required' };
+  }
+  const provided = config.userConfig.serverCredentials[serverName] ?? {};
+  const missing = required.filter((name) => {
+    const fromEnv = process.env[name];
+    if (typeof fromEnv === 'string' && fromEnv.length > 0) return false;
+    const fromCfg = provided[name];
+    if (typeof fromCfg === 'string' && fromCfg.length > 0) return false;
+    return true;
+  });
+  if (missing.length === 0) {
+    return {
+      name: serverName,
+      status: 'ok',
+      message: `${required.length} credential${required.length === 1 ? '' : 's'} set`,
+    };
+  }
+  return {
+    name: serverName,
+    status: 'warn',
+    message: `missing: ${missing.join(', ')}`,
+    hint: 'Set the env var(s) or run `ironcurtain config` to store the credentials.',
+  };
+}
+
+/**
+ * Walks an MCP server config to collect declared env-var names from
+ * `-e <NAME>` argument pairs and from the keys of `config.env`.
+ */
+export function collectDeclaredEnvVars(serverConfig: MCPServerConfig): string[] {
+  const names = new Set<string>();
+  for (let i = 0; i < serverConfig.args.length - 1; i++) {
+    if (serverConfig.args[i] === '-e') {
+      const candidate = serverConfig.args[i + 1];
+      // Plain `-e VAR` (Docker forward) — skip `KEY=value` form because
+      // those carry an inline value, not a host-env reference.
+      if (typeof candidate === 'string' && !candidate.includes('=')) {
+        names.add(candidate);
+      }
+    }
+  }
+  if (serverConfig.env) {
+    for (const key of Object.keys(serverConfig.env)) {
+      // Skip transport-style env vars that carry hard-coded values rather
+      // than secrets. Only flag vars that are likely credential refs.
+      if (looksLikeCredentialEnv(key)) {
+        names.add(key);
+      }
+    }
+  }
+  return [...names].sort();
+}
+
+const CREDENTIAL_KEYWORDS = ['TOKEN', 'KEY', 'SECRET', 'PASSWORD', 'API'];
+
+function looksLikeCredentialEnv(name: string): boolean {
+  const upper = name.toUpperCase();
+  return CREDENTIAL_KEYWORDS.some((kw) => upper.includes(kw));
+}
+
+// ---------------------------------------------------------------------------
+// MCP server liveness
+// ---------------------------------------------------------------------------
+
+export interface ServerLivenessOptions {
+  readonly probe?: typeof probeServer;
+}
+
+/**
+ * Builds the per-server CheckResult based on whether the server's
+ * declared credentials are present. Servers with missing credentials
+ * are skipped (no spawn) to avoid spurious failures.
+ */
+export async function checkMcpServerLiveness(
+  config: IronCurtainConfig,
+  options: ServerLivenessOptions = {},
+): Promise<CheckResult[]> {
+  const probe = options.probe ?? probeServer;
+  const entries = Object.entries(config.mcpServers);
+  if (entries.length === 0) {
+    return [
+      {
+        name: '(no servers configured)',
+        status: 'skip',
+        message: 'mcp-servers.json contains no entries',
+      },
+    ];
+  }
+
+  const tasks = entries.map(async ([name, serverConfig]): Promise<CheckResult> => {
+    if (hasUnsetCredentials(serverConfig, config)) {
+      return { name, status: 'skip', message: 'skipped — missing creds' };
+    }
+    const result = await probe(name, serverConfig);
+    return formatProbeResult(name, result);
+  });
+
+  return Promise.all(tasks);
+}
+
+function hasUnsetCredentials(serverConfig: MCPServerConfig, config: IronCurtainConfig): boolean {
+  const required = collectDeclaredEnvVars(serverConfig);
+  if (required.length === 0) return false;
+  for (const varName of required) {
+    const fromEnv = process.env[varName];
+    if (typeof fromEnv === 'string' && fromEnv.length > 0) continue;
+    // serverCredentials lookup — keyed by server name in user config, but
+    // we don't have the server name here. The caller passes the resolved
+    // config; we look it up via reverse-lookup on mcpServers.
+    const serverName = findServerName(serverConfig, config.mcpServers);
+    const credBag = serverName ? config.userConfig.serverCredentials[serverName] : undefined;
+    const fromCfg: string | undefined = credBag ? credBag[varName] : undefined;
+    if (typeof fromCfg === 'string' && fromCfg.length > 0) continue;
+    return true;
+  }
+  return false;
+}
+
+function findServerName(
+  serverConfig: MCPServerConfig,
+  mcpServers: Record<string, MCPServerConfig>,
+): string | undefined {
+  for (const [name, candidate] of Object.entries(mcpServers)) {
+    if (candidate === serverConfig) return name;
+  }
+  return undefined;
+}
+
+function formatProbeResult(name: string, result: ProbeResult): CheckResult {
+  if (result.status === 'ok') {
+    const elapsed = formatElapsed(result.elapsedMs);
+    return { name, status: 'ok', message: `${result.toolCount} tool${result.toolCount === 1 ? '' : 's'}, ${elapsed}` };
+  }
+  return {
+    name,
+    status: 'fail',
+    message: `failed after ${formatElapsed(result.elapsedMs)}`,
+    hint: result.reason,
+  };
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Optional API round-trip checks (--check-api)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a 1-token generateText call against the configured Anthropic
+ * agent model. Surfaces network/auth failures that won't show up until
+ * the agent actually starts.
+ */
+export async function checkAnthropicApi(config: IronCurtainConfig): Promise<CheckResult> {
+  const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
+  if (apiKey.length === 0) {
+    return {
+      name: 'Anthropic API round-trip',
+      status: 'skip',
+      message: 'no API key — round-trip uses API key auth only',
+    };
+  }
+  try {
+    const start = Date.now();
+    const model = await createLanguageModel(config.agentModelId, config.userConfig);
+    await generateText({
+      model,
+      prompt: 'Reply with the single word OK.',
+      maxOutputTokens: 1,
+    });
+    const elapsed = formatElapsed(Date.now() - start);
+    return { name: 'Anthropic API round-trip', status: 'ok', message: `responded in ${elapsed}` };
+  } catch (err) {
+    return {
+      name: 'Anthropic API round-trip',
+      status: 'fail',
+      message: err instanceof Error ? err.message : String(err),
+      hint: 'Verify ANTHROPIC_API_KEY is valid and the configured agentModelId exists.',
+    };
+  }
+}
+
+/**
+ * Validates the OAuth refresh token without persisting the new
+ * credentials. Used only under --check-api.
+ */
+export async function checkOAuthRefresh(): Promise<CheckResult> {
+  const creds = loadOAuthCredentials();
+  if (!creds) {
+    return {
+      name: 'OAuth refresh',
+      status: 'skip',
+      message: 'no OAuth credentials file',
+    };
+  }
+  try {
+    const start = Date.now();
+    const refreshed = await refreshOAuthToken(creds.refreshToken);
+    const elapsed = formatElapsed(Date.now() - start);
+    if (!refreshed) {
+      return {
+        name: 'OAuth refresh',
+        status: 'fail',
+        message: `refresh failed (${elapsed})`,
+        hint: 'Run `claude login` to obtain a new refresh token.',
+      };
+    }
+    // Intentionally do NOT call saveOAuthCredentials — diagnostics-only.
+    return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed})` };
+  } catch (err) {
+    return {
+      name: 'OAuth refresh',
+      status: 'fail',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -14,6 +14,7 @@ import {
   loadOAuthCredentials,
   isTokenExpired,
   refreshOAuthToken,
+  saveOAuthCredentials,
   extractFromKeychain,
   extractFromKeychainWithService,
   type AuthMethod,
@@ -473,6 +474,13 @@ export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise
   const name = `${label} API round-trip`;
   const apiKey = resolveApiKeyForProvider(provider, config.userConfig);
   if (apiKey.length === 0) {
+    if (provider === 'anthropic' && loadOAuthCredentials() !== null) {
+      return {
+        name,
+        status: 'skip',
+        message: 'OAuth-only setup — covered by OAuth refresh check below',
+      };
+    }
     return {
       name,
       status: 'skip',
@@ -512,8 +520,11 @@ function formatProviderLabel(provider: ProviderId): string {
 }
 
 /**
- * Validates the OAuth refresh token without persisting the new
- * credentials. Used only under --check-api.
+ * Validates the OAuth refresh flow by exchanging the stored refresh token
+ * for new credentials. Anthropic rotates refresh tokens, so the new
+ * credentials MUST be persisted — otherwise the next refresh attempt
+ * (whether by doctor or by the running agent) fails because the local
+ * refresh token has been invalidated server-side. Used only under --check-api.
  */
 export async function checkOAuthRefresh(): Promise<CheckResult> {
   const creds = loadOAuthCredentials();
@@ -536,7 +547,7 @@ export async function checkOAuthRefresh(): Promise<CheckResult> {
         hint: 'Run `claude login` to obtain a new refresh token.',
       };
     }
-    // Intentionally do NOT call saveOAuthCredentials — diagnostics-only.
+    saveOAuthCredentials(refreshed);
     return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed})` };
   } catch (err) {
     return {

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -9,19 +9,7 @@
 
 import { checkSandboxViability } from '../utils/preflight-checks.js';
 import { checkDockerAvailable, type DockerAvailability } from '../session/preflight.js';
-import {
-  detectAuthMethod,
-  loadOAuthCredentials,
-  isTokenExpired,
-  saveOAuthCredentials,
-  extractFromKeychain,
-  extractFromKeychainWithService,
-  writeToKeychain,
-  OAUTH_CLIENT_ID,
-  OAUTH_TOKEN_URL,
-  type AuthMethod,
-  type OAuthCredentials,
-} from '../docker/oauth-credentials.js';
+import { detectAuthMethod, readOnlyCredentialSources } from '../docker/oauth-credentials.js';
 import {
   resolveApiKeyForProvider,
   createLanguageModel,
@@ -31,11 +19,8 @@ import {
 import { loadGeneratedPolicy, getPackageGeneratedDir, findAnnotationServerDrift, loadConfig } from '../config/index.js';
 import { computeConstitutionHash } from '../config/paths.js';
 import type { IronCurtainConfig, MCPServerConfig } from '../config/types.js';
+import { isObjectWithProp } from '../utils/is-plain-object.js';
 import { probeServer, type ProbeResult } from './mcp-liveness.js';
-
-// ---------------------------------------------------------------------------
-// Shared types
-// ---------------------------------------------------------------------------
 
 export type CheckStatus = 'ok' | 'warn' | 'fail' | 'skip';
 
@@ -46,10 +31,6 @@ export interface CheckResult {
   /** Optional remediation suggestion shown indented under the result. */
   readonly hint?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Environment checks
-// ---------------------------------------------------------------------------
 
 /** Minimum and maximum supported Node.js major versions. */
 const NODE_MIN_MAJOR = 22;
@@ -115,10 +96,6 @@ export async function checkDocker(
     hint: status.detailedMessage,
   };
 }
-
-// ---------------------------------------------------------------------------
-// Configuration / policy checks
-// ---------------------------------------------------------------------------
 
 export interface ConfigLoadOk {
   readonly result: CheckResult;
@@ -259,77 +236,6 @@ export function checkAnnotationDrift(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Credential checks
-// ---------------------------------------------------------------------------
-
-/**
- * Computes a human-readable description for an OAuth-typed AuthMethod,
- * including expiry information.
- */
-function describeOAuthExpiry(auth: Extract<AuthMethod, { kind: 'oauth' }>): {
-  message: string;
-  status: CheckStatus;
-  hint?: string;
-} {
-  const remainingMs = auth.credentials.expiresAt - Date.now();
-  if (remainingMs <= 0) {
-    return {
-      message: 'OAuth (expired)',
-      status: 'warn',
-      hint: 'Token will be refreshed automatically on next use, or run `claude login` to re-authenticate.',
-    };
-  }
-  const remainingDays = Math.floor(remainingMs / (24 * 60 * 60 * 1000));
-  if (remainingDays >= 1) {
-    return {
-      message: `OAuth (expires in ${remainingDays} day${remainingDays === 1 ? '' : 's'})`,
-      status: 'ok',
-    };
-  }
-  const remainingHours = Math.max(1, Math.floor(remainingMs / (60 * 60 * 1000)));
-  if (isTokenExpired(auth.credentials)) {
-    return {
-      message: `OAuth (expires in ${remainingHours}h, will auto-refresh)`,
-      status: 'ok',
-    };
-  }
-  return {
-    message: `OAuth (expires in ${remainingHours}h)`,
-    status: 'ok',
-  };
-}
-
-/**
- * Checks Anthropic credential availability. Uses the production
- * detectAuthMethod by default, but injects no-op refresh/save so doctor
- * doesn't accidentally rewrite credential files when invoked.
- */
-export async function checkAnthropicCredentials(config: IronCurtainConfig): Promise<CheckResult> {
-  const auth = await detectAuthMethod(config, {
-    loadFromFile: loadOAuthCredentials,
-    loadFromKeychain: extractFromKeychain,
-    // No refresh/save during diagnostics: the user did not opt into
-    // mutating their credential store. --check-api can verify the
-    // refresh token works without persisting the result.
-    loadFromKeychainWithService: extractFromKeychainWithService,
-  });
-
-  if (auth.kind === 'oauth') {
-    const desc = describeOAuthExpiry(auth);
-    return { name: 'Anthropic', status: desc.status, message: desc.message, hint: desc.hint };
-  }
-  if (auth.kind === 'apikey') {
-    return { name: 'Anthropic', status: 'ok', message: 'API key set' };
-  }
-  return {
-    name: 'Anthropic',
-    status: 'warn',
-    message: 'no credentials detected',
-    hint: 'Set ANTHROPIC_API_KEY or run `claude login` to obtain OAuth credentials.',
-  };
-}
-
 /**
  * Reports per-MCP-server credential presence. Looks at:
  *   - `-e <VAR>` arguments (Docker convention used by mcp-servers.json)
@@ -404,10 +310,6 @@ function looksLikeCredentialEnv(name: string): boolean {
   return CREDENTIAL_KEYWORDS.some((kw) => upper.includes(kw));
 }
 
-// ---------------------------------------------------------------------------
-// MCP server liveness
-// ---------------------------------------------------------------------------
-
 export interface ServerLivenessOptions {
   readonly probe?: typeof probeServer;
 }
@@ -462,10 +364,6 @@ function formatElapsed(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-// ---------------------------------------------------------------------------
-// Optional API round-trip checks (--check-api)
-// ---------------------------------------------------------------------------
-
 /**
  * Runs a 1-token generateText call against the configured agent model,
  * checking the API key for that model's provider (which may not be
@@ -477,7 +375,7 @@ export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise
   const name = `${label} API round-trip`;
   const apiKey = resolveApiKeyForProvider(provider, config.userConfig);
   if (apiKey.length === 0) {
-    if (provider === 'anthropic' && loadOAuthFromAnySource() !== null) {
+    if (provider === 'anthropic' && (await detectAuthMethod(config, readOnlyCredentialSources)).kind === 'oauth') {
       return {
         name,
         status: 'skip',
@@ -523,19 +421,24 @@ function describeApiError(err: unknown): string {
   const parts: string[] = [];
   if (err.message) parts.push(err.message);
   // AI SDK APICallError surfaces the URL it tried to hit.
-  const url = (err as { url?: unknown }).url;
-  if (typeof url === 'string' && url.length > 0) parts.push(`url=${url}`);
+  if (isObjectWithProp(err, 'url') && typeof err.url === 'string' && err.url.length > 0) {
+    parts.push(`url=${err.url}`);
+  }
   // Status code from APICallError.
-  const status = (err as { statusCode?: unknown }).statusCode;
-  if (typeof status === 'number') parts.push(`status=${status}`);
+  if (isObjectWithProp(err, 'statusCode') && typeof err.statusCode === 'number') {
+    parts.push(`status=${err.statusCode}`);
+  }
   // Underlying cause (e.g., fetch's TypeError with the system error code).
-  const cause = (err as { cause?: unknown }).cause;
-  if (cause instanceof Error && cause.message) {
-    parts.push(`cause=${cause.message}`);
-    const code = (cause as { code?: unknown }).code;
-    if (typeof code === 'string') parts.push(`code=${code}`);
-  } else if (typeof cause === 'string') {
-    parts.push(`cause=${cause}`);
+  if (isObjectWithProp(err, 'cause')) {
+    const cause = err.cause;
+    if (cause instanceof Error && cause.message) {
+      parts.push(`cause=${cause.message}`);
+      if (isObjectWithProp(cause, 'code') && typeof cause.code === 'string') {
+        parts.push(`code=${cause.code}`);
+      }
+    } else if (typeof cause === 'string') {
+      parts.push(`cause=${cause}`);
+    }
   }
   return parts.join(' | ');
 }
@@ -548,127 +451,4 @@ const PROVIDER_LABELS: Record<ProviderId, string> = {
 
 function formatProviderLabel(provider: ProviderId): string {
   return PROVIDER_LABELS[provider];
-}
-
-/**
- * Validates the OAuth refresh flow by exchanging the stored refresh token
- * for new credentials. Anthropic rotates refresh tokens, so the new
- * credentials MUST be persisted — otherwise the next refresh attempt
- * (whether by doctor or by the running agent) fails because the local
- * refresh token has been invalidated server-side.
- *
- * Calls the token endpoint directly (rather than via refreshOAuthToken)
- * so failures surface the HTTP status code — a generic "refresh failed"
- * isn't actionable. Used only under --check-api.
- */
-export async function checkOAuthRefresh(): Promise<CheckResult> {
-  const found = loadOAuthFromAnySource();
-  if (!found) {
-    return {
-      name: 'OAuth refresh',
-      status: 'skip',
-      message: 'no OAuth credentials in file or Keychain',
-    };
-  }
-  try {
-    const start = Date.now();
-    const result = await probeOAuthRefresh(found.credentials.refreshToken);
-    const elapsed = formatElapsed(Date.now() - start);
-    if (result.kind === 'http-error') {
-      return {
-        name: 'OAuth refresh',
-        status: 'fail',
-        message: `refresh rejected (HTTP ${result.status}, ${elapsed})`,
-        hint:
-          result.status === 400 || result.status === 401
-            ? 'Refresh token has been invalidated (likely consumed by an earlier refresh). Run `claude login` to issue a new one.'
-            : 'Run `claude login` to obtain a new refresh token.',
-      };
-    }
-    if (result.kind === 'parse-error') {
-      return {
-        name: 'OAuth refresh',
-        status: 'fail',
-        message: `refresh response unparseable (${elapsed})`,
-        hint: result.detail,
-      };
-    }
-    persistRefreshedOAuth(found.source, result.credentials);
-    const sourceLabel = found.source.kind === 'keychain' ? 'Keychain' : 'file';
-    return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed}, ${sourceLabel})` };
-  } catch (err) {
-    const cause = err instanceof Error && err.cause instanceof Error ? ` (${err.cause.message})` : '';
-    return {
-      name: 'OAuth refresh',
-      status: 'fail',
-      message: (err instanceof Error ? err.message : String(err)) + cause,
-    };
-  }
-}
-
-type OAuthSource = { kind: 'file' } | { kind: 'keychain'; serviceName: string };
-
-/**
- * Loads OAuth credentials from the credentials file or, on macOS, the
- * Keychain. Returns the credentials together with the source so callers
- * can write rotated tokens back to the same place.
- */
-function loadOAuthFromAnySource(): { credentials: OAuthCredentials; source: OAuthSource } | null {
-  const fileCreds = loadOAuthCredentials();
-  if (fileCreds) {
-    return { credentials: fileCreds, source: { kind: 'file' } };
-  }
-  const kc = extractFromKeychainWithService();
-  if (kc) {
-    return { credentials: kc.credentials, source: { kind: 'keychain', serviceName: kc.serviceName } };
-  }
-  return null;
-}
-
-function persistRefreshedOAuth(source: OAuthSource, credentials: OAuthCredentials): void {
-  if (source.kind === 'file') {
-    saveOAuthCredentials(credentials);
-  } else {
-    writeToKeychain(credentials, source.serviceName);
-  }
-}
-
-type RefreshProbeResult =
-  | { kind: 'ok'; credentials: OAuthCredentials }
-  | { kind: 'http-error'; status: number }
-  | { kind: 'parse-error'; detail: string };
-
-async function probeOAuthRefresh(refreshToken: string): Promise<RefreshProbeResult> {
-  const body = new URLSearchParams({
-    grant_type: 'refresh_token',
-    refresh_token: refreshToken,
-    client_id: OAUTH_CLIENT_ID,
-  });
-  const response = await fetch(OAUTH_TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!response.ok) {
-    return { kind: 'http-error', status: response.status };
-  }
-  const data = (await response.json()) as Record<string, unknown>;
-  const accessToken = data.access_token;
-  const expiresIn = data.expires_in;
-  if (typeof accessToken !== 'string' || accessToken.length === 0) {
-    return { kind: 'parse-error', detail: 'response missing access_token' };
-  }
-  if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
-    return { kind: 'parse-error', detail: 'response missing or invalid expires_in' };
-  }
-  const newRefresh = data.refresh_token;
-  return {
-    kind: 'ok',
-    credentials: {
-      accessToken,
-      refreshToken: typeof newRefresh === 'string' && newRefresh.length > 0 ? newRefresh : refreshToken,
-      expiresAt: Date.now() + expiresIn * 1000,
-    },
-  };
 }

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -400,6 +400,11 @@ export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise
       model,
       prompt: 'Reply with the single word OK.',
       maxOutputTokens: 1,
+      // Cap the round-trip so a network blackhole or DNS stall can't hang
+      // doctor. maxRetries: 0 turns off the SDK's default 3-attempt retry —
+      // for diagnostics we want fast failure, not eventual failure.
+      abortSignal: AbortSignal.timeout(API_ROUNDTRIP_TIMEOUT_MS),
+      maxRetries: 0,
     });
     const elapsed = formatElapsed(Date.now() - start);
     return { name, status: 'ok', message: `responded in ${elapsed}` };
@@ -412,6 +417,9 @@ export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise
     };
   }
 }
+
+/** Hard cap on the agent-model API round-trip; healthy calls are 1-3s. */
+const API_ROUNDTRIP_TIMEOUT_MS = 15_000;
 
 /**
  * Renders an AI SDK error with as much diagnostic info as we can extract.

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -241,7 +241,7 @@ export function checkAnnotationDrift(
  *   - `-e <VAR>` arguments (Docker convention used by mcp-servers.json)
  *   - keys of `config.env`
  * For each declared env var, the check passes if the value is set in
- * process.env or in serverCredentials[serverName].
+ * process.env, inline in serverConfig.env, or in serverCredentials[serverName].
  */
 export function checkServerCredentials(
   serverName: string,
@@ -253,9 +253,12 @@ export function checkServerCredentials(
     return { name: serverName, status: 'ok', message: 'no credentials required' };
   }
   const provided = config.userConfig.serverCredentials[serverName] ?? {};
+  const inline = serverConfig.env ?? {};
   const missing = required.filter((name) => {
     const fromEnv = process.env[name];
     if (typeof fromEnv === 'string' && fromEnv.length > 0) return false;
+    const fromInline = inline[name];
+    if (typeof fromInline === 'string' && fromInline.length > 0) return false;
     const fromCfg = provided[name];
     if (typeof fromCfg === 'string' && fromCfg.length > 0) return false;
     return true;

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -16,6 +16,7 @@ import {
   saveOAuthCredentials,
   extractFromKeychain,
   extractFromKeychainWithService,
+  writeToKeychain,
   OAUTH_CLIENT_ID,
   OAUTH_TOKEN_URL,
   type AuthMethod,
@@ -476,7 +477,7 @@ export async function checkAgentApiRoundtrip(config: IronCurtainConfig): Promise
   const name = `${label} API round-trip`;
   const apiKey = resolveApiKeyForProvider(provider, config.userConfig);
   if (apiKey.length === 0) {
-    if (provider === 'anthropic' && loadOAuthCredentials() !== null) {
+    if (provider === 'anthropic' && loadOAuthFromAnySource() !== null) {
       return {
         name,
         status: 'skip',
@@ -561,17 +562,17 @@ function formatProviderLabel(provider: ProviderId): string {
  * isn't actionable. Used only under --check-api.
  */
 export async function checkOAuthRefresh(): Promise<CheckResult> {
-  const creds = loadOAuthCredentials();
-  if (!creds) {
+  const found = loadOAuthFromAnySource();
+  if (!found) {
     return {
       name: 'OAuth refresh',
       status: 'skip',
-      message: 'no OAuth credentials file',
+      message: 'no OAuth credentials in file or Keychain',
     };
   }
   try {
     const start = Date.now();
-    const result = await probeOAuthRefresh(creds.refreshToken);
+    const result = await probeOAuthRefresh(found.credentials.refreshToken);
     const elapsed = formatElapsed(Date.now() - start);
     if (result.kind === 'http-error') {
       return {
@@ -592,8 +593,9 @@ export async function checkOAuthRefresh(): Promise<CheckResult> {
         hint: result.detail,
       };
     }
-    saveOAuthCredentials(result.credentials);
-    return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed})` };
+    persistRefreshedOAuth(found.source, result.credentials);
+    const sourceLabel = found.source.kind === 'keychain' ? 'Keychain' : 'file';
+    return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed}, ${sourceLabel})` };
   } catch (err) {
     const cause = err instanceof Error && err.cause instanceof Error ? ` (${err.cause.message})` : '';
     return {
@@ -601,6 +603,33 @@ export async function checkOAuthRefresh(): Promise<CheckResult> {
       status: 'fail',
       message: (err instanceof Error ? err.message : String(err)) + cause,
     };
+  }
+}
+
+type OAuthSource = { kind: 'file' } | { kind: 'keychain'; serviceName: string };
+
+/**
+ * Loads OAuth credentials from the credentials file or, on macOS, the
+ * Keychain. Returns the credentials together with the source so callers
+ * can write rotated tokens back to the same place.
+ */
+function loadOAuthFromAnySource(): { credentials: OAuthCredentials; source: OAuthSource } | null {
+  const fileCreds = loadOAuthCredentials();
+  if (fileCreds) {
+    return { credentials: fileCreds, source: { kind: 'file' } };
+  }
+  const kc = extractFromKeychainWithService();
+  if (kc) {
+    return { credentials: kc.credentials, source: { kind: 'keychain', serviceName: kc.serviceName } };
+  }
+  return null;
+}
+
+function persistRefreshedOAuth(source: OAuthSource, credentials: OAuthCredentials): void {
+  if (source.kind === 'file') {
+    saveOAuthCredentials(credentials);
+  } else {
+    writeToKeychain(credentials, source.serviceName);
   }
 }
 

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -1,0 +1,164 @@
+/**
+ * `ironcurtain doctor` — on-demand diagnostics.
+ *
+ * Unlike pre-flight (which is a fail-fast gate), doctor:
+ *   - runs every check (continue-on-failure),
+ *   - includes active probes pre-flight has no reason to run,
+ *   - opt-in API round-trip via --check-api.
+ *
+ * Process exit status: 0 if no checks return `fail`, 1 otherwise.
+ * Warnings do not affect the exit code.
+ */
+
+import { parseArgs } from 'node:util';
+import { checkHelp, type CommandSpec } from '../cli-help.js';
+import {
+  checkAnnotationDrift,
+  checkAnthropicApi,
+  checkAnthropicCredentials,
+  checkConfigLoad,
+  checkConstitutionDrift,
+  checkDocker,
+  checkMcpServerLiveness,
+  checkNodeVersion,
+  checkOAuthRefresh,
+  checkPolicyArtifacts,
+  checkSandbox,
+  checkServerCredentials,
+  type CheckResult,
+} from './checks.js';
+import { printCheck, printSection, printSummary } from './output.js';
+
+const DOCTOR_HELP: CommandSpec = {
+  name: 'ironcurtain doctor',
+  description: 'Diagnose installation, credentials, and MCP server health',
+  usage: ['ironcurtain doctor [options]'],
+  options: [
+    { flag: 'check-api', description: 'Also run an Anthropic API round-trip and OAuth refresh probe' },
+    { flag: 'help', short: 'h', description: 'Show this help message' },
+  ],
+  examples: ['ironcurtain doctor', 'ironcurtain doctor --check-api'],
+};
+
+export interface DoctorCliArgs {
+  readonly checkApi: boolean;
+  readonly help: boolean;
+}
+
+export function parseDoctorArgs(argv: string[]): DoctorCliArgs {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      'check-api': { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+  });
+  return {
+    checkApi: values['check-api'] === true,
+    help: values.help === true,
+  };
+}
+
+/**
+ * Runs the doctor pipeline. Exits with 1 if any check returned `fail`.
+ */
+export async function runDoctorCommand(argv: string[]): Promise<void> {
+  let args: DoctorCliArgs;
+  try {
+    args = parseDoctorArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+  if (checkHelp(args, DOCTOR_HELP)) return;
+
+  process.stdout.write('ironcurtain doctor\n');
+
+  const collected: CheckResult[] = [];
+
+  // Environment — sequential because failures invalidate later checks.
+  printSection('Environment', { first: true });
+  const nodeResult = checkNodeVersion();
+  printCheck(nodeResult);
+  collected.push(nodeResult);
+
+  const sandboxResult = await checkSandbox();
+  printCheck(sandboxResult);
+  collected.push(sandboxResult);
+
+  const dockerResult = await checkDocker();
+  printCheck(dockerResult);
+  collected.push(dockerResult);
+
+  // Configuration — gates everything that needs the resolved config.
+  printSection('Configuration');
+  const configCheck = checkConfigLoad();
+  printCheck(configCheck.result);
+  collected.push(configCheck.result);
+
+  if (!configCheck.config) {
+    // Without a config we can't proceed past the basic environment.
+    printSummary(collected);
+    if (collected.some((c) => c.status === 'fail')) process.exit(1);
+    return;
+  }
+  const config = configCheck.config;
+
+  const policyCheck = checkPolicyArtifacts(config);
+  for (const r of policyCheck.results) {
+    printCheck(r);
+    collected.push(r);
+  }
+
+  if (policyCheck.compiledPolicy !== undefined) {
+    const constitutionResult = checkConstitutionDrift(config, policyCheck.compiledPolicy);
+    printCheck(constitutionResult);
+    collected.push(constitutionResult);
+
+    const annotationResult = checkAnnotationDrift(policyCheck.toolAnnotations, config.mcpServers);
+    printCheck(annotationResult);
+    collected.push(annotationResult);
+  }
+
+  // Credentials.
+  printSection('Credentials');
+  const anthropicResult = await checkAnthropicCredentials(config);
+  printCheck(anthropicResult);
+  collected.push(anthropicResult);
+
+  for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
+    const r = checkServerCredentials(serverName, serverConfig, config);
+    // Only show servers that need credentials — the "no credentials required"
+    // result would clutter the output with one line per server.
+    if (r.message === 'no credentials required') continue;
+    printCheck(r);
+    collected.push(r);
+  }
+
+  // MCP servers — parallel probes.
+  printSection('MCP servers');
+  const livenessResults = await checkMcpServerLiveness(config);
+  for (const r of livenessResults) {
+    printCheck(r);
+    collected.push(r);
+  }
+
+  // Optional API round-trip.
+  if (args.checkApi) {
+    printSection('API round-trip');
+    const apiResult = await checkAnthropicApi(config);
+    printCheck(apiResult);
+    collected.push(apiResult);
+
+    const refreshResult = await checkOAuthRefresh();
+    printCheck(refreshResult);
+    collected.push(refreshResult);
+  }
+
+  printSummary(collected);
+
+  if (collected.some((c) => c.status === 'fail')) {
+    process.exit(1);
+  }
+}

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -15,26 +15,35 @@ import { checkHelp, type CommandSpec } from '../cli-help.js';
 import {
   checkAgentApiRoundtrip,
   checkAnnotationDrift,
-  checkAnthropicCredentials,
   checkConfigLoad,
   checkConstitutionDrift,
   checkDocker,
   checkMcpServerLiveness,
   checkNodeVersion,
-  checkOAuthRefresh,
   checkPolicyArtifacts,
   checkSandbox,
   checkServerCredentials,
   type CheckResult,
 } from './checks.js';
+import { checkAnthropicCredentials, checkOAuthRefresh } from './oauth-checks.js';
+import { probeServer } from './mcp-liveness.js';
 import { printCheck, printSection, printSummary } from './output.js';
+
+/**
+ * Injectable dependencies for runDoctorCommand. Tests pass a probe stub
+ * to avoid spawning real MCP servers; production calls receive the
+ * default probe automatically.
+ */
+export interface DoctorDeps {
+  readonly probeMcpServer?: typeof probeServer;
+}
 
 const DOCTOR_HELP: CommandSpec = {
   name: 'ironcurtain doctor',
   description: 'Diagnose installation, credentials, and MCP server health',
   usage: ['ironcurtain doctor [options]'],
   options: [
-    { flag: 'check-api', description: 'Also run an Anthropic API round-trip and OAuth refresh probe' },
+    { flag: 'check-api', description: 'Also run an agent-model API round-trip and OAuth refresh probe' },
     { flag: 'help', short: 'h', description: 'Show this help message' },
   ],
   examples: ['ironcurtain doctor', 'ironcurtain doctor --check-api'],
@@ -63,7 +72,7 @@ export function parseDoctorArgs(argv: string[]): DoctorCliArgs {
 /**
  * Runs the doctor pipeline. Exits with 1 if any check returned `fail`.
  */
-export async function runDoctorCommand(argv: string[]): Promise<void> {
+export async function runDoctorCommand(argv: string[], deps: DoctorDeps = {}): Promise<void> {
   let args: DoctorCliArgs;
   try {
     args = parseDoctorArgs(argv);
@@ -141,7 +150,7 @@ export async function runDoctorCommand(argv: string[]): Promise<void> {
 
   // MCP servers — parallel probes.
   printSection('MCP servers');
-  const livenessResults = await checkMcpServerLiveness(config);
+  const livenessResults = await checkMcpServerLiveness(config, { probe: deps.probeMcpServer });
   for (const r of livenessResults) {
     printCheck(r);
     collected.push(r);
@@ -154,7 +163,7 @@ export async function runDoctorCommand(argv: string[]): Promise<void> {
     printCheck(apiResult);
     collected.push(apiResult);
 
-    const refreshResult = await checkOAuthRefresh();
+    const refreshResult = await checkOAuthRefresh(config);
     printCheck(refreshResult);
     collected.push(refreshResult);
   }

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -23,6 +23,7 @@ import {
   checkPolicyArtifacts,
   checkSandbox,
   checkServerCredentials,
+  collectDeclaredEnvVars,
   type CheckResult,
 } from './checks.js';
 import { checkAnthropicCredentials, checkOAuthRefresh } from './oauth-checks.js';
@@ -140,10 +141,11 @@ export async function runDoctorCommand(argv: string[], deps: DoctorDeps = {}): P
   collected.push(anthropicResult);
 
   for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
+    // Skip servers with no declared credential env vars — they'd otherwise
+    // produce one "no credentials required" line per server, drowning out
+    // the servers that actually need attention.
+    if (collectDeclaredEnvVars(serverConfig).length === 0) continue;
     const r = checkServerCredentials(serverName, serverConfig, config);
-    // Only show servers that need credentials — the "no credentials required"
-    // result would clutter the output with one line per server.
-    if (r.message === 'no credentials required') continue;
     printCheck(r);
     collected.push(r);
   }

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -77,17 +77,21 @@ export async function runDoctorCommand(argv: string[]): Promise<void> {
 
   const collected: CheckResult[] = [];
 
-  // Environment — sequential because failures invalidate later checks.
+  // Environment — sandbox and docker probes are independent, kick off in
+  // parallel and await in declaration order so output stays deterministic.
   printSection('Environment', { first: true });
   const nodeResult = checkNodeVersion();
   printCheck(nodeResult);
   collected.push(nodeResult);
 
-  const sandboxResult = await checkSandbox();
+  const sandboxPromise = checkSandbox();
+  const dockerPromise = checkDocker();
+
+  const sandboxResult = await sandboxPromise;
   printCheck(sandboxResult);
   collected.push(sandboxResult);
 
-  const dockerResult = await checkDocker();
+  const dockerResult = await dockerPromise;
   printCheck(dockerResult);
   collected.push(dockerResult);
 
@@ -100,8 +104,7 @@ export async function runDoctorCommand(argv: string[]): Promise<void> {
   if (!configCheck.config) {
     // Without a config we can't proceed past the basic environment.
     printSummary(collected);
-    if (collected.some((c) => c.status === 'fail')) process.exit(1);
-    return;
+    exitWithStatus(collected);
   }
   const config = configCheck.config;
 
@@ -157,8 +160,16 @@ export async function runDoctorCommand(argv: string[]): Promise<void> {
   }
 
   printSummary(collected);
+  exitWithStatus(collected);
+}
 
-  if (collected.some((c) => c.status === 'fail')) {
-    process.exit(1);
-  }
+/**
+ * Exits the process with status 1 on any check failure, 0 otherwise.
+ * Always exits explicitly because MCP server subprocesses spawned by the
+ * liveness probes can keep the Node event loop alive past the last printed
+ * line, even after `client.close()` (the MCP SDK doesn't aggressively
+ * SIGKILL the child).
+ */
+function exitWithStatus(collected: CheckResult[]): never {
+  process.exit(collected.some((c) => c.status === 'fail') ? 1 : 0);
 }

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -13,8 +13,8 @@
 import { parseArgs } from 'node:util';
 import { checkHelp, type CommandSpec } from '../cli-help.js';
 import {
+  checkAgentApiRoundtrip,
   checkAnnotationDrift,
-  checkAnthropicApi,
   checkAnthropicCredentials,
   checkConfigLoad,
   checkConstitutionDrift,
@@ -150,7 +150,7 @@ export async function runDoctorCommand(argv: string[]): Promise<void> {
   // Optional API round-trip.
   if (args.checkApi) {
     printSection('API round-trip');
-    const apiResult = await checkAnthropicApi(config);
+    const apiResult = await checkAgentApiRoundtrip(config);
     printCheck(apiResult);
     collected.push(apiResult);
 

--- a/src/doctor/mcp-liveness.ts
+++ b/src/doctor/mcp-liveness.ts
@@ -1,0 +1,106 @@
+/**
+ * MCP server liveness probe used by `ironcurtain doctor`.
+ *
+ * Spawns a short-lived MCP client, sends initialize + tools/list, and
+ * closes. Pattern copied from src/pipeline/annotate.ts (do NOT refactor
+ * annotate.ts — keep this module independent so the probe surface stays
+ * minimal).
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { MCPServerConfig } from '../config/types.js';
+import { permissiveJsonSchemaValidator } from '../trusted-process/permissive-output-validator.js';
+import { VERSION } from '../version.js';
+
+/** Per-server probe deadline. 5s is enough for npx warm-cache servers. */
+const PROBE_TIMEOUT_MS = 5_000;
+
+export interface ProbeOk {
+  readonly status: 'ok';
+  readonly toolCount: number;
+  readonly elapsedMs: number;
+}
+
+export interface ProbeFail {
+  readonly status: 'fail';
+  readonly elapsedMs: number;
+  readonly reason: string;
+}
+
+export type ProbeResult = ProbeOk | ProbeFail;
+
+/**
+ * Wraps a promise in a deadline. Resolves to the original value, or rejects
+ * with a timeout error if the deadline elapses first. Does not cancel the
+ * underlying promise — the caller is responsible for cleanup.
+ */
+function withDeadline<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolveOk, rejectErr) => {
+    const timer = setTimeout(() => {
+      rejectErr(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolveOk(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        rejectErr(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
+}
+
+/**
+ * Probes a single MCP server: connect, list tools, close.
+ *
+ * Catches all errors and converts them to a ProbeFail result so callers
+ * can run multiple probes in parallel without a single failure aborting
+ * the whole batch (Promise.all would otherwise reject on the first error).
+ */
+export async function probeServer(name: string, config: MCPServerConfig): Promise<ProbeResult> {
+  const start = Date.now();
+  let client: Client | undefined;
+  try {
+    const transport = new StdioClientTransport({
+      command: config.command,
+      args: config.args,
+      env: { ...(process.env as Record<string, string>), ...(config.env ?? {}) },
+      stderr: 'pipe',
+    });
+    if (transport.stderr) {
+      // Drain stderr to prevent backpressure on chatty servers.
+      transport.stderr.on('data', () => {});
+    }
+
+    client = new Client(
+      { name: `ironcurtain-doctor:${name}`, version: VERSION },
+      { jsonSchemaValidator: permissiveJsonSchemaValidator },
+    );
+
+    await withDeadline(client.connect(transport), PROBE_TIMEOUT_MS, `connect(${name})`);
+    const toolsResult = await withDeadline(client.listTools(), PROBE_TIMEOUT_MS, `listTools(${name})`);
+
+    return {
+      status: 'ok',
+      toolCount: toolsResult.tools.length,
+      elapsedMs: Date.now() - start,
+    };
+  } catch (err) {
+    return {
+      status: 'fail',
+      elapsedMs: Date.now() - start,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (client) {
+      try {
+        await client.close();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  }
+}

--- a/src/doctor/mcp-liveness.ts
+++ b/src/doctor/mcp-liveness.ts
@@ -13,8 +13,11 @@ import type { MCPServerConfig } from '../config/types.js';
 import { permissiveJsonSchemaValidator } from '../trusted-process/permissive-output-validator.js';
 import { VERSION } from '../version.js';
 
-/** Per-server probe deadline. 5s is enough for npx warm-cache servers. */
+/** Per-server probe deadline (covers connect + listTools combined). */
 const PROBE_TIMEOUT_MS = 5_000;
+
+/** Hard cap on close() — best-effort cleanup; the subprocess is reaped on doctor exit anyway. */
+const CLOSE_TIMEOUT_MS = 1_000;
 
 export interface ProbeOk {
   readonly status: 'ok';
@@ -75,13 +78,20 @@ export async function probeServer(name: string, config: MCPServerConfig): Promis
       transport.stderr.on('data', () => {});
     }
 
-    client = new Client(
+    const c = new Client(
       { name: `ironcurtain-doctor:${name}`, version: VERSION },
       { jsonSchemaValidator: permissiveJsonSchemaValidator },
     );
+    client = c;
 
-    await withDeadline(client.connect(transport), PROBE_TIMEOUT_MS, `connect(${name})`);
-    const toolsResult = await withDeadline(client.listTools(), PROBE_TIMEOUT_MS, `listTools(${name})`);
+    const toolsResult = await withDeadline(
+      (async () => {
+        await c.connect(transport);
+        return c.listTools();
+      })(),
+      PROBE_TIMEOUT_MS,
+      `probe(${name})`,
+    );
 
     return {
       status: 'ok',
@@ -96,11 +106,9 @@ export async function probeServer(name: string, config: MCPServerConfig): Promis
     };
   } finally {
     if (client) {
-      try {
-        await client.close();
-      } catch {
-        // Best-effort cleanup.
-      }
+      // close() can hang when the server is wedged; cap it so a stuck server
+      // can't block the rest of the doctor run.
+      await withDeadline(client.close(), CLOSE_TIMEOUT_MS, `close(${name})`).catch(() => undefined);
     }
   }
 }

--- a/src/doctor/oauth-checks.ts
+++ b/src/doctor/oauth-checks.ts
@@ -1,0 +1,181 @@
+/**
+ * OAuth-specific diagnostic checks for `ironcurtain doctor`.
+ *
+ * Split from checks.ts so the OAuth refresh/persist machinery (which
+ * touches the credentials file and macOS Keychain) lives next to
+ * oauth-credentials.ts and stays out of the general-purpose check surface.
+ */
+
+import {
+  detectAuthMethod,
+  isTokenExpired,
+  refreshOAuthToken,
+  saveOAuthCredentials,
+  writeToKeychain,
+  readOnlyCredentialSources,
+  type AuthMethod,
+  type OAuthCredentials,
+  type RefreshResult,
+} from '../docker/oauth-credentials.js';
+import type { IronCurtainConfig } from '../config/types.js';
+import type { CheckResult, CheckStatus } from './checks.js';
+
+/**
+ * Computes a human-readable description for an OAuth-typed AuthMethod,
+ * including expiry information.
+ */
+function describeOAuthExpiry(auth: Extract<AuthMethod, { kind: 'oauth' }>): {
+  message: string;
+  status: CheckStatus;
+  hint?: string;
+} {
+  const remainingMs = auth.credentials.expiresAt - Date.now();
+  if (remainingMs <= 0) {
+    return {
+      message: 'OAuth (expired)',
+      status: 'warn',
+      hint: 'Token will be refreshed automatically on next use, or run `claude login` to re-authenticate.',
+    };
+  }
+  const remainingDays = Math.floor(remainingMs / (24 * 60 * 60 * 1000));
+  if (remainingDays >= 1) {
+    return {
+      message: `OAuth (expires in ${remainingDays} day${remainingDays === 1 ? '' : 's'})`,
+      status: 'ok',
+    };
+  }
+  const remainingHours = Math.max(1, Math.floor(remainingMs / (60 * 60 * 1000)));
+  if (isTokenExpired(auth.credentials)) {
+    return {
+      message: `OAuth (expires in ${remainingHours}h, will auto-refresh)`,
+      status: 'ok',
+    };
+  }
+  return {
+    message: `OAuth (expires in ${remainingHours}h)`,
+    status: 'ok',
+  };
+}
+
+/**
+ * Checks Anthropic credential availability. Uses detectAuthMethod with
+ * no-refresh sources so doctor never rewrites the credentials file just
+ * by being run.
+ */
+export async function checkAnthropicCredentials(config: IronCurtainConfig): Promise<CheckResult> {
+  const auth = await detectAuthMethod(config, readOnlyCredentialSources);
+
+  if (auth.kind === 'oauth') {
+    const desc = describeOAuthExpiry(auth);
+    return { name: 'Anthropic', status: desc.status, message: desc.message, hint: desc.hint };
+  }
+  if (auth.kind === 'apikey') {
+    return { name: 'Anthropic', status: 'ok', message: 'API key set' };
+  }
+  return {
+    name: 'Anthropic',
+    status: 'warn',
+    message: 'no credentials detected',
+    hint: 'Set ANTHROPIC_API_KEY or run `claude login` to obtain OAuth credentials.',
+  };
+}
+
+/**
+ * Validates the OAuth refresh flow by exchanging the stored refresh token
+ * for new credentials. Anthropic rotates refresh tokens, so the new
+ * credentials MUST be persisted — otherwise the next refresh attempt
+ * (whether by doctor or by the running agent) fails because the local
+ * refresh token has been invalidated server-side.
+ */
+export async function checkOAuthRefresh(config: IronCurtainConfig): Promise<CheckResult> {
+  const auth = await detectAuthMethod(config, readOnlyCredentialSources);
+  if (auth.kind !== 'oauth') {
+    return {
+      name: 'OAuth refresh',
+      status: 'skip',
+      message: 'no OAuth credentials in file or Keychain',
+    };
+  }
+
+  let result: RefreshResult;
+  let elapsed: string;
+  try {
+    const start = Date.now();
+    result = await refreshOAuthToken(auth.credentials.refreshToken);
+    elapsed = formatElapsed(Date.now() - start);
+  } catch (err) {
+    const cause = err instanceof Error && err.cause instanceof Error ? ` (${err.cause.message})` : '';
+    return {
+      name: 'OAuth refresh',
+      status: 'fail',
+      message: (err instanceof Error ? err.message : String(err)) + cause,
+    };
+  }
+
+  if (result.kind !== 'ok') {
+    return formatRefreshFailure(result, elapsed);
+  }
+
+  // Refresh succeeded server-side; the old refresh token is now consumed.
+  // If we can't persist the rotated credentials, the host is effectively
+  // logged out — surface that clearly rather than swallowing the write error.
+  try {
+    persistRefreshedOAuth(auth, result.credentials);
+  } catch (err) {
+    return {
+      name: 'OAuth refresh',
+      status: 'fail',
+      message: `refresh succeeded but persistence failed: ${err instanceof Error ? err.message : String(err)}`,
+      hint: 'The server-side refresh token has rotated; your stored credentials are now invalid. Run `claude login` to recover.',
+    };
+  }
+
+  const sourceLabel = auth.source === 'keychain' ? 'Keychain' : 'file';
+  return { name: 'OAuth refresh', status: 'ok', message: `valid (${elapsed}, ${sourceLabel})` };
+}
+
+function formatRefreshFailure(result: Exclude<RefreshResult, { kind: 'ok' }>, elapsed: string): CheckResult {
+  if (result.kind === 'http-error') {
+    return {
+      name: 'OAuth refresh',
+      status: 'fail',
+      message: `refresh rejected (HTTP ${result.status}, ${elapsed})`,
+      hint:
+        result.status === 400 || result.status === 401
+          ? 'Refresh token has been invalidated (likely consumed by an earlier refresh). Run `claude login` to issue a new one.'
+          : 'Run `claude login` to obtain a new refresh token.',
+    };
+  }
+  if (result.kind === 'parse-error') {
+    return {
+      name: 'OAuth refresh',
+      status: 'fail',
+      message: `refresh response unparseable (${elapsed})`,
+      hint: result.detail,
+    };
+  }
+  return {
+    name: 'OAuth refresh',
+    status: 'fail',
+    message: `network error (${elapsed})`,
+    hint: result.message,
+  };
+}
+
+/**
+ * Writes refreshed credentials back to the same place they came from.
+ * Anthropic rotates refresh tokens on every grant, so skipping this would
+ * leave the host with an invalidated refresh token next run.
+ */
+function persistRefreshedOAuth(auth: Extract<AuthMethod, { kind: 'oauth' }>, credentials: OAuthCredentials): void {
+  if (auth.source === 'file') {
+    saveOAuthCredentials(credentials);
+  } else {
+    writeToKeychain(credentials, auth.keychainServiceName);
+  }
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}

--- a/src/doctor/output.ts
+++ b/src/doctor/output.ts
@@ -1,0 +1,84 @@
+/**
+ * Output formatting for `ironcurtain doctor`.
+ *
+ * Uses process.stdout.write directly because src/logger.ts may hijack
+ * console.* on the host process. Each helper writes a single line.
+ */
+
+import chalk from 'chalk';
+import type { CheckResult } from './checks.js';
+
+/** Width of the name column in the doctor output table. */
+const NAME_COLUMN_WIDTH = 24;
+
+/** Status -> glyph mapping. The glyphs are ASCII-friendly fallbacks. */
+const STATUS_GLYPH: Record<CheckResult['status'], string> = {
+  ok: chalk.green('✓'), // ✓
+  warn: chalk.yellow('⚠'), // ⚠
+  fail: chalk.red('✗'), // ✗
+  skip: chalk.dim('↷'), // ↷
+};
+
+/** Pads `text` with spaces on the right to reach at least `width` characters. */
+function padRight(text: string, width: number): string {
+  return text.length >= width ? text : text + ' '.repeat(width - text.length);
+}
+
+/**
+ * Prints a section heading to stdout (e.g. "Environment", "MCP servers").
+ * A blank line is emitted before the heading except for the first section.
+ */
+export function printSection(title: string, opts: { first?: boolean } = {}): void {
+  if (!opts.first) {
+    process.stdout.write('\n');
+  }
+  process.stdout.write(chalk.bold(title) + '\n');
+}
+
+/**
+ * Prints a single check result as one (or two) lines:
+ *   <glyph> <name padded><message>
+ *     └─ <hint>
+ *
+ * The hint is only emitted when present.
+ */
+export function printCheck(check: CheckResult): void {
+  const glyph = STATUS_GLYPH[check.status];
+  const name = padRight(check.name, NAME_COLUMN_WIDTH);
+  process.stdout.write(`  ${glyph} ${name}${check.message}\n`);
+  if (check.hint) {
+    process.stdout.write(`    ${chalk.dim('└─')} ${check.hint}\n`);
+  }
+}
+
+/**
+ * Prints the summary footer counting checks by status.
+ */
+export function printSummary(checks: readonly CheckResult[]): void {
+  let ok = 0;
+  let warn = 0;
+  let fail = 0;
+  let skip = 0;
+  for (const c of checks) {
+    switch (c.status) {
+      case 'ok':
+        ok++;
+        break;
+      case 'warn':
+        warn++;
+        break;
+      case 'fail':
+        fail++;
+        break;
+      case 'skip':
+        skip++;
+        break;
+    }
+  }
+  process.stdout.write('\n');
+  const okPart = chalk.green(`${ok} ok`);
+  const warnPart = chalk.yellow(`${warn} warn`);
+  const failPart = chalk.red(`${fail} fail`);
+  const skipPart = chalk.dim(`${skip} skipped`);
+  process.stdout.write(`Summary: ${okPart}, ${warnPart}, ${failPart}, ${skipPart}\n`);
+}

--- a/src/doctor/output.ts
+++ b/src/doctor/output.ts
@@ -11,12 +11,12 @@ import type { CheckResult } from './checks.js';
 /** Width of the name column in the doctor output table. */
 const NAME_COLUMN_WIDTH = 24;
 
-/** Status -> glyph mapping. The glyphs are ASCII-friendly fallbacks. */
+/** Status -> glyph mapping. Uses Unicode symbols; terminals without UTF-8 will see replacement chars. */
 const STATUS_GLYPH: Record<CheckResult['status'], string> = {
-  ok: chalk.green('✓'), // ✓
-  warn: chalk.yellow('⚠'), // ⚠
-  fail: chalk.red('✗'), // ✗
-  skip: chalk.dim('↷'), // ↷
+  ok: chalk.green('✓'),
+  warn: chalk.yellow('⚠'),
+  fail: chalk.red('✗'),
+  skip: chalk.dim('↷'),
 };
 
 /**

--- a/src/doctor/output.ts
+++ b/src/doctor/output.ts
@@ -19,9 +19,14 @@ const STATUS_GLYPH: Record<CheckResult['status'], string> = {
   skip: chalk.dim('↷'), // ↷
 };
 
-/** Pads `text` with spaces on the right to reach at least `width` characters. */
+/**
+ * Pads `text` with spaces on the right to reach at least `width` characters,
+ * always with at least one trailing space so columns don't collide when the
+ * text is already at or above the width.
+ */
 function padRight(text: string, width: number): string {
-  return text.length >= width ? text : text + ' '.repeat(width - text.length);
+  const target = Math.max(width, text.length + 1);
+  return text + ' '.repeat(target - text.length);
 }
 
 /**

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -12,17 +12,9 @@ import { promisify } from 'node:util';
 import type { IronCurtainConfig } from '../config/types.js';
 import type { AgentId } from '../docker/agent-adapter.js';
 import type { SessionMode } from './types.js';
-import {
-  detectAuthMethod,
-  loadOAuthCredentials,
-  extractFromKeychain,
-  refreshOAuthToken,
-  saveOAuthCredentials,
-  extractFromKeychainWithService,
-  writeToKeychain,
-  type CredentialSources,
-} from '../docker/oauth-credentials.js';
+import { detectAuthMethod, preflightCredentialSources, type CredentialSources } from '../docker/oauth-credentials.js';
 import { resolveApiKeyForProvider } from '../config/model-provider.js';
+import { isObjectWithProp } from '../utils/is-plain-object.js';
 
 const execFile = promisify(execFileCb);
 
@@ -89,24 +81,6 @@ export async function checkDockerAvailable(): Promise<DockerAvailability> {
   }
 }
 
-/** Type-narrowing helper for inspecting unknown error shapes. */
-function isObjectWithProp<K extends string>(value: unknown, key: K): value is Record<K, unknown> {
-  return typeof value === 'object' && value !== null && key in value;
-}
-
-/**
- * Credential sources for preflight detection including Keychain lookup (~19ms)
- * and token refresh so that expired credentials are refreshed at startup.
- */
-const preflightSources: CredentialSources = {
-  loadFromFile: loadOAuthCredentials,
-  loadFromKeychain: extractFromKeychain,
-  refreshToken: refreshOAuthToken,
-  saveToFile: saveOAuthCredentials,
-  loadFromKeychainWithService: extractFromKeychainWithService,
-  writeToKeychain,
-};
-
 /**
  * Checks whether credentials (OAuth or API key) are available for the given agent.
  * Returns the auth kind if available, or null if no credentials found.
@@ -126,8 +100,8 @@ async function detectCredentials(
   }
 
   // Default path: Anthropic OAuth + API key detection (Claude Code and others).
-  // Uses preflightSources, which may refresh expired tokens and update credential storage.
-  const auth = await detectAuthMethod(config, sources ?? preflightSources);
+  // Uses preflightCredentialSources, which may refresh expired tokens and update credential storage.
+  const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
   if (auth.kind === 'none') return null;
   return auth.kind === 'oauth' ? 'oauth' : 'apikey';
 }
@@ -206,7 +180,7 @@ async function resolveAutoDetect(
   const [dockerStatus, credKind, authMethod] = await Promise.all([
     isDockerAvailable(),
     detectCredentials(defaultAgent, config, credentialSources),
-    detectAuthMethod(config, credentialSources ?? preflightSources),
+    detectAuthMethod(config, credentialSources ?? preflightCredentialSources),
   ]);
 
   if (!dockerStatus.available) {

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -27,7 +27,7 @@ const DOCKER_UNAVAILABLE_REASON = 'Docker not available';
  */
 export class PreflightError extends Error {
   constructor(message: string) {
-    super(message);
+    super(`${message}\n\nRun \`ironcurtain doctor\` for a full diagnostic.`);
     this.name = 'PreflightError';
   }
 }

--- a/src/utils/is-plain-object.ts
+++ b/src/utils/is-plain-object.ts
@@ -2,3 +2,11 @@
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
+
+/**
+ * Type guard that narrows `unknown` to an object known to carry a given key.
+ * Useful for safely inspecting properties on caught errors without `as` casts.
+ */
+export function isObjectWithProp<K extends string>(value: unknown, key: K): value is Record<K, unknown> {
+  return typeof value === 'object' && value !== null && key in value;
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -263,6 +263,13 @@ describe('checkServerCredentials', () => {
     expect(checkServerCredentials('svc', server, cfg).status).toBe('ok');
   });
 
+  it('passes when env var is set inline in serverConfig.env', () => {
+    delete process.env.MY_TOKEN;
+    const server = buildServerConfig({ args: [], env: { MY_TOKEN: 'inline-value' } });
+    const cfg = buildConfig({ mcpServers: { svc: server } });
+    expect(checkServerCredentials('svc', server, cfg).status).toBe('ok');
+  });
+
   it('warns when credentials are missing', () => {
     delete process.env.MY_TOKEN;
     const server = buildServerConfig({ args: ['-e', 'MY_TOKEN'] });

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -13,6 +13,29 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import chalk from 'chalk';
 
+// Module mocks for the OAuth-refresh and API-round-trip unit tests below.
+// `vi.fn(actual.fn)` keeps default behavior intact so the integration-style
+// tests in `describe('runDoctorCommand', ...)` still hit the real impls;
+// individual unit tests override with `mockResolvedValueOnce` / `mockReturnValueOnce`.
+vi.mock('../src/docker/oauth-credentials.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/docker/oauth-credentials.js')>();
+  return {
+    ...actual,
+    detectAuthMethod: vi.fn(actual.detectAuthMethod),
+    refreshOAuthToken: vi.fn(actual.refreshOAuthToken),
+    saveOAuthCredentials: vi.fn(actual.saveOAuthCredentials),
+    writeToKeychain: vi.fn(actual.writeToKeychain),
+  };
+});
+vi.mock('ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ai')>();
+  return { ...actual, generateText: vi.fn(actual.generateText) };
+});
+vi.mock('../src/config/model-provider.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/config/model-provider.js')>();
+  return { ...actual, createLanguageModel: vi.fn(actual.createLanguageModel) };
+});
+
 import {
   checkAnnotationDrift,
   checkConstitutionDrift,
@@ -25,6 +48,9 @@ import {
 } from '../src/doctor/checks.js';
 import type { ProbeResult } from '../src/doctor/mcp-liveness.js';
 import type { IronCurtainConfig, MCPServerConfig } from '../src/config/types.js';
+import { detectAuthMethod, refreshOAuthToken, saveOAuthCredentials } from '../src/docker/oauth-credentials.js';
+import { generateText } from 'ai';
+import { createLanguageModel } from '../src/config/model-provider.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -392,6 +418,7 @@ describe('runDoctorCommand', () => {
   const savedHome = process.env.IRONCURTAIN_HOME;
   const savedColor = process.env.FORCE_COLOR;
   const savedAllowed = process.env.ALLOWED_DIRECTORY;
+  const savedChalkLevel = chalk.level;
 
   beforeEach(() => {
     tmp = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-int-'));
@@ -411,6 +438,7 @@ describe('runDoctorCommand', () => {
     else process.env.FORCE_COLOR = savedColor;
     if (savedAllowed === undefined) delete process.env.ALLOWED_DIRECTORY;
     else process.env.ALLOWED_DIRECTORY = savedAllowed;
+    chalk.level = savedChalkLevel;
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -423,26 +451,23 @@ describe('runDoctorCommand', () => {
   });
 
   it('prints all sections and a summary footer', async () => {
-    // Stub mcp-servers.json indirectly: loadConfig() reads from
-    // src/config/mcp-servers.json which exists in the repo. The default
-    // config will produce real MCP probes; we don't actually spawn them
-    // because we mock checkMcpServerLiveness via vi.mock below.
-    vi.resetModules();
-    vi.doMock('../src/doctor/mcp-liveness.js', () => ({
-      probeServer: async (): Promise<ProbeResult> => ({
+    // loadConfig() reads from src/config/mcp-servers.json which exists
+    // in the repo. We pass a probe stub through DoctorDeps to avoid
+    // actually spawning the configured MCP server processes.
+    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
+    const probeStub = vi.fn(
+      async (): Promise<ProbeResult> => ({
         status: 'ok',
         toolCount: 1,
         elapsedMs: 10,
       }),
-    }));
-    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
-    const { output } = await captureOutput(() => runDoctorCommand([]));
+    );
+    const { output } = await captureOutput(() => runDoctorCommand([], { probeMcpServer: probeStub }));
     expect(output).toContain('Environment');
     expect(output).toContain('Configuration');
     expect(output).toContain('Credentials');
     expect(output).toContain('MCP servers');
     expect(output).toMatch(/Summary: \d+ ok, \d+ warn, \d+ fail/);
-    vi.doUnmock('../src/doctor/mcp-liveness.js');
   });
 
   it('rejects unknown flags by printing an error', async () => {
@@ -450,6 +475,149 @@ describe('runDoctorCommand', () => {
     const { output, exitCode } = await captureOutput(() => runDoctorCommand(['--bogus']));
     expect(output).toMatch(/--bogus/i);
     expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkOAuthRefresh
+// ---------------------------------------------------------------------------
+
+describe('checkOAuthRefresh', () => {
+  const baseConfig = buildConfig();
+  const oauthAuth = {
+    kind: 'oauth' as const,
+    source: 'file' as const,
+    credentials: { accessToken: 'old', refreshToken: 'rt-old', expiresAt: Date.now() + 60_000 },
+  };
+  const freshCreds = { accessToken: 'new', refreshToken: 'rt-new', expiresAt: Date.now() + 3_600_000 };
+
+  it('skips when no OAuth credentials are present', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce({ kind: 'none' });
+    const { checkOAuthRefresh } = await import('../src/doctor/oauth-checks.js');
+    const r = await checkOAuthRefresh(baseConfig);
+    expect(r.status).toBe('skip');
+    expect(r.message).toMatch(/no OAuth credentials/);
+  });
+
+  it('returns ok and persists rotated credentials on successful refresh', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce(oauthAuth);
+    vi.mocked(refreshOAuthToken).mockResolvedValueOnce({ kind: 'ok', credentials: freshCreds });
+    vi.mocked(saveOAuthCredentials).mockReturnValueOnce(undefined);
+    const { checkOAuthRefresh } = await import('../src/doctor/oauth-checks.js');
+    const r = await checkOAuthRefresh(baseConfig);
+    expect(r.status).toBe('ok');
+    expect(r.message).toMatch(/valid \(.*, file\)/);
+    expect(saveOAuthCredentials).toHaveBeenCalledWith(freshCreds);
+  });
+
+  it('reports HTTP rejection with the status code and a re-login hint', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce(oauthAuth);
+    vi.mocked(refreshOAuthToken).mockResolvedValueOnce({ kind: 'http-error', status: 401 });
+    const { checkOAuthRefresh } = await import('../src/doctor/oauth-checks.js');
+    const r = await checkOAuthRefresh(baseConfig);
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/HTTP 401/);
+    expect(r.hint).toMatch(/Refresh token has been invalidated/);
+  });
+
+  it('reports network errors with the underlying message', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce(oauthAuth);
+    vi.mocked(refreshOAuthToken).mockResolvedValueOnce({ kind: 'network-error', message: 'ECONNRESET' });
+    const { checkOAuthRefresh } = await import('../src/doctor/oauth-checks.js');
+    const r = await checkOAuthRefresh(baseConfig);
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/network error/);
+    expect(r.hint).toBe('ECONNRESET');
+  });
+
+  it('reports parse errors with the detail', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce(oauthAuth);
+    vi.mocked(refreshOAuthToken).mockResolvedValueOnce({ kind: 'parse-error', detail: 'missing access_token' });
+    const { checkOAuthRefresh } = await import('../src/doctor/oauth-checks.js');
+    const r = await checkOAuthRefresh(baseConfig);
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/unparseable/);
+    expect(r.hint).toBe('missing access_token');
+  });
+
+  it('reports persistence failure separately so the user knows credentials are now invalid', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce(oauthAuth);
+    vi.mocked(refreshOAuthToken).mockResolvedValueOnce({ kind: 'ok', credentials: freshCreds });
+    vi.mocked(saveOAuthCredentials).mockImplementationOnce(() => {
+      throw new Error('EACCES: write denied');
+    });
+    const { checkOAuthRefresh } = await import('../src/doctor/oauth-checks.js');
+    const r = await checkOAuthRefresh(baseConfig);
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/refresh succeeded but persistence failed/);
+    expect(r.message).toMatch(/EACCES/);
+    expect(r.hint).toMatch(/Run `claude login`/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkAgentApiRoundtrip
+// ---------------------------------------------------------------------------
+
+describe('checkAgentApiRoundtrip', () => {
+  const baseConfig = buildConfig();
+  const fakeModel = {} as never;
+
+  function configWithApiKey(provider: 'anthropic' | 'openai' | 'google', key: string) {
+    return buildConfig({
+      agentModelId: `${provider}:test-model`,
+      userConfig: { ...baseConfig.userConfig, [`${provider}ApiKey`]: key },
+    });
+  }
+
+  it('skips with provider-aware message when no API key is set and provider is non-Anthropic', async () => {
+    // For non-Anthropic providers the OAuth fallback branch is short-circuited,
+    // so detectAuthMethod is never called — no need to mock it here.
+    const { checkAgentApiRoundtrip } = await import('../src/doctor/checks.js');
+    const r = await checkAgentApiRoundtrip(buildConfig({ agentModelId: 'openai:gpt-4' }));
+    expect(r.name).toBe('OpenAI API round-trip');
+    expect(r.status).toBe('skip');
+    expect(r.message).toMatch(/no OpenAI API key/);
+  });
+
+  it('skips with OAuth-aware message when Anthropic provider has OAuth but no API key', async () => {
+    vi.mocked(detectAuthMethod).mockResolvedValueOnce({
+      kind: 'oauth',
+      source: 'file',
+      credentials: { accessToken: 'a', refreshToken: 'r', expiresAt: Date.now() + 60_000 },
+    });
+    const { checkAgentApiRoundtrip } = await import('../src/doctor/checks.js');
+    const r = await checkAgentApiRoundtrip(baseConfig);
+    expect(r.name).toBe('Anthropic API round-trip');
+    expect(r.status).toBe('skip');
+    expect(r.message).toMatch(/OAuth-only setup/);
+  });
+
+  it('reports ok with elapsed time on a successful round-trip', async () => {
+    vi.mocked(createLanguageModel).mockResolvedValueOnce(fakeModel);
+    vi.mocked(generateText).mockResolvedValueOnce({} as never);
+    const { checkAgentApiRoundtrip } = await import('../src/doctor/checks.js');
+    const r = await checkAgentApiRoundtrip(configWithApiKey('anthropic', 'sk-test'));
+    expect(r.status).toBe('ok');
+    expect(r.message).toMatch(/responded in/);
+  });
+
+  it('extracts url, status, cause, and code from AI SDK errors via describeApiError', async () => {
+    vi.mocked(createLanguageModel).mockResolvedValueOnce(fakeModel);
+    const sdkError = Object.assign(new Error('Cannot connect to API'), {
+      url: 'https://api.anthropic.com/v1/messages',
+      statusCode: 500,
+      cause: Object.assign(new Error('fetch failed'), { code: 'ECONNREFUSED' }),
+    });
+    vi.mocked(generateText).mockRejectedValueOnce(sdkError);
+    const { checkAgentApiRoundtrip } = await import('../src/doctor/checks.js');
+    const r = await checkAgentApiRoundtrip(configWithApiKey('anthropic', 'sk-test'));
+    expect(r.status).toBe('fail');
+    expect(r.message).toContain('Cannot connect to API');
+    expect(r.message).toContain('url=https://api.anthropic.com/v1/messages');
+    expect(r.message).toContain('status=500');
+    expect(r.message).toContain('cause=fetch failed');
+    expect(r.message).toContain('code=ECONNREFUSED');
   });
 });
 

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Tests for `ironcurtain doctor`.
+ *
+ * Two layers:
+ *   - Pure unit tests for each check function (no IO unless mocked).
+ *   - Integration smoke test that drives `runDoctorCommand([])` against a
+ *     tmpdir IRONCURTAIN_HOME and asserts exit-code propagation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import chalk from 'chalk';
+
+import {
+  checkAnnotationDrift,
+  checkConstitutionDrift,
+  checkDocker,
+  checkMcpServerLiveness,
+  checkNodeVersion,
+  checkServerCredentials,
+  collectDeclaredEnvVars,
+  type CheckResult,
+} from '../src/doctor/checks.js';
+import type { ProbeResult } from '../src/doctor/mcp-liveness.js';
+import type { IronCurtainConfig, MCPServerConfig } from '../src/config/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Captures stdout/stderr writes (and console.error) and suppresses process.exit. */
+async function captureOutput(fn: () => Promise<void>): Promise<{ output: string; exitCode: number | undefined }> {
+  const writes: string[] = [];
+  const origStdout = process.stdout.write;
+  const origStderr = process.stderr.write;
+  const origConsoleError = console.error;
+  process.stdout.write = ((chunk: string) => {
+    writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    writes.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  console.error = ((...args: unknown[]) => {
+    writes.push(args.map(String).join(' ') + '\n');
+  }) as typeof console.error;
+
+  const origExit = process.exit;
+  let exitCode: number | undefined;
+  process.exit = ((code?: number) => {
+    exitCode = code;
+    throw new Error(`__exit_${code ?? 0}`);
+  }) as typeof process.exit;
+
+  try {
+    await fn();
+  } catch (err) {
+    if (!(err instanceof Error) || !err.message.startsWith('__exit_')) {
+      throw err;
+    }
+  } finally {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+    console.error = origConsoleError;
+    process.exit = origExit;
+  }
+  return { output: writes.join(''), exitCode };
+}
+
+function buildServerConfig(overrides: Partial<MCPServerConfig> = {}): MCPServerConfig {
+  return {
+    command: 'true',
+    args: [],
+    ...overrides,
+  };
+}
+
+function buildConfig(overrides: Partial<IronCurtainConfig> = {}): IronCurtainConfig {
+  const userConfigStub = {
+    agentModelId: 'anthropic:claude-sonnet-4-6',
+    policyModelId: 'anthropic:claude-sonnet-4-6',
+    prefilterModelId: 'anthropic:claude-haiku-4-5',
+    anthropicApiKey: '',
+    googleApiKey: '',
+    openaiApiKey: '',
+    anthropicBaseUrl: '',
+    openaiBaseUrl: '',
+    googleBaseUrl: '',
+    escalationTimeoutSeconds: 300,
+    resourceBudget: {
+      maxTotalTokens: 1_000_000,
+      maxSteps: 200,
+      maxSessionSeconds: 1800,
+      maxEstimatedCostUsd: 5,
+      warnThresholdPercent: 80,
+    },
+    autoCompact: { enabled: true, thresholdTokens: 100_000, keepRecentMessages: 10, summaryModelId: 'anthropic:m' },
+    autoApprove: { enabled: false, modelId: 'anthropic:m' },
+    auditRedaction: { enabled: true },
+    memory: { enabled: true, autoSave: true, llmBaseUrl: undefined, llmApiKey: undefined },
+    webSearch: { provider: null, brave: null, tavily: null, serpapi: null },
+    serverCredentials: {},
+    signal: null,
+    gooseProvider: 'anthropic' as const,
+    gooseModel: 'claude',
+    preferredDockerAgent: 'claude-code' as const,
+    packageInstall: { enabled: true, quarantineDays: 2, allowedPackages: [], deniedPackages: [] },
+  };
+  return {
+    auditLogPath: '/tmp/audit.jsonl',
+    allowedDirectory: '/tmp',
+    mcpServers: {},
+    protectedPaths: [],
+    generatedDir: '/tmp/generated',
+    constitutionPath: '/tmp/constitution.md',
+    agentModelId: 'anthropic:claude-sonnet-4-6',
+    escalationTimeoutSeconds: 300,
+    userConfig: userConfigStub,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit: checkNodeVersion
+// ---------------------------------------------------------------------------
+
+describe('checkNodeVersion', () => {
+  it('passes for supported major versions', () => {
+    expect(checkNodeVersion('22.13.0').status).toBe('ok');
+    expect(checkNodeVersion('23.5.0').status).toBe('ok');
+    expect(checkNodeVersion('24.0.0').status).toBe('ok');
+  });
+
+  it('fails for too-old major version', () => {
+    const result = checkNodeVersion('20.10.0');
+    expect(result.status).toBe('fail');
+    expect(result.hint).toMatch(/22\.x/);
+  });
+
+  it('fails for too-new major version', () => {
+    const result = checkNodeVersion('25.0.0');
+    expect(result.status).toBe('fail');
+  });
+
+  it('fails for unparseable input', () => {
+    expect(checkNodeVersion('not-a-version').status).toBe('fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkDocker
+// ---------------------------------------------------------------------------
+
+describe('checkDocker', () => {
+  it('returns ok when Docker is available', async () => {
+    const result = await checkDocker(async () => ({ available: true }));
+    expect(result.status).toBe('ok');
+    expect(result.message).toBe('running');
+  });
+
+  it('returns warn when Docker is unavailable', async () => {
+    const result = await checkDocker(async () => ({
+      available: false,
+      reason: 'not found',
+      detailedMessage: 'docker: command not found',
+    }));
+    expect(result.status).toBe('warn');
+    expect(result.hint).toBe('docker: command not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: collectDeclaredEnvVars + checkServerCredentials
+// ---------------------------------------------------------------------------
+
+describe('collectDeclaredEnvVars', () => {
+  it('collects -e flags from args (Docker convention)', () => {
+    const cfg = buildServerConfig({
+      command: 'docker',
+      args: ['run', '-i', '--rm', '-e', 'GITHUB_PERSONAL_ACCESS_TOKEN', 'ghcr.io/x'],
+    });
+    expect(collectDeclaredEnvVars(cfg)).toEqual(['GITHUB_PERSONAL_ACCESS_TOKEN']);
+  });
+
+  it('skips -e KEY=value form', () => {
+    const cfg = buildServerConfig({ args: ['-e', 'TOKEN=abc'] });
+    expect(collectDeclaredEnvVars(cfg)).toEqual([]);
+  });
+
+  it('collects credential-like env keys from config.env', () => {
+    const cfg = buildServerConfig({
+      env: { MY_API_KEY: '', MCP_TRANSPORT_TYPE: 'stdio' },
+    });
+    // Only MY_API_KEY is credential-shaped.
+    expect(collectDeclaredEnvVars(cfg)).toEqual(['MY_API_KEY']);
+  });
+
+  it('returns empty when nothing declared', () => {
+    expect(collectDeclaredEnvVars(buildServerConfig())).toEqual([]);
+  });
+});
+
+describe('checkServerCredentials', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('passes when no credentials are needed', () => {
+    const cfg = buildConfig({ mcpServers: { foo: buildServerConfig() } });
+    const result = checkServerCredentials('foo', cfg.mcpServers.foo, cfg);
+    expect(result.status).toBe('ok');
+    expect(result.message).toBe('no credentials required');
+  });
+
+  it('passes when env var is set in process.env', () => {
+    process.env.MY_TOKEN = 'abc';
+    const server = buildServerConfig({ args: ['-e', 'MY_TOKEN'] });
+    const cfg = buildConfig({ mcpServers: { svc: server } });
+    expect(checkServerCredentials('svc', server, cfg).status).toBe('ok');
+  });
+
+  it('passes when env var is set in serverCredentials', () => {
+    delete process.env.MY_TOKEN;
+    const server = buildServerConfig({ args: ['-e', 'MY_TOKEN'] });
+    const cfg = buildConfig({
+      mcpServers: { svc: server },
+      userConfig: {
+        ...buildConfig().userConfig,
+        serverCredentials: { svc: { MY_TOKEN: 'xyz' } },
+      },
+    });
+    expect(checkServerCredentials('svc', server, cfg).status).toBe('ok');
+  });
+
+  it('warns when credentials are missing', () => {
+    delete process.env.MY_TOKEN;
+    const server = buildServerConfig({ args: ['-e', 'MY_TOKEN'] });
+    const cfg = buildConfig({ mcpServers: { svc: server } });
+    const result = checkServerCredentials('svc', server, cfg);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('MY_TOKEN');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkConstitutionDrift
+// ---------------------------------------------------------------------------
+
+describe('checkConstitutionDrift', () => {
+  let tmp: string;
+  const savedHome = process.env.IRONCURTAIN_HOME;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-drift-'));
+    process.env.IRONCURTAIN_HOME = tmp;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = savedHome;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns ok when hashes match', async () => {
+    const constitutionPath = resolve(tmp, 'constitution.md');
+    writeFileSync(constitutionPath, 'base');
+    writeFileSync(resolve(tmp, 'constitution-user.md'), 'rules');
+    const { computeConstitutionHash } = await import('../src/config/paths.js');
+    const hash = computeConstitutionHash(constitutionPath);
+    const cfg = buildConfig({ constitutionPath });
+    expect(checkConstitutionDrift(cfg, { constitutionHash: hash }).status).toBe('ok');
+  });
+
+  it('returns warn when hashes differ', () => {
+    const constitutionPath = resolve(tmp, 'constitution.md');
+    writeFileSync(constitutionPath, 'base');
+    writeFileSync(resolve(tmp, 'constitution-user.md'), 'rules');
+    const cfg = buildConfig({ constitutionPath });
+    const result = checkConstitutionDrift(cfg, { constitutionHash: 'stale' });
+    expect(result.status).toBe('warn');
+    expect(result.hint).toMatch(/compile-policy/);
+  });
+
+  it('returns fail when constitution file is missing', () => {
+    const cfg = buildConfig({ constitutionPath: resolve(tmp, 'missing.md') });
+    expect(checkConstitutionDrift(cfg, { constitutionHash: 'x' }).status).toBe('fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkAnnotationDrift
+// ---------------------------------------------------------------------------
+
+describe('checkAnnotationDrift', () => {
+  it('returns ok when annotations cover all configured servers', () => {
+    const annotations = {
+      generatedAt: '',
+      servers: { fs: { inputHash: 'h', tools: [] } },
+    };
+    const mcpServers = { fs: buildServerConfig() };
+    expect(checkAnnotationDrift(annotations, mcpServers).status).toBe('ok');
+  });
+
+  it('warns when a configured server has no annotations', () => {
+    const annotations = { generatedAt: '', servers: {} };
+    const mcpServers = { fs: buildServerConfig() };
+    const result = checkAnnotationDrift(annotations, mcpServers);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('missing: fs');
+    expect(result.hint).toContain('annotate-tools --server fs');
+  });
+
+  it('warns when annotations have orphaned entries', () => {
+    const annotations = {
+      generatedAt: '',
+      servers: { gone: { inputHash: 'h', tools: [] } },
+    };
+    const mcpServers = {};
+    const result = checkAnnotationDrift(annotations, mcpServers);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('orphaned: gone');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkMcpServerLiveness
+// ---------------------------------------------------------------------------
+
+describe('checkMcpServerLiveness', () => {
+  it('returns a single skip entry when no servers are configured', async () => {
+    const cfg = buildConfig({ mcpServers: {} });
+    const results = await checkMcpServerLiveness(cfg);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('skip');
+  });
+
+  it('skips servers with missing credentials without spawning', async () => {
+    delete process.env.MY_TOKEN;
+    const probe = vi.fn();
+    const server = buildServerConfig({ args: ['-e', 'MY_TOKEN'] });
+    const cfg = buildConfig({ mcpServers: { svc: server } });
+    const results = await checkMcpServerLiveness(cfg, { probe });
+    expect(probe).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ name: 'svc', status: 'skip' });
+  });
+
+  it('runs probes for servers with credentials', async () => {
+    process.env.MY_TOKEN = 'value';
+    const probe = vi.fn(
+      async (): Promise<ProbeResult> => ({
+        status: 'ok',
+        toolCount: 7,
+        elapsedMs: 412,
+      }),
+    );
+    const cfg = buildConfig({
+      mcpServers: { svc: buildServerConfig({ args: ['-e', 'MY_TOKEN'] }) },
+    });
+    const results = await checkMcpServerLiveness(cfg, { probe });
+    expect(probe).toHaveBeenCalledOnce();
+    expect(results[0].status).toBe('ok');
+    expect(results[0].message).toContain('7 tools');
+    delete process.env.MY_TOKEN;
+  });
+
+  it('reports probe failures as fail with reason in hint', async () => {
+    const probe = vi.fn(
+      async (): Promise<ProbeResult> => ({
+        status: 'fail',
+        elapsedMs: 1200,
+        reason: 'spawn ENOENT',
+      }),
+    );
+    const cfg = buildConfig({ mcpServers: { svc: buildServerConfig() } });
+    const results = await checkMcpServerLiveness(cfg, { probe });
+    expect(results[0].status).toBe('fail');
+    expect(results[0].hint).toBe('spawn ENOENT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: runDoctorCommand exit-code propagation
+// ---------------------------------------------------------------------------
+
+describe('runDoctorCommand', () => {
+  let tmp: string;
+  const savedHome = process.env.IRONCURTAIN_HOME;
+  const savedColor = process.env.FORCE_COLOR;
+  const savedAllowed = process.env.ALLOWED_DIRECTORY;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-int-'));
+    process.env.IRONCURTAIN_HOME = tmp;
+    process.env.FORCE_COLOR = '0';
+    chalk.level = 0;
+    // Avoid any incidental ANTHROPIC_API_KEY from the runner environment
+    // affecting credential checks (we want deterministic 'no creds').
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.ALLOWED_DIRECTORY = tmp;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = savedHome;
+    if (savedColor === undefined) delete process.env.FORCE_COLOR;
+    else process.env.FORCE_COLOR = savedColor;
+    if (savedAllowed === undefined) delete process.env.ALLOWED_DIRECTORY;
+    else process.env.ALLOWED_DIRECTORY = savedAllowed;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('prints help and returns when --help is passed', async () => {
+    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
+    const { output, exitCode } = await captureOutput(() => runDoctorCommand(['--help']));
+    expect(output).toContain('ironcurtain doctor');
+    expect(output).toContain('--check-api');
+    expect(exitCode).toBeUndefined();
+  });
+
+  it('prints all sections and a summary footer', async () => {
+    // Stub mcp-servers.json indirectly: loadConfig() reads from
+    // src/config/mcp-servers.json which exists in the repo. The default
+    // config will produce real MCP probes; we don't actually spawn them
+    // because we mock checkMcpServerLiveness via vi.mock below.
+    vi.resetModules();
+    vi.doMock('../src/doctor/mcp-liveness.js', () => ({
+      probeServer: async (): Promise<ProbeResult> => ({
+        status: 'ok',
+        toolCount: 1,
+        elapsedMs: 10,
+      }),
+    }));
+    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
+    const { output } = await captureOutput(() => runDoctorCommand([]));
+    expect(output).toContain('Environment');
+    expect(output).toContain('Configuration');
+    expect(output).toContain('Credentials');
+    expect(output).toContain('MCP servers');
+    expect(output).toMatch(/Summary: \d+ ok, \d+ warn, \d+ fail/);
+    vi.doUnmock('../src/doctor/mcp-liveness.js');
+  });
+
+  it('rejects unknown flags by printing an error', async () => {
+    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
+    const { output, exitCode } = await captureOutput(() => runDoctorCommand(['--bogus']));
+    expect(output).toMatch(/--bogus/i);
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke: CheckResult shape stays stable
+// ---------------------------------------------------------------------------
+
+describe('CheckResult shape', () => {
+  it('all unit checks return a name, status, and message', () => {
+    const samples: CheckResult[] = [
+      checkNodeVersion('22.13.0'),
+      checkAnnotationDrift({ generatedAt: '', servers: {} }, {}),
+    ];
+    for (const r of samples) {
+      expect(typeof r.name).toBe('string');
+      expect(['ok', 'warn', 'fail', 'skip']).toContain(r.status);
+      expect(typeof r.message).toBe('string');
+    }
+  });
+});

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -626,6 +626,19 @@ describe('checkAgentApiRoundtrip', () => {
     expect(r.message).toContain('cause=fetch failed');
     expect(r.message).toContain('code=ECONNREFUSED');
   });
+
+  it('passes a timeout abortSignal to generateText so a hung provider cannot block doctor', async () => {
+    vi.mocked(createLanguageModel).mockResolvedValueOnce(fakeModel);
+    vi.mocked(generateText).mockResolvedValueOnce({} as never);
+    const { checkAgentApiRoundtrip } = await import('../src/doctor/checks.js');
+    await checkAgentApiRoundtrip(configWithApiKey('anthropic', 'sk-test'));
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as {
+      abortSignal?: AbortSignal;
+      maxRetries?: number;
+    };
+    expect(callArgs.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(callArgs.maxRetries).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/oauth-credentials.test.ts
+++ b/test/oauth-credentials.test.ts
@@ -628,7 +628,7 @@ describe('refreshOAuthToken', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns new credentials on successful refresh', async () => {
+  it('returns ok with new credentials on successful refresh', async () => {
     const mockResponse = {
       ok: true,
       json: async () => ({
@@ -640,10 +640,11 @@ describe('refreshOAuthToken', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse as Response);
 
     const result = await refreshOAuthToken('old-refresh-token');
-    expect(result).not.toBeNull();
-    expect(result!.accessToken).toBe('new-access-token');
-    expect(result!.refreshToken).toBe('new-refresh-token');
-    expect(result!.expiresAt).toBeGreaterThan(Date.now());
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') throw new Error('expected ok');
+    expect(result.credentials.accessToken).toBe('new-access-token');
+    expect(result.credentials.refreshToken).toBe('new-refresh-token');
+    expect(result.credentials.expiresAt).toBeGreaterThan(Date.now());
 
     const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
     expect(fetchCall[0]).toBe('https://platform.claude.com/v1/oauth/token');
@@ -656,31 +657,47 @@ describe('refreshOAuthToken', () => {
     expect(opts.signal).toBeDefined();
   });
 
-  it('returns null on HTTP error', async () => {
+  it('returns http-error with status on non-2xx response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,
       status: 400,
     } as Response);
 
     const result = await refreshOAuthToken('bad-refresh-token');
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: 'http-error', status: 400 });
   });
 
-  it('returns null on network error', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network error'));
+  it('returns network-error with message when fetch rejects', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('connect ECONNREFUSED'));
 
     const result = await refreshOAuthToken('any-token');
-    expect(result).toBeNull();
+    expect(result.kind).toBe('network-error');
+    if (result.kind !== 'network-error') throw new Error('expected network-error');
+    expect(result.message).toBe('connect ECONNREFUSED');
   });
 
-  it('returns null when response lacks access_token and expires_in', async () => {
+  it('returns parse-error when response lacks expires_in', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({ access_token: 'token' }), // missing expires_in
     } as Response);
 
     const result = await refreshOAuthToken('any-token');
-    expect(result).toBeNull();
+    expect(result.kind).toBe('parse-error');
+    if (result.kind !== 'parse-error') throw new Error('expected parse-error');
+    expect(result.detail).toMatch(/expires_in/);
+  });
+
+  it('returns parse-error when response lacks access_token', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ expires_in: 3600 }),
+    } as Response);
+
+    const result = await refreshOAuthToken('any-token');
+    expect(result.kind).toBe('parse-error');
+    if (result.kind !== 'parse-error') throw new Error('expected parse-error');
+    expect(result.detail).toMatch(/access_token/);
   });
 
   it('preserves original refresh token when response omits refresh_token', async () => {
@@ -690,12 +707,13 @@ describe('refreshOAuthToken', () => {
     } as Response);
 
     const result = await refreshOAuthToken('original-refresh-token');
-    expect(result).not.toBeNull();
-    expect(result!.accessToken).toBe('new-access');
-    expect(result!.refreshToken).toBe('original-refresh-token');
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') throw new Error('expected ok');
+    expect(result.credentials.accessToken).toBe('new-access');
+    expect(result.credentials.refreshToken).toBe('original-refresh-token');
   });
 
-  it('returns null when expires_in is invalid', async () => {
+  it('returns parse-error when expires_in is invalid', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -706,7 +724,26 @@ describe('refreshOAuthToken', () => {
     } as Response);
 
     const result = await refreshOAuthToken('any-token');
-    expect(result).toBeNull();
+    expect(result.kind).toBe('parse-error');
+  });
+});
+
+describe('refreshResultToCreds', () => {
+  it('flattens ok to credentials', async () => {
+    const { refreshResultToCreds } = await import('../src/docker/oauth-credentials.js');
+    const creds: OAuthCredentials = {
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: Date.now() + 3_600_000,
+    };
+    expect(refreshResultToCreds({ kind: 'ok', credentials: creds })).toBe(creds);
+  });
+
+  it('flattens non-ok variants to null', async () => {
+    const { refreshResultToCreds } = await import('../src/docker/oauth-credentials.js');
+    expect(refreshResultToCreds({ kind: 'http-error', status: 401 })).toBeNull();
+    expect(refreshResultToCreds({ kind: 'parse-error', detail: 'x' })).toBeNull();
+    expect(refreshResultToCreds({ kind: 'network-error', message: 'x' })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `ironcurtain doctor`, a user-invokable subcommand that runs every health check independently and surfaces a single punch list (✓ / ⚠ / ✗ / ↷) instead of the fail-fast pre-flight gate added in #203. Built to address the BishopFox setup-experience feedback (Aaron, Ben) where users hit cryptic mid-task errors and had to spelunk to find what was misconfigured.

**What it checks (default run, ~5–10s):**
- **Environment** — Node version (22–24), V8 sandbox viability (reuses preflight cache), Docker availability with categorized errors.
- **Configuration** — `~/.ironcurtain/config.json` parses, compiled policy artifacts present, constitution drift, tool-annotation drift.
- **Credentials** — Anthropic OAuth/API key presence + OAuth expiry; per-MCP-server env-var presence.
- **MCP servers** — live `initialize` + `tools/list` against each configured server with credentials present, run in parallel with a 5s per-server timeout. Servers missing credentials report `skipped — missing creds` without a spawn.

**Behind `--check-api` (opt-in, ~1¢, ~1–2s):**
- 1-token Anthropic `generateText` round-trip.
- OAuth refresh-token round-trip (validated, not persisted).

**Architectural notes:**
- Reuses existing helpers throughout (`checkSandboxViability`, `checkDockerAvailable`, `detectAuthMethod`, `loadGeneratedPolicy`, `findAnnotationServerDrift`, `computeConstitutionHash`, etc.). Only the MCP liveness probe is new code, modeled on the pattern in `src/pipeline/annotate.ts`.
- Doctor is intentionally **not** gated by the sandbox preflight (`requiresSandbox` in `src/cli.ts`) so it can diagnose a broken sandbox.
- All `process.exit` calls live in `runDoctorCommand`; check functions are pure and unit-testable.
- Sandbox + Docker probes run concurrently (independent async work).
- Always exits explicitly because the MCP probes' subprocesses can keep the Node event loop alive past `client.close()`.

## Test plan

- [ ] `npx vitest run test/doctor.test.ts` — 28 tests pass.
- [ ] `ironcurtain doctor` on a healthy install → all green, exit 0, returns control to shell.
- [ ] `ironcurtain doctor` after `sudo systemctl stop docker` → Docker line shows daemon-not-running with hint, exit 1.
- [ ] `ironcurtain doctor` with an MCP server whose token is missing → `↷ servername  skipped — missing creds` (no spawn attempt).
- [ ] `ironcurtain doctor --check-api` with a bogus `ANTHROPIC_API_KEY` → `Anthropic API round-trip` line reports `invalid x-api-key`, exit 1.
- [ ] On Node 25, doctor reports the V8 sandbox failure with the "use Node 22–24" hint instead of crashing (relies on the existing `checkSandboxViability` subprocess isolation).

## Out of scope

- Docker MITM round-trip probe (the macOS IPv6 issue from the BishopFox feedback) — too platform-specific for v1; deferred.
- `--fix` flag for auto-remediation — diagnostic-only in v1; deferred.