### PR TITLE
Detect degenerate Claude Code responses as resumable transient failures

### DIFF
--- a/packages/web-ui/src/routes/Workflows.svelte
+++ b/packages/web-ui/src/routes/Workflows.svelte
@@ -551,7 +551,7 @@
                           disabled
                           aria-disabled="true"
                           data-testid={`resume-${row.workflowId}`}
-                          title="Workflow is not resumable in its current phase -- use Investigate"
+                          title="Workflow has already completed — use Investigate to inspect"
                         >
                           Resume
                         </Button>

--- a/packages/web-ui/src/routes/Workflows.test.ts
+++ b/packages/web-ui/src/routes/Workflows.test.ts
@@ -206,25 +206,28 @@ describe('Workflows route', () => {
       expect(screen.getByText('failed-row')).toBeTruthy();
     });
 
-    it('Resume button is disabled for terminal phases and enabled for waiting_human/interrupted', async () => {
+    it('Resume button is disabled only for completed runs; every other phase is resumable (matches engine isCheckpointResumable)', async () => {
       mockListResumable.mockResolvedValue([
         makePastRun({ workflowId: 'p-done', phase: 'completed' }),
         makePastRun({ workflowId: 'p-wait', phase: 'waiting_human' }),
         makePastRun({ workflowId: 'p-int', phase: 'interrupted' }),
         makePastRun({ workflowId: 'p-fail', phase: 'failed' }),
+        makePastRun({ workflowId: 'p-abort', phase: 'aborted' }),
       ]);
       render(Workflows);
       await screen.findByTestId('resume-p-done');
 
       const resumeDone = screen.getByTestId('resume-p-done') as HTMLButtonElement;
       const resumeFail = screen.getByTestId('resume-p-fail') as HTMLButtonElement;
+      const resumeAbort = screen.getByTestId('resume-p-abort') as HTMLButtonElement;
       const resumeWait = screen.getByTestId('resume-p-wait') as HTMLButtonElement;
       const resumeInt = screen.getByTestId('resume-p-int') as HTMLButtonElement;
 
       expect(resumeDone.disabled).toBe(true);
       expect(resumeDone.getAttribute('aria-disabled')).toBe('true');
-      expect(resumeFail.disabled).toBe(true);
 
+      expect(resumeFail.disabled).toBe(false);
+      expect(resumeAbort.disabled).toBe(false);
       expect(resumeWait.disabled).toBe(false);
       expect(resumeInt.disabled).toBe(false);
     });

--- a/packages/web-ui/src/routes/workflows-helpers.test.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.test.ts
@@ -140,14 +140,13 @@ describe('workflows-helpers', () => {
   });
 
   describe('isResumablePhase', () => {
-    it('allows waiting_human and interrupted', () => {
-      expect(isResumablePhase('waiting_human')).toBe(true);
-      expect(isResumablePhase('interrupted')).toBe(true);
-    });
-    it('rejects terminal phases', () => {
-      for (const p of ['completed', 'failed', 'aborted'] as PastRunPhase[]) {
-        expect(isResumablePhase(p)).toBe(false);
+    it('allows every non-completed phase (mirrors engine isCheckpointResumable)', () => {
+      for (const p of ['waiting_human', 'interrupted', 'aborted', 'failed'] as PastRunPhase[]) {
+        expect(isResumablePhase(p)).toBe(true);
       }
+    });
+    it('rejects only completed', () => {
+      expect(isResumablePhase('completed')).toBe(false);
     });
   });
 

--- a/packages/web-ui/src/routes/workflows-helpers.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.ts
@@ -135,8 +135,19 @@ export function truncate(text: string, max = 80): string {
   return text.slice(0, max) + '…';
 }
 
-/** Phases that allow a Resume action from the Past-runs table. */
-const RESUMABLE_PHASES = new Set<PastRunPhase>([PHASE.WAITING_HUMAN, PHASE.INTERRUPTED]);
+/**
+ * Phases that allow a Resume action from the Past-runs table.
+ *
+ * Mirrors the engine's `isCheckpointResumable` (`src/workflow/checkpoint.ts`):
+ * any past-run phase except `'completed'` carries a checkpoint that
+ * `WorkflowOrchestrator.resume()` will accept. `'aborted'` is included
+ * because both the quota-exhaustion and transient-failure paths
+ * deliberately stamp `phase: 'aborted'` to keep the run resumable;
+ * `'failed'` is included because the engine permits resume of error
+ * targets so the user can pick the run back up after fixing the
+ * underlying cause.
+ */
+const RESUMABLE_PHASES = new Set<PastRunPhase>([PHASE.WAITING_HUMAN, PHASE.INTERRUPTED, PHASE.ABORTED, PHASE.FAILED]);
 
 export function isResumablePhase(phase: PastRunPhase): boolean {
   return RESUMABLE_PHASES.has(phase);

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -246,13 +246,23 @@ exit $STATUS
     extractResponse(exitCode: number, stdout: string): AgentResponse {
       if (exitCode !== 0) {
         // Before falling back to the generic "exited non-zero" wrapper,
-        // look inside Claude Code's JSON envelope for a structured
-        // quota-exhaustion signal. Claude Code exits non-zero on 429
-        // but still prints its result envelope on stdout — we would
-        // otherwise throw that signal away.
+        // look inside Claude Code's JSON envelope for structured signals.
+        // The CLI exits non-zero on 429 (quota) and may also exit non-zero
+        // on the upstream-stall envelope (`type: 'result'`,
+        // `output_tokens=0`, `stop_reason=null`); both signals must
+        // survive the non-zero exit.
         const quotaExhausted = extractClaudeCodeQuotaSignal(stdout);
         if (quotaExhausted) {
           return { text: quotaExhausted.rawMessage, quotaExhausted };
+        }
+        const transientFailure = extractTransientSignalFromStdout(stdout);
+        if (transientFailure) {
+          // Treat as resumable-abort, NOT hardFailure: the orchestrator's
+          // hard-retry rotation cannot recover a stalled upstream.
+          return {
+            text: transientFailure.text,
+            transientFailure: { kind: 'degenerate_response', rawMessage: transientFailure.rawMessage },
+          };
         }
         // Zero output on non-zero exit indicates the claude process was
         // killed (SIGTERM) or crashed before producing any assistant text —
@@ -339,26 +349,29 @@ function extractClaudeCodeQuotaSignal(stdout: string): AgentResponse['quotaExhau
 }
 
 /**
- * Detects the degenerate "upstream stall" envelope: exit=0, JSON parses,
- * `result` non-empty (typically the agent's preamble), but
- * `usage.output_tokens === 0` AND `stop_reason === null` (or undefined).
- * Matches the captured envelopes from a sustained LiteLLM/Z.AI outage
- * where the stream hung server-side and no assistant message was
- * generated.
+ * Detects the degenerate "upstream stall" envelope: a Claude Code result
+ * envelope (`type: 'result'`) where JSON parses and `result` is non-empty
+ * (typically the agent's preamble), but `usage.output_tokens === 0` AND
+ * `stop_reason === null` (or undefined). Matches the captured envelopes
+ * from a sustained LiteLLM/Z.AI outage where the stream hung server-side
+ * and no assistant message was generated.
  *
- * Predicate is strict (AND of both signals) so legitimate empty
- * completions — `stop_reason === 'end_turn'` with `output_tokens === 0`
- * — and partial streams — `output_tokens > 0` with `stop_reason === null`
- * — do NOT match. Reads defensively: if `usage` is absent or wrongly
- * typed (CLI version drift), returns undefined and lets the caller
- * treat the response as healthy. False positives here would route a
- * normal completion to the resumable-abort path, which is much worse
- * than a missed detection.
+ * Three layers of defensiveness, all in service of "false positives are
+ * much worse than missed detections" — flagging a healthy completion as
+ * transient would route it to the resumable-abort path:
+ *
+ *  - `type` gate: only Claude Code's result envelopes match. An
+ *    arbitrary object that happens to carry a `result` key plus the two
+ *    field names will not be flagged.
+ *  - AND-of-both-signals: legitimate empty completions
+ *    (`stop_reason === 'end_turn'` with `output_tokens === 0`) and
+ *    partial streams (`output_tokens > 0` with `stop_reason === null`)
+ *    do NOT match.
+ *  - Type-narrowing on `usage`: absent or wrongly-typed `usage` (CLI
+ *    version drift, schema change) yields undefined.
  */
-function detectClaudeCodeTransientFailure(
-  parsed: Record<string, unknown>,
-  stdout: string,
-): { rawMessage: string } | undefined {
+function detectTransientFailure(parsed: Record<string, unknown>, stdout: string): { rawMessage: string } | undefined {
+  if (parsed.type !== 'result') return undefined;
   const usage = parsed.usage;
   if (!usage || typeof usage !== 'object') return undefined;
   const outputTokens = (usage as Record<string, unknown>).output_tokens;
@@ -366,6 +379,28 @@ function detectClaudeCodeTransientFailure(
   const stopReason = parsed.stop_reason;
   if (stopReason !== null && stopReason !== undefined) return undefined;
   return { rawMessage: stdout.trim() };
+}
+
+/**
+ * JSON-parses stdout and runs the transient-stall detector. Used by the
+ * `exit !== 0` path of `extractResponse`, where `parseClaudeCodeJson`
+ * doesn't run. Returns the matched signal plus the envelope's `result`
+ * preamble for surfacing as the turn's `text`. Undefined on parse
+ * failure or when the predicate does not match.
+ */
+function extractTransientSignalFromStdout(stdout: string): { text: string; rawMessage: string } | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const transient = detectTransientFailure(obj, stdout);
+  if (!transient) return undefined;
+  const text = typeof obj.result === 'string' ? obj.result : stdout.trim();
+  return { text, rawMessage: transient.rawMessage };
 }
 
 /**
@@ -378,7 +413,7 @@ function parseClaudeCodeJson(stdout: string): AgentResponse {
     if (parsed && typeof parsed === 'object' && 'result' in parsed) {
       const obj = parsed as Record<string, unknown>;
       const text = typeof obj.result === 'string' ? obj.result : stdout.trim();
-      const transient = detectClaudeCodeTransientFailure(obj, stdout);
+      const transient = detectTransientFailure(obj, stdout);
       const base: AgentResponse =
         typeof obj.total_cost_usd === 'number' ? { text, costUsd: obj.total_cost_usd } : { text };
       if (transient) {

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -245,23 +245,23 @@ exit $STATUS
 
     extractResponse(exitCode: number, stdout: string): AgentResponse {
       if (exitCode !== 0) {
-        // Before falling back to the generic "exited non-zero" wrapper,
-        // look inside Claude Code's JSON envelope for structured signals.
-        // The CLI exits non-zero on 429 (quota) and may also exit non-zero
-        // on the upstream-stall envelope (`type: 'result'`,
-        // `output_tokens=0`, `stop_reason=null`); both signals must
-        // survive the non-zero exit.
-        const quotaExhausted = extractClaudeCodeQuotaSignal(stdout);
+        // The CLI exits non-zero on 429 (quota) and on the upstream-stall
+        // envelope (`type: 'result'`, `output_tokens=0`,
+        // `stop_reason=null`); both signals must survive the non-zero
+        // exit. Parse stdout once and dispatch to both detectors.
+        const parsed = tryParseJsonObject(stdout);
+        const quotaExhausted = parsed ? extractClaudeCodeQuotaSignal(parsed, stdout) : undefined;
         if (quotaExhausted) {
           return { text: quotaExhausted.rawMessage, quotaExhausted };
         }
-        const transientFailure = extractTransientSignalFromStdout(stdout);
-        if (transientFailure) {
+        const transient = parsed ? detectTransientFailure(parsed, stdout) : undefined;
+        if (transient) {
           // Treat as resumable-abort, NOT hardFailure: the orchestrator's
           // hard-retry rotation cannot recover a stalled upstream.
+          const text = typeof parsed?.result === 'string' ? parsed.result : stdout.trim();
           return {
-            text: transientFailure.text,
-            transientFailure: { kind: 'degenerate_response', rawMessage: transientFailure.rawMessage },
+            text,
+            transientFailure: { kind: 'degenerate_response', rawMessage: transient.rawMessage },
           };
         }
         // Zero output on non-zero exit indicates the claude process was
@@ -312,19 +312,8 @@ exit $STATUS
  */
 const QUOTA_RESET_REGEX = /Your limit will reset at (\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})/;
 
-/**
- * Extracts a quota-exhaustion signal from Claude Code's JSON error
- * envelope. Returns undefined when the envelope is missing, malformed,
- * or carries a different error class. When present, `rawMessage` is
- * always set (from the envelope's `result` string or a stringified
- * fallback) and `resetAt` is populated only when the human-readable
- * reset timestamp can be parsed.
- *
- * Contract: this helper populates `AgentResponse.quotaExhausted`,
- * which the workflow orchestrator treats as a terminal "pause and
- * resume later" signal — do not fold unrelated errors into this path.
- */
-function extractClaudeCodeQuotaSignal(stdout: string): AgentResponse['quotaExhausted'] | undefined {
+/** JSON.parse with defensive narrowing to a Record. Returns undefined on parse error or non-object. */
+function tryParseJsonObject(stdout: string): Record<string, unknown> | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(stdout);
@@ -332,10 +321,26 @@ function extractClaudeCodeQuotaSignal(stdout: string): AgentResponse['quotaExhau
     return undefined;
   }
   if (!parsed || typeof parsed !== 'object') return undefined;
-  const obj = parsed as Record<string, unknown>;
-  if (obj.api_error_status !== 429) return undefined;
+  return parsed as Record<string, unknown>;
+}
 
-  const resultText = typeof obj.result === 'string' ? obj.result : undefined;
+/**
+ * Extracts a quota-exhaustion signal from a parsed Claude Code envelope.
+ * Returns undefined when the envelope carries a different error class.
+ * `resetAt` is populated only when the human-readable reset timestamp
+ * can be parsed.
+ *
+ * Contract: this helper populates `AgentResponse.quotaExhausted`, which
+ * the workflow orchestrator treats as a terminal "pause and resume
+ * later" signal — do not fold unrelated errors into this path.
+ */
+function extractClaudeCodeQuotaSignal(
+  parsed: Record<string, unknown>,
+  stdout: string,
+): AgentResponse['quotaExhausted'] | undefined {
+  if (parsed.api_error_status !== 429) return undefined;
+
+  const resultText = typeof parsed.result === 'string' ? parsed.result : undefined;
   const rawMessage = resultText ?? stdout.trim();
   const match = resultText ? QUOTA_RESET_REGEX.exec(resultText) : null;
   if (match) {
@@ -350,25 +355,14 @@ function extractClaudeCodeQuotaSignal(stdout: string): AgentResponse['quotaExhau
 
 /**
  * Detects the degenerate "upstream stall" envelope: a Claude Code result
- * envelope (`type: 'result'`) where JSON parses and `result` is non-empty
- * (typically the agent's preamble), but `usage.output_tokens === 0` AND
- * `stop_reason === null` (or undefined). Matches the captured envelopes
- * from a sustained LiteLLM/Z.AI outage where the stream hung server-side
- * and no assistant message was generated.
+ * envelope where `usage.output_tokens === 0` AND `stop_reason === null/undefined`.
  *
- * Three layers of defensiveness, all in service of "false positives are
- * much worse than missed detections" — flagging a healthy completion as
- * transient would route it to the resumable-abort path:
- *
- *  - `type` gate: only Claude Code's result envelopes match. An
- *    arbitrary object that happens to carry a `result` key plus the two
- *    field names will not be flagged.
- *  - AND-of-both-signals: legitimate empty completions
- *    (`stop_reason === 'end_turn'` with `output_tokens === 0`) and
- *    partial streams (`output_tokens > 0` with `stop_reason === null`)
- *    do NOT match.
- *  - Type-narrowing on `usage`: absent or wrongly-typed `usage` (CLI
- *    version drift, schema change) yields undefined.
+ * False positives here are much worse than missed detections — they would
+ * route a healthy completion to the resumable-abort path. Hence the
+ * `type === 'result'` gate, the strict AND on both signals (so legitimate
+ * empty completions with `stop_reason === 'end_turn'` and partial streams
+ * with `output_tokens > 0` do not match), and the defensive `usage`
+ * narrowing (CLI version drift / schema change yields undefined).
  */
 function detectTransientFailure(parsed: Record<string, unknown>, stdout: string): { rawMessage: string } | undefined {
   if (parsed.type !== 'result') return undefined;
@@ -382,47 +376,20 @@ function detectTransientFailure(parsed: Record<string, unknown>, stdout: string)
 }
 
 /**
- * JSON-parses stdout and runs the transient-stall detector. Used by the
- * `exit !== 0` path of `extractResponse`, where `parseClaudeCodeJson`
- * doesn't run. Returns the matched signal plus the envelope's `result`
- * preamble for surfacing as the turn's `text`. Undefined on parse
- * failure or when the predicate does not match.
- */
-function extractTransientSignalFromStdout(stdout: string): { text: string; rawMessage: string } | undefined {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stdout);
-  } catch {
-    return undefined;
-  }
-  if (!parsed || typeof parsed !== 'object') return undefined;
-  const obj = parsed as Record<string, unknown>;
-  const transient = detectTransientFailure(obj, stdout);
-  if (!transient) return undefined;
-  const text = typeof obj.result === 'string' ? obj.result : stdout.trim();
-  return { text, rawMessage: transient.rawMessage };
-}
-
-/**
  * Parses Claude Code's `--output-format json` response.
  * Falls back to raw stdout when the output is not valid JSON.
  */
 function parseClaudeCodeJson(stdout: string): AgentResponse {
-  try {
-    const parsed: unknown = JSON.parse(stdout);
-    if (parsed && typeof parsed === 'object' && 'result' in parsed) {
-      const obj = parsed as Record<string, unknown>;
-      const text = typeof obj.result === 'string' ? obj.result : stdout.trim();
-      const transient = detectTransientFailure(obj, stdout);
-      const base: AgentResponse =
-        typeof obj.total_cost_usd === 'number' ? { text, costUsd: obj.total_cost_usd } : { text };
-      if (transient) {
-        return { ...base, transientFailure: { kind: 'degenerate_response', rawMessage: transient.rawMessage } };
-      }
-      return base;
+  const parsed = tryParseJsonObject(stdout);
+  if (parsed && 'result' in parsed) {
+    const text = typeof parsed.result === 'string' ? parsed.result : stdout.trim();
+    const transient = detectTransientFailure(parsed, stdout);
+    const base: AgentResponse =
+      typeof parsed.total_cost_usd === 'number' ? { text, costUsd: parsed.total_cost_usd } : { text };
+    if (transient) {
+      return { ...base, transientFailure: { kind: 'degenerate_response', rawMessage: transient.rawMessage } };
     }
-  } catch {
-    // JSON parse failed -- fall through to raw text
+    return base;
   }
   return { text: stdout.trim() };
 }

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -359,13 +359,16 @@ function extractClaudeCodeQuotaSignal(
  *
  * False positives here are much worse than missed detections — they would
  * route a healthy completion to the resumable-abort path. Hence the
- * `type === 'result'` gate, the strict AND on both signals (so legitimate
- * empty completions with `stop_reason === 'end_turn'` and partial streams
- * with `output_tokens > 0` do not match), and the defensive `usage`
+ * `type === 'result'` + `typeof result === 'string'` envelope gates (a
+ * real Claude Code result envelope always carries both), the strict AND
+ * on the two stall signals (so legitimate empty completions with
+ * `stop_reason === 'end_turn'` and partial streams with
+ * `output_tokens > 0` do not match), and the defensive `usage`
  * narrowing (CLI version drift / schema change yields undefined).
  */
 function detectTransientFailure(parsed: Record<string, unknown>, stdout: string): { rawMessage: string } | undefined {
   if (parsed.type !== 'result') return undefined;
+  if (typeof parsed.result !== 'string') return undefined;
   const usage = parsed.usage;
   if (!usage || typeof usage !== 'object') return undefined;
   const outputTokens = (usage as Record<string, unknown>).output_tokens;

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -339,6 +339,36 @@ function extractClaudeCodeQuotaSignal(stdout: string): AgentResponse['quotaExhau
 }
 
 /**
+ * Detects the degenerate "upstream stall" envelope: exit=0, JSON parses,
+ * `result` non-empty (typically the agent's preamble), but
+ * `usage.output_tokens === 0` AND `stop_reason === null` (or undefined).
+ * Matches the captured envelopes from a sustained LiteLLM/Z.AI outage
+ * where the stream hung server-side and no assistant message was
+ * generated.
+ *
+ * Predicate is strict (AND of both signals) so legitimate empty
+ * completions — `stop_reason === 'end_turn'` with `output_tokens === 0`
+ * — and partial streams — `output_tokens > 0` with `stop_reason === null`
+ * — do NOT match. Reads defensively: if `usage` is absent or wrongly
+ * typed (CLI version drift), returns undefined and lets the caller
+ * treat the response as healthy. False positives here would route a
+ * normal completion to the resumable-abort path, which is much worse
+ * than a missed detection.
+ */
+function detectClaudeCodeTransientFailure(
+  parsed: Record<string, unknown>,
+  stdout: string,
+): { rawMessage: string } | undefined {
+  const usage = parsed.usage;
+  if (!usage || typeof usage !== 'object') return undefined;
+  const outputTokens = (usage as Record<string, unknown>).output_tokens;
+  if (typeof outputTokens !== 'number' || outputTokens !== 0) return undefined;
+  const stopReason = parsed.stop_reason;
+  if (stopReason !== null && stopReason !== undefined) return undefined;
+  return { rawMessage: stdout.trim() };
+}
+
+/**
  * Parses Claude Code's `--output-format json` response.
  * Falls back to raw stdout when the output is not valid JSON.
  */
@@ -348,10 +378,13 @@ function parseClaudeCodeJson(stdout: string): AgentResponse {
     if (parsed && typeof parsed === 'object' && 'result' in parsed) {
       const obj = parsed as Record<string, unknown>;
       const text = typeof obj.result === 'string' ? obj.result : stdout.trim();
-      if (typeof obj.total_cost_usd === 'number') {
-        return { text, costUsd: obj.total_cost_usd };
+      const transient = detectClaudeCodeTransientFailure(obj, stdout);
+      const base: AgentResponse =
+        typeof obj.total_cost_usd === 'number' ? { text, costUsd: obj.total_cost_usd } : { text };
+      if (transient) {
+        return { ...base, transientFailure: { kind: 'degenerate_response', rawMessage: transient.rawMessage } };
       }
-      return { text };
+      return base;
     }
   } catch {
     // JSON parse failed -- fall through to raw text

--- a/src/docker/adapters/goose.ts
+++ b/src/docker/adapters/goose.ts
@@ -295,14 +295,23 @@ export function createGooseAdapter(userConfig?: ResolvedUserConfig): AgentAdapte
      * a 429 under Goose will therefore take the generic abort path
      * instead of pausing cleanly.
      *
-     * Closing this gap requires either (a) adopting a Goose structured
+     * The same gap applies to `AgentResponse.transientFailure`: detecting
+     * an upstream stall (degenerate response with no assistant content)
+     * relies on the JSON envelope's `usage.output_tokens` and
+     * `stop_reason` fields, which Goose does not surface. A workflow run
+     * that hits a sustained upstream stall under Goose will therefore
+     * take the generic abort path instead of marking the run as
+     * transient-resumable.
+     *
+     * Closing these gaps requires either (a) adopting a Goose structured
      * output mode when one becomes available, or (b) a fragile stderr
      * regex against known provider messages ("Usage limit reached",
      * "429", "rate_limit_exceeded"); (b) is deliberately not attempted
      * without broader testing across providers. See the Claude Code
      * adapter (`adapters/claude-code.ts`) for the target contract and
-     * `AgentResponse.quotaExhausted` in `../agent-adapter.ts` for the
-     * interface-level requirement on adapters.
+     * `AgentResponse.quotaExhausted` / `AgentResponse.transientFailure`
+     * in `../agent-adapter.ts` for the interface-level requirement on
+     * adapters.
      */
     extractResponse(exitCode: number, stdout: string): AgentResponse {
       const clean = stripAnsi(stdout);

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -60,6 +60,32 @@ export interface AgentResponse {
     readonly resetAt?: Date;
     readonly rawMessage: string;
   };
+  /**
+   * Set when the adapter detected a transient upstream failure that
+   * produced a syntactically-valid envelope with no usable content —
+   * for instance, a sustained LiteLLM/Z.AI stall surfaced by Claude Code
+   * as `usage.output_tokens === 0` AND `stop_reason === null` while
+   * `result` contains only the agent's preamble. The CLI exits 0 and
+   * its JSON parses, but no assistant message was generated.
+   *
+   * Shaped as a discriminated union (`kind`) so future detected shapes
+   * (`'connection_reset'`, `'5xx_passthrough'`, etc.) can extend without
+   * a breaking change. Mirrors the contract of `quotaExhausted`: the
+   * orchestrator MUST treat this as terminal-but-resumable, MUST NOT
+   * retry the turn (the in-loop reprompt against a stalled upstream is
+   * hopeless), and MUST preserve the checkpoint so `workflow resume`
+   * can re-enter the failing state once the upstream is healthy.
+   *
+   * `rawMessage` is the original envelope/stdout, preserved for
+   * diagnostics. Adapters that cannot produce this signal must leave
+   * the field undefined; falling through to the generic abort path is
+   * acceptable when the CLI offers no machine-readable transient
+   * signal.
+   */
+  readonly transientFailure?: {
+    readonly kind: 'degenerate_response';
+    readonly rawMessage: string;
+  };
 }
 
 /**

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -315,6 +315,7 @@ export class DockerAgentSession implements Session {
         text: response.text,
         hardFailure: response.hardFailure ?? false,
         quotaExhausted: response.quotaExhausted,
+        transientFailure: response.transientFailure,
       };
     } finally {
       // Restore to 'ready' on both success and exception so a failed

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -480,6 +480,22 @@ export interface AgentTurnResult {
     readonly resetAt?: Date;
     readonly rawMessage: string;
   };
+  /**
+   * Set when the adapter detected a transient upstream failure (a
+   * degenerate response envelope with no usable content — e.g. a
+   * sustained upstream stall surfaced as `usage.output_tokens === 0`
+   * AND `stop_reason === null`). Workflow callers MUST treat this as
+   * terminal-but-resumable: halt the run, preserve the checkpoint, and
+   * surface it as `phase: 'aborted'` so `workflow resume` can re-enter
+   * once the upstream is healthy. The orchestrator does NOT retry on
+   * this signal — an in-loop reprompt against a stalled upstream is
+   * hopeless. See `AgentResponse.transientFailure` in
+   * `src/docker/agent-adapter.ts` for the adapter-side contract.
+   */
+  readonly transientFailure?: {
+    readonly kind: 'degenerate_response';
+    readonly rawMessage: string;
+  };
 }
 
 export interface Session {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -481,16 +481,10 @@ export interface AgentTurnResult {
     readonly rawMessage: string;
   };
   /**
-   * Set when the adapter detected a transient upstream failure (a
-   * degenerate response envelope with no usable content — e.g. a
-   * sustained upstream stall surfaced as `usage.output_tokens === 0`
-   * AND `stop_reason === null`). Workflow callers MUST treat this as
-   * terminal-but-resumable: halt the run, preserve the checkpoint, and
-   * surface it as `phase: 'aborted'` so `workflow resume` can re-enter
-   * once the upstream is healthy. The orchestrator does NOT retry on
-   * this signal — an in-loop reprompt against a stalled upstream is
-   * hopeless. See `AgentResponse.transientFailure` in
-   * `src/docker/agent-adapter.ts` for the adapter-side contract.
+   * Mirrors `AgentResponse.transientFailure` in
+   * `src/docker/agent-adapter.ts`. See that field's JSDoc for the
+   * canonical contract; in short: terminal-but-resumable, no retry,
+   * checkpoint preserved.
    */
   readonly transientFailure?: {
     readonly kind: 'degenerate_response';

--- a/src/web-ui/dispatch/workflow-dispatch.ts
+++ b/src/web-ui/dispatch/workflow-dispatch.ts
@@ -489,7 +489,7 @@ export function computePastRunPhase(
  * Per D6: the destination state of the last `state_transition` lives in the
  * `event` field (orchestrator.handleTransition writes it there). For non-terminal,
  * non-gate destinations, post-transition `quota_exhausted` → 'aborted',
- * `error` → 'failed', neither → 'interrupted'.
+ * `transient_failure` → 'aborted', `error` → 'failed', none → 'interrupted'.
  */
 export function synthesizePhaseFromMessageLog(
   entries: readonly MessageLogEntry[],
@@ -499,18 +499,21 @@ export function synthesizePhaseFromMessageLog(
   // When a newer transition arrives, the post-transition accumulators reset.
   let lastTransition: StateTransitionEntry | undefined;
   let sawQuotaExhausted = false;
+  let sawTransientFailure = false;
   let sawError = false;
   for (const entry of entries) {
     if (entry.type === 'state_transition') {
       if (lastTransition === undefined || entry.ts > lastTransition.ts) {
         lastTransition = entry;
         sawQuotaExhausted = false;
+        sawTransientFailure = false;
         sawError = false;
       }
       continue;
     }
     if (lastTransition === undefined || entry.ts <= lastTransition.ts) continue;
     if (entry.type === 'quota_exhausted') sawQuotaExhausted = true;
+    else if (entry.type === 'transient_failure') sawTransientFailure = true;
     else if (entry.type === 'error') sawError = true;
   }
   if (lastTransition === undefined) return 'interrupted';
@@ -518,6 +521,7 @@ export function synthesizePhaseFromMessageLog(
   if (stateDef?.type === 'terminal') return phaseFromTerminalStateName(lastTransition.event);
   if (stateDef?.type === 'human_gate') return 'waiting_human';
   if (sawQuotaExhausted) return 'aborted';
+  if (sawTransientFailure) return 'aborted';
   if (sawError) return 'failed';
   return 'interrupted';
 }

--- a/src/workflow/errors.ts
+++ b/src/workflow/errors.ts
@@ -68,3 +68,44 @@ export class WorkflowQuotaExhaustedError extends Error {
 export function isWorkflowQuotaExhaustedError(err: unknown): err is WorkflowQuotaExhaustedError {
   return err instanceof WorkflowQuotaExhaustedError;
 }
+
+/**
+ * Thrown when the agent adapter reports a transient upstream failure
+ * (a degenerate response envelope with no usable content — e.g. a
+ * sustained upstream stall) for a state's turn. Sibling of
+ * `WorkflowQuotaExhaustedError`: both signal terminal-but-resumable
+ * conditions where retrying is hopeless.
+ *
+ * Consumers MUST NOT remove the on-disk checkpoint and MUST surface the
+ * run as resumable — `workflow resume <id>` re-enters the failing agent
+ * state once the upstream is healthy. The orchestrator forces
+ * `phase: 'aborted'` when this fires so `isCheckpointResumable` returns
+ * true regardless of which terminal `findErrorTarget` resolved to.
+ *
+ * `kind` is the discriminator from `AgentResponse.transientFailure`
+ * (today only `'degenerate_response'`); `rawMessage` is the original
+ * envelope/stdout, preserved for diagnostics.
+ */
+export interface WorkflowTransientFailureOptions {
+  readonly stateId: string;
+  readonly kind: 'degenerate_response';
+  readonly rawMessage: string;
+}
+
+export class WorkflowTransientFailureError extends Error {
+  readonly stateId: string;
+  readonly kind: 'degenerate_response';
+  readonly rawMessage: string;
+
+  constructor(options: WorkflowTransientFailureOptions) {
+    super(`Agent turn aborted: upstream stall (kind=${options.kind})`);
+    this.name = 'WorkflowTransientFailureError';
+    this.stateId = options.stateId;
+    this.kind = options.kind;
+    this.rawMessage = options.rawMessage;
+  }
+}
+
+export function isWorkflowTransientFailureError(err: unknown): err is WorkflowTransientFailureError {
+  return err instanceof WorkflowTransientFailureError;
+}

--- a/src/workflow/errors.ts
+++ b/src/workflow/errors.ts
@@ -71,20 +71,12 @@ export function isWorkflowQuotaExhaustedError(err: unknown): err is WorkflowQuot
 
 /**
  * Thrown when the agent adapter reports a transient upstream failure
- * (a degenerate response envelope with no usable content — e.g. a
- * sustained upstream stall) for a state's turn. Sibling of
+ * (see `AgentResponse.transientFailure`). Sibling of
  * `WorkflowQuotaExhaustedError`: both signal terminal-but-resumable
- * conditions where retrying is hopeless.
- *
- * Consumers MUST NOT remove the on-disk checkpoint and MUST surface the
- * run as resumable — `workflow resume <id>` re-enters the failing agent
- * state once the upstream is healthy. The orchestrator forces
- * `phase: 'aborted'` when this fires so `isCheckpointResumable` returns
- * true regardless of which terminal `findErrorTarget` resolved to.
- *
- * `kind` is the discriminator from `AgentResponse.transientFailure`
- * (today only `'degenerate_response'`); `rawMessage` is the original
- * envelope/stdout, preserved for diagnostics.
+ * conditions. Consumers MUST NOT remove the on-disk checkpoint; the
+ * orchestrator forces `phase: 'aborted'` so `isCheckpointResumable`
+ * returns true regardless of which terminal `findErrorTarget` resolved
+ * to.
  */
 export interface WorkflowTransientFailureOptions {
   readonly stateId: string;

--- a/src/workflow/message-log.ts
+++ b/src/workflow/message-log.ts
@@ -79,13 +79,9 @@ export interface QuotaExhaustedEntry extends BaseEntry {
 }
 
 /**
- * Emitted when the adapter detected a transient upstream failure (a
- * degenerate response envelope with no usable content — e.g. a sustained
- * upstream stall) and the orchestrator halted the run instead of
- * retrying. `kind` is the discriminator from
- * `AgentResponse.transientFailure` (today only `'degenerate_response'`);
- * `rawMessage` preserves the original envelope/stdout for humans
- * inspecting the log.
+ * Emitted when the orchestrator halted the run on
+ * `AgentResponse.transientFailure`. `rawMessage` preserves the original
+ * envelope/stdout for humans inspecting the log.
  */
 export interface TransientFailureEntry extends BaseEntry {
   readonly type: 'transient_failure';

--- a/src/workflow/message-log.ts
+++ b/src/workflow/message-log.ts
@@ -78,6 +78,22 @@ export interface QuotaExhaustedEntry extends BaseEntry {
   readonly rawMessage: string;
 }
 
+/**
+ * Emitted when the adapter detected a transient upstream failure (a
+ * degenerate response envelope with no usable content — e.g. a sustained
+ * upstream stall) and the orchestrator halted the run instead of
+ * retrying. `kind` is the discriminator from
+ * `AgentResponse.transientFailure` (today only `'degenerate_response'`);
+ * `rawMessage` preserves the original envelope/stdout for humans
+ * inspecting the log.
+ */
+export interface TransientFailureEntry extends BaseEntry {
+  readonly type: 'transient_failure';
+  readonly role: string;
+  readonly kind: 'degenerate_response';
+  readonly rawMessage: string;
+}
+
 /** Discriminated union of all log entry types. */
 export type MessageLogEntry =
   | AgentSentEntry
@@ -87,7 +103,8 @@ export type MessageLogEntry =
   | GateResolvedEntry
   | ErrorEntry
   | StateTransitionEntry
-  | QuotaExhaustedEntry;
+  | QuotaExhaustedEntry
+  | TransientFailureEntry;
 
 // ---------------------------------------------------------------------------
 // MessageLog

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -2011,7 +2011,7 @@ export class WorkflowOrchestrator implements WorkflowController {
         phase: 'aborted',
         reason:
           `Upstream stall: agent returned no content (kind=${instance.transientFailure.kind}; ` +
-          `resumable — run "workflow resume <id>" once upstream is healthy)\n${excerpt}`,
+          `resumable — run "ironcurtain workflow resume <baseDir>" once upstream is healthy)\n${excerpt}`,
       };
     } else if (stateValue === 'aborted' || stateValue.includes('abort')) {
       instance.finalStatus = {

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -439,22 +439,15 @@ interface WorkflowInstance {
    */
   quotaExhausted?: { readonly resetAt?: Date; readonly rawMessage: string };
   /**
-   * Stamped when an agent turn reports a transient upstream failure
-   * (a degenerate response envelope with no usable content — e.g. a
-   * sustained upstream stall). Sibling of `quotaExhausted`: drives the
-   * same checkpoint-preserving abort path so `workflow resume` can
-   * re-enter once the upstream is healthy. Survives only in-process;
-   * the checkpoint itself does not record it.
+   * Sibling of `quotaExhausted`: drives the same checkpoint-preserving
+   * abort path. Survives only in-process; the checkpoint does not
+   * record it.
    *
-   * Resume-correctness depends on a prior state-transition checkpoint
-   * existing for `handleWorkflowComplete` to preserve: the orchestrator
-   * only checkpoints on actual state changes, not on entry to the
-   * `initial:` state. A transient failure on the initial agent state
-   * therefore lands in the terminal-snapshot checkpoint (no usable
-   * `existing.machineState` to preserve), and resume re-enters the
-   * terminal instead of the failing state. Same limitation applies to
-   * `quotaExhausted`. Closing it would require a checkpoint-on-start
-   * change that is out of scope for this signal.
+   * Initial-state caveat: the orchestrator only checkpoints on actual
+   * state transitions, so a transient failure on the `initial:` state
+   * has no prior checkpoint to preserve and resume will re-enter the
+   * terminal rather than the failing state. Applies to `quotaExhausted`
+   * too; closing requires a checkpoint-on-start change.
    */
   transientFailure?: { readonly kind: 'degenerate_response'; readonly rawMessage: string };
 }
@@ -2012,16 +2005,13 @@ export class WorkflowOrchestrator implements WorkflowController {
       // `findErrorTarget` resolved to. Without this, a workflow whose
       // only terminal is `done` would land on `done` and
       // `handleWorkflowComplete` would mark the run `completed`, breaking
-      // resume. The truncated rawMessage excerpt makes the abort reason
-      // self-explanatory in CLI / web UI surfaces without dumping the
-      // full envelope.
+      // resume.
       const excerpt = instance.transientFailure.rawMessage.slice(0, 200);
       instance.finalStatus = {
         phase: 'aborted',
         reason:
           `Upstream stall: agent returned no content (kind=${instance.transientFailure.kind}; ` +
-          `resumable — run "workflow resume <id>" once upstream is healthy)` +
-          (excerpt ? `\n${excerpt}` : ''),
+          `resumable — run "workflow resume <id>" once upstream is healthy)\n${excerpt}`,
       };
     } else if (stateValue === 'aborted' || stateValue.includes('abort')) {
       instance.finalStatus = {

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -445,6 +445,16 @@ interface WorkflowInstance {
    * same checkpoint-preserving abort path so `workflow resume` can
    * re-enter once the upstream is healthy. Survives only in-process;
    * the checkpoint itself does not record it.
+   *
+   * Resume-correctness depends on a prior state-transition checkpoint
+   * existing for `handleWorkflowComplete` to preserve: the orchestrator
+   * only checkpoints on actual state changes, not on entry to the
+   * `initial:` state. A transient failure on the initial agent state
+   * therefore lands in the terminal-snapshot checkpoint (no usable
+   * `existing.machineState` to preserve), and resume re-enters the
+   * terminal instead of the failing state. Same limitation applies to
+   * `quotaExhausted`. Closing it would require a checkpoint-on-start
+   * change that is out of scope for this signal.
    */
   transientFailure?: { readonly kind: 'degenerate_response'; readonly rawMessage: string };
 }
@@ -1676,11 +1686,14 @@ export class WorkflowOrchestrator implements WorkflowController {
         }
         if (result.transientFailure) {
           const { kind, rawMessage } = result.transientFailure;
-          // Mirror the quota path's structure: append a structured
-          // `transient_failure` log entry, stamp the instance, throw a
-          // dedicated error. Do NOT call logReceived here — the
-          // structured entry is sufficient and a parallel agent_received
-          // entry would clutter `workflow inspect`.
+          // Same shape as the quota branch — append a structured log
+          // entry, stamp the instance, throw a dedicated error — but
+          // deliberately skip `logReceived`. Quota envelopes carry the
+          // provider's actual rate-limit message in `result.text`, which
+          // is worth recording as the agent's turn. Transient envelopes
+          // carry only the agent's preamble with no real assistant
+          // content, so logging it as `agent_received` would falsely
+          // imply the agent produced a turn.
           messageLog.append({
             ...this.logBase(instance),
             type: 'transient_failure',

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -77,7 +77,13 @@ import { validateDefinition } from './validate.js';
 import { parseDefinitionFile } from './discovery.js';
 import { discoverWorkflowRuns } from './workflow-discovery.js';
 import { isCheckpointResumable } from './checkpoint.js';
-import { AgentInvocationError, WorkflowQuotaExhaustedError, isWorkflowQuotaExhaustedError } from './errors.js';
+import {
+  AgentInvocationError,
+  WorkflowQuotaExhaustedError,
+  WorkflowTransientFailureError,
+  isWorkflowQuotaExhaustedError,
+  isWorkflowTransientFailureError,
+} from './errors.js';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -432,6 +438,15 @@ interface WorkflowInstance {
    * Survives only in-process; the checkpoint itself does not record it.
    */
   quotaExhausted?: { readonly resetAt?: Date; readonly rawMessage: string };
+  /**
+   * Stamped when an agent turn reports a transient upstream failure
+   * (a degenerate response envelope with no usable content — e.g. a
+   * sustained upstream stall). Sibling of `quotaExhausted`: drives the
+   * same checkpoint-preserving abort path so `workflow resume` can
+   * re-enter once the upstream is healthy. Survives only in-process;
+   * the checkpoint itself does not record it.
+   */
+  transientFailure?: { readonly kind: 'degenerate_response'; readonly rawMessage: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -1624,17 +1639,19 @@ export class WorkflowOrchestrator implements WorkflowController {
       };
 
       // Uniform agent-turn entrypoint: every prompt and reprompt must flow
-      // through here so the quota-exhaustion short-circuit applies to ALL
-      // of them. Retrying or reprompting a turn whose adapter reported
-      // quota exhaustion would only burn more of the already-exhausted
-      // budget — instead we log a `quota_exhausted` event once and throw
+      // through here so the quota-exhaustion / transient-failure
+      // short-circuits apply to ALL of them. Retrying or reprompting a turn
+      // whose adapter reported either signal would only burn more of the
+      // already-exhausted budget (quota) or hammer a stalled upstream
+      // (transient) — instead we log the structured event once and throw
       // a dedicated error so higher layers can distinguish "paused by
-      // provider" from "aborted by bug" (today both abort; M4 turns this
-      // into a `paused` terminal phase without touching here).
+      // provider" / "stalled upstream" from "aborted by bug" (today all
+      // three abort; M4 turns these into a `paused` terminal phase without
+      // touching here).
       //
       // Sessions without `sendMessageDetailed` (e.g., built-in in-process
       // sessions) degrade cleanly to `sendMessage`, which cannot produce
-      // a quota signal — the short-circuit simply never fires for them.
+      // either signal — the short-circuits simply never fire for them.
       const sendAgentTurn = async (msg: string): Promise<AgentTurnResult> => {
         const result = session.sendMessageDetailed
           ? await session.sendMessageDetailed(msg)
@@ -1656,6 +1673,23 @@ export class WorkflowOrchestrator implements WorkflowController {
           // to be a normal terminal (e.g. `done`).
           instance.quotaExhausted = { resetAt, rawMessage };
           throw new WorkflowQuotaExhaustedError({ stateId, resetAt, rawMessage });
+        }
+        if (result.transientFailure) {
+          const { kind, rawMessage } = result.transientFailure;
+          // Mirror the quota path's structure: append a structured
+          // `transient_failure` log entry, stamp the instance, throw a
+          // dedicated error. Do NOT call logReceived here — the
+          // structured entry is sufficient and a parallel agent_received
+          // entry would clutter `workflow inspect`.
+          messageLog.append({
+            ...this.logBase(instance),
+            type: 'transient_failure',
+            role: stateConfig.persona,
+            kind,
+            rawMessage,
+          });
+          instance.transientFailure = { kind, rawMessage };
+          throw new WorkflowTransientFailureError({ stateId, kind, rawMessage });
         }
         return result;
       };
@@ -1815,13 +1849,14 @@ export class WorkflowOrchestrator implements WorkflowController {
         responseText,
       };
     } catch (err) {
-      // Quota exhaustion already produced its own structured
-      // `quota_exhausted` log entry inside `sendAgentTurn`; appending a
-      // generic `error` entry here would double-log the same event and
-      // make `workflow inspect` surface both a yellow quota line and a
-      // red error line for the same failure. Suppress the generic entry
-      // when the cause is a `WorkflowQuotaExhaustedError`.
-      if (!isWorkflowQuotaExhaustedError(err)) {
+      // Quota exhaustion / transient upstream failure already produced
+      // their own structured log entries inside `sendAgentTurn`;
+      // appending a generic `error` entry here would double-log the same
+      // event and make `workflow inspect` surface a duplicate red error
+      // line alongside the structured signal. Suppress the generic entry
+      // when the cause is a `WorkflowQuotaExhaustedError` or
+      // `WorkflowTransientFailureError`.
+      if (!isWorkflowQuotaExhaustedError(err) && !isWorkflowTransientFailureError(err)) {
         instance.messageLog.append({
           ...this.logBase(instance),
           type: 'error',
@@ -1957,6 +1992,23 @@ export class WorkflowOrchestrator implements WorkflowController {
       instance.finalStatus = {
         phase: 'aborted',
         reason: `Upstream quota exhausted${resetHint}`,
+      };
+    } else if (instance.transientFailure) {
+      // Mirror the quota branch: a transient upstream failure must force
+      // an abort-preserving terminal regardless of which state
+      // `findErrorTarget` resolved to. Without this, a workflow whose
+      // only terminal is `done` would land on `done` and
+      // `handleWorkflowComplete` would mark the run `completed`, breaking
+      // resume. The truncated rawMessage excerpt makes the abort reason
+      // self-explanatory in CLI / web UI surfaces without dumping the
+      // full envelope.
+      const excerpt = instance.transientFailure.rawMessage.slice(0, 200);
+      instance.finalStatus = {
+        phase: 'aborted',
+        reason:
+          `Upstream stall: agent returned no content (kind=${instance.transientFailure.kind}; ` +
+          `resumable — run "workflow resume <id>" once upstream is healthy)` +
+          (excerpt ? `\n${excerpt}` : ''),
       };
     } else if (stateValue === 'aborted' || stateValue.includes('abort')) {
       instance.finalStatus = {

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -552,6 +552,11 @@ function runInspect(args: string[]): void {
               `${prefix} ${YELLOW}[quota/${entry.role}]${RESET} resets=${entry.resetAt ?? 'unknown'} — ${truncate(entry.rawMessage, 80)}`,
             );
             break;
+          case 'transient_failure':
+            writeStdout(
+              `${prefix} ${YELLOW}[transient/${entry.role}]${RESET} kind=${entry.kind} — ${truncate(entry.rawMessage, 80)}`,
+            );
+            break;
           case 'state_transition': {
             const toDesc = stateDescriptions?.get(entry.event);
             const toLabel = toDesc ? `${entry.event} ${DIM}\u2014 "${toDesc}"${RESET}` : entry.event;

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -338,6 +338,57 @@ describe('Claude Code Adapter', () => {
     expect(response.transientFailure).toBeUndefined();
   });
 
+  it('surfaces transientFailure even when CLI exits non-zero on the degenerate envelope', () => {
+    // The degenerate envelope can arrive with a non-zero exit code (e.g.
+    // the CLI surfacing a 5xx after the stream begins). The detector
+    // must run in BOTH the exit=0 and exit!=0 paths so the structured
+    // signal isn't lost to the generic hard-failure path.
+    const envelope = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      result: 'preamble',
+      usage: { input_tokens: 100, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.transientFailure).toBeDefined();
+    expect(response.transientFailure!.kind).toBe('degenerate_response');
+    expect(response.text).toBe('preamble');
+    // Must NOT route through hardFailure: the orchestrator's hard-retry
+    // rotation cannot recover a stalled upstream.
+    expect(response.hardFailure).toBeUndefined();
+    expect(response.quotaExhausted).toBeUndefined();
+  });
+
+  it('does not flag transientFailure when JSON envelope lacks type=result (predicate strictness)', () => {
+    // An arbitrary object that happens to carry `result` plus the two
+    // signal fields must NOT be flagged. Locks the `type === 'result'`
+    // gate against future changes.
+    const envelope = JSON.stringify({
+      type: 'something_else',
+      result: 'preamble',
+      usage: { input_tokens: 100, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+  });
+
+  it('does not flag transientFailure when result field is absent', () => {
+    // parseClaudeCodeJson gates on 'result' in parsed before running
+    // the detector; this lock-in test confirms a malformed envelope
+    // missing `result` falls through to the raw-stdout fallback.
+    const envelope = JSON.stringify({
+      type: 'result',
+      usage: { input_tokens: 100, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+    // Falls through to raw-stdout text.
+    expect(response.text).toBe(envelope);
+  });
+
   it('returns conversation state config for session resume', () => {
     const config = claudeCodeAdapter.getConversationStateConfig!();
     expect(config.hostDirName).toBe('claude-state');

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -248,6 +248,96 @@ describe('Claude Code Adapter', () => {
     expect(response.quotaExhausted).toBeUndefined();
   });
 
+  it('surfaces transientFailure when usage.output_tokens=0 AND stop_reason=null (degenerate stall envelope)', () => {
+    // Mirrors the captured envelope from a sustained LiteLLM/Z.AI outage:
+    // CLI exits 0, JSON parses, `result` non-empty (preamble), but the
+    // stream hung server-side and produced no assistant content.
+    const envelope = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      result: 'I will analyze the workspace next.',
+      usage: { input_tokens: 1234, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeDefined();
+    expect(response.transientFailure!.kind).toBe('degenerate_response');
+    expect(response.transientFailure!.rawMessage).toContain('output_tokens');
+    // text retains the preamble so the message log has something to show.
+    expect(response.text).toBe('I will analyze the workspace next.');
+    // Transient failure must NOT route through the hardFailure or
+    // quotaExhausted paths.
+    expect(response.hardFailure).toBeUndefined();
+    expect(response.quotaExhausted).toBeUndefined();
+  });
+
+  it('does not flag transientFailure on a healthy completion (stop_reason=end_turn, output_tokens>0)', () => {
+    const envelope = JSON.stringify({
+      type: 'result',
+      result: 'Task completed',
+      usage: { input_tokens: 100, output_tokens: 50 },
+      stop_reason: 'end_turn',
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+    expect(response.text).toBe('Task completed');
+  });
+
+  it('does not flag transientFailure on a legitimate empty completion (output_tokens=0 AND stop_reason=end_turn)', () => {
+    // Boundary case documenting predicate strictness: a legitimate empty
+    // completion sets stop_reason='end_turn', so it must NOT match.
+    const envelope = JSON.stringify({
+      type: 'result',
+      result: '',
+      usage: { input_tokens: 100, output_tokens: 0 },
+      stop_reason: 'end_turn',
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+  });
+
+  it('does not flag transientFailure on a partial-stream shape (output_tokens>0 AND stop_reason=null)', () => {
+    // Boundary case: partial-stream detection is Phase 2 (out of scope
+    // here). Confirms the predicate is strict (AND of both signals).
+    const envelope = JSON.stringify({
+      type: 'result',
+      result: 'partial output',
+      usage: { input_tokens: 100, output_tokens: 5 },
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+  });
+
+  it('does not flag transientFailure when usage is absent (defensive: CLI version drift)', () => {
+    const envelope = JSON.stringify({
+      type: 'result',
+      result: 'something',
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+  });
+
+  it('does not flag transientFailure when usage is wrongly typed (defensive)', () => {
+    const envelope = JSON.stringify({
+      type: 'result',
+      result: 'something',
+      usage: 'not an object',
+      stop_reason: null,
+    });
+    const response = claudeCodeAdapter.extractResponse(0, envelope);
+    expect(response.transientFailure).toBeUndefined();
+  });
+
+  it('hard-failure (exit=143, empty stdout) sets hardFailure=true and not transientFailure', () => {
+    // Mutual-exclusion regression guard: a kill-on-exit failure must NOT
+    // be misclassified as a degenerate-response transient failure.
+    const response = claudeCodeAdapter.extractResponse(143, '');
+    expect(response.hardFailure).toBe(true);
+    expect(response.transientFailure).toBeUndefined();
+  });
+
   it('returns conversation state config for session resume', () => {
     const config = claudeCodeAdapter.getConversationStateConfig!();
     expect(config.hostDirName).toBe('claude-state');

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -375,9 +375,9 @@ describe('Claude Code Adapter', () => {
   });
 
   it('does not flag transientFailure when result field is absent', () => {
-    // parseClaudeCodeJson gates on 'result' in parsed before running
-    // the detector; this lock-in test confirms a malformed envelope
-    // missing `result` falls through to the raw-stdout fallback.
+    // The detector gates on `typeof parsed.result === 'string'` so a
+    // malformed envelope missing `result` does NOT match — applies to
+    // both exit=0 and exit!=0 paths.
     const envelope = JSON.stringify({
       type: 'result',
       usage: { input_tokens: 100, output_tokens: 0 },
@@ -387,6 +387,29 @@ describe('Claude Code Adapter', () => {
     expect(response.transientFailure).toBeUndefined();
     // Falls through to raw-stdout text.
     expect(response.text).toBe(envelope);
+  });
+
+  it('does not flag transientFailure on non-zero exit when result field is absent or non-string', () => {
+    // Locks in cross-path consistency: the exit!=0 branch must apply
+    // the same `typeof parsed.result === 'string'` gate as the exit=0
+    // branch, otherwise a drifted envelope without `result` could
+    // false-positive to the resumable-abort path.
+    const noResult = JSON.stringify({
+      type: 'result',
+      usage: { input_tokens: 100, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const noResultResponse = claudeCodeAdapter.extractResponse(1, noResult);
+    expect(noResultResponse.transientFailure).toBeUndefined();
+
+    const nonStringResult = JSON.stringify({
+      type: 'result',
+      result: { nested: 'object' },
+      usage: { input_tokens: 100, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const nonStringResponse = claudeCodeAdapter.extractResponse(1, nonStringResult);
+    expect(nonStringResponse.transientFailure).toBeUndefined();
   });
 
   it('returns conversation state config for session resume', () => {

--- a/test/docker-agent-session-retry.test.ts
+++ b/test/docker-agent-session-retry.test.ts
@@ -237,6 +237,33 @@ describe('DockerAgentSession retry path', () => {
     expect(flagValue(calls[1], '--session-id')).toBeUndefined();
   });
 
+  it('forwards transientFailure from a degenerate response envelope (exit=0, output_tokens=0, stop_reason=null)', async () => {
+    // Plumbing-level coverage at the session seam: the adapter detects
+    // the stall envelope, the session must surface it through
+    // sendMessageDetailed unchanged so the orchestrator can short-circuit
+    // on it.
+    const degenerateEnvelope = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      result: 'preamble only',
+      usage: { input_tokens: 1234, output_tokens: 0 },
+      stop_reason: null,
+    });
+    const { exec } = scriptedExec([{ exitCode: 0, stdout: degenerateEnvelope, stderr: '' }]);
+    const deps = buildDeps(tempDir, exec);
+    session = new DockerAgentSession(deps);
+    await session.initialize();
+
+    const result = await session.sendMessageDetailed('do the thing');
+
+    expect(result.transientFailure).toBeDefined();
+    expect(result.transientFailure!.kind).toBe('degenerate_response');
+    expect(result.transientFailure!.rawMessage).toContain('output_tokens');
+    expect(result.hardFailure).toBe(false);
+    expect(result.quotaExhausted).toBeUndefined();
+    expect(result.text).toBe('preamble only');
+  });
+
   it('sendMessage delegates to sendMessageDetailed and returns just the text', async () => {
     const { exec } = scriptedExec([{ exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' }]);
     const deps = buildDeps(tempDir, exec);

--- a/test/workflow-dispatch.test.ts
+++ b/test/workflow-dispatch.test.ts
@@ -726,6 +726,52 @@ describe('synthesizePhaseFromMessageLog', () => {
     expect(synthesizePhaseFromMessageLog(entries, def)).toBe('aborted');
   });
 
+  it('prefers "aborted" over "failed" when both transient_failure and error follow the last transition', () => {
+    // Symmetric to the quota_exhausted + error precedence test above:
+    // the new transient_failure signal must also outrank a generic
+    // error entry in phase synthesis.
+    const def = defWithStates({
+      start: {
+        type: 'agent',
+        description: 's',
+        persona: 'global',
+        prompt: 'p',
+        inputs: [],
+        outputs: [],
+        transitions: [{ to: 'plan' }],
+      },
+      plan: {
+        type: 'agent',
+        description: 'p',
+        persona: 'global',
+        prompt: 'p',
+        inputs: [],
+        outputs: [],
+        transitions: [],
+      },
+    });
+    const entries: MessageLogEntry[] = [
+      transitionTo('plan', 'start', '2026-04-23T10:00:00.000Z'),
+      {
+        type: 'error',
+        ts: '2026-04-23T10:05:00.000Z',
+        workflowId,
+        state: 'plan',
+        error: 'agent crashed',
+      },
+      {
+        type: 'transient_failure',
+        ts: '2026-04-23T10:06:00.000Z',
+        workflowId,
+        state: 'plan',
+        role: 'planner',
+        kind: 'degenerate_response',
+        rawMessage: '{"usage":{"output_tokens":0},"stop_reason":null}',
+      },
+    ];
+    expect(synthesizePhaseFromMessageLog(entries, def)).toBe('aborted');
+  });
+
   it('ignores events that occurred BEFORE the last transition', () => {
     // quota_exhausted at ts=09:00 predates the transition at ts=10:00; ignored.
     const def = defWithStates({

--- a/test/workflow-dispatch.test.ts
+++ b/test/workflow-dispatch.test.ts
@@ -644,6 +644,46 @@ describe('synthesizePhaseFromMessageLog', () => {
     expect(synthesizePhaseFromMessageLog(entries, def)).toBe('completed');
   });
 
+  it('returns "aborted" when last state is non-terminal and a transient_failure follows', () => {
+    // Mirrors the quota_exhausted case for the new transient-failure
+    // signal: a checkpoint-less past run that aborted via the transient
+    // path must classify as `'aborted'` (not `'interrupted'`) so the
+    // past-runs UI labels it correctly.
+    const def = defWithStates({
+      start: {
+        type: 'agent',
+        description: 's',
+        persona: 'global',
+        prompt: 'p',
+        inputs: [],
+        outputs: [],
+        transitions: [{ to: 'plan' }],
+      },
+      plan: {
+        type: 'agent',
+        description: 'p',
+        persona: 'global',
+        prompt: 'p',
+        inputs: [],
+        outputs: [],
+        transitions: [],
+      },
+    });
+    const entries: MessageLogEntry[] = [
+      transitionTo('plan', 'start', '2026-04-23T10:00:00.000Z'),
+      {
+        type: 'transient_failure',
+        ts: '2026-04-23T10:05:00.000Z',
+        workflowId,
+        state: 'plan',
+        role: 'planner',
+        kind: 'degenerate_response',
+        rawMessage: '{"usage":{"output_tokens":0},"stop_reason":null}',
+      },
+    ];
+    expect(synthesizePhaseFromMessageLog(entries, def)).toBe('aborted');
+  });
+
   it('prefers "aborted" over "failed" when both quota_exhausted and error follow the last transition', () => {
     const def = defWithStates({
       start: {
@@ -1416,6 +1456,53 @@ describe('workflows.listResumable', () => {
     expect(byId.get(idDone)?.phase).toBe('completed');
     expect(byId.get(idAbort)?.phase).toBe('aborted');
     expect(byId.get(idGate)?.phase).toBe('waiting_human');
+  });
+
+  it('surfaces a transient-aborted run as phase "aborted" in listResumable (resume-eligibility)', async () => {
+    // The orchestrator forces `finalStatus.phase = 'aborted'` when the
+    // adapter reports `transientFailure`, even when the workflow's only
+    // terminal is `done`. listResumable must surface that as 'aborted'
+    // (via computePastRunPhase short-circuiting on finalStatus.phase) so
+    // the past-runs UI shows a Resume affordance for the row.
+    const id = 'wf-transient-aborted' as WorkflowId;
+    const def = makeDefinition({
+      initial: 'plan',
+      states: {
+        plan: {
+          type: 'agent',
+          description: 'p',
+          persona: 'global',
+          prompt: 'p',
+          inputs: [],
+          outputs: ['plan'],
+          transitions: [{ to: 'done' }],
+        },
+        done: { type: 'terminal', description: 'finished' },
+      },
+    });
+    // Checkpoint preserves the failing agent state's machineState (the
+    // orchestrator does NOT overwrite it on transient abort) and
+    // stamps finalStatus.phase = 'aborted'.
+    const cp = makeCheckpoint({
+      machineState: 'plan',
+      timestamp: '2026-04-23T15:00:00.000Z',
+      finalStatus: { phase: 'aborted', reason: 'Upstream stall: agent returned no content' },
+    });
+    seedRunDirectory(baseDir, id, { definition: def, checkpoint: cp });
+
+    const ctx = createContext({
+      baseDir,
+      controller: { listActive: vi.fn().mockReturnValue([]) },
+      loadPastRun: () => makeLoad({ checkpoint: cp, definition: def }),
+    });
+
+    const dtos = (await workflowDispatch(ctx, 'workflows.listResumable', {})) as PastRunDto[];
+
+    expect(dtos).toHaveLength(1);
+    expect(dtos[0].workflowId).toBe(id);
+    expect(dtos[0].phase).toBe('aborted');
+    // The failing agent state is preserved, so resume can re-enter it.
+    expect(dtos[0].currentState).toBe('plan');
   });
 
   it('leaves durationMs undefined for every row (checkpoint schema gap)', async () => {

--- a/test/workflow/orchestrator-transient.test.ts
+++ b/test/workflow/orchestrator-transient.test.ts
@@ -41,7 +41,8 @@ import {
 // Workflow definition whose ONLY terminal is `done` — no `aborted`/`failed`
 // terminal. This is the critical shape: without the
 // `instance.transientFailure` stamp, `handleWorkflowComplete` would mark
-// the run `phase: 'completed'` and remove the checkpoint, breaking
+// the run `phase: 'completed'`, leaving a terminal checkpoint that
+// `isCheckpointResumable` treats as non-resumable and thus breaking
 // resume.
 const simpleAgentDef: WorkflowDefinition = {
   name: 'simple-agent-transient',

--- a/test/workflow/orchestrator-transient.test.ts
+++ b/test/workflow/orchestrator-transient.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Orchestrator transient-failure short-circuit tests.
+ *
+ * Sibling of `orchestrator-quota.test.ts`. The transient-failure path
+ * fires when the adapter detects a degenerate response envelope (e.g.,
+ * `usage.output_tokens === 0` AND `stop_reason === null`) — indicating a
+ * sustained upstream stall. The orchestrator must:
+ *
+ *  - Halt the run immediately (no reprompt, no rotation — an in-loop
+ *    retry against a stalled upstream is hopeless).
+ *  - Force `phase: 'aborted'` regardless of which terminal
+ *    `findErrorTarget` resolved to, so the on-disk checkpoint is
+ *    preserved and `isCheckpointResumable` returns true.
+ *  - Append exactly ONE structured `transient_failure` log entry and
+ *    NO generic `error` entry (double-log regression guard).
+ *  - Allow `workflow resume` to re-enter the failing agent state and
+ *    drive the run forward once the upstream is healthy. This is the
+ *    primary acceptance criterion.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { WorkflowDefinition } from '../../src/workflow/types.js';
+import { WorkflowOrchestrator } from '../../src/workflow/orchestrator.js';
+import type { MessageLogEntry, TransientFailureEntry, QuotaExhaustedEntry } from '../../src/workflow/message-log.js';
+import {
+  MockSession,
+  noStatusResponse,
+  approvedResponse,
+  simulateArtifacts,
+  findWorkflowDir,
+  writeDefinitionFile,
+  createDeps,
+  createCheckpointStore,
+  waitForCompletion,
+  stubPersonasForTest,
+} from './test-helpers.js';
+
+// Workflow definition whose ONLY terminal is `done` — no `aborted`/`failed`
+// terminal. This is the critical shape: without the
+// `instance.transientFailure` stamp, `handleWorkflowComplete` would mark
+// the run `phase: 'completed'` and remove the checkpoint, breaking
+// resume.
+const simpleAgentDef: WorkflowDefinition = {
+  name: 'simple-agent-transient',
+  description: 'Single agent to done',
+  initial: 'implement',
+  settings: { mode: 'builtin' },
+  states: {
+    implement: {
+      type: 'agent',
+      description: 'Writes code',
+      persona: 'coder',
+      prompt: 'You are a coder.',
+      inputs: [],
+      outputs: ['code'],
+      transitions: [{ to: 'done' }],
+    },
+    done: { type: 'terminal', description: 'Done' },
+  },
+};
+
+const RAW_MESSAGE = '{"result":"preamble only","usage":{"output_tokens":0},"stop_reason":null}';
+
+function readMessageLog(baseDir: string): MessageLogEntry[] {
+  const logPath = resolve(findWorkflowDir(baseDir), 'messages.jsonl');
+  if (!existsSync(logPath)) return [];
+  const lines = readFileSync(logPath, 'utf-8').split('\n').filter(Boolean);
+  return lines.map((l) => JSON.parse(l) as MessageLogEntry);
+}
+
+describe('WorkflowOrchestrator transient-failure short-circuit', () => {
+  let tmpDir: string;
+  let activeOrchestrators: WorkflowOrchestrator[];
+  let cleanupPersonas: (() => void) | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'orchestrator-transient-test-'));
+    activeOrchestrators = [];
+    cleanupPersonas = stubPersonasForTest(tmpDir, simpleAgentDef);
+  });
+
+  afterEach(async () => {
+    for (const o of activeOrchestrators) {
+      await o.shutdownAll();
+    }
+    cleanupPersonas?.();
+    rmSync(tmpDir, { recursive: true, force: true });
+    const baseName = resolve(tmpDir).split('/').pop()!;
+    const ckptDir = resolve(tmpDir, '..', `${baseName}-ckpt`);
+    rmSync(ckptDir, { recursive: true, force: true });
+  });
+
+  function trackOrchestrator(o: WorkflowOrchestrator): WorkflowOrchestrator {
+    activeOrchestrators.push(o);
+    return o;
+  }
+
+  it('halts immediately when the primary turn reports transientFailure, preserves checkpoint, and does not double-log', async () => {
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const allSessions: MockSession[] = [];
+
+    const sessionFactory = vi.fn(async () => {
+      const session = new MockSession({
+        responses: [
+          {
+            text: 'preamble only',
+            hardFailure: false,
+            transientFailure: { kind: 'degenerate_response', rawMessage: RAW_MESSAGE },
+          },
+        ],
+      });
+      allSessions.push(session);
+      return session;
+    });
+
+    const checkpointStore = createCheckpointStore(tmpDir);
+    const deps = createDeps(tmpDir, { createSession: sessionFactory, checkpointStore });
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    // The workflow has no `aborted` terminal — `findErrorTarget` would
+    // route to `done` and `handleWorkflowComplete` would mark the run
+    // `completed` if not for the `instance.transientFailure` stamp. The
+    // user's resumability requirement hinges on this assertion.
+    const status = orchestrator.getStatus(workflowId);
+    expect(status?.phase).toBe('aborted');
+    if (status?.phase === 'aborted') {
+      expect(status.reason).toContain('Upstream stall');
+      expect(status.reason).toContain('degenerate_response');
+      expect(status.reason).toContain('resume');
+    }
+
+    // Checkpoint MUST be preserved so `workflow resume` works.
+    expect(checkpointStore.load(workflowId)).not.toBeNull();
+
+    // Exactly ONE turn — no rotation, no reprompt.
+    const session = allSessions[0];
+    expect(session.sentMessages).toHaveLength(1);
+    expect(session.rotateCalls).toEqual([]);
+
+    // Exactly one transient_failure entry, zero generic error entries.
+    const log = readMessageLog(tmpDir);
+    const transientEntries = log.filter((e): e is TransientFailureEntry => e.type === 'transient_failure');
+    expect(transientEntries).toHaveLength(1);
+    expect(transientEntries[0].role).toBe('coder');
+    expect(transientEntries[0].kind).toBe('degenerate_response');
+    expect(transientEntries[0].rawMessage).toBe(RAW_MESSAGE);
+
+    const errorEntries = log.filter((e) => e.type === 'error');
+    expect(errorEntries).toHaveLength(0);
+  });
+
+  it('forces aborted phase even when the workflow definition has no aborted terminal (resume-eligibility guarantee)', async () => {
+    // Explicit duplicate of the assertion above, called out separately
+    // because this is THE acceptance criterion for the user's
+    // requirement: a transient upstream error must leave the workflow
+    // in a resumable state, regardless of YAML shape.
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const sessionFactory = vi.fn(
+      async () =>
+        new MockSession({
+          responses: [
+            {
+              text: 'preamble',
+              hardFailure: false,
+              transientFailure: { kind: 'degenerate_response', rawMessage: RAW_MESSAGE },
+            },
+          ],
+        }),
+    );
+
+    const checkpointStore = createCheckpointStore(tmpDir);
+    const deps = createDeps(tmpDir, { createSession: sessionFactory, checkpointStore });
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
+    expect(checkpointStore.load(workflowId)).not.toBeNull();
+  });
+
+  it('end-to-end resume round-trip: aborts on transient failure, then resume() re-runs the agent state to completion', async () => {
+    // Primary acceptance test: user must be able to recover the run via
+    // `workflow resume <id>` once the upstream is healthy.
+    //
+    // Uses a two-agent workflow so the failure on the second agent is
+    // preceded by a state-transition checkpoint that pins the failing
+    // state — that's the checkpoint `handleWorkflowComplete` preserves
+    // when stamping `phase: 'aborted'` on transient failure. (A single
+    // initial-state failure has no prior state-transition checkpoint;
+    // out of scope for this fix.)
+    const twoAgentDef: WorkflowDefinition = {
+      name: 'two-agent-transient',
+      description: 'Plan then implement',
+      initial: 'plan',
+      settings: { mode: 'builtin' },
+      states: {
+        plan: {
+          type: 'agent',
+          description: 'Plans',
+          persona: 'planner',
+          prompt: 'You are a planner.',
+          inputs: [],
+          outputs: ['plan'],
+          transitions: [{ to: 'implement' }],
+        },
+        implement: {
+          type: 'agent',
+          description: 'Writes code',
+          persona: 'coder',
+          prompt: 'You are a coder.',
+          inputs: ['plan'],
+          outputs: ['code'],
+          transitions: [{ to: 'done' }],
+        },
+        done: { type: 'terminal', description: 'Done' },
+      },
+    };
+    const cleanup = stubPersonasForTest(tmpDir, twoAgentDef);
+    try {
+      const defPath = writeDefinitionFile(tmpDir, twoAgentDef);
+
+      // First orchestrator: planner succeeds, coder transient-fails.
+      const failingFactory = vi.fn(async (opts: { persona?: string }) => {
+        if (opts.persona === 'planner') {
+          const wfDir = findWorkflowDir(tmpDir);
+          simulateArtifacts(wfDir, ['plan']);
+          return new MockSession({ responses: [approvedResponse('planned')] });
+        }
+        return new MockSession({
+          responses: [
+            {
+              text: 'preamble',
+              hardFailure: false,
+              transientFailure: { kind: 'degenerate_response', rawMessage: RAW_MESSAGE },
+            },
+          ],
+        });
+      });
+
+      const checkpointStore = createCheckpointStore(tmpDir);
+      const deps1 = createDeps(tmpDir, {
+        createSession: failingFactory as unknown as ReturnType<typeof vi.fn>,
+        checkpointStore,
+      });
+      const orchestrator1 = trackOrchestrator(new WorkflowOrchestrator(deps1));
+
+      const workflowId = await orchestrator1.start(defPath, 'write code');
+      await waitForCompletion(orchestrator1, workflowId);
+
+      expect(orchestrator1.getStatus(workflowId)?.phase).toBe('aborted');
+      const cp = checkpointStore.load(workflowId);
+      expect(cp).not.toBeNull();
+      // Checkpoint must point at the failing state, not the terminal.
+      expect(cp!.machineState).toBe('implement');
+      expect(cp!.finalStatus?.phase).toBe('aborted');
+
+      // Second orchestrator: coder now succeeds. Resume re-enters
+      // 'implement' and drives to completion.
+      await orchestrator1.shutdownAll();
+
+      const healthyFactory = vi.fn(async (opts: { persona?: string }) => {
+        const wfDir = findWorkflowDir(tmpDir);
+        simulateArtifacts(wfDir, ['code']);
+        return new MockSession({ responses: [approvedResponse(`${opts.persona} resumed`)] });
+      });
+
+      const deps2 = createDeps(tmpDir, {
+        createSession: healthyFactory as unknown as ReturnType<typeof vi.fn>,
+        checkpointStore,
+      });
+      const orchestrator2 = trackOrchestrator(new WorkflowOrchestrator(deps2));
+
+      await orchestrator2.resume(workflowId);
+      await waitForCompletion(orchestrator2, workflowId);
+
+      // The coder must have been re-invoked on resume.
+      expect(healthyFactory).toHaveBeenCalled();
+      expect(orchestrator2.getStatus(workflowId)?.phase).toBe('completed');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('prefers the quota short-circuit over the transient-failure short-circuit when both signals are set', async () => {
+    // Document precedence: quota exhaustion is checked first. When both
+    // signals are set on a turn, the quota path wins — only a
+    // quota_exhausted log entry is emitted, no transient_failure entry.
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const sessionFactory = vi.fn(
+      async () =>
+        new MockSession({
+          responses: [
+            {
+              text: 'stalled',
+              hardFailure: false,
+              quotaExhausted: { rawMessage: 'rate limited' },
+              transientFailure: { kind: 'degenerate_response', rawMessage: RAW_MESSAGE },
+            },
+          ],
+        }),
+    );
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
+
+    const log = readMessageLog(tmpDir);
+    const quotaEntries = log.filter((e): e is QuotaExhaustedEntry => e.type === 'quota_exhausted');
+    const transientEntries = log.filter((e): e is TransientFailureEntry => e.type === 'transient_failure');
+    expect(quotaEntries).toHaveLength(1);
+    expect(transientEntries).toHaveLength(0);
+  });
+
+  it('halts when transientFailure surfaces on the missing-status-block reprompt', async () => {
+    // The four `sendAgentTurn` call sites share the same closure, so
+    // coverage of two sites (initial + missing-status-block reprompt)
+    // is sufficient to confirm the short-circuit applies uniformly.
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+    const allSessions: MockSession[] = [];
+
+    const sessionFactory = vi.fn(async () => {
+      let callCount = 0;
+      const session = new MockSession({
+        responses: () => {
+          callCount++;
+          if (callCount === 1) {
+            // Primary turn: produces text but no agent_status block,
+            // triggering the missing-status-block reprompt.
+            simulateArtifacts(findWorkflowDir(tmpDir), ['code']);
+            return noStatusResponse();
+          }
+          if (callCount === 2) {
+            return {
+              text: 'preamble',
+              hardFailure: false,
+              transientFailure: { kind: 'degenerate_response', rawMessage: RAW_MESSAGE },
+            };
+          }
+          throw new Error(`Unexpected call ${callCount} — reprompt should have short-circuited`);
+        },
+      });
+      allSessions.push(session);
+      return session;
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
+
+    const session = allSessions[0];
+    expect(session.sentMessages).toHaveLength(2);
+    expect(session.rotateCalls).toEqual([]);
+
+    const log = readMessageLog(tmpDir);
+    const transientEntries = log.filter((e): e is TransientFailureEntry => e.type === 'transient_failure');
+    expect(transientEntries).toHaveLength(1);
+  });
+});

--- a/test/workflow/orchestrator-transient.test.ts
+++ b/test/workflow/orchestrator-transient.test.ts
@@ -322,6 +322,12 @@ describe('WorkflowOrchestrator transient-failure short-circuit', () => {
     expect(transientEntries).toHaveLength(0);
   });
 
+  it.todo(
+    'resume re-enters the failing state after a transient failure on the initial agent state ' +
+      '(blocked: orchestrator does not checkpoint on initial-state entry, so the abort-time checkpoint ' +
+      'falls back to the terminal snapshot — same gap exists for quotaExhausted)',
+  );
+
   it('halts when transientFailure surfaces on the missing-status-block reprompt', async () => {
     // The four `sendAgentTurn` call sites share the same closure, so
     // coverage of two sites (initial + missing-status-block reprompt)


### PR DESCRIPTION
## Summary

- A sustained upstream stall (e.g. LiteLLM/Z.AI outage) surfaces as an `exit=0` envelope where JSON parses but `usage.output_tokens === 0` AND `stop_reason === null`. Previously this fell through the soft-failure reprompt path and aborted as `phase: 'completed'` when the workflow's only terminal was `done` — making `workflow resume` refuse the run.
- New `AgentResponse.transientFailure` signal mirrors the existing `quotaExhausted` pattern: orchestrator short-circuits, appends a structured `transient_failure` log entry, and forces `finalStatus.phase = 'aborted'` while preserving the prior state-transition checkpoint, so `workflow resume` can re-enter the failing agent state once the upstream is healthy.
- Web-UI `synthesizePhaseFromMessageLog` learns the new signal so checkpoint-less past runs aborted via this path classify as `'aborted'` (not `'interrupted'`). `workflows.listResumable` and `workflows.resume` work via existing `finalStatus.phase` plumbing.

## Scope

- **Detection**: `src/docker/adapters/claude-code.ts` — `detectTransientFailure` (gated on `type === 'result'` + AND of both signals + defensive `usage` narrowing) runs in BOTH the `exit=0` and `exit !== 0` paths via a single `tryParseJsonObject` helper (parse-once).
- **Plumbing**: `AgentResponse` (`src/docker/agent-adapter.ts`), `AgentTurnResult` (`src/session/types.ts`), `DockerAgentSession`, `WorkflowTransientFailureError` (`src/workflow/errors.ts`), `TransientFailureEntry` (`src/workflow/message-log.ts`), and `WorkflowInstance.transientFailure` (`src/workflow/orchestrator.ts`).
- **Goose adapter**: documented gap (no JSON output mode to detect from).
- **Known limitation**: a transient failure on the workflow's `initial:` agent state lacks a prior state-transition checkpoint to preserve, so resume re-enters the terminal rather than the failing state. Same gap exists for `quotaExhausted`. Captured as `it.todo` in `orchestrator-transient.test.ts` and JSDoc'd on `WorkflowInstance.transientFailure`.

## Test plan

- [x] `npm test -- test/workflow/orchestrator-transient.test.ts` — 5 cases incl. end-to-end resume round-trip on a multi-state workflow
- [x] `npm test -- test/docker-agent-adapter.test.ts` — predicate coverage incl. `type !== 'result'` gate, missing `result`, `exit !== 0` + degenerate envelope, mutual-exclusion with `hardFailure`
- [x] `npm test -- test/docker-agent-session-retry.test.ts` — session-seam pass-through
- [x] `npm test -- test/workflow-dispatch.test.ts` — web-UI `synthesizePhaseFromMessageLog` covers `transient_failure` + non-terminal transition and `transient_failure` + `error` precedence
- [x] `npm test` — full suite (4235 passed, 1 todo for the documented initial-state gap)
- [x] `npm run lint && npm run build`
- [ ] Manual smoke: doctor a real workflow's `checkpoint.json` to set `finalStatus.phase = 'aborted'` and `machineState` to a non-terminal agent state, then `ironcurtain workflow resume <baseDir>` (CLI) and confirm the past-runs UI surfaces a Resume affordance (`ironcurtain daemon --web-ui`)

## Commits

1. `9839c55` — Detect degenerate responses as resumable transient failures (initial implementation)
2. `789c1b0` — Address review findings (predicate gating on `type === 'result'`, detection on non-zero exit, comment fix, initial-state gap doc)
3. `c424165` — Simplify plumbing (parse-once on non-zero exit, JSDoc dedup, dead-code removal; net –61 lines)