### PR TITLE
fix(workflow): route MITM tokens to active agent session + accumulate totalTokens

### DIFF
--- a/packages/web-ui/scripts/agent-session-events.ts
+++ b/packages/web-ui/scripts/agent-session-events.ts
@@ -1,0 +1,22 @@
+/**
+ * Helper for constructing `workflow.agent_session_ended` payloads.
+ *
+ * Used by the scenario runner, the mock WS server, and their tests so
+ * the payload shape stays in lock-step with the daemon contract in
+ * `src/web-ui/web-event-bus.ts`. If the wire format gains a field,
+ * extend this helper and every emitter picks it up.
+ */
+
+export interface AgentSessionEndedPayload {
+  readonly workflowId: string;
+  readonly stateId: string;
+  readonly sessionId: string;
+}
+
+export function makeAgentSessionEndedPayload(
+  workflowId: string,
+  stateId: string,
+  sessionId: string,
+): AgentSessionEndedPayload {
+  return { workflowId, stateId, sessionId };
+}

--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -1261,7 +1261,13 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
         name: newWf.name,
         taskDescription: String(params.taskDescription ?? ''),
       });
-      broadcast('workflow.agent_started', { workflowId: newId, stateId: 'plan', persona: 'planner' });
+      const planSessionId = `${newId}-plan-${Date.now()}`;
+      broadcast('workflow.agent_started', {
+        workflowId: newId,
+        stateId: 'plan',
+        persona: 'planner',
+        sessionId: planSessionId,
+      });
       broadcast('workflow.state_entered', { workflowId: newId, state: 'plan' });
 
       trackTimer(
@@ -1274,6 +1280,11 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
               stateId: 'plan',
               verdict: 'success',
               confidence: '0.87',
+            });
+            broadcast('workflow.agent_session_ended', {
+              workflowId: newId,
+              stateId: 'plan',
+              sessionId: planSessionId,
             });
             wf.currentState = 'plan_review';
             wf.phase = 'waiting_human';
@@ -1355,10 +1366,13 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
         const nextState = resolveEvent === 'FORCE_REVISION' ? 'plan' : 'implement';
         resolveWf.phase = 'running';
         resolveWf.currentState = nextState;
+        const nextPersona = nextState === 'plan' ? 'planner' : 'coder';
+        const nextSessionId = `${resolveWfId}-${nextState}-${Date.now()}`;
         broadcast('workflow.agent_started', {
           workflowId: resolveWfId,
           stateId: nextState,
-          persona: nextState === 'plan' ? 'planner' : 'coder',
+          persona: nextPersona,
+          sessionId: nextSessionId,
         });
         broadcast('workflow.state_entered', { workflowId: resolveWfId, state: nextState });
 
@@ -1372,6 +1386,11 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
                 stateId: nextState,
                 verdict: 'success',
                 confidence: '0.79',
+              });
+              broadcast('workflow.agent_session_ended', {
+                workflowId: resolveWfId,
+                stateId: nextState,
+                sessionId: nextSessionId,
               });
               if (nextState === 'implement') {
                 wf.currentState = 'review';

--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -18,6 +18,7 @@ import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { parseArgs } from 'util';
 import { loadReplayPlan, createReplayController, type ReplayController, type ReplayPlan } from './replay-engine.js';
+import { makeAgentSessionEndedPayload } from './agent-session-events.js';
 
 // ---------------------------------------------------------------------------
 // Types (mirrors the daemon protocol without importing from src/)
@@ -1281,11 +1282,7 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
               verdict: 'success',
               confidence: '0.87',
             });
-            broadcast('workflow.agent_session_ended', {
-              workflowId: newId,
-              stateId: 'plan',
-              sessionId: planSessionId,
-            });
+            broadcast('workflow.agent_session_ended', makeAgentSessionEndedPayload(newId, 'plan', planSessionId));
             wf.currentState = 'plan_review';
             wf.phase = 'waiting_human';
             const gateId = `${newId}-plan_review`;
@@ -1387,11 +1384,10 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
                 verdict: 'success',
                 confidence: '0.79',
               });
-              broadcast('workflow.agent_session_ended', {
-                workflowId: resolveWfId,
-                stateId: nextState,
-                sessionId: nextSessionId,
-              });
+              broadcast(
+                'workflow.agent_session_ended',
+                makeAgentSessionEndedPayload(resolveWfId, nextState, nextSessionId),
+              );
               if (nextState === 'implement') {
                 wf.currentState = 'review';
                 broadcast('workflow.state_entered', { workflowId: resolveWfId, state: 'review' });

--- a/packages/web-ui/src/lib/event-handler.ts
+++ b/packages/web-ui/src/lib/event-handler.ts
@@ -144,10 +144,21 @@ export type WebEvent =
       event: 'workflow.state_entered';
       payload: { workflowId: string; state: string; previousState?: string };
     }
-  | { event: 'workflow.agent_started'; payload: { workflowId: string; stateId: string; persona: string } }
+  | {
+      event: 'workflow.agent_started';
+      // `sessionId` is the daemon's bridge-registration key; frontend doesn't
+      // use it today but mirrors the contract in src/web-ui/web-event-bus.ts.
+      payload: { workflowId: string; stateId: string; persona: string; sessionId?: string };
+    }
   | {
       event: 'workflow.agent_completed';
       payload: { workflowId: string; stateId: string; verdict?: string; confidence?: string };
+    }
+  | {
+      // Fires in the orchestrator's `finally` so success, failure, and abort
+      // paths all clean up the bridge mapping. Mirror of the daemon contract.
+      event: 'workflow.agent_session_ended';
+      payload: { workflowId: string; stateId: string; sessionId: string };
     }
   | { event: 'workflow.completed'; payload: { workflowId: string } }
   | { event: 'workflow.failed'; payload: { workflowId: string; error: string } }
@@ -200,12 +211,17 @@ export function parseEvent(event: string, payload: unknown): WebEvent | undefine
     case 'workflow.agent_started':
       return {
         event,
-        payload: data as { workflowId: string; stateId: string; persona: string },
+        payload: data as { workflowId: string; stateId: string; persona: string; sessionId?: string },
       };
     case 'workflow.agent_completed':
       return {
         event,
         payload: data as { workflowId: string; stateId: string; verdict?: string; confidence?: string },
+      };
+    case 'workflow.agent_session_ended':
+      return {
+        event,
+        payload: data as { workflowId: string; stateId: string; sessionId: string },
       };
     case 'workflow.completed':
       return { event, payload: data as { workflowId: string } };
@@ -376,6 +392,7 @@ function applyEvent(state: AppStateLike, effects: EventSideEffects, parsed: WebE
     }
 
     case 'workflow.agent_started':
+    case 'workflow.agent_session_ended':
       // Informational; no state mutation needed.
       return true;
 

--- a/packages/web-ui/src/lib/event-handler.ts
+++ b/packages/web-ui/src/lib/event-handler.ts
@@ -146,9 +146,12 @@ export type WebEvent =
     }
   | {
       event: 'workflow.agent_started';
-      // `sessionId` is the daemon's bridge-registration key; frontend doesn't
-      // use it today but mirrors the contract in src/web-ui/web-event-bus.ts.
-      payload: { workflowId: string; stateId: string; persona: string; sessionId?: string };
+      // `sessionId` is the daemon's bridge-registration key and is always
+      // emitted by the orchestrator (see src/workflow/orchestrator.ts
+      // `emitLifecycleEvent({ kind: 'agent_started', ... })`). Frontend
+      // consumers may not read it today, but the field is required on the
+      // wire so future per-session attribution doesn't require a type churn.
+      payload: { workflowId: string; stateId: string; persona: string; sessionId: string };
     }
   | {
       event: 'workflow.agent_completed';
@@ -211,7 +214,7 @@ export function parseEvent(event: string, payload: unknown): WebEvent | undefine
     case 'workflow.agent_started':
       return {
         event,
-        payload: data as { workflowId: string; stateId: string; persona: string; sessionId?: string },
+        payload: data as { workflowId: string; stateId: string; persona: string; sessionId: string },
       };
     case 'workflow.agent_completed':
       return {

--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -20,7 +20,7 @@ import { loadConfig } from '../config/index.js';
 import { loadUserConfig, type ResolvedUserConfig } from '../config/user-config.js';
 import { getJobWorkspaceDir, getJobGeneratedDir, getJobDir, getWebUiStatePath } from '../config/paths.js';
 import type { IronCurtainConfig } from '../config/types.js';
-import type { SessionMode, SessionId, EscalationRequest } from '../session/types.js';
+import { parseSessionId, type SessionMode, type SessionId, type EscalationRequest } from '../session/types.js';
 import { SessionManager, type SessionSource } from '../session/session-manager.js';
 import { HeadlessTransport } from '../cron/headless-transport.js';
 import { shouldAutoSaveMemory } from '../memory/auto-save.js';
@@ -110,9 +110,11 @@ export class IronCurtainDaemon {
    * are drawn from SessionManager.reserveLabel() to keep the label
    * space unified.
    *
-   * Keyed by SessionId so session reuse (resumeSessionId across state
-   * re-entries) maps to the same bridge label -- the viz's subscription
-   * stays correlated across agent transitions without churn.
+   * Each `agent_started` mints a fresh SessionId (even when
+   * `freshSession: false` reuses the AgentConversationId) and reserves
+   * a fresh label. `agent_session_ended` always tears down. The map
+   * is keyed by SessionId so the tear-down handler can recover the
+   * label assigned at start time.
    */
   private readonly workflowAgentLabels = new Map<SessionId, number>();
 
@@ -757,24 +759,25 @@ export class IronCurtainDaemon {
         // Workflow-owned agent sessions are not registered in
         // SessionManager (they run without a Transport). Map them
         // into the bridge here so token events produced by the
-        // session reach `observe --all` subscribers. Reuses the
-        // existing label if the same SessionId reappears (happens
-        // when `freshSession: false` replays history through a new
-        // Session instance with the same ID).
-        const { sessionId } = payload as { sessionId: string };
-        const sid = sessionId as SessionId;
-        let label = this.workflowAgentLabels.get(sid);
-        if (label === undefined) {
-          label = this.sessionManager.reserveLabel();
-          this.workflowAgentLabels.set(sid, label);
-        }
+        // session reach `observe --all` subscribers. A fresh label
+        // is reserved per agent session; `agent_session_ended` tears
+        // it down unconditionally. `Session.getInfo().id` is freshly
+        // minted per session even when `freshSession: false` reuses
+        // the `AgentConversationId`, so every `agent_started` event
+        // carries a distinct SessionId and reserving a fresh label is
+        // always correct.
+        const sid = parseSessionId((payload as { sessionId?: unknown }).sessionId);
+        if (sid === undefined) return;
+        const label = this.sessionManager.reserveLabel();
+        this.workflowAgentLabels.set(sid, label);
         bridge.registerSession(label, sid);
       } else if (event === 'workflow.agent_session_ended') {
-        // Fires unconditionally (success or failure) in the
-        // orchestrator's finally block, so cleanup is symmetric
-        // with registration above.
-        const { sessionId } = payload as { sessionId: string };
-        const sid = sessionId as SessionId;
+        // A fresh label is reserved per agent session; this handler
+        // tears it down unconditionally (fires in the orchestrator's
+        // finally block so success, failure, and abort paths all
+        // converge here).
+        const sid = parseSessionId((payload as { sessionId?: unknown }).sessionId);
+        if (sid === undefined) return;
         const label = this.workflowAgentLabels.get(sid);
         if (label !== undefined) {
           this.workflowAgentLabels.delete(sid);

--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -20,7 +20,7 @@ import { loadConfig } from '../config/index.js';
 import { loadUserConfig, type ResolvedUserConfig } from '../config/user-config.js';
 import { getJobWorkspaceDir, getJobGeneratedDir, getJobDir, getWebUiStatePath } from '../config/paths.js';
 import type { IronCurtainConfig } from '../config/types.js';
-import type { SessionMode, EscalationRequest } from '../session/types.js';
+import type { SessionMode, SessionId, EscalationRequest } from '../session/types.js';
 import { SessionManager, type SessionSource } from '../session/session-manager.js';
 import { HeadlessTransport } from '../cron/headless-transport.js';
 import { shouldAutoSaveMemory } from '../memory/auto-save.js';
@@ -102,6 +102,19 @@ export class IronCurtainDaemon {
 
   /** Control request handler (saved for web UI reuse). */
   private controlRequestHandler: ControlRequestHandler | null = null;
+
+  /**
+   * Tracks bridge labels allocated for workflow-owned agent sessions.
+   * Workflow sessions don't go through SessionManager (they have no
+   * Transport), so they need their own SessionId -> label map. Labels
+   * are drawn from SessionManager.reserveLabel() to keep the label
+   * space unified.
+   *
+   * Keyed by SessionId so session reuse (resumeSessionId across state
+   * re-entries) maps to the same bridge label -- the viz's subscription
+   * stays correlated across agent transitions without churn.
+   */
+  private readonly workflowAgentLabels = new Map<SessionId, number>();
 
   /** Resolve to exit the daemon. */
   private exitResolve: (() => void) | null = null;
@@ -740,6 +753,33 @@ export class IronCurtainDaemon {
         }
       } else if (event === 'session.ended') {
         bridge.closeSession((payload as { label: number }).label);
+      } else if (event === 'workflow.agent_started') {
+        // Workflow-owned agent sessions are not registered in
+        // SessionManager (they run without a Transport). Map them
+        // into the bridge here so token events produced by the
+        // session reach `observe --all` subscribers. Reuses the
+        // existing label if the same SessionId reappears (happens
+        // when `freshSession: false` replays history through a new
+        // Session instance with the same ID).
+        const { sessionId } = payload as { sessionId: string };
+        const sid = sessionId as SessionId;
+        let label = this.workflowAgentLabels.get(sid);
+        if (label === undefined) {
+          label = this.sessionManager.reserveLabel();
+          this.workflowAgentLabels.set(sid, label);
+        }
+        bridge.registerSession(label, sid);
+      } else if (event === 'workflow.agent_session_ended') {
+        // Fires unconditionally (success or failure) in the
+        // orchestrator's finally block, so cleanup is symmetric
+        // with registration above.
+        const { sessionId } = payload as { sessionId: string };
+        const sid = sessionId as SessionId;
+        const label = this.workflowAgentLabels.get(sid);
+        if (label !== undefined) {
+          this.workflowAgentLabels.delete(sid);
+          bridge.closeSession(label);
+        }
       }
     });
 

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -369,12 +369,12 @@ export async function prepareDockerInfrastructure(
     packageValidation = { validator, auditLogPath: packageAuditLogPath };
   }
 
-  // MITM proxy uses its `sessionId` option as a token-stream routing key
-  // (see MitmProxyOptions.sessionId). The routing key must match what
-  // token-stream subscribers use; today bundleId is the right value in
-  // both single-session and workflow modes. The cast bridges the brand
-  // gap: the bus signature is typed as SessionId, but the actual value
-  // here is a BundleId acting as a bundle-scoped routing token.
+  // Initial token-stream routing id. Single-session mode: bundleId is
+  // the session id, so the bridge subscribes under the same key.
+  // Workflow shared-container mode: the orchestrator overrides this
+  // per-agent via setTokenSessionId() around each executeAgentState,
+  // so the bundleId default is only an initial placeholder. Double-cast
+  // bridges the BundleId → SessionId brand gap on MitmProxyOptions.
   const routingId = bundleId as unknown as SessionId;
   const mitmProxy = useTcp
     ? createMitmProxy({

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -164,6 +164,17 @@ export interface PreContainerInfrastructure {
   readonly conversationStateDir?: string;
   /** Conversation state config from the adapter, if resume is supported. */
   readonly conversationStateConfig?: ConversationStateConfig;
+  /**
+   * Routes token-stream events from the MITM proxy's LLM API tap under the
+   * given session ID, or disables routing when `undefined`.
+   *
+   * Required because a single long-lived infrastructure bundle (shared
+   * across workflow agent states) must label extracted events with the
+   * *active* per-state session ID rather than a static ID baked in at
+   * construction time. Callers flip this around each agent run; thin
+   * wrapper over `MitmProxy.setTokenSessionId()`.
+   */
+  setTokenSessionId(id: import('../session/types.js').SessionId | undefined): void;
 }
 
 /**
@@ -371,7 +382,6 @@ export async function prepareDockerInfrastructure(
         registries,
         packageValidation,
         controlPort: 0,
-        sessionId: bundleId,
       })
     : createMitmProxy({
         socketPath: getBundleMitmProxySocketPath(bundleId),
@@ -380,7 +390,6 @@ export async function prepareDockerInfrastructure(
         registries,
         packageValidation,
         controlSocketPath: getBundleMitmControlSocketPath(bundleId),
-        sessionId: bundleId,
       });
 
   const docker = createDockerManager();
@@ -473,6 +482,9 @@ export async function prepareDockerInfrastructure(
       authKind,
       conversationStateDir,
       conversationStateConfig,
+      setTokenSessionId: (id) => {
+        mitmProxy.setTokenSessionId(id);
+      },
     };
   } catch (error) {
     // Best-effort cleanup of proxies started above

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -26,7 +26,7 @@ import { createHash } from 'node:crypto';
 import { quote } from 'shell-quote';
 import type { IronCurtainConfig } from '../config/types.js';
 import { getBundleRuntimeRoot } from '../config/paths.js';
-import { getBundleShortId, type BundleId, type SessionMode } from '../session/types.js';
+import { getBundleShortId, type BundleId, type SessionId, type SessionMode } from '../session/types.js';
 import { DEFAULT_CONTAINER_SCOPE, type WorkflowId } from '../workflow/types.js';
 import { CONTAINER_WORKSPACE_DIR, type AgentAdapter, type ConversationStateConfig } from './agent-adapter.js';
 import type { DockerProxy } from './code-mode-proxy.js';
@@ -372,8 +372,10 @@ export async function prepareDockerInfrastructure(
   // MITM proxy uses its `sessionId` option as a token-stream routing key
   // (see MitmProxyOptions.sessionId). The routing key must match what
   // token-stream subscribers use; today bundleId is the right value in
-  // both single-session and workflow modes. Name kept inside MitmProxy for
-  // historical reasons; the value is a bundle-scoped routing token.
+  // both single-session and workflow modes. The cast bridges the brand
+  // gap: the bus signature is typed as SessionId, but the actual value
+  // here is a BundleId acting as a bundle-scoped routing token.
+  const routingId = bundleId as unknown as SessionId;
   const mitmProxy = useTcp
     ? createMitmProxy({
         listenPort: 0,
@@ -382,6 +384,7 @@ export async function prepareDockerInfrastructure(
         registries,
         packageValidation,
         controlPort: 0,
+        sessionId: routingId,
       })
     : createMitmProxy({
         socketPath: getBundleMitmProxySocketPath(bundleId),
@@ -390,6 +393,7 @@ export async function prepareDockerInfrastructure(
         registries,
         packageValidation,
         controlSocketPath: getBundleMitmControlSocketPath(bundleId),
+        sessionId: routingId,
       });
 
   const docker = createDockerManager();

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -158,7 +158,7 @@ export interface MitmProxyOptions {
    * is set (initial value `undefined` AND no subsequent `setTokenSessionId`
    * call), extraction sites skip publishing entirely.
    */
-  readonly sessionId?: string;
+  readonly sessionId?: import('../session/types.js').SessionId;
 }
 
 export interface ProviderKeyMapping {
@@ -499,9 +499,7 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
   // — no sentinel value is published. The module-scoped singleton bus is
   // fetched lazily at each push site so `resetTokenStreamBus()` between
   // tests is honored.
-  let tokenSessionId: import('../session/types.js').SessionId | undefined = options.sessionId as
-    | import('../session/types.js').SessionId
-    | undefined;
+  let tokenSessionId: import('../session/types.js').SessionId | undefined = options.sessionId;
 
   // Parse CA cert and key from PEM
   const caCert = forge.pki.certificateFromPem(options.ca.certPem);

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -87,6 +87,21 @@ export interface MitmProxy {
   stop(): Promise<void>;
   /** Runtime control for the dynamic host allowlist. */
   readonly hosts: DynamicHostController;
+  /**
+   * Set (or clear) the session ID that token-stream events extracted from
+   * LLM API responses are routed under.
+   *
+   * The MITM proxy is long-lived in shared-container workflow mode, where
+   * multiple per-state agent sessions share a single proxy instance. Token
+   * events for the active agent must be labeled with that agent's session
+   * ID, not with any static workflow-wide ID. Callers flip this value
+   * around each agent run: set to the session's ID before the agent runs,
+   * reset to `undefined` when the session ends.
+   *
+   * When the current session ID is `undefined`, extraction sites skip the
+   * `bus.push()` entirely — no events are emitted under a sentinel value.
+   */
+  setTokenSessionId(id: import('../session/types.js').SessionId | undefined): void;
 }
 
 export interface MitmProxyOptions {
@@ -133,10 +148,15 @@ export interface MitmProxyOptions {
    */
   readonly dnsLookup?: http.RequestOptions['lookup'];
   /**
-   * Session ID for token stream routing. When provided, the proxy taps
-   * SSE/JSON responses from LLM API endpoints and pushes parsed token
-   * events into the module-scoped singleton bus (see `getTokenStreamBus`).
-   * When absent, extractor installation is skipped entirely.
+   * Initial session ID for token stream routing. When provided, token
+   * events extracted from LLM API endpoints are published into the
+   * module-scoped singleton bus (see `getTokenStreamBus`) under this ID.
+   *
+   * The value is mutable at runtime via `MitmProxy.setTokenSessionId()`:
+   * long-lived proxies (shared-container workflows) flip this around each
+   * agent so the active agent's session ID is used. When no session ID
+   * is set (initial value `undefined` AND no subsequent `setTokenSessionId`
+   * call), extraction sites skip publishing entirely.
    */
   readonly sessionId?: string;
 }
@@ -472,11 +492,16 @@ export function extractFromJsonResponse(body: Buffer, sessionId: import('../sess
 }
 
 export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
-  // Token stream extractor installation is gated on `sessionId` alone.
-  // When present, the module-scoped singleton bus is fetched lazily at
-  // each extractor-install point (see below) so `resetTokenStreamBus()`
-  // between tests is honored.
-  const tokenSessionId = options.sessionId;
+  // Token stream extractor installation is gated on `tokenSessionId`.
+  // This is a mutable per-proxy value that callers flip around each
+  // active agent (see `setTokenSessionId` on the returned handle). When
+  // `undefined`, all extractor-install sites skip `bus.push()` entirely
+  // — no sentinel value is published. The module-scoped singleton bus is
+  // fetched lazily at each push site so `resetTokenStreamBus()` between
+  // tests is honored.
+  let tokenSessionId: import('../session/types.js').SessionId | undefined = options.sessionId as
+    | import('../session/types.js').SessionId
+    | undefined;
 
   // Parse CA cert and key from PEM
   const caCert = forge.pki.certificateFromPem(options.ca.certPem);
@@ -769,26 +794,26 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
           clientRes.socket?.setNoDelay(true);
 
           const contentType = upstreamRes.headers['content-type'] ?? '';
-          if (tokenSessionId && contentType.includes('text/event-stream')) {
+          // Snapshot the active token session ID at response-attach time.
+          // `tokenSessionId` is mutable across agents; capturing it here
+          // ensures events from this specific response are routed under
+          // the ID that was active when the upstream started responding,
+          // even if the orchestrator flips the ID mid-flight.
+          const sidAtAttach = tokenSessionId;
+          if (sidAtAttach && contentType.includes('text/event-stream')) {
             const tokenBus = getTokenStreamBus();
-            const sid = tokenSessionId as import('../session/types.js').SessionId;
             const sseProvider = resolveSseProvider(targetHost);
             const extractor = new SseExtractorTransform(sseProvider, (event) => {
-              tokenBus.push(sid, event);
+              tokenBus.push(sidAtAttach, event);
             });
             upstreamRes.pipe(extractor).pipe(clientRes);
-          } else if (
-            tokenSessionId &&
-            isLlmMessagesEndpoint(path as string) &&
-            contentType.includes('application/json')
-          ) {
+          } else if (sidAtAttach && isLlmMessagesEndpoint(path as string) && contentType.includes('application/json')) {
             // Non-streaming JSON response: buffer for extraction while piping to client.
             // The passthrough stream always forwards the full response to the client.
             // Capture is bounded at MAX_JSON_RESPONSE_CAPTURE_BYTES: once exceeded,
             // we stop accumulating chunks (and skip extraction at end-of-stream),
             // but the passthrough listener stays attached so the stream completes
             // normally and the client still sees every byte.
-            const sid = tokenSessionId as import('../session/types.js').SessionId;
             const passthrough = new PassThrough();
             const capture = createBoundedJsonResponseCapture();
             passthrough.on('data', (chunk: Buffer) => capture.onData(chunk));
@@ -796,7 +821,7 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
               capture.onEnd((body) => {
                 if (body === null) return; // overflowed -- skip extraction
                 try {
-                  extractFromJsonResponse(body, sid);
+                  extractFromJsonResponse(body, sidAtAttach);
                 } catch {
                   // Extraction errors must never affect the forwarding path
                 }
@@ -895,10 +920,13 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
 
         // Extract tool_result events from the request body for token stream observation.
         // Done before rewriting so we see the original messages array.
-        if (tokenSessionId && isLlmMessagesEndpoint(path as string)) {
+        // Snapshot the session ID here so a concurrent `setTokenSessionId`
+        // call does not split a single request's events across two IDs.
+        const sidForToolResults = tokenSessionId;
+        if (sidForToolResults && isLlmMessagesEndpoint(path as string)) {
           try {
             const bodyParsed = JSON.parse(rawBody.toString()) as Record<string, unknown>;
-            extractToolResults(bodyParsed, tokenSessionId as import('../session/types.js').SessionId);
+            extractToolResults(bodyParsed, sidForToolResults);
           } catch {
             // Parse failure is fine -- the rewriter below will also attempt to parse
           }
@@ -1562,6 +1590,10 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
 
   return {
     hosts: hostController,
+
+    setTokenSessionId(id: import('../session/types.js').SessionId | undefined): void {
+      tokenSessionId = id;
+    },
 
     async start() {
       // Pre-warm cert cache for all configured providers and registries

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -794,11 +794,8 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
           clientRes.socket?.setNoDelay(true);
 
           const contentType = upstreamRes.headers['content-type'] ?? '';
-          // Snapshot the active token session ID at response-attach time.
-          // `tokenSessionId` is mutable across agents; capturing it here
-          // ensures events from this specific response are routed under
-          // the ID that was active when the upstream started responding,
-          // even if the orchestrator flips the ID mid-flight.
+          // Pin this response's events to the id active when it started,
+          // so an orchestrator mid-flight flip can't split one stream.
           const sidAtAttach = tokenSessionId;
           if (sidAtAttach && contentType.includes('text/event-stream')) {
             const tokenBus = getTokenStreamBus();
@@ -919,9 +916,8 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
         let finalBody = rawBody;
 
         // Extract tool_result events from the request body for token stream observation.
-        // Done before rewriting so we see the original messages array.
-        // Snapshot the session ID here so a concurrent `setTokenSessionId`
-        // call does not split a single request's events across two IDs.
+        // Snapshot here (before rewrite) so a concurrent setTokenSessionId
+        // flip can't split this request's events across two ids.
         const sidForToolResults = tokenSessionId;
         if (sidForToolResults && isLlmMessagesEndpoint(path as string)) {
           try {

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -272,6 +272,9 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       escalationDir,
       bundleId,
     );
+    // PTY sessions are standalone: pin the MITM proxy's token-stream
+    // routing ID to this session's ID for the session's lifetime.
+    infra.setTokenSessionId(effectiveSessionId as import('../session/types.js').SessionId);
 
     ({ docker, proxy, mitmProxy, useTcp } = infra);
     const {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -266,6 +266,9 @@ async function createDockerSession(
     if (options.workflowInfrastructure) {
       // Borrow path: the orchestrator owns the bundle's lifetime. We do
       // not call createDockerInfrastructure(); we do not destroy on close.
+      // The orchestrator is also responsible for `setTokenSessionId`: it
+      // flips the MITM proxy's routing target to the active agent's session
+      // ID before each run and clears it on session end.
       infra = options.workflowInfrastructure;
     } else {
       // Standalone path: factory creates and owns the bundle.
@@ -283,6 +286,11 @@ async function createDockerSession(
         sessionConfig.escalationDir,
         bundleId,
       );
+      // Standalone sessions use their bundle for the session's entire
+      // lifetime; pin the token-stream routing ID to this session's ID.
+      // Clearing on close is unnecessary because the bundle itself is
+      // destroyed by `session.close()` (ownsInfra=true).
+      infra.setTokenSessionId(sessionId);
       builtInfra = true;
     }
 

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -104,6 +104,17 @@ export class SessionManager {
   currentLabel: number | null = null;
 
   /**
+   * Reserves a fresh label without registering a session. Exists so
+   * that non-managed sessions (workflow-owned agent sessions, which
+   * run without a Transport) can share the same label space as
+   * managed sessions. A single label authority avoids collisions in
+   * the TokenStreamBridge, which keys per-session state by label.
+   */
+  reserveLabel(): number {
+    return this.nextLabel++;
+  }
+
+  /**
    * Registers a new session and returns its assigned label.
    *
    * For Signal sessions: sets currentLabel to the new session.

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -86,8 +86,14 @@ export interface EscalationResolutionResult {
  *
  * Invariants:
  * - Labels are monotonically increasing integers starting at 1.
- * - At most one session exists per label.
+ * - At most one registered session exists per label.
  * - currentLabel is always either null or a valid label in the map.
+ *
+ * Label space is shared with workflow-owned agent sessions via
+ * `reserveLabel()` — those labels are live at the TokenStreamBridge
+ * but have no entry in this manager's `sessions` map. Code that
+ * iterates `sessions` or calls `end(label)` will silently skip them;
+ * their lifecycle is owned by the workflow orchestrator.
  */
 export class SessionManager {
   private sessions = new Map<number, ManagedSession>();

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -19,6 +19,17 @@ export function createSessionId(): SessionId {
 }
 
 /**
+ * Coerce an unknown WS-boundary value into a SessionId, or return undefined
+ * if it is not a string. Use at the JSON-RPC / WebSocket boundary so the
+ * `as SessionId` brand-injection happens at one typed seam instead of
+ * scattered across call sites.
+ */
+export function parseSessionId(value: unknown): SessionId | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value as SessionId;
+}
+
+/**
  * Unique key for a Docker infrastructure bundle: one container + its
  * MITM proxy, Code Mode proxy, CA, fake keys, and sockets tree. A
  * single-session CLI run has one `BundleId` (equal to the session's

--- a/src/web-ui/web-event-bus.ts
+++ b/src/web-ui/web-event-bus.ts
@@ -54,12 +54,12 @@ export interface WebEventMap {
     stateId: string;
     persona: string;
     /**
-     * Session ID of the agent session. The daemon's bridge wiring
+     * Session ID of the agent session. The daemon always emits this;
+     * the WS broadcast path delivers it to frontend clients, which
+     * type it as required (see `event-handler.ts`'s `WebEvent` union).
+     * Its primary consumer today is the daemon's bridge wiring, which
      * registers this mapping so token events produced by the
-     * workflow-owned session reach `observe --all` subscribers. Also
-     * reaches frontend clients via the WS broadcast path — frontend
-     * types currently omit it so it's silently dropped at parse time;
-     * harmless until a future consumer wants per-session attribution.
+     * workflow-owned session reach `observe --all` subscribers.
      */
     sessionId: string;
   };
@@ -73,7 +73,6 @@ export interface WebEventMap {
   'workflow.agent_session_ended': {
     workflowId: string;
     stateId: string;
-    persona: string;
     sessionId: string;
   };
 

--- a/src/web-ui/web-event-bus.ts
+++ b/src/web-ui/web-event-bus.ts
@@ -49,8 +49,33 @@ export interface WebEventMap {
   'workflow.failed': { workflowId: string; error: string };
   'workflow.gate_raised': { workflowId: string; gate: HumanGateRequestDto };
   'workflow.gate_dismissed': { workflowId: string; gateId: string };
-  'workflow.agent_started': { workflowId: string; stateId: string; persona: string };
+  'workflow.agent_started': {
+    workflowId: string;
+    stateId: string;
+    persona: string;
+    /**
+     * Session ID of the agent session. The daemon's bridge wiring
+     * registers this mapping so token events produced by the
+     * workflow-owned session reach `observe --all` subscribers. Also
+     * reaches frontend clients via the WS broadcast path — frontend
+     * types currently omit it so it's silently dropped at parse time;
+     * harmless until a future consumer wants per-session attribution.
+     */
+    sessionId: string;
+  };
   'workflow.agent_completed': { workflowId: string; stateId: string; verdict?: string; confidence?: string };
+  /**
+   * Fires unconditionally in the orchestrator's agent-state finally
+   * block, pairing 1:1 with 'workflow.agent_started'. The daemon's
+   * bridge wiring uses this to tear down the per-session token-stream
+   * mapping on both success and failure paths.
+   */
+  'workflow.agent_session_ended': {
+    workflowId: string;
+    stateId: string;
+    persona: string;
+    sessionId: string;
+  };
 
   // Token stream events (targeted delivery via bridge, not broadcast)
   'session.token_stream': { label: number; events: readonly TokenStreamEvent[] };

--- a/src/web-ui/workflow-manager.ts
+++ b/src/web-ui/workflow-manager.ts
@@ -381,7 +381,6 @@ export class WorkflowManager {
         this.eventBus.emit('workflow.agent_session_ended', {
           workflowId: event.workflowId,
           stateId: event.state,
-          persona: event.persona,
           sessionId: event.sessionId,
         });
         break;

--- a/src/web-ui/workflow-manager.ts
+++ b/src/web-ui/workflow-manager.ts
@@ -367,6 +367,7 @@ export class WorkflowManager {
           workflowId: event.workflowId,
           stateId: event.state,
           persona: event.persona,
+          sessionId: event.sessionId,
         });
         break;
       case 'agent_completed':
@@ -374,6 +375,14 @@ export class WorkflowManager {
           workflowId: event.workflowId,
           stateId: event.state,
           verdict: event.verdict,
+        });
+        break;
+      case 'agent_session_ended':
+        this.eventBus.emit('workflow.agent_session_ended', {
+          workflowId: event.workflowId,
+          stateId: event.state,
+          persona: event.persona,
+          sessionId: event.sessionId,
         });
         break;
     }

--- a/src/workflow/machine-builder.ts
+++ b/src/workflow/machine-builder.ts
@@ -45,6 +45,15 @@ export interface AgentInvokeResult {
   readonly outputHash: string;
   /** Raw response text from session.sendMessage(). */
   readonly responseText: string;
+  /**
+   * Cumulative workflow-level output-token count at the moment this
+   * agent finished. Copied onto `ctx.totalTokens` by the XState
+   * `updateContextFromAgentResult` assign action. Sourced from the
+   * orchestrator's token-stream bus subscription, which sums every
+   * `message_end.outputTokens` seen for sessions belonging to this
+   * workflow run.
+   */
+  readonly totalTokens: number;
 }
 
 /** Input provided to each invoked deterministic service. */
@@ -482,7 +491,12 @@ export function buildWorkflowMachine(definition: WorkflowDefinition, taskDescrip
             ...context.agentConversationsByState,
             [stateId]: result.agentConversationId,
           },
-          totalTokens: context.totalTokens,
+          // Sourced from `instance.outputTokens` in the orchestrator,
+          // which subscribes to the token-stream bus and accumulates
+          // `message_end.outputTokens` across every session this workflow
+          // has spawned. The orchestrator always supplies a numeric
+          // cumulative value — the field is required on AgentInvokeResult.
+          totalTokens: result.totalTokens,
           previousAgentOutput: truncateAgentOutput(stripStatusBlock(result.responseText)),
           previousAgentNotes: output.notes ? truncateAgentOutput(output.notes) : null,
           previousStateName: stateId,

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -459,33 +459,17 @@ interface WorkflowInstance {
    */
   quotaExhausted?: { readonly resetAt?: Date; readonly rawMessage: string };
   /**
-   * Workflow-scoped cumulative output-token counter. Accumulates the
-   * `outputTokens` field of every `message_end` event observed on the
-   * token-stream bus for sessions known to belong to this workflow
-   * (see `tokenSessionIds`). The next `executeAgentState` invocation
-   * snapshots this into `AgentInvokeResult.totalTokens`, which the
-   * XState `updateContextFromAgentResult` action copies onto
-   * `context.totalTokens`. Kept on the instance so survives across
-   * state transitions within a single workflow run.
+   * Three coordinated pieces of token-stream accounting state, grouped
+   * so lifecycle (setup/teardown) operates on one value. `outputTokens`
+   * accumulates `message_end.outputTokens` for any event whose session
+   * id is in `sessionIds`. `unsubscribe` is set at `setupTokenSubscription`
+   * and cleared on teardown; presence indicates "subscribed."
    */
-  outputTokens: number;
-  /**
-   * Session IDs the orchestrator has opened during this workflow run.
-   * Populated before `agent_started` emission, pruned in the
-   * executeAgentState `finally` block. Events on the bus for session IDs
-   * not in this set (e.g. other workflows sharing the global bus) are
-   * ignored by the token-counter subscriber — the workflow's counter is
-   * a workflow-local sum, not a global one.
-   */
-  readonly tokenSessionIds: Set<SessionId>;
-  /**
-   * Unsubscribe handle for the token-stream bus subscription installed
-   * at workflow start. Cleared by `teardownTokenSubscription()` on
-   * completion, abort, or shutdown. `undefined` until subscription is
-   * installed (e.g. resume before first `agent_started`, or never for
-   * workflows that never reach an agent state).
-   */
-  tokenUnsubscribe?: () => void;
+  tokens: {
+    outputTokens: number;
+    readonly sessionIds: Set<SessionId>;
+    unsubscribe?: () => void;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -940,8 +924,8 @@ export class WorkflowOrchestrator implements WorkflowController {
 
   /**
    * Subscribes the workflow to the global token-stream bus. Accumulates
-   * `message_end.outputTokens` into `instance.outputTokens` for any event
-   * whose session ID is in `instance.tokenSessionIds`. The set is managed
+   * `message_end.outputTokens` into `instance.tokens.outputTokens` for any
+   * event whose session ID is in `instance.tokens.sessionIds`. The set is managed
    * by `executeAgentState` (added before `agent_started`, removed in the
    * `finally` block after `agent_session_ended`).
    *
@@ -950,11 +934,11 @@ export class WorkflowOrchestrator implements WorkflowController {
    */
   private setupTokenSubscription(instance: WorkflowInstance): void {
     // Defensive: re-entry by resume-after-crash should not double-subscribe.
-    if (instance.tokenUnsubscribe) return;
-    instance.tokenUnsubscribe = getTokenStreamBus().subscribeAll((sessionId, event) => {
+    if (instance.tokens.unsubscribe) return;
+    instance.tokens.unsubscribe = getTokenStreamBus().subscribeAll((sessionId, event) => {
       if (event.kind !== 'message_end') return;
-      if (!instance.tokenSessionIds.has(sessionId)) return;
-      instance.outputTokens += event.outputTokens;
+      if (!instance.tokens.sessionIds.has(sessionId)) return;
+      instance.tokens.outputTokens += event.outputTokens;
     });
   }
 
@@ -963,16 +947,16 @@ export class WorkflowOrchestrator implements WorkflowController {
    * call from both normal completion and abort paths.
    */
   private teardownTokenSubscription(instance: WorkflowInstance): void {
-    if (instance.tokenUnsubscribe) {
+    if (instance.tokens.unsubscribe) {
       try {
-        instance.tokenUnsubscribe();
+        instance.tokens.unsubscribe();
       } catch {
         // Unsubscribe is best-effort; errors here should never prevent
         // workflow teardown from completing.
       }
-      instance.tokenUnsubscribe = undefined;
+      instance.tokens.unsubscribe = undefined;
     }
-    instance.tokenSessionIds.clear();
+    instance.tokens.sessionIds.clear();
   }
 
   // -----------------------------------------------------------------------
@@ -1041,8 +1025,10 @@ export class WorkflowOrchestrator implements WorkflowController {
       currentPersonaByBundle: new Map(),
       mintedServersByBundle: new Map(),
       aborted: false,
-      outputTokens: 0,
-      tokenSessionIds: new Set(),
+      tokens: {
+        outputTokens: 0,
+        sessionIds: new Set(),
+      },
     };
 
     // Under `sharedContainer: true`, bundles are minted lazily by
@@ -1115,11 +1101,13 @@ export class WorkflowOrchestrator implements WorkflowController {
       currentPersonaByBundle: new Map(),
       mintedServersByBundle: new Map(),
       aborted: false,
-      // Resume picks up the checkpointed totalTokens as the accumulator's
-      // starting point so post-resume message_end events keep adding to
-      // the running total instead of resetting it.
-      outputTokens: checkpoint.context.totalTokens,
-      tokenSessionIds: new Set(),
+      tokens: {
+        // Resume picks up the checkpointed totalTokens as the accumulator's
+        // starting point so post-resume message_end events keep adding to
+        // the running total instead of resetting it.
+        outputTokens: checkpoint.context.totalTokens,
+        sessionIds: new Set(),
+      },
     };
 
     // Resume does NOT reclaim the original containers — any
@@ -1787,24 +1775,13 @@ export class WorkflowOrchestrator implements WorkflowController {
         message: command,
       });
 
-      // Route MITM-extracted token-stream events under this agent's
-      // session ID so the daemon's `TokenStreamBridge` (which registered
-      // on `agent_started` below) receives them. In shared-container mode
-      // the MITM proxy is long-lived and shared across agents; without
-      // this flip, events route under whatever ID the previous agent
-      // (or the initial `createDockerInfrastructure` call) left behind
-      // and silently miss the bridge.
-      //
-      // No-op when `infra` is unset (builtin workflows, per-state-container
-      // mode) — the session has its own MITM whose routing is pinned by
-      // `createDockerSession`.
+      // Shared-container mode: the MITM is long-lived across agents. Flip
+      // its routing id so this agent's events land under its own session id
+      // (matching what the bridge registers below). Optional-chain because
+      // builtin/per-state-container workflows have no shared `infra`.
       const agentSessionId = session.getInfo().id;
       bundle?.setTokenSessionId(agentSessionId);
-
-      // Register this session for the workflow's token accumulator.
-      // `setupTokenSubscription`'s listener filters by this set, so events
-      // from sessions outside the workflow never bleed into the counter.
-      instance.tokenSessionIds.add(agentSessionId);
+      instance.tokens.sessionIds.add(agentSessionId);
 
       this.emitLifecycleEvent({
         kind: 'agent_started',
@@ -1958,7 +1935,7 @@ export class WorkflowOrchestrator implements WorkflowController {
         // value to update ctx.totalTokens; it reflects every `message_end`
         // the bus subscriber has seen so far, including all earlier
         // agents in the workflow.
-        totalTokens: instance.outputTokens,
+        totalTokens: instance.tokens.outputTokens,
       };
     } catch (err) {
       // Quota exhaustion already produced its own structured
@@ -1982,25 +1959,14 @@ export class WorkflowOrchestrator implements WorkflowController {
       await session.close().catch((closeErr: unknown) => {
         writeStderr(`[workflow] session.close() failed for "${stateId}": ${toErrorMessage(closeErr)}`);
       });
-      // Clear the MITM proxy's token-stream routing ID BEFORE emitting
-      // `agent_session_ended`. Ordering matters:
-      //   - `session.close()` has already returned, so no further
-      //     `sendMessage` calls against this session are possible and any
-      //     in-flight Anthropic API streams have drained (the agent's
-      //     final response is what `sendMessage` awaited).
-      //   - Clearing before the bridge teardown prevents any residual
-      //     events from pushing under this (now stale) session ID.
-      //   - The next `agent_started` flip is what installs the next
-      //     agent's ID, so leaving this cleared between agents is safe.
+      // Order: close session (drains in-flight LLM stream) → clear MITM
+      // routing → drop from accumulator filter → emit agent_session_ended.
+      // Clearing the MITM id before the bridge teardown means any stray
+      // late event cannot push under an about-to-be-unregistered label.
       bundle?.setTokenSessionId(undefined);
-      // Drop the session from the token-accumulator filter set so late
-      // bus events (typically shouldn't happen post-close, but belt-and-
-      // suspenders) are ignored. The cumulative counter stays intact —
-      // earlier events for this session have already been added.
-      instance.tokenSessionIds.delete(endedSessionId);
-      // Emit regardless of success / failure so consumers (e.g. the
-      // daemon's bridge wiring) can release per-agent resources. Pairs
-      // 1:1 with `agent_started`.
+      instance.tokens.sessionIds.delete(endedSessionId);
+      // Pairs 1:1 with agent_started; emitted unconditionally in finally
+      // so success, failure, and abort paths all clean up the bridge.
       this.emitLifecycleEvent({
         kind: 'agent_session_ended',
         workflowId,

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -331,7 +331,6 @@ export type WorkflowLifecycleEvent =
       readonly kind: 'agent_session_ended';
       readonly workflowId: WorkflowId;
       readonly state: string;
-      readonly persona: string;
       readonly sessionId: SessionId;
     };
 
@@ -918,9 +917,6 @@ export class WorkflowOrchestrator implements WorkflowController {
   // cheaper (one bus listener, one unsubscribe on completion) than
   // subscribing and unsubscribing on every `agent_started` /
   // `agent_session_ended` pair.
-  //
-  // Dynamic import so the workflow module can stay usable in pure-Code-Mode
-  // contexts where the docker bundle isn't pulled in.
 
   /**
    * Subscribes the workflow to the global token-stream bus. Accumulates
@@ -1971,7 +1967,6 @@ export class WorkflowOrchestrator implements WorkflowController {
         kind: 'agent_session_ended',
         workflowId,
         state: stateId,
-        persona: stateConfig.persona,
         sessionId: endedSessionId,
       });
     }

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -42,6 +42,7 @@ import {
 import { POLICY_LOAD_PATH } from '../trusted-process/control-server.js';
 import { loadConfig, loadPersonaPolicyArtifacts } from '../config/index.js';
 import { validatePolicyDir } from '../config/validate-policy-dir.js';
+import { getTokenStreamBus } from '../docker/token-stream-bus.js';
 import { getPersonaDefinitionPath, resolvePersona } from '../persona/resolve.js';
 import { extractRequiredServers } from '../trusted-process/policy-roots.js';
 import { createPersonaName } from '../persona/types.js';
@@ -457,6 +458,34 @@ interface WorkflowInstance {
    * Survives only in-process; the checkpoint itself does not record it.
    */
   quotaExhausted?: { readonly resetAt?: Date; readonly rawMessage: string };
+  /**
+   * Workflow-scoped cumulative output-token counter. Accumulates the
+   * `outputTokens` field of every `message_end` event observed on the
+   * token-stream bus for sessions known to belong to this workflow
+   * (see `tokenSessionIds`). The next `executeAgentState` invocation
+   * snapshots this into `AgentInvokeResult.totalTokens`, which the
+   * XState `updateContextFromAgentResult` action copies onto
+   * `context.totalTokens`. Kept on the instance so survives across
+   * state transitions within a single workflow run.
+   */
+  outputTokens: number;
+  /**
+   * Session IDs the orchestrator has opened during this workflow run.
+   * Populated before `agent_started` emission, pruned in the
+   * executeAgentState `finally` block. Events on the bus for session IDs
+   * not in this set (e.g. other workflows sharing the global bus) are
+   * ignored by the token-counter subscriber — the workflow's counter is
+   * a workflow-local sum, not a global one.
+   */
+  readonly tokenSessionIds: Set<SessionId>;
+  /**
+   * Unsubscribe handle for the token-stream bus subscription installed
+   * at workflow start. Cleared by `teardownTokenSubscription()` on
+   * completion, abort, or shutdown. `undefined` until subscription is
+   * installed (e.g. resume before first `agent_started`, or never for
+   * workflows that never reach an agent state).
+   */
+  tokenUnsubscribe?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -894,6 +923,59 @@ export class WorkflowOrchestrator implements WorkflowController {
   }
 
   // -----------------------------------------------------------------------
+  // Token-stream accumulation (workflow-scoped totalTokens counter)
+  // -----------------------------------------------------------------------
+  //
+  // The token-stream bus is global (see `getTokenStreamBus()` in
+  // `src/docker/token-stream-bus.ts`), so the orchestrator subscribes with
+  // `subscribeAll()` and filters inside the listener by the workflow's own
+  // session-ID set. Per-workflow rather than per-agent: `ctx.totalTokens`
+  // is a workflow-level cumulative sum, so one long-lived subscription is
+  // cheaper (one bus listener, one unsubscribe on completion) than
+  // subscribing and unsubscribing on every `agent_started` /
+  // `agent_session_ended` pair.
+  //
+  // Dynamic import so the workflow module can stay usable in pure-Code-Mode
+  // contexts where the docker bundle isn't pulled in.
+
+  /**
+   * Subscribes the workflow to the global token-stream bus. Accumulates
+   * `message_end.outputTokens` into `instance.outputTokens` for any event
+   * whose session ID is in `instance.tokenSessionIds`. The set is managed
+   * by `executeAgentState` (added before `agent_started`, removed in the
+   * `finally` block after `agent_session_ended`).
+   *
+   * Installed synchronously so the subscription is live before any agent
+   * state runs — no window where bus events go unobserved.
+   */
+  private setupTokenSubscription(instance: WorkflowInstance): void {
+    // Defensive: re-entry by resume-after-crash should not double-subscribe.
+    if (instance.tokenUnsubscribe) return;
+    instance.tokenUnsubscribe = getTokenStreamBus().subscribeAll((sessionId, event) => {
+      if (event.kind !== 'message_end') return;
+      if (!instance.tokenSessionIds.has(sessionId)) return;
+      instance.outputTokens += event.outputTokens;
+    });
+  }
+
+  /**
+   * Tears down the token-stream bus subscription. Idempotent: safe to
+   * call from both normal completion and abort paths.
+   */
+  private teardownTokenSubscription(instance: WorkflowInstance): void {
+    if (instance.tokenUnsubscribe) {
+      try {
+        instance.tokenUnsubscribe();
+      } catch {
+        // Unsubscribe is best-effort; errors here should never prevent
+        // workflow teardown from completing.
+      }
+      instance.tokenUnsubscribe = undefined;
+    }
+    instance.tokenSessionIds.clear();
+  }
+
+  // -----------------------------------------------------------------------
   // WorkflowController implementation
   // -----------------------------------------------------------------------
 
@@ -959,6 +1041,8 @@ export class WorkflowOrchestrator implements WorkflowController {
       currentPersonaByBundle: new Map(),
       mintedServersByBundle: new Map(),
       aborted: false,
+      outputTokens: 0,
+      tokenSessionIds: new Set(),
     };
 
     // Under `sharedContainer: true`, bundles are minted lazily by
@@ -970,6 +1054,7 @@ export class WorkflowOrchestrator implements WorkflowController {
     // before any Docker resource is touched.
 
     this.workflows.set(workflowId, instance);
+    this.setupTokenSubscription(instance);
     this.emitLifecycleEvent({ kind: 'started', workflowId, name: definition.name, taskDescription });
     this.subscribeToActor(instance);
     actor.start();
@@ -1030,6 +1115,11 @@ export class WorkflowOrchestrator implements WorkflowController {
       currentPersonaByBundle: new Map(),
       mintedServersByBundle: new Map(),
       aborted: false,
+      // Resume picks up the checkpointed totalTokens as the accumulator's
+      // starting point so post-resume message_end events keep adding to
+      // the running total instead of resetting it.
+      outputTokens: checkpoint.context.totalTokens,
+      tokenSessionIds: new Set(),
     };
 
     // Resume does NOT reclaim the original containers — any
@@ -1046,6 +1136,7 @@ export class WorkflowOrchestrator implements WorkflowController {
     }
 
     this.workflows.set(workflowId, instance);
+    this.setupTokenSubscription(instance);
     this.emitLifecycleEvent({
       kind: 'started',
       workflowId,
@@ -1245,6 +1336,10 @@ export class WorkflowOrchestrator implements WorkflowController {
       phase: 'aborted',
       reason: 'Workflow aborted by user',
     };
+
+    // Release the token-stream bus subscription before the async infra
+    // teardown so no late events land against a finalized workflow.
+    this.teardownTokenSubscription(instance);
 
     // Tear down workflow-scoped Docker infrastructure after all sessions
     // are closed. Error-tolerant (see destroyWorkflowInfrastructure).
@@ -1692,12 +1787,31 @@ export class WorkflowOrchestrator implements WorkflowController {
         message: command,
       });
 
+      // Route MITM-extracted token-stream events under this agent's
+      // session ID so the daemon's `TokenStreamBridge` (which registered
+      // on `agent_started` below) receives them. In shared-container mode
+      // the MITM proxy is long-lived and shared across agents; without
+      // this flip, events route under whatever ID the previous agent
+      // (or the initial `createDockerInfrastructure` call) left behind
+      // and silently miss the bridge.
+      //
+      // No-op when `infra` is unset (builtin workflows, per-state-container
+      // mode) — the session has its own MITM whose routing is pinned by
+      // `createDockerSession`.
+      const agentSessionId = session.getInfo().id;
+      bundle?.setTokenSessionId(agentSessionId);
+
+      // Register this session for the workflow's token accumulator.
+      // `setupTokenSubscription`'s listener filters by this set, so events
+      // from sessions outside the workflow never bleed into the counter.
+      instance.tokenSessionIds.add(agentSessionId);
+
       this.emitLifecycleEvent({
         kind: 'agent_started',
         workflowId,
         state: stateId,
         persona: stateConfig.persona,
-        sessionId: session.getInfo().id,
+        sessionId: agentSessionId,
       });
 
       // Two-phase retry: (1) hard-failure retries re-send the ORIGINAL
@@ -1839,6 +1953,12 @@ export class WorkflowOrchestrator implements WorkflowController {
         artifacts,
         outputHash,
         responseText,
+        // Snapshot the workflow's cumulative output-token count AT THE
+        // END of this agent's turn. The XState assign action uses this
+        // value to update ctx.totalTokens; it reflects every `message_end`
+        // the bus subscriber has seen so far, including all earlier
+        // agents in the workflow.
+        totalTokens: instance.outputTokens,
       };
     } catch (err) {
       // Quota exhaustion already produced its own structured
@@ -1862,6 +1982,22 @@ export class WorkflowOrchestrator implements WorkflowController {
       await session.close().catch((closeErr: unknown) => {
         writeStderr(`[workflow] session.close() failed for "${stateId}": ${toErrorMessage(closeErr)}`);
       });
+      // Clear the MITM proxy's token-stream routing ID BEFORE emitting
+      // `agent_session_ended`. Ordering matters:
+      //   - `session.close()` has already returned, so no further
+      //     `sendMessage` calls against this session are possible and any
+      //     in-flight Anthropic API streams have drained (the agent's
+      //     final response is what `sendMessage` awaited).
+      //   - Clearing before the bridge teardown prevents any residual
+      //     events from pushing under this (now stale) session ID.
+      //   - The next `agent_started` flip is what installs the next
+      //     agent's ID, so leaving this cleared between agents is safe.
+      bundle?.setTokenSessionId(undefined);
+      // Drop the session from the token-accumulator filter set so late
+      // bus events (typically shouldn't happen post-close, but belt-and-
+      // suspenders) are ignored. The cumulative counter stays intact —
+      // earlier events for this session have already been added.
+      instance.tokenSessionIds.delete(endedSessionId);
       // Emit regardless of success / failure so consumers (e.g. the
       // daemon's bridge wiring) can release per-agent resources. Pairs
       // 1:1 with `agent_started`.
@@ -2037,6 +2173,11 @@ export class WorkflowOrchestrator implements WorkflowController {
 
     instance.tab.write(`[done] ${instance.finalStatus.phase}`);
     instance.tab.close();
+
+    // Release the token-stream bus subscription. Done eagerly (before the
+    // async destroyWorkflowInfrastructure) because it's a synchronous
+    // callback — idempotent if already cleared by abort().
+    this.teardownTokenSubscription(instance);
 
     // Tear down workflow-scoped Docker infrastructure. Runs asynchronously
     // because the actor subscription is sync; destroyWorkflowInfrastructure

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -50,6 +50,7 @@ import type {
   AgentTurnResult,
   BundleId,
   Session,
+  SessionId,
   SessionOptions,
   SessionMode,
 } from '../session/types.js';
@@ -300,6 +301,13 @@ export type WorkflowLifecycleEvent =
       readonly workflowId: WorkflowId;
       readonly state: string;
       readonly persona: string;
+      /**
+       * Session ID of the agent session. Consumers (e.g. the daemon's
+       * token-stream bridge wiring) use this to register the session
+       * so token events produced by this agent are routable to
+       * `observe --all` subscribers.
+       */
+      readonly sessionId: SessionId;
     }
   | {
       readonly kind: 'agent_completed';
@@ -307,6 +315,23 @@ export type WorkflowLifecycleEvent =
       readonly state: string;
       readonly persona: string;
       readonly verdict: string;
+    }
+  /**
+   * Emitted unconditionally in the `executeAgentState` finally block --
+   * both on success (after `agent_completed`) and on failure (when the
+   * agent state threw or the verdict retry failed). Pairs 1:1 with
+   * `agent_started` and signals that the session has been closed.
+   *
+   * Consumers that registered per-agent resources (e.g. token-stream
+   * bridge entries) must clean up in response to this event so no
+   * state leaks across rapid state transitions.
+   */
+  | {
+      readonly kind: 'agent_session_ended';
+      readonly workflowId: WorkflowId;
+      readonly state: string;
+      readonly persona: string;
+      readonly sessionId: SessionId;
     };
 
 /** Extended workflow detail for the web UI. */
@@ -1672,6 +1697,7 @@ export class WorkflowOrchestrator implements WorkflowController {
         workflowId,
         state: stateId,
         persona: stateConfig.persona,
+        sessionId: session.getInfo().id,
       });
 
       // Two-phase retry: (1) hard-failure retries re-send the ORIGINAL
@@ -1832,8 +1858,19 @@ export class WorkflowOrchestrator implements WorkflowController {
       throw new AgentInvocationError({ stateId, agentConversationId: currentConversationId, cause: err });
     } finally {
       instance.activeSessions.delete(session);
+      const endedSessionId = session.getInfo().id;
       await session.close().catch((closeErr: unknown) => {
         writeStderr(`[workflow] session.close() failed for "${stateId}": ${toErrorMessage(closeErr)}`);
+      });
+      // Emit regardless of success / failure so consumers (e.g. the
+      // daemon's bridge wiring) can release per-agent resources. Pairs
+      // 1:1 with `agent_started`.
+      this.emitLifecycleEvent({
+        kind: 'agent_session_ended',
+        workflowId,
+        state: stateId,
+        persona: stateConfig.persona,
+        sessionId: endedSessionId,
       });
     }
   }

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -1955,10 +1955,10 @@ export class WorkflowOrchestrator implements WorkflowController {
       await session.close().catch((closeErr: unknown) => {
         writeStderr(`[workflow] session.close() failed for "${stateId}": ${toErrorMessage(closeErr)}`);
       });
-      // Order: close session (drains in-flight LLM stream) → clear MITM
-      // routing → drop from accumulator filter → emit agent_session_ended.
-      // Clearing the MITM id before the bridge teardown means any stray
-      // late event cannot push under an about-to-be-unregistered label.
+      // session.close() drains in-flight streams that captured the
+      // agent's session id at attach time; they keep posting under it
+      // until they finish, regardless of setTokenSessionId(undefined).
+      // The clear here only governs future attachments.
       bundle?.setTokenSessionId(undefined);
       instance.tokens.sessionIds.delete(endedSessionId);
       // Pairs 1:1 with agent_started; emitted unconditionally in finally

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -59,6 +59,12 @@ describe('DockerInfrastructure interface', () => {
       mitmProxy: {
         start: async () => ({ socketPath: '/tmp/mitm.sock' }),
         stop: async () => {},
+        hosts: {
+          addHost: () => true,
+          removeHost: () => true,
+          listHosts: () => ({ providers: [], dynamic: [] }),
+        },
+        setTokenSessionId: () => {},
       },
       docker: {
         preflight: async () => {},
@@ -105,6 +111,7 @@ describe('DockerInfrastructure interface', () => {
       authKind: 'apikey',
       containerId: 'container-id',
       containerName: 'ironcurtain-test-session',
+      setTokenSessionId: () => {},
     };
 
     // Verify key fields are accessible at runtime
@@ -286,6 +293,12 @@ const makeMockMitmProxy = (): MitmProxy => ({
     return { socketPath: '/tmp/test-mitm-proxy.sock' };
   },
   async stop() {},
+  hosts: {
+    addHost: () => true,
+    removeHost: () => true,
+    listHosts: () => ({ providers: [], dynamic: [] }),
+  },
+  setTokenSessionId: () => {},
 });
 
 /** Minimal config accepted by createSessionContainers. */
@@ -359,6 +372,7 @@ function makeMockCore(opts: MockCoreOptions): PreContainerInfrastructure {
     socketsDir,
     mitmAddr,
     authKind: 'apikey',
+    setTokenSessionId: () => {},
   };
 }
 

--- a/test/docker-session-factory.test.ts
+++ b/test/docker-session-factory.test.ts
@@ -178,6 +178,7 @@ function createMockInfra(rootDir: string, idSuffix = 'borrow'): DockerInfrastruc
     containerName: 'ironcurtain-borrowed',
     sidecarContainerId: undefined,
     internalNetwork: undefined,
+    setTokenSessionId: () => {},
   };
 }
 

--- a/test/docker-session.test.ts
+++ b/test/docker-session.test.ts
@@ -183,6 +183,12 @@ function createMockInfra(opts: MockInfraOptions): DockerInfrastructure {
             return { port: 8443 };
           },
           async stop() {},
+          hosts: {
+            addHost: () => true,
+            removeHost: () => true,
+            listHosts: () => ({ providers: [], dynamic: [] }),
+          },
+          setTokenSessionId: () => {},
         } as MitmProxy)
       : createMockMitmProxy());
   const proxy = opts.proxy ?? createMockProxy(join(opts.sessionDir, 'proxy.sock'), useTcp ? 9123 : undefined);
@@ -215,6 +221,7 @@ function createMockInfra(opts: MockInfraOptions): DockerInfrastructure {
     containerName: opts.containerName ?? `ironcurtain-${shortId}`,
     sidecarContainerId: opts.sidecarContainerId,
     internalNetwork: opts.internalNetwork,
+    setTokenSessionId: () => {},
   };
 }
 

--- a/test/helpers/docker-mocks.ts
+++ b/test/helpers/docker-mocks.ts
@@ -220,6 +220,12 @@ export function createMockMitmProxy(): MitmProxy {
       return { socketPath: '/tmp/test-mitm-proxy.sock' };
     },
     async stop() {},
+    hosts: {
+      addHost: () => true,
+      removeHost: () => true,
+      listHosts: () => ({ providers: [], dynamic: [] }),
+    },
+    setTokenSessionId: () => {},
   };
 }
 

--- a/test/mitm-proxy-token-stream.test.ts
+++ b/test/mitm-proxy-token-stream.test.ts
@@ -220,7 +220,7 @@ describe('MitmProxy token stream integration', () => {
         socketPath,
         ca,
         providers: [],
-        sessionId: 'test-session',
+        sessionId: 'test-session' as SessionId,
       }),
     ).not.toThrow();
   });
@@ -260,7 +260,7 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        sessionId: sessionId as string,
+        sessionId,
       });
       await proxy.start();
 
@@ -317,7 +317,7 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        sessionId: sessionId as string,
+        sessionId,
       });
       await proxy.start();
 
@@ -437,7 +437,7 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        sessionId: sessionId as string,
+        sessionId,
       });
       await proxy.start();
 
@@ -499,7 +499,7 @@ describe('MitmProxy token stream integration', () => {
         ca,
         providers: [provider],
         dnsLookup: localhostDnsLookup,
-        sessionId: sessionId as string,
+        sessionId,
       });
       await proxy.start();
 

--- a/test/mitm-proxy-token-stream.test.ts
+++ b/test/mitm-proxy-token-stream.test.ts
@@ -526,3 +526,175 @@ describe('MitmProxy token stream integration', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// MitmProxy.setTokenSessionId: dynamic per-agent rerouting
+// ---------------------------------------------------------------------------
+//
+// The MITM proxy is long-lived in shared-container workflow mode: a single
+// instance services back-to-back agent sessions with distinct session IDs.
+// `setTokenSessionId` lets the orchestrator flip the routing target per
+// agent. These tests cover the four lifecycle transitions the workflow
+// orchestrator drives:
+//   - proxy built with no initial sessionId → no routing
+//   - set to sid-a → events route under sid-a
+//   - set to sid-b → events route under sid-b (not sid-a)
+//   - set to undefined → no routing (events dropped, not routed under
+//     a sentinel value)
+
+describe('MitmProxy.setTokenSessionId dynamic routing', () => {
+  let proxy: MitmProxy | undefined;
+  let tempDir: string;
+  let ca: CertificateAuthority;
+  let socketPath: string;
+
+  beforeEach(() => {
+    resetTokenStreamBus();
+    tempDir = mkdtempSync(join(tmpdir(), 'mitm-dynamic-session-test-'));
+    ca = loadOrCreateCA(join(tempDir, 'ca'));
+    socketPath = join(tempDir, 'mitm-proxy.sock');
+  });
+
+  afterEach(async () => {
+    if (proxy) {
+      await proxy.stop();
+      proxy = undefined;
+    }
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  /** Build an Anthropic-like provider pointing at a local HTTP server. */
+  function makeTestProvider(upstreamPort: number): {
+    config: ProviderConfig;
+    fakeKey: string;
+    realKey: string;
+  } {
+    return {
+      config: {
+        host: 'api.anthropic.com',
+        displayName: 'Anthropic (test)',
+        allowedEndpoints: [{ method: 'POST', path: '/v1/messages' }],
+        keyInjection: { type: 'header', headerName: 'x-api-key' },
+        fakeKeyPrefix: 'sk-ant-test-',
+        upstreamTarget: {
+          hostname: '127.0.0.1',
+          port: upstreamPort,
+          pathPrefix: '',
+          useTls: false,
+        },
+      },
+      fakeKey: 'sk-ant-test-fake-key',
+      realKey: 'sk-ant-test-real-key',
+    };
+  }
+
+  /**
+   * Sends one POST /v1/messages with an SSE response body. Returns after
+   * the response has fully drained so extraction-side events are settled.
+   */
+  async function drivePOST(upstreamPort: number, provider: ReturnType<typeof makeTestProvider>): Promise<void> {
+    const { socket } = await sendConnect(socketPath, 'api.anthropic.com', 443);
+    expect(socket).not.toBeNull();
+    await makeHttpsRequest(socket!, ca, 'api.anthropic.com', {
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        'x-api-key': provider.fakeKey,
+        'content-type': 'application/json',
+      },
+      body: '{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}',
+    });
+    // Give SSE passthrough a moment to flush the final event.
+    await new Promise((r) => setTimeout(r, 20));
+  }
+
+  it('routes events under the current sessionId and reroutes when it changes', async () => {
+    const ssePayload = [
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"X"}}',
+      '',
+    ].join('\n');
+    const { server: upstream, port: upstreamPort } = await createSseUpstream(ssePayload);
+
+    try {
+      // Subscribe globally so we can observe which sessionId each event
+      // is routed under across the lifecycle.
+      const routedUnder: SessionId[] = [];
+      getTokenStreamBus().subscribeAll((sid, event) => {
+        if (event.kind === 'text_delta') routedUnder.push(sid);
+      });
+
+      const provider = makeTestProvider(upstreamPort);
+      // Build the proxy WITHOUT an initial sessionId to prove the routing
+      // is driven purely by setTokenSessionId.
+      proxy = createMitmProxy({
+        socketPath,
+        ca,
+        providers: [provider],
+        dnsLookup: localhostDnsLookup,
+      });
+      await proxy.start();
+
+      // (1) No session set -> no events routed.
+      await drivePOST(upstreamPort, provider);
+      expect(routedUnder).toEqual([]);
+
+      // (2) Set sid-a -> events route under sid-a.
+      proxy.setTokenSessionId('sid-a' as SessionId);
+      await drivePOST(upstreamPort, provider);
+      expect(routedUnder).toEqual(['sid-a']);
+
+      // (3) Set sid-b -> subsequent events route under sid-b, NOT sid-a.
+      proxy.setTokenSessionId('sid-b' as SessionId);
+      await drivePOST(upstreamPort, provider);
+      expect(routedUnder).toEqual(['sid-a', 'sid-b']);
+
+      // (4) Set undefined -> no further events routed.
+      proxy.setTokenSessionId(undefined);
+      await drivePOST(upstreamPort, provider);
+      expect(routedUnder).toEqual(['sid-a', 'sid-b']);
+    } finally {
+      upstream.close();
+    }
+  });
+
+  it('respects a constructor-supplied sessionId as the initial value', async () => {
+    const ssePayload = [
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Y"}}',
+      '',
+    ].join('\n');
+    const { server: upstream, port: upstreamPort } = await createSseUpstream(ssePayload);
+
+    try {
+      const initial: SessionId[] = [];
+      getTokenStreamBus().subscribeAll((sid, event) => {
+        if (event.kind === 'text_delta') initial.push(sid);
+      });
+
+      const provider = makeTestProvider(upstreamPort);
+      // Construct with sessionId — should function as the initial value
+      // of the mutable slot (backward compat with the old one-shot API).
+      proxy = createMitmProxy({
+        socketPath,
+        ca,
+        providers: [provider],
+        dnsLookup: localhostDnsLookup,
+        sessionId: 'initial-sid',
+      });
+      await proxy.start();
+
+      await drivePOST(upstreamPort, provider);
+      expect(initial).toEqual(['initial-sid']);
+
+      // Clearing works from the constructor-supplied initial state too.
+      proxy.setTokenSessionId(undefined);
+      await drivePOST(upstreamPort, provider);
+      expect(initial).toEqual(['initial-sid']);
+    } finally {
+      upstream.close();
+    }
+  });
+});

--- a/test/token-stream-bridge.test.ts
+++ b/test/token-stream-bridge.test.ts
@@ -624,5 +624,99 @@ describe('TokenStreamBridge', () => {
       expect(payload.events).toHaveLength(1);
       expect(payload.events[0].kind).toBe('text_delta');
     });
+
+    /**
+     * Workflow agent sessions are created by WorkflowOrchestrator, not
+     * via `sessions.create`, so they never emit `session.created`. Before
+     * the fix, token events for these sessions were silently dropped at
+     * `TokenStreamBridge.addGlobalClient` (sessionToLabel lookup returned
+     * undefined). The fix wires workflow lifecycle events (`agent_started`
+     * / `agent_session_ended`) through the daemon to `bridge.registerSession`
+     * / `bridge.closeSession`.
+     *
+     * This test simulates that wiring at the bridge boundary:
+     *   1. Simulate the global observer (`observe --all`) subscribing.
+     *   2. Simulate the daemon's workflow.agent_started handler registering
+     *      the session.
+     *   3. Verify events published by the MITM reach the observer.
+     *   4. Simulate agent_session_ended -> closeSession.
+     *   5. Verify post-teardown events are dropped (no cross-agent bleed).
+     */
+    it('workflow-agent lifecycle routes events then tears down on session end', () => {
+      const bridge = new TokenStreamBridge(sender);
+      const observeClient = mockWs();
+      const sid = sessionId('workflow-agent-session-1');
+      const label = 101; // would come from SessionManager.reserveLabel()
+
+      // Observer subscribes before the workflow session starts (the
+      // viz pre-subscribes on page load).
+      bridge.addGlobalClient(observeClient);
+
+      // Daemon's `workflow.agent_started` handler: register the mapping.
+      bridge.registerSession(label, sid);
+
+      // MITM publishes token events during session.sendMessage().
+      getTokenStreamBus().push(sid, textDelta('agent thinking'));
+      getTokenStreamBus().push(sid, textDelta('more tokens'));
+      vi.advanceTimersByTime(50);
+
+      expect(sender.calls).toHaveLength(1);
+      const firstPayload = sender.calls[0].payload as { label: number; events: TokenStreamEvent[] };
+      expect(firstPayload.label).toBe(label);
+      expect(firstPayload.events).toHaveLength(2);
+
+      // Daemon's `workflow.agent_session_ended` handler: tear down the
+      // mapping. Fires unconditionally in the orchestrator's finally
+      // block (symmetric with registration).
+      bridge.closeSession(label);
+
+      // Post-teardown pushes must not reach the observer -- no label
+      // resolvable, no events delivered.
+      sender.calls.length = 0;
+      getTokenStreamBus().push(sid, textDelta('stale event after teardown'));
+      vi.advanceTimersByTime(50);
+      expect(sender.calls).toHaveLength(0);
+    });
+
+    /**
+     * Rapid state transitions: agent A ends, agent B starts with a
+     * fresh session ID. The bridge must not leak A's label/mapping into
+     * B's subscription, and B's events must route with B's own label.
+     */
+    it('handles rapid session churn without stale mappings', () => {
+      const bridge = new TokenStreamBridge(sender);
+      const observeClient = mockWs();
+      const sidA = sessionId('workflow-agent-A');
+      const sidB = sessionId('workflow-agent-B');
+      const labelA = 201;
+      const labelB = 202;
+
+      bridge.addGlobalClient(observeClient);
+
+      // Agent A runs.
+      bridge.registerSession(labelA, sidA);
+      getTokenStreamBus().push(sidA, textDelta('A-event'));
+      vi.advanceTimersByTime(50);
+      expect(sender.calls).toHaveLength(1);
+      expect((sender.calls[0].payload as { label: number }).label).toBe(labelA);
+
+      // A ends, B starts with a fresh ID and label.
+      bridge.closeSession(labelA);
+      bridge.registerSession(labelB, sidB);
+
+      sender.calls.length = 0;
+      getTokenStreamBus().push(sidB, textDelta('B-event'));
+      // A replayed stale event (e.g. in-flight MITM buffer) must not reach
+      // the observer under B's label.
+      getTokenStreamBus().push(sidA, textDelta('A-stale'));
+      vi.advanceTimersByTime(50);
+
+      // Only the B event is delivered; A's stale event has no label.
+      expect(sender.calls).toHaveLength(1);
+      const payload = sender.calls[0].payload as { label: number; events: TokenStreamEvent[] };
+      expect(payload.label).toBe(labelB);
+      expect(payload.events).toHaveLength(1);
+      expect((payload.events[0] as { text?: string }).text).toBe('B-event');
+    });
   });
 });

--- a/test/workflow/machine-test-helpers.ts
+++ b/test/workflow/machine-test-helpers.ts
@@ -20,6 +20,7 @@ export function makeAgentResult(overrides: Partial<AgentInvokeResult> = {}): Age
     artifacts: {},
     outputHash: 'hash-1',
     responseText: 'Agent response text',
+    totalTokens: 0,
     ...overrides,
   };
 }

--- a/test/workflow/orchestrator-bifurcated.test.ts
+++ b/test/workflow/orchestrator-bifurcated.test.ts
@@ -54,6 +54,7 @@ function makeStubInfrastructure(
     workflowId,
     bundleId,
     scope,
+    setTokenSessionId: () => {},
   } as unknown as DockerInfrastructure & { readonly __scope: string };
 }
 

--- a/test/workflow/orchestrator-policy-cycling.test.ts
+++ b/test/workflow/orchestrator-policy-cycling.test.ts
@@ -46,6 +46,7 @@ function makeStubInfrastructure(workflowId: string, bundleId: BundleId): DockerI
     __stub: true,
     workflowId,
     bundleId,
+    setTokenSessionId: () => {},
   } as unknown as DockerInfrastructure;
 }
 

--- a/test/workflow/orchestrator-session-paths.test.ts
+++ b/test/workflow/orchestrator-session-paths.test.ts
@@ -44,6 +44,7 @@ function makeStubInfrastructure(workflowId: string, bundleId: BundleId): DockerI
     __stub: true,
     workflowId,
     bundleId,
+    setTokenSessionId: () => {},
   } as unknown as DockerInfrastructure;
 }
 

--- a/test/workflow/orchestrator-shared-container.test.ts
+++ b/test/workflow/orchestrator-shared-container.test.ts
@@ -569,6 +569,7 @@ describe('WorkflowOrchestrator shared-container mode', () => {
         const bundle = {
           __stub: true,
           workflowId: input.workflowId,
+          bundleId: input.bundleId,
           setTokenSessionId: (id: string | undefined) => {
             tokenSessionIdCalls.push(id);
           },
@@ -648,6 +649,7 @@ describe('WorkflowOrchestrator shared-container mode', () => {
         return {
           __stub: true,
           workflowId: input.workflowId,
+          bundleId: input.bundleId,
           setTokenSessionId: (id: string | undefined) => {
             tokenSessionIdCalls.push(id);
           },
@@ -737,7 +739,7 @@ describe('WorkflowOrchestrator shared-container mode', () => {
       const defPath = writeDefinitionFile(tmpDir, twoAgentDef);
 
       const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) =>
-        makeStubInfrastructure(input.workflowId),
+        makeStubInfrastructure(input.workflowId, input.bundleId),
       );
       const destroyInfra = vi.fn(async () => {});
 
@@ -798,7 +800,7 @@ describe('WorkflowOrchestrator shared-container mode', () => {
     const defPath = writeDefinitionFile(tmpDir, dockerWorkflowDef);
 
     const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) =>
-      makeStubInfrastructure(input.workflowId),
+      makeStubInfrastructure(input.workflowId, input.bundleId),
     );
     const destroyInfra = vi.fn(async () => {});
 

--- a/test/workflow/orchestrator-shared-container.test.ts
+++ b/test/workflow/orchestrator-shared-container.test.ts
@@ -30,12 +30,17 @@ import {
  * `BundleId` per scope and passes it into the factory as `input.bundleId`;
  * the stub echoes that value back so identity comparisons work across
  * subsequent calls.
+ *
+ * `setTokenSessionId` is a no-op so the orchestrator's per-agent
+ * rerouting calls don't crash. Tests that care about the routing calls
+ * should override it with a `vi.fn()`.
  */
 function makeStubInfrastructure(workflowId: string, bundleId: BundleId): DockerInfrastructure {
   const bundle = {
     __stub: true,
     workflowId,
     bundleId,
+    setTokenSessionId: () => {},
   } as unknown as DockerInfrastructure;
   return bundle;
 }
@@ -500,5 +505,321 @@ describe('WorkflowOrchestrator shared-container mode', () => {
 
     expect(createInfra).not.toHaveBeenCalled();
     expect(destroyInfra).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: per-agent `setTokenSessionId` on the shared MITM proxy
+  // -------------------------------------------------------------------------
+  //
+  // Before the fix, `createWorkflowInfrastructure` baked the workflow ID
+  // into the MITM proxy as a static sessionId. Each per-state agent session
+  // has its own generated SessionId, so token events extracted by the
+  // long-lived MITM proxy were pushed under the workflow ID instead of the
+  // active agent's session ID. The daemon's `TokenStreamBridge` registers
+  // the per-state ID (via the `agent_started` lifecycle event), so events
+  // keyed on the workflow ID never reached any subscriber — silently
+  // dropped at the bridge.
+  //
+  // The fix is that the orchestrator flips
+  // `instance.infra.setTokenSessionId` around each agent run:
+  //   - Before emitting `agent_started`: set to the session's ID.
+  //   - In the `finally` block, BEFORE emitting `agent_session_ended`:
+  //     set to `undefined`.
+  //
+  // These tests lock that contract.
+
+  it('flips setTokenSessionId to the per-agent session ID around each agent run', async () => {
+    // Two sequential agent states so we can observe two distinct session
+    // IDs flow through the MITM proxy.
+    const twoAgentDef: WorkflowDefinition = {
+      name: 'docker-two-agents',
+      description: 'Two back-to-back agents in shared-container mode',
+      initial: 'first',
+      settings: { mode: 'docker', dockerAgent: 'claude-code', sharedContainer: true },
+      states: {
+        first: {
+          type: 'agent',
+          description: 'First agent',
+          persona: 'global',
+          prompt: 'You are the first agent.',
+          inputs: [],
+          outputs: ['a'],
+          transitions: [{ to: 'second' }],
+        },
+        second: {
+          type: 'agent',
+          description: 'Second agent',
+          persona: 'global',
+          prompt: 'You are the second agent.',
+          inputs: ['a'],
+          outputs: ['b'],
+          transitions: [{ to: 'done' }],
+        },
+        done: { type: 'terminal', description: 'Done' },
+      },
+    };
+
+    const stubCleanup = stubPersonasForTest(tmpDir, twoAgentDef);
+    try {
+      const defPath = writeDefinitionFile(tmpDir, twoAgentDef);
+
+      // Record every setTokenSessionId call on the shared bundle.
+      const tokenSessionIdCalls: Array<string | undefined> = [];
+      const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) => {
+        const bundle = {
+          __stub: true,
+          workflowId: input.workflowId,
+          setTokenSessionId: (id: string | undefined) => {
+            tokenSessionIdCalls.push(id);
+          },
+        } as unknown as DockerInfrastructure;
+        return bundle;
+      });
+      const destroyInfra = vi.fn(async () => {});
+
+      // Each invocation returns a distinct session ID so the test can
+      // assert the orchestrator used the session's ID (not the workflow's).
+      let sessionCounter = 0;
+      const sessionFactory = vi.fn(async () => {
+        sessionCounter++;
+        return createArtifactAwareSession(
+          [{ text: approvedResponse('done'), artifacts: [sessionCounter === 1 ? 'a' : 'b'] }],
+          tmpDir,
+          `agent-session-${sessionCounter}`,
+        );
+      });
+
+      const orchestrator = new WorkflowOrchestrator(
+        createDeps(tmpDir, {
+          createSession: sessionFactory,
+          createWorkflowInfrastructure: createInfra,
+          destroyWorkflowInfrastructure: destroyInfra,
+        }),
+      );
+      activeOrchestrator = orchestrator;
+
+      const workflowId = await orchestrator.start(defPath, 'task');
+      await waitForCompletion(orchestrator, workflowId);
+
+      // Expect the orchestrator to have driven the following sequence:
+      //   1. set('agent-session-1')    ← before `agent_started` for "first"
+      //   2. set(undefined)            ← in `finally` of "first"
+      //   3. set('agent-session-2')    ← before `agent_started` for "second"
+      //   4. set(undefined)            ← in `finally` of "second"
+      // The per-agent ID (NOT the workflowId) is what lands on the proxy.
+      expect(tokenSessionIdCalls).toEqual(['agent-session-1', undefined, 'agent-session-2', undefined]);
+      // Sanity: the workflow ID was NEVER used as a routing target.
+      expect(tokenSessionIdCalls).not.toContain(workflowId);
+    } finally {
+      stubCleanup();
+    }
+  });
+
+  it('clears setTokenSessionId on failure so the next agent does not inherit a stale ID', async () => {
+    // A workflow where the agent fails (no status block + retry also
+    // fails). The `finally` block must still flip setTokenSessionId back
+    // to `undefined` — otherwise a subsequent agent in a follow-up run
+    // would see events routed under the previous session's ID.
+    const failingAgentDef: WorkflowDefinition = {
+      name: 'docker-failing-agent',
+      description: 'Single agent that fails (status block retry exhausted)',
+      initial: 'broken',
+      settings: { mode: 'docker', dockerAgent: 'claude-code', sharedContainer: true },
+      states: {
+        broken: {
+          type: 'agent',
+          description: 'Fails to produce a status block',
+          persona: 'global',
+          prompt: 'You are broken.',
+          inputs: [],
+          outputs: ['result'],
+          transitions: [{ to: 'done' }],
+        },
+        done: { type: 'terminal', description: 'Done' },
+      },
+    };
+
+    const stubCleanup = stubPersonasForTest(tmpDir, failingAgentDef);
+    try {
+      const defPath = writeDefinitionFile(tmpDir, failingAgentDef);
+
+      const tokenSessionIdCalls: Array<string | undefined> = [];
+      const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) => {
+        return {
+          __stub: true,
+          workflowId: input.workflowId,
+          setTokenSessionId: (id: string | undefined) => {
+            tokenSessionIdCalls.push(id);
+          },
+        } as unknown as DockerInfrastructure;
+      });
+      const destroyInfra = vi.fn(async () => {});
+
+      // Import inline to avoid leaking this helper import into every test
+      // above.
+      const { MockSession, noStatusResponse, simulateArtifacts, findWorkflowDir } = await import('./test-helpers.js');
+
+      const sessionFactory = vi.fn(async () => {
+        simulateArtifacts(findWorkflowDir(tmpDir), ['result']);
+        return new MockSession({
+          sessionId: 'failing-session-abc',
+          responses: [noStatusResponse(), noStatusResponse()],
+        });
+      });
+
+      const orchestrator = new WorkflowOrchestrator(
+        createDeps(tmpDir, {
+          createSession: sessionFactory,
+          createWorkflowInfrastructure: createInfra,
+          destroyWorkflowInfrastructure: destroyInfra,
+        }),
+      );
+      activeOrchestrator = orchestrator;
+
+      const workflowId = await orchestrator.start(defPath, 'task');
+      await waitForCompletion(orchestrator, workflowId);
+
+      // Even on the failure path (status retry exhausted → throw), the
+      // `finally` block must set sessionId back to undefined.
+      expect(tokenSessionIdCalls).toEqual(['failing-session-abc', undefined]);
+    } finally {
+      stubCleanup();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Regression: workflow totalTokens accumulation via the token-stream bus
+  // -------------------------------------------------------------------------
+  //
+  // Before the fix, `ctx.totalTokens` was initialized to 0 in the machine
+  // but never written again — the workflow summary's "Total Tokens" card
+  // always showed 0 regardless of LLM usage. The orchestrator now
+  // subscribes to the token-stream bus at workflow start, accumulates
+  // `message_end.outputTokens` into a per-workflow counter, and threads
+  // that total through `AgentInvokeResult` into `ctx.totalTokens`.
+
+  it('accumulates outputTokens from message_end events into ctx.totalTokens', async () => {
+    // Reset the bus so this test is isolated from any other bus state.
+    const { resetTokenStreamBus, getTokenStreamBus } = await import('../../src/docker/token-stream-bus.js');
+    resetTokenStreamBus();
+    const bus = getTokenStreamBus();
+
+    const twoAgentDef: WorkflowDefinition = {
+      name: 'docker-token-accum',
+      description: 'Two agents emitting token events',
+      initial: 'first',
+      settings: { mode: 'docker', dockerAgent: 'claude-code', sharedContainer: true },
+      states: {
+        first: {
+          type: 'agent',
+          description: 'First agent',
+          persona: 'global',
+          prompt: 'You are the first agent.',
+          inputs: [],
+          outputs: ['a'],
+          transitions: [{ to: 'second' }],
+        },
+        second: {
+          type: 'agent',
+          description: 'Second agent',
+          persona: 'global',
+          prompt: 'You are the second agent.',
+          inputs: ['a'],
+          outputs: ['b'],
+          transitions: [{ to: 'done' }],
+        },
+        done: { type: 'terminal', description: 'Done' },
+      },
+    };
+
+    const stubCleanup = stubPersonasForTest(tmpDir, twoAgentDef);
+    try {
+      const defPath = writeDefinitionFile(tmpDir, twoAgentDef);
+
+      const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) =>
+        makeStubInfrastructure(input.workflowId),
+      );
+      const destroyInfra = vi.fn(async () => {});
+
+      const { MockSession, approvedResponse, simulateArtifacts, findWorkflowDir } = await import('./test-helpers.js');
+
+      let sessionCounter = 0;
+      const sessionFactory = vi.fn(async () => {
+        sessionCounter++;
+        const sessionId = `agent-session-${sessionCounter}`;
+        const artifacts = [sessionCounter === 1 ? 'a' : 'b'];
+        const outputTokensForSession = sessionCounter === 1 ? 100 : 50;
+        // Simulate the MITM proxy's SSE tap firing during `sendMessage`:
+        // before returning the agent's response, push a `message_end`
+        // event onto the bus under this session's ID. The orchestrator's
+        // bus subscriber should accumulate the `outputTokens` into
+        // `instance.outputTokens`.
+        return new MockSession({
+          sessionId,
+          responses: () => {
+            bus.push(sessionId as unknown as import('../../src/session/types.js').SessionId, {
+              kind: 'message_end',
+              stopReason: 'end_turn',
+              inputTokens: 0,
+              outputTokens: outputTokensForSession,
+              timestamp: Date.now(),
+            });
+            simulateArtifacts(findWorkflowDir(tmpDir), artifacts);
+            return approvedResponse('done');
+          },
+        });
+      });
+
+      const orchestrator = new WorkflowOrchestrator(
+        createDeps(tmpDir, {
+          createSession: sessionFactory,
+          createWorkflowInfrastructure: createInfra,
+          destroyWorkflowInfrastructure: destroyInfra,
+        }),
+      );
+      activeOrchestrator = orchestrator;
+
+      const workflowId = await orchestrator.start(defPath, 'task');
+      await waitForCompletion(orchestrator, workflowId);
+
+      const detail = orchestrator.getDetail(workflowId);
+      expect(detail).toBeDefined();
+      // Sum: 100 (first agent) + 50 (second agent) = 150.
+      expect(detail!.context.totalTokens).toBe(150);
+    } finally {
+      stubCleanup();
+    }
+  });
+
+  it('keeps ctx.totalTokens at 0 when no token events arrive on the bus', async () => {
+    const { resetTokenStreamBus } = await import('../../src/docker/token-stream-bus.js');
+    resetTokenStreamBus();
+
+    const defPath = writeDefinitionFile(tmpDir, dockerWorkflowDef);
+
+    const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) =>
+      makeStubInfrastructure(input.workflowId),
+    );
+    const destroyInfra = vi.fn(async () => {});
+
+    const sessionFactory = vi.fn(async () =>
+      createArtifactAwareSession([{ text: approvedResponse('done'), artifacts: ['result'] }], tmpDir),
+    );
+
+    const orchestrator = new WorkflowOrchestrator(
+      createDeps(tmpDir, {
+        createSession: sessionFactory,
+        createWorkflowInfrastructure: createInfra,
+        destroyWorkflowInfrastructure: destroyInfra,
+      }),
+    );
+    activeOrchestrator = orchestrator;
+
+    const workflowId = await orchestrator.start(defPath, 'task');
+    await waitForCompletion(orchestrator, workflowId);
+
+    const detail = orchestrator.getDetail(workflowId);
+    expect(detail).toBeDefined();
+    expect(detail!.context.totalTokens).toBe(0);
   });
 });

--- a/test/workflow/orchestrator.test.ts
+++ b/test/workflow/orchestrator.test.ts
@@ -1071,4 +1071,93 @@ describe('WorkflowOrchestrator', () => {
       expect(msg).toContain('ironcurtain persona create');
     }
   });
+
+  // -----------------------------------------------------------------------
+  // Agent-session lifecycle events (for token-stream bridge wiring)
+  // -----------------------------------------------------------------------
+  //
+  // These tests pin the contract that the daemon's bridge wiring depends
+  // on. Regressing the sessionId field or the `finally` emission of
+  // `agent_session_ended` silently breaks workflow token streaming.
+
+  it('emits agent_started and agent_session_ended with sessionId (success path)', async () => {
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+
+    const sessionFactory = vi.fn(async () => {
+      return createArtifactAwareSession(
+        [{ text: approvedResponse('done'), artifacts: ['code'] }],
+        tmpDir,
+        'coder-session-42',
+      );
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = new WorkflowOrchestrator(deps);
+    activeOrchestrator = orchestrator;
+    const lifecycleEvents: WorkflowLifecycleEvent[] = [];
+    orchestrator.onEvent((e) => lifecycleEvents.push(e));
+
+    const workflowId = await orchestrator.start(defPath, 'code task');
+    await waitForCompletion(orchestrator, workflowId);
+
+    const started = lifecycleEvents.find((e) => e.kind === 'agent_started');
+    const completed = lifecycleEvents.find((e) => e.kind === 'agent_completed');
+    const ended = lifecycleEvents.find((e) => e.kind === 'agent_session_ended');
+
+    expect(started).toBeDefined();
+    expect(completed).toBeDefined();
+    expect(ended).toBeDefined();
+
+    // `agent_started` carries the real sessionId -- the bridge wiring
+    // relies on this to register the mapping.
+    expect((started as { sessionId: string }).sessionId).toBe('coder-session-42');
+
+    // `agent_session_ended` also carries the sessionId so cleanup can
+    // find the mapping.
+    expect((ended as { sessionId: string }).sessionId).toBe('coder-session-42');
+
+    // Ordering: started -> completed -> ended. The finally fires after
+    // the success-path agent_completed emission.
+    const startedIdx = lifecycleEvents.findIndex((e) => e.kind === 'agent_started');
+    const completedIdx = lifecycleEvents.findIndex((e) => e.kind === 'agent_completed');
+    const endedIdx = lifecycleEvents.findIndex((e) => e.kind === 'agent_session_ended');
+    expect(startedIdx).toBeLessThan(completedIdx);
+    expect(completedIdx).toBeLessThan(endedIdx);
+  });
+
+  it('emits agent_session_ended on failure path (no agent_completed)', async () => {
+    // Agent never produces a status block -> two sendMessage calls both
+    // fail parse -> executeAgentState throws. The `finally` block must
+    // still fire `agent_session_ended` so bridge entries are cleaned up.
+    const defPath = writeDefinitionFile(tmpDir, simpleAgentDef);
+
+    const sessionFactory = vi.fn(async () => {
+      simulateArtifacts(findWorkflowDir(tmpDir), ['code']);
+      return new MockSession({
+        sessionId: 'failing-coder-session',
+        responses: [noStatusResponse(), noStatusResponse()],
+      });
+    });
+
+    const deps = createDeps(tmpDir, { createSession: sessionFactory });
+    const orchestrator = new WorkflowOrchestrator(deps);
+    activeOrchestrator = orchestrator;
+    const lifecycleEvents: WorkflowLifecycleEvent[] = [];
+    orchestrator.onEvent((e) => lifecycleEvents.push(e));
+
+    const workflowId = await orchestrator.start(defPath, 'write code');
+    await waitForCompletion(orchestrator, workflowId);
+
+    const started = lifecycleEvents.find((e) => e.kind === 'agent_started');
+    const completed = lifecycleEvents.find((e) => e.kind === 'agent_completed');
+    const ended = lifecycleEvents.find((e) => e.kind === 'agent_session_ended');
+
+    // Started and ended fire regardless of verdict parsing; completed
+    // only fires on success.
+    expect(started).toBeDefined();
+    expect(completed).toBeUndefined();
+    expect(ended).toBeDefined();
+    expect((started as { sessionId: string }).sessionId).toBe('failing-coder-session');
+    expect((ended as { sessionId: string }).sessionId).toBe('failing-coder-session');
+  });
 });


### PR DESCRIPTION
## Summary

Two related fixes extracted from PR #197 (workflow visualization) so they can land independently:

1. **MITM token-routing in shared-container workflows.** The proxy is long-lived across agent states. Previously its routing `sessionId` was baked in at construction (workflow id), so the bridge — which registers per-agent session ids — dropped every event. Fix: mutable `setTokenSessionId()`, flipped by the orchestrator around each `executeAgentState`. Per-response `sidAtAttach` / `sidForToolResults` snapshots prevent a mid-stream flip from splitting a single SSE response across two ids.

2. **`ctx.totalTokens` accumulator.** Previously always 0 on the workflow summary. Fix: per-workflow subscription on the `TokenStreamBus` singleton that sums `message_end.outputTokens` across all the workflow's agent sessions; threaded onto `AgentInvokeResult.totalTokens` → XState `assign` → `ctx.totalTokens`. Resume seeds the accumulator from the checkpointed total.

Plus the supporting wiring: new `workflow.agent_started` (with `sessionId`) and `workflow.agent_session_ended` events on `WebEventBus`; daemon handlers that register/close sessions on the `TokenStreamBridge`; `SessionManager.reserveLabel()` so workflow-owned agent sessions share label space; frontend types + mock-ws-server.

After this lands, \`ironcurtain observe\` will receive token streams correctly in shared-container workflows, and the workflow summary's Total Tokens field will display real counts instead of always 0.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Main unit suite passes (4221 tests)
- [x] Web-ui unit suite passes (338 tests)
- [x] \`npm run lint\` clean
- [x] New tests: \`test/mitm-proxy-token-stream.test.ts\`, \`test/token-stream-bridge.test.ts\`, plus three new tests in \`test/workflow/orchestrator-shared-container.test.ts\` (\`flips setTokenSessionId\`, \`clears on failure\`, \`accumulates outputTokens\`)
- [ ] Manual: run a real shared-container workflow and confirm tokens flow + summary shows non-zero totalTokens

## Source

Cherry-picked from PR #197 (\`feat/workflow-visualization\`). The viz UI in #197 depends on these fixes; once this lands, that PR will merge \`master\` back and shrink accordingly.