### PR TITLE
Fix web UI e2e tests broken by mobile drawer and gate auto-fetch

### DIFF
--- a/packages/web-ui/e2e/auth.spec.ts
+++ b/packages/web-ui/e2e/auth.spec.ts
@@ -22,7 +22,7 @@ test.describe('Auth gate', () => {
 
     // The sidebar nav only renders once past the auth gate; it must
     // never appear for a rejected token.
-    await expect(page.locator('nav')).not.toBeVisible();
+    await expect(page.getByTestId('sidebar-nav')).not.toBeVisible();
 
     // And the bad token must be purged from sessionStorage so a
     // subsequent page load doesn't re-offer it.
@@ -41,7 +41,7 @@ test.describe('Auth gate', () => {
     await page.getByRole('button', { name: 'Connect' }).click();
 
     // Auth gate drops and we land in the app.
-    await expect(page.locator('nav')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('sidebar-nav')).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('auth-error')).not.toBeVisible();
   });
 });

--- a/packages/web-ui/e2e/dashboard.spec.ts
+++ b/packages/web-ui/e2e/dashboard.spec.ts
@@ -27,6 +27,10 @@ test.describe('Dashboard', () => {
   });
 
   test('shows connection indicator as Live', async ({ page }) => {
-    await expect(page.getByTestId('connection-status').getByText('Live')).toBeVisible({ timeout: 5_000 });
+    // Both the desktop sidebar and the offscreen mobile drawer render a
+    // connection-status indicator, so scope to the desktop sidebar.
+    await expect(page.getByTestId('sidebar-nav').getByTestId('connection-status').getByText('Live')).toBeVisible({
+      timeout: 5_000,
+    });
   });
 });

--- a/packages/web-ui/e2e/escalations.spec.ts
+++ b/packages/web-ui/e2e/escalations.spec.ts
@@ -121,7 +121,9 @@ test.describe('Escalations', () => {
 
     // The nav item for Escalations should show a badge count
     // Wait for the escalation event to propagate
-    await expect(page.locator('nav').locator('button', { hasText: 'Escalations' }).locator('.font-mono')).toBeVisible({
+    await expect(
+      page.getByTestId('sidebar-nav').locator('button', { hasText: 'Escalations' }).locator('.font-mono'),
+    ).toBeVisible({
       timeout: 10_000,
     });
   });
@@ -159,7 +161,9 @@ test.describe('Escalation Modal', () => {
     await expect(modal).not.toBeVisible({ timeout: 3_000 });
 
     // Sidebar badge should still show the count
-    await expect(page.locator('nav').locator('button', { hasText: 'Escalations' }).locator('.font-mono')).toBeVisible();
+    await expect(
+      page.getByTestId('sidebar-nav').locator('button', { hasText: 'Escalations' }).locator('.font-mono'),
+    ).toBeVisible();
   });
 
   test('approving in modal removes the escalation', async ({ page }) => {
@@ -213,7 +217,7 @@ test.describe('Escalation Modal', () => {
 
     // Sidebar badge should be gone
     await expect(
-      page.locator('nav').locator('button', { hasText: 'Escalations' }).locator('.font-mono'),
+      page.getByTestId('sidebar-nav').locator('button', { hasText: 'Escalations' }).locator('.font-mono'),
     ).not.toBeVisible();
   });
 

--- a/packages/web-ui/e2e/helpers.ts
+++ b/packages/web-ui/e2e/helpers.ts
@@ -15,7 +15,10 @@ export async function connectWithToken(page: Page): Promise<void> {
   await page.goto('/?token=mock-dev-token');
   // The sidebar nav appears only after the auth gate is passed and
   // the WS connection is established (appState.connected becomes true).
-  await expect(page.locator('nav')).toBeVisible({ timeout: 10_000 });
+  // Target the desktop sidebar by test id; the mobile drawer also
+  // renders a <nav> in the DOM (offscreen) so a bare 'nav' selector
+  // would hit a strict-mode violation.
+  await expect(page.getByTestId('sidebar-nav')).toBeVisible({ timeout: 10_000 });
 }
 
 /**
@@ -25,7 +28,56 @@ export async function navigateTo(
   page: Page,
   view: 'Dashboard' | 'Sessions' | 'Escalations' | 'Jobs' | 'Workflows',
 ): Promise<void> {
-  await page.locator('nav').getByRole('button', { name: view }).click();
+  await page.getByTestId('sidebar-nav').getByRole('button', { name: view }).click();
+}
+
+/**
+ * Navigate to the Workflows list view, dismissing any auto-opened detail view.
+ *
+ * The mock server seeds a workflow in `waiting_human` phase, and on connect
+ * the store fetches its gate and populates `pendingGates`. The Workflows.svelte
+ * auto-select effect then opens the detail view of that workflow. Tests that
+ * need the list view must wait for the auto-select to settle, then dismiss the
+ * detail view.
+ */
+export async function navigateToWorkflowsList(page: Page): Promise<void> {
+  // Wait for the gate fetch to complete before navigating so the auto-select
+  // effect has fired by the time we land on the Workflows view. The gate badge
+  // on the sidebar's Workflows nav item is the visible signal that
+  // pendingGates is populated.
+  const workflowsNavBadge = page
+    .getByTestId('sidebar-nav')
+    .locator('button', { hasText: 'Workflows' })
+    .locator('.font-mono');
+  await expect(workflowsNavBadge).toBeVisible({ timeout: 10_000 });
+
+  await navigateTo(page, 'Workflows');
+
+  // Auto-select may now be opening the detail view; click Back if so.
+  const heading = page.getByRole('heading', { name: 'Workflows', exact: true });
+  const backButton = page.getByRole('button', { name: /Back/ });
+  await expect(heading.or(backButton).first()).toBeVisible({ timeout: 10_000 });
+  if (await backButton.isVisible().catch(() => false)) {
+    await backButton.click();
+  }
+  await expect(heading).toBeVisible({ timeout: 5_000 });
+}
+
+/**
+ * Clear the seeded code-review gate so subsequent actions (e.g., starting a
+ * new workflow that raises a gate) won't trigger the auto-select effect
+ * navigating away to the seeded workflow's detail view.
+ *
+ * Assumes we are on the Workflows list view with code-review present.
+ */
+export async function approveSeededGate(page: Page): Promise<void> {
+  await page.locator('tr', { hasText: 'code-review' }).click();
+  await expect(page.getByText('Review Required')).toBeVisible({ timeout: 5_000 });
+  await page.getByRole('button', { name: 'Approve' }).click();
+  await expect(page.getByText('Review Required')).not.toBeVisible({ timeout: 5_000 });
+  // Return to the list view; the gate badge should be gone.
+  await page.getByRole('button', { name: /Back/ }).click();
+  await expect(page.getByRole('heading', { name: 'Workflows', exact: true })).toBeVisible({ timeout: 5_000 });
 }
 
 /**

--- a/packages/web-ui/e2e/theme.spec.ts
+++ b/packages/web-ui/e2e/theme.spec.ts
@@ -13,34 +13,39 @@ test.describe('Theme switching', () => {
   });
 
   test('opens the theme picker from the sidebar', async ({ page }) => {
-    // The theme picker trigger shows "Theme: Iron" in the sidebar
-    await page.getByText('Theme:', { exact: false }).click();
+    // The mobile drawer also renders a ThemePicker bound to the same
+    // showThemePicker state, so its menu items appear in the DOM too.
+    // Scope to the desktop sidebar to avoid strict-mode violations.
+    const sidebar = page.getByTestId('sidebar-nav');
+    await sidebar.getByText('Theme:', { exact: false }).click();
 
-    // Theme options should appear
-    await expect(page.getByText('Daylight')).toBeVisible();
-    await expect(page.getByText('Midnight')).toBeVisible();
+    // Theme options should appear in the desktop sidebar's dropdown
+    await expect(sidebar.getByText('Daylight')).toBeVisible();
+    await expect(sidebar.getByText('Midnight')).toBeVisible();
   });
 
   test('switching to Daylight changes the data-theme attribute', async ({ page }) => {
-    await page.getByText('Theme:', { exact: false }).click();
-    await page.getByText('Daylight').click();
+    const sidebar = page.getByTestId('sidebar-nav');
+    await sidebar.getByText('Theme:', { exact: false }).click();
+    await sidebar.getByText('Daylight').click();
 
     const theme = await page.locator('html').getAttribute('data-theme');
     expect(theme).toBe('daylight');
   });
 
   test('switching to Midnight changes the data-theme attribute', async ({ page }) => {
-    await page.getByText('Theme:', { exact: false }).click();
-    await page.getByText('Midnight').click();
+    const sidebar = page.getByTestId('sidebar-nav');
+    await sidebar.getByText('Theme:', { exact: false }).click();
+    await sidebar.getByText('Midnight').click();
 
     const theme = await page.locator('html').getAttribute('data-theme');
     expect(theme).toBe('midnight');
   });
 
   test('theme persists via localStorage', async ({ page }) => {
-    // Switch to midnight
-    await page.getByText('Theme:', { exact: false }).click();
-    await page.getByText('Midnight').click();
+    const sidebar = page.getByTestId('sidebar-nav');
+    await sidebar.getByText('Theme:', { exact: false }).click();
+    await sidebar.getByText('Midnight').click();
 
     // Verify localStorage was updated
     const storedTheme = await page.evaluate(() => localStorage.getItem('ic-theme'));

--- a/packages/web-ui/e2e/workflows.spec.ts
+++ b/packages/web-ui/e2e/workflows.spec.ts
@@ -1,15 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { connectWithToken, navigateTo, resetMockServer } from './helpers.js';
+import {
+  approveSeededGate,
+  connectWithToken,
+  navigateTo,
+  navigateToWorkflowsList,
+  resetMockServer,
+} from './helpers.js';
 
 test.describe('Workflow Dashboard', () => {
   test.beforeEach(async ({ page, request }) => {
     await resetMockServer(request);
     await connectWithToken(page);
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
   });
 
   test('shows the workflow list with active workflows', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Workflows' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Workflows', exact: true })).toBeVisible();
 
     // The mock server seeds two workflows: design-and-code (running) and code-review (waiting_human)
     // Use table cell locators to avoid matching dropdown options that also contain these names
@@ -40,7 +46,10 @@ test.describe('Start Workflow', () => {
   test.beforeEach(async ({ page, request }) => {
     await resetMockServer(request);
     await connectWithToken(page);
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
+    // Clear the seeded gate so the auto-select effect doesn't redirect to
+    // code-review when the new workflow's gate fires later in the test.
+    await approveSeededGate(page);
   });
 
   test('starts a new workflow via the form', async ({ page }) => {
@@ -93,7 +102,7 @@ test.describe('Workflow Detail View', () => {
   test.beforeEach(async ({ page, request }) => {
     await resetMockServer(request);
     await connectWithToken(page);
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
   });
 
   test('clicking a workflow row opens the detail view', async ({ page }) => {
@@ -153,7 +162,7 @@ test.describe('Workflow Detail View', () => {
     await page.getByRole('button', { name: /Back/ }).click();
 
     // Should see the workflow list heading again
-    await expect(page.getByRole('heading', { name: 'Workflows' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Workflows', exact: true })).toBeVisible();
   });
 });
 
@@ -161,7 +170,7 @@ test.describe('Gate Review Panel', () => {
   test.beforeEach(async ({ page, request }) => {
     await resetMockServer(request);
     await connectWithToken(page);
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
   });
 
   test('gate review panel appears for waiting workflow', async ({ page }) => {
@@ -320,7 +329,7 @@ test.describe('Gate Count Badge', () => {
     // but pendingGates only gets populated when a workflow detail is loaded (via
     // workflows.get) or a gate_raised event is broadcast. Navigate to Workflows and
     // open the code-review detail to seed the gate into appState.pendingGates.
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
     await page.locator('tr', { hasText: 'code-review' }).click();
     await expect(page.getByText('Review Required')).toBeVisible({ timeout: 5_000 });
 
@@ -329,13 +338,13 @@ test.describe('Gate Count Badge', () => {
     await navigateTo(page, 'Dashboard');
 
     // The Workflows nav button should show a badge with the gate count
-    const workflowsNav = page.locator('nav').locator('button', { hasText: 'Workflows' });
+    const workflowsNav = page.getByTestId('sidebar-nav').locator('button', { hasText: 'Workflows' });
     await expect(workflowsNav.locator('.font-mono')).toBeVisible({ timeout: 5_000 });
   });
 
   test('gate badge disappears after resolving all gates', async ({ page }) => {
     // Navigate to workflows and open the waiting workflow
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
     await page.locator('tr', { hasText: 'code-review' }).click();
 
     // Wait for gate panel
@@ -351,7 +360,7 @@ test.describe('Gate Count Badge', () => {
     await page.getByRole('button', { name: /Back/ }).click();
 
     // The badge should no longer be visible in the nav
-    const workflowsNav = page.locator('nav').locator('button', { hasText: 'Workflows' });
+    const workflowsNav = page.getByTestId('sidebar-nav').locator('button', { hasText: 'Workflows' });
     await expect(workflowsNav.locator('.font-mono')).not.toBeVisible({ timeout: 5_000 });
   });
 });
@@ -360,7 +369,7 @@ test.describe('Workflow List Actions', () => {
   test.beforeEach(async ({ page, request }) => {
     await resetMockServer(request);
     await connectWithToken(page);
-    await navigateTo(page, 'Workflows');
+    await navigateToWorkflowsList(page);
   });
 
   test('abort button in workflow list triggers confirmation and aborts', async ({ page }) => {
@@ -373,8 +382,9 @@ test.describe('Workflow List Actions', () => {
     page.on('dialog', (dialog) => dialog.accept());
     await abortButton.click();
 
-    // After abort, the workflow should change phase.
-    // Both the phase badge and currentState cell show "aborted"; use first() to avoid strict mode error.
-    await expect(runningRow.getByText('aborted').first()).toBeVisible({ timeout: 5_000 });
+    // After abort, the workflow's phase becomes 'failed' (per the front-end's
+    // workflow.failed handler), so it is filtered out of the Active workflows
+    // table. The Abort button on this row should disappear.
+    await expect(abortButton).not.toBeVisible({ timeout: 5_000 });
   });
 });

--- a/packages/web-ui/src/App.svelte
+++ b/packages/web-ui/src/App.svelte
@@ -347,7 +347,7 @@
     </div>
 
     <!-- Desktop sidebar: hidden below md. -->
-    <nav class="hidden md:flex w-56 bg-sidebar border-r border-border flex-col shrink-0">
+    <nav data-testid="sidebar-nav" class="hidden md:flex w-56 bg-sidebar border-r border-border flex-col shrink-0">
       {@render navContents()}
     </nav>
 


### PR DESCRIPTION
## Summary

The web UI e2e suite was failing 62 of 63 tests. Three independent regressions had stacked up because the e2e tests aren't gated by CI:

- **Mobile drawer** (PR #200) added a second `<nav>` to the DOM. `page.locator('nav')` in the test helpers became ambiguous under Playwright strict mode, breaking nearly every test in `connectWithToken`.
- **Gate auto-fetch on connect** (PR #173) populates `pendingGates` for any seeded `waiting_human` workflow, which causes `Workflows.svelte`'s auto-select effect to navigate straight to the detail view. Tests written before that change still expected the list view.
- **`workflow.failed` semantics** (PR #200) changed how the active vs. past-runs split works, so a workflow that's been aborted is now filtered out of the active table rather than re-rendered with an 'aborted' label.

This PR isolates the production change (a single `data-testid`) and adapts the tests to the current behavior. Result: **63/63 e2e tests passing** locally.

## Changes

- `packages/web-ui/src/App.svelte` — add `data-testid=\"sidebar-nav\"` to the desktop sidebar so tests can disambiguate from the offscreen mobile drawer.
- `packages/web-ui/e2e/helpers.ts` — switch nav locators to `getByTestId`. New helpers:
  - `navigateToWorkflowsList` waits for the gate fetch to land (visible badge), then dismisses the auto-opened detail view via Back, deterministically resolving the race.
  - `approveSeededGate` clears the canned `code-review` gate so tests that start a new workflow don't get redirected to the seeded one when its gate raises.
- `packages/web-ui/e2e/{auth,dashboard,escalations,theme,workflows}.spec.ts` — scope locators to `sidebar-nav`, use `exact: true` on the `Workflows` heading (was substring-matching `Active workflows`), and update the abort test to assert that the row is removed from the active table.

## Test plan

- [x] `npm run e2e -w packages/web-ui` passes (63/63)
- [x] `npm run e2e -w packages/web-ui -- workflows.spec.ts` passes (23/23)
- [x] `npm run lint -w packages/web-ui` clean
- [x] `npm run check -w packages/web-ui` clean
- [x] Pre-commit hook (Prettier + ESLint + svelte-check) passes