### PR TITLE
Fix `mux` PTY session: mount bundle sockets dir for MITM bridge

### DIFF
--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -45,6 +45,26 @@ export interface PtySessionOptions {
   readonly resumeSessionId?: string;
   /** Persona name. Used to build CLAUDE.md and system prompt augmentation. */
   readonly persona?: string;
+  /**
+   * Override for the PTY attach step. Defaults to the production `attachPty`
+   * which proxies the user's terminal into the container PTY socket.
+   * Tests inject a stub that performs assertions against the live container
+   * (via `docker exec`) and returns an exit code without taking over stdio.
+   */
+  readonly attach?: PtyAttachFn;
+}
+
+export type PtyAttachFn = (options: PtyProxyOptions) => Promise<number>;
+
+/** UDS path (Linux) or { host, port } (macOS). */
+export type PtyTarget = string | { readonly host: string; readonly port: number };
+
+export interface PtyProxyOptions {
+  readonly target: PtyTarget;
+  /** Docker container ID (for SIGWINCH forwarding). */
+  readonly containerId: string;
+  /** Abort signal for graceful shutdown (e.g., SIGTERM). */
+  readonly signal?: AbortSignal;
 }
 
 /** Maximum time to wait for the PTY socket to appear (ms). */
@@ -181,9 +201,6 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
   const sessionConfig = { ...dirConfig.config, isPtySession: true };
   const { sandboxDir, escalationDir, systemPromptAugmentation } = dirConfig;
 
-  const socketsDir = resolve(sessionDir, 'sockets');
-  mkdirSync(socketsDir, { recursive: true, mode: 0o700 });
-
   logger.info(`PTY session ${effectiveSessionId} ${isResume ? 'resuming' : 'starting'}`);
 
   const initSpinner = ora({
@@ -261,6 +278,7 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       adapter,
       fakeKeys,
       orientationDir,
+      socketsDir,
       systemPrompt: baseSystemPrompt,
       image,
       mitmAddr,
@@ -518,8 +536,10 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     initSpinner.succeed(chalk.dim('PTY session ready'));
     process.stderr.write('\n');
 
-    // Attach terminal via Node.js PTY proxy
-    const exitCode = await attachPty({
+    // Attach terminal via Node.js PTY proxy. Tests inject a stub via
+    // `options.attach` to drive assertions against the live container.
+    const attachFn = options.attach ?? attachPty;
+    const exitCode = await attachFn({
       target: ptyTarget,
       containerId,
       signal: shutdownController.signal,
@@ -613,23 +633,12 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
 
 // --- PTY proxy ---
 
-/** UDS path (Linux) or { host, port } (macOS). */
-type PtyTarget = string | { host: string; port: number };
-
 /** Creates a net.Socket connection to the PTY target (UDS or TCP). */
 function connectToTarget(target: PtyTarget): ReturnType<typeof createConnection> {
   if (typeof target === 'string') {
     return createConnection({ path: target });
   }
   return createConnection({ host: target.host, port: target.port });
-}
-
-interface PtyProxyOptions {
-  readonly target: PtyTarget;
-  /** Docker container ID (for SIGWINCH forwarding). */
-  readonly containerId: string;
-  /** Abort signal for graceful shutdown (e.g., SIGTERM). */
-  readonly signal?: AbortSignal;
 }
 
 /**

--- a/test/helpers/docker-available.ts
+++ b/test/helpers/docker-available.ts
@@ -1,0 +1,35 @@
+/**
+ * Synchronous Docker availability checks for use in `describe.skipIf(...)`.
+ *
+ * Vitest's `skipIf` evaluates synchronously, so we shell out via
+ * `execFileSync` and cache the result for the test process lifetime.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+let dockerAvailable: boolean | undefined;
+const imageAvailable = new Map<string, boolean>();
+
+export function isDockerAvailable(): boolean {
+  if (dockerAvailable !== undefined) return dockerAvailable;
+  try {
+    execFileSync('docker', ['info'], { timeout: 5_000, stdio: 'pipe' });
+    dockerAvailable = true;
+  } catch {
+    dockerAvailable = false;
+  }
+  return dockerAvailable;
+}
+
+export function isDockerImageAvailable(image: string): boolean {
+  const cached = imageAvailable.get(image);
+  if (cached !== undefined) return cached;
+  try {
+    execFileSync('docker', ['image', 'inspect', image], { timeout: 5_000, stdio: 'pipe' });
+    imageAvailable.set(image, true);
+    return true;
+  } catch {
+    imageAvailable.set(image, false);
+    return false;
+  }
+}

--- a/test/pty-entrypoint.integration.test.ts
+++ b/test/pty-entrypoint.integration.test.ts
@@ -130,6 +130,14 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
   const observations: BridgeObservations = {};
 
   beforeAll(async () => {
+    // Capture env var originals FIRST, before any I/O that could throw.
+    // If we captured these later, a partial-setup failure would leave
+    // `original*` as undefined and afterAll would `delete` env vars the
+    // runner had set, instead of restoring them.
+    originalHome = process.env.IRONCURTAIN_HOME;
+    originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
+    originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+
     // Sandbox all IronCurtain on-disk state into a tempdir.
     homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-pty-test-'));
     workspaceDir = join(homeDir, 'workspace');
@@ -140,9 +148,6 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
     // port is known when we override `ANTHROPIC_BASE_URL`.
     upstream = await startUpstreamResponder();
 
-    originalHome = process.env.IRONCURTAIN_HOME;
-    originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
-    originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
     process.env.IRONCURTAIN_HOME = homeDir;
     // Force API-key auth so detectAuthMethod doesn't read host OAuth state.
     process.env.IRONCURTAIN_DOCKER_AUTH = 'apikey';

--- a/test/pty-entrypoint.integration.test.ts
+++ b/test/pty-entrypoint.integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Integration test: PTY container entrypoint UDS→TCP bridge, driven through
+ * the real `runPtySession` code path.
+ *
+ * This is the regression guard for two failure modes:
+ *
+ *  1. **Mount source mismatch** — `pty-session.ts` builds a `mounts` array
+ *     for `docker.create` whose `/run/ironcurtain` source must equal the
+ *     bundle's `getBundleSocketsDir(bundleId)` (where MITM publishes its
+ *     socket). PR #191 broke this by routing PTY through a stale
+ *     `<sessionDir>/sockets` path; the test catches that by exercising the
+ *     real `runPtySession` flow and asserting the MITM socket is visible
+ *     inside the container.
+ *
+ *  2. **Entrypoint bridge contract** — `entrypoint-claude-code.sh` must start
+ *     `socat TCP-LISTEN:18080 ↔ UNIX-CONNECT:mitm-proxy.sock` so claude
+ *     (HTTPS_PROXY=http://127.0.0.1:18080) can reach the host MITM. The test
+ *     asserts the bridge is live and a CONNECT through it succeeds.
+ *
+ * Always-on when Docker and `ironcurtain-claude-code:latest` are present.
+ * `IRONCURTAIN_HOME` is pointed at a tempdir so the run leaves no state on
+ * the user's machine.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { cpSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { runPtySession, type PtyAttachFn } from '../src/docker/pty-session.js';
+import type { IronCurtainConfig } from '../src/config/types.js';
+import { isDockerAvailable, isDockerImageAvailable } from './helpers/docker-available.js';
+import { testCompiledPolicy, testToolAnnotations } from './fixtures/test-policy.js';
+
+const execFile = promisify(execFileCb);
+
+const IMAGE = 'ironcurtain-claude-code:latest';
+
+async function dockerExec(
+  containerId: string,
+  ...cmd: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const { stdout, stderr } = await execFile('docker', ['exec', containerId, ...cmd], { timeout: 15_000 });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', exitCode: e.code ?? 1 };
+  }
+}
+
+const dockerReady = isDockerAvailable() && isDockerImageAvailable(IMAGE);
+
+interface BridgeObservations {
+  containerId?: string;
+  socketTestExitCode?: number;
+  bridgeProcs?: string;
+  curlStderr?: string;
+}
+
+describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via runPtySession)', () => {
+  let homeDir: string;
+  let workspaceDir: string;
+  let originalHome: string | undefined;
+  let originalAuth: string | undefined;
+  const observations: BridgeObservations = {};
+
+  beforeAll(async () => {
+    // Sandbox all IronCurtain on-disk state into a tempdir so the test
+    // leaves no debris in ~/.ironcurtain/.
+    homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-pty-test-'));
+    workspaceDir = join(homeDir, 'workspace');
+    mkdirSync(workspaceDir, { recursive: true });
+
+    originalHome = process.env.IRONCURTAIN_HOME;
+    originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
+    process.env.IRONCURTAIN_HOME = homeDir;
+    // Force API-key auth so detectAuthMethod doesn't read host OAuth state.
+    process.env.IRONCURTAIN_DOCKER_AUTH = 'apikey';
+
+    // Reuse the host's CA so the image content-hash matches the prebuilt
+    // `ironcurtain-claude-code:latest`. A fresh CA would force an image
+    // rebuild on every run (multi-minute), which is unacceptable for a
+    // routine integration test.
+    const hostCaDir = join(homedir(), '.ironcurtain', 'ca');
+    if (existsSync(hostCaDir)) {
+      cpSync(hostCaDir, join(homeDir, 'ca'), { recursive: true });
+    }
+
+    const generatedDir = join(homeDir, 'generated');
+    mkdirSync(generatedDir, { recursive: true });
+    writeFileSync(join(generatedDir, 'compiled-policy.json'), JSON.stringify(testCompiledPolicy));
+    writeFileSync(join(generatedDir, 'tool-annotations.json'), JSON.stringify(testToolAnnotations));
+
+    const config = {
+      auditLogPath: join(homeDir, 'audit.jsonl'),
+      allowedDirectory: workspaceDir,
+      // Empty mcpServers — the policy fixture references some, but
+      // `extractRequiredServers` only spawns servers actually used by the
+      // active rules; with no client tool calls, none start up.
+      mcpServers: {},
+      protectedPaths: [],
+      generatedDir,
+      constitutionPath: join(homeDir, 'constitution.md'),
+      agentModelId: 'anthropic:claude-sonnet-4-6',
+      escalationTimeoutSeconds: 300,
+      userConfig: {
+        agentModelId: 'anthropic:claude-sonnet-4-6',
+        policyModelId: 'anthropic:claude-sonnet-4-6',
+        anthropicApiKey: 'sk-ant-api03-fake-test-key-for-pty-integration',
+        googleApiKey: '',
+        openaiApiKey: '',
+        escalationTimeoutSeconds: 300,
+        resourceBudget: {
+          maxTotalTokens: 1_000_000,
+          maxSteps: 200,
+          maxSessionSeconds: 1800,
+          maxEstimatedCostUsd: 5.0,
+          warnThresholdPercent: 80,
+        },
+        autoCompact: {
+          enabled: false,
+          thresholdTokens: 80_000,
+          keepRecentMessages: 10,
+          summaryModelId: 'anthropic:claude-haiku-4-5',
+        },
+        autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
+        auditRedaction: { enabled: true },
+        memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
+        packageInstall: {
+          enabled: false,
+          quarantineDays: 2,
+          allowedPackages: [],
+          deniedPackages: [],
+        },
+        serverCredentials: {},
+      },
+    } as unknown as IronCurtainConfig;
+
+    // The attach stub runs INSIDE runPtySession after the container is up.
+    // It collects observations against the live container and returns 0 so
+    // the production cleanup path runs normally.
+    const attach: PtyAttachFn = async ({ containerId }) => {
+      observations.containerId = containerId;
+
+      const sock = await dockerExec(containerId, 'test', '-S', '/run/ironcurtain/mitm-proxy.sock');
+      observations.socketTestExitCode = sock.exitCode;
+
+      const procs = await dockerExec(containerId, 'sh', '-c', 'pgrep -af "TCP-LISTEN:18080" || true');
+      observations.bridgeProcs = procs.stdout;
+
+      const curl = await dockerExec(
+        containerId,
+        'curl',
+        '-sv',
+        '--max-time',
+        '10',
+        '--proxy',
+        'http://127.0.0.1:18080',
+        '-o',
+        '/dev/null',
+        'https://api.anthropic.com/v1/messages',
+      );
+      observations.curlStderr = curl.stderr;
+
+      return 0;
+    };
+
+    await runPtySession({
+      config,
+      mode: { kind: 'docker', agent: 'claude-code' },
+      workspacePath: workspaceDir,
+      attach,
+    });
+  }, 90_000);
+
+  afterAll(() => {
+    if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = originalHome;
+    if (originalAuth === undefined) delete process.env.IRONCURTAIN_DOCKER_AUTH;
+    else process.env.IRONCURTAIN_DOCKER_AUTH = originalAuth;
+    if (homeDir) rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it('runPtySession spawns the container and invokes attach with its id', () => {
+    expect(observations.containerId).toBeTruthy();
+  });
+
+  it('mounts the bundle sockets dir at /run/ironcurtain (regression guard for #191)', () => {
+    // If pty-session.ts mounts the wrong source directory, the MITM socket
+    // is missing inside the container and `test -S` exits 1.
+    expect(observations.socketTestExitCode).toBe(0);
+  });
+
+  it('entrypoint starts the in-container UDS→TCP bridge on port 18080', () => {
+    expect(observations.bridgeProcs ?? '').toContain('UNIX-CONNECT:/run/ironcurtain/mitm-proxy.sock');
+  });
+
+  it('container can reach the host MITM via http://127.0.0.1:18080', () => {
+    // CONNECT to api.anthropic.com:443 is on the proxy's host allowlist.
+    // TLS handshake fails (curl doesn't trust the IronCurtain CA) but the
+    // CONNECT itself completing proves the bridge is alive end-to-end.
+    expect(observations.curlStderr ?? '').toContain('CONNECT tunnel established');
+  });
+});

--- a/test/pty-entrypoint.integration.test.ts
+++ b/test/pty-entrypoint.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration test: PTY container entrypoint UDS→TCP bridge, driven through
  * the real `runPtySession` code path.
  *
- * This is the regression guard for two failure modes:
+ * Regression guard for two failure modes:
  *
  *  1. **Mount source mismatch** — `pty-session.ts` builds a `mounts` array
  *     for `docker.create` whose `/run/ironcurtain` source must equal the
@@ -15,19 +15,32 @@
  *  2. **Entrypoint bridge contract** — `entrypoint-claude-code.sh` must start
  *     `socat TCP-LISTEN:18080 ↔ UNIX-CONNECT:mitm-proxy.sock` so claude
  *     (HTTPS_PROXY=http://127.0.0.1:18080) can reach the host MITM. The test
- *     asserts the bridge is live and a CONNECT through it succeeds.
+ *     issues a `curl -k` from inside the container to a Claude Code endpoint
+ *     and verifies a local upstream responder received the forwarded request.
  *
- * Always-on when Docker and `ironcurtain-claude-code:latest` are present.
- * `IRONCURTAIN_HOME` is pointed at a tempdir so the run leaves no state on
- * the user's machine.
+ * Hermetic by construction:
+ *
+ *   - `IRONCURTAIN_HOME` is redirected to a tempdir; on cleanup the tempdir
+ *     is removed entirely. No state lands under `~/.ironcurtain/`.
+ *   - `ANTHROPIC_BASE_URL` is overridden to a local HTTP responder bound to
+ *     127.0.0.1, so MITM's upstream forward never contacts api.anthropic.com.
+ *     `-k` makes the curl call independent of whether the IronCurtain CA is
+ *     present in the container's trust store.
+ *
+ * Always-on when Docker, the prebuilt `ironcurtain-claude-code:latest` image,
+ * AND the host CA used to build that image are all present. The CA is sourced
+ * from the active `IRONCURTAIN_HOME` (captured before the test overrides it)
+ * — using a non-matching CA would force a multi-minute image rebuild, so we
+ * skip rather than rebuild.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { cpSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import { execFile as execFileCb } from 'node:child_process';
+import { createServer as createHttpServer, type IncomingMessage, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { promisify } from 'node:util';
 
 import { runPtySession, type PtyAttachFn } from '../src/docker/pty-session.js';
@@ -52,13 +65,47 @@ async function dockerExec(
   }
 }
 
-const dockerReady = isDockerAvailable() && isDockerImageAvailable(IMAGE);
+/**
+ * Locates the CA directory the running `ironcurtain-claude-code:latest` image
+ * was likely built from. Honors `IRONCURTAIN_HOME` if set (matching the
+ * production resolution in `src/config/paths.ts:getIronCurtainHome`), otherwise
+ * defaults to `~/.ironcurtain`. Returns null if no CA is present.
+ *
+ * Read this BEFORE the test overrides `IRONCURTAIN_HOME` so we point at the
+ * developer's real CA, not the temp sandbox.
+ */
+function findHostCaDir(): string | null {
+  const home = process.env.IRONCURTAIN_HOME ?? join(homedir(), '.ironcurtain');
+  const ca = join(home, 'ca');
+  return existsSync(ca) ? ca : null;
+}
+
+const hostCaDir = findHostCaDir();
+const dockerReady = isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+
+/** Local upstream responder: 200s every request and counts hits per path. */
+function startUpstreamResponder(): Promise<{ server: Server; port: number; received: IncomingMessage[] }> {
+  const received: IncomingMessage[] = [];
+  return new Promise((resolveStart, rejectStart) => {
+    const server = createHttpServer((req, res) => {
+      received.push(req);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{}');
+    });
+    server.on('error', rejectStart);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo;
+      resolveStart({ server, port: addr.port, received });
+    });
+  });
+}
 
 interface BridgeObservations {
   containerId?: string;
   socketTestExitCode?: number;
   bridgeProcs?: string;
-  curlStderr?: string;
+  curlExitCode?: number;
+  curlHttpCode?: string;
 }
 
 describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via runPtySession)', () => {
@@ -66,29 +113,32 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
   let workspaceDir: string;
   let originalHome: string | undefined;
   let originalAuth: string | undefined;
+  let originalAnthropicBaseUrl: string | undefined;
+  let upstream: { server: Server; port: number; received: IncomingMessage[] } | undefined;
   const observations: BridgeObservations = {};
 
   beforeAll(async () => {
-    // Sandbox all IronCurtain on-disk state into a tempdir so the test
-    // leaves no debris in ~/.ironcurtain/.
+    // Sandbox all IronCurtain on-disk state into a tempdir.
     homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-pty-test-'));
     workspaceDir = join(homeDir, 'workspace');
     mkdirSync(workspaceDir, { recursive: true });
 
+    // Local responder stands in for api.anthropic.com so MITM's upstream
+    // forward never leaves the host. Started before env vars are set so the
+    // port is known when we override `ANTHROPIC_BASE_URL`.
+    upstream = await startUpstreamResponder();
+
     originalHome = process.env.IRONCURTAIN_HOME;
     originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
+    originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
     process.env.IRONCURTAIN_HOME = homeDir;
     // Force API-key auth so detectAuthMethod doesn't read host OAuth state.
     process.env.IRONCURTAIN_DOCKER_AUTH = 'apikey';
+    process.env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${upstream.port}`;
 
-    // Reuse the host's CA so the image content-hash matches the prebuilt
-    // `ironcurtain-claude-code:latest`. A fresh CA would force an image
-    // rebuild on every run (multi-minute), which is unacceptable for a
-    // routine integration test.
-    const hostCaDir = join(homedir(), '.ironcurtain', 'ca');
-    if (existsSync(hostCaDir)) {
-      cpSync(hostCaDir, join(homeDir, 'ca'), { recursive: true });
-    }
+    // Reuse the host CA so the image content-hash matches the prebuilt image.
+    // hostCaDir is non-null here because we gated `dockerReady` on it.
+    cpSync(hostCaDir as string, join(homeDir, 'ca'), { recursive: true });
 
     const generatedDir = join(homeDir, 'generated');
     mkdirSync(generatedDir, { recursive: true });
@@ -99,8 +149,8 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
       auditLogPath: join(homeDir, 'audit.jsonl'),
       allowedDirectory: workspaceDir,
       // Empty mcpServers — the policy fixture references some, but
-      // `extractRequiredServers` only spawns servers actually used by the
-      // active rules; with no client tool calls, none start up.
+      // `extractRequiredServers` only spawns servers used by active rules;
+      // with no tool calls, none start up.
       mcpServers: {},
       protectedPaths: [],
       generatedDir,
@@ -140,7 +190,7 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
       },
     } as unknown as IronCurtainConfig;
 
-    // The attach stub runs INSIDE runPtySession after the container is up.
+    // The attach stub runs inside runPtySession after the container is up.
     // It collects observations against the live container and returns 0 so
     // the production cleanup path runs normally.
     const attach: PtyAttachFn = async ({ containerId }) => {
@@ -152,19 +202,27 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
       const procs = await dockerExec(containerId, 'sh', '-c', 'pgrep -af "TCP-LISTEN:18080" || true');
       observations.bridgeProcs = procs.stdout;
 
+      // GET /api/claude_code/settings is in the Anthropic provider allowlist.
+      // `-k` skips client-side cert verification (the IronCurtain CA in the
+      // image trust store is irrelevant either way), so the TLS handshake
+      // with MITM completes and the request is forwarded to the local
+      // upstream responder via the ANTHROPIC_BASE_URL override.
       const curl = await dockerExec(
         containerId,
         'curl',
-        '-sv',
+        '-ksS',
         '--max-time',
         '10',
         '--proxy',
         'http://127.0.0.1:18080',
         '-o',
         '/dev/null',
-        'https://api.anthropic.com/v1/messages',
+        '-w',
+        '%{http_code}',
+        'https://api.anthropic.com/api/claude_code/settings',
       );
-      observations.curlStderr = curl.stderr;
+      observations.curlExitCode = curl.exitCode;
+      observations.curlHttpCode = curl.stdout.trim();
 
       return 0;
     };
@@ -177,11 +235,14 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
     });
   }, 90_000);
 
-  afterAll(() => {
+  afterAll(async () => {
     if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
     else process.env.IRONCURTAIN_HOME = originalHome;
     if (originalAuth === undefined) delete process.env.IRONCURTAIN_DOCKER_AUTH;
     else process.env.IRONCURTAIN_DOCKER_AUTH = originalAuth;
+    if (originalAnthropicBaseUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+    if (upstream) await new Promise<void>((r) => upstream!.server.close(() => r()));
     if (homeDir) rmSync(homeDir, { recursive: true, force: true });
   });
 
@@ -199,10 +260,15 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
     expect(observations.bridgeProcs ?? '').toContain('UNIX-CONNECT:/run/ironcurtain/mitm-proxy.sock');
   });
 
-  it('container can reach the host MITM via http://127.0.0.1:18080', () => {
-    // CONNECT to api.anthropic.com:443 is on the proxy's host allowlist.
-    // TLS handshake fails (curl doesn't trust the IronCurtain CA) but the
-    // CONNECT itself completing proves the bridge is alive end-to-end.
-    expect(observations.curlStderr ?? '').toContain('CONNECT tunnel established');
+  it('a request through the bridge reaches the host MITM and is forwarded to the upstream', () => {
+    // curl getting HTTP 200 proves the full chain end-to-end:
+    // container curl → bridge socat (port 18080) → host MITM (UDS) →
+    // upstream forward (ANTHROPIC_BASE_URL → local responder). curl reads
+    // the response from its own connection, so a 200 here can only come
+    // from our test responder. (Claude Code's own startup probes also hit
+    // the responder concurrently — those are not what we're asserting on.)
+    expect(observations.curlExitCode).toBe(0);
+    expect(observations.curlHttpCode).toBe('200');
+    expect(upstream?.received.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/pty-entrypoint.integration.test.ts
+++ b/test/pty-entrypoint.integration.test.ts
@@ -27,6 +27,11 @@
  *     `-k` makes the curl call independent of whether the IronCurtain CA is
  *     present in the container's trust store.
  *
+ * Linux-only by design: the bridge being asserted here is part of the Linux
+ * UDS transport (`useTcpTransport()` is false). macOS PTY mode reaches MITM
+ * via `host.docker.internal:<mitmPort>` through a socat sidecar — that path
+ * has no in-container 18080 bridge and would need its own end-to-end test.
+ *
  * Always-on when Docker, the prebuilt `ironcurtain-claude-code:latest` image,
  * AND the host CA used to build that image are all present. The CA is sourced
  * from the active `IRONCURTAIN_HOME` (captured before the test overrides it)
@@ -45,6 +50,7 @@ import { promisify } from 'node:util';
 
 import { runPtySession, type PtyAttachFn } from '../src/docker/pty-session.js';
 import type { IronCurtainConfig } from '../src/config/types.js';
+import { useTcpTransport } from '../src/docker/platform.js';
 import { isDockerAvailable, isDockerImageAvailable } from './helpers/docker-available.js';
 import { testCompiledPolicy, testToolAnnotations } from './fixtures/test-policy.js';
 
@@ -81,7 +87,13 @@ function findHostCaDir(): string | null {
 }
 
 const hostCaDir = findHostCaDir();
-const dockerReady = isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+// Linux-only: the in-container UDS→TCP bridge being asserted here is part
+// of the Linux UDS transport. On macOS (`useTcpTransport()` returns true),
+// the container reaches MITM via `host.docker.internal:<mitmPort>` through
+// a socat sidecar instead — `127.0.0.1:18080` and `mitm-proxy.sock` simply
+// don't exist there. macOS PTY mode would need its own end-to-end test
+// asserting the sidecar forward.
+const dockerReady = !useTcpTransport() && isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
 
 /** Local upstream responder: 200s every request and counts hits per path. */
 function startUpstreamResponder(): Promise<{ server: Server; port: number; received: IncomingMessage[] }> {


### PR DESCRIPTION
## Summary

`ironcurtain mux` (interactive PTY) showed "API down" with zero MITM traffic. Root cause: PR #191 moved per-bundle UDS sockets to `~/.ironcurtain/run/<bid12>/sockets/` and updated `docker-infrastructure.ts` to mount `core.socketsDir`, but missed the parallel mount in `pty-session.ts`. PTY mode kept mounting `<sessionDir>/sockets/` (which contains only `pty.sock`) at `/run/ironcurtain`. With no `mitm-proxy.sock` visible inside the container, the entrypoint's `[ -S … ]` check silently failed, the in-container UDS→TCP bridge never started, and Claude hit `Connection refused` on `127.0.0.1:18080`.

- **Fix** (`src/docker/pty-session.ts`): drop the stale local `socketsDir = resolve(sessionDir, 'sockets')` and consume `socketsDir` from the infrastructure handle so PTY and batch share one path.
- **Regression guard** (`test/pty-entrypoint.integration.test.ts`): drives the real `runPtySession` end-to-end via a new optional `attach` injection on `PtySessionOptions`, asserts the MITM socket is visible inside the container, and confirms a CONNECT through the bridge reaches the host MITM. Auto-skip if Docker or `ironcurtain-claude-code:latest` aren't present; ~4s when active.
- **Helper** (`test/helpers/docker-available.ts`): synchronous Docker / image availability checks for use in `describe.skipIf(...)`.

The new `attach?: PtyAttachFn` field on `PtySessionOptions` is an optional DI seam (defaults to the production `attachPty`); same pattern `orchestrator.ts` already uses for `createWorkflowInfrastructure` deps.

## Test plan

- [x] `npm test -- --run test/pty-session.test.ts test/pty-entrypoint.integration.test.ts` (15 tests, ~4s)
- [x] Reintroduce the buggy mount source → 3/4 new assertions fail with the exact "Connection refused on 127.0.0.1:18080" symptom the user originally reported. Revert → all green
- [x] `npx tsc --noEmit`, `npx eslint`, `npx prettier`
- [ ] Manual: `ironcurtain mux` reaches Anthropic and shows API as up (no `ANTHROPIC_BASE_URL` override needed)