### PR TITLE
Consolidate Docker availability probe with retry-on-timeout

### DIFF
--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -10,6 +10,8 @@ import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { DockerContainerConfig, DockerExecResult, DockerManager } from './types.js';
 import * as logger from '../logger.js';
+import { checkDockerAvailable, type DockerAvailability } from '../session/preflight.js';
+import { isExecError, isExecTimeout } from '../utils/exec-error.js';
 
 /** Async exec function signature matching promisified execFile. */
 export type ExecFileFn = (
@@ -116,15 +118,17 @@ export function buildCreateArgs(config: DockerContainerConfig): string[] {
   return args;
 }
 
-export function createDockerManager(execFileFn?: ExecFileFn): DockerManager {
+export function createDockerManager(
+  execFileFn?: ExecFileFn,
+  dockerAvailabilityProbe: () => Promise<DockerAvailability> = checkDockerAvailable,
+): DockerManager {
   const exec = execFileFn ?? defaultExecFile;
 
   return {
     async preflight(image: string): Promise<void> {
-      try {
-        await exec('docker', ['info'], { timeout: 10_000 });
-      } catch {
-        throw new Error('Docker is not available. Ensure Docker daemon is running.');
+      const status = await dockerAvailabilityProbe();
+      if (!status.available) {
+        throw new Error(`Docker is not available. ${status.detailedMessage}`);
       }
 
       try {
@@ -154,14 +158,14 @@ export function createDockerManager(execFileFn?: ExecFileFn): DockerManager {
         return { exitCode: 0, stdout, stderr };
       } catch (err: unknown) {
         if (isExecError(err)) {
-          if (isTimeoutError(err)) {
+          if (isExecTimeout(err)) {
             logger.warn(
               `[docker-manager] exec timed out after ${timeout}ms (killed=${String(err.killed)}, ` +
                 `signal=${err.signal ?? 'none'}): docker exec ${nameOrId} ${command[0] ?? ''}`,
             );
           }
           return {
-            exitCode: err.code ?? 1,
+            exitCode: typeof err.code === 'number' ? err.code : 1,
             stdout: err.stdout,
             stderr: err.stderr,
           };
@@ -375,20 +379,4 @@ export function createDockerManager(execFileFn?: ExecFileFn): DockerManager {
       return true;
     },
   };
-}
-
-interface ExecError {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-  killed?: boolean;
-  signal?: string;
-}
-
-function isExecError(err: unknown): err is ExecError {
-  return typeof err === 'object' && err !== null && 'stdout' in err;
-}
-
-function isTimeoutError(err: ExecError): boolean {
-  return err.killed === true && err.signal === 'SIGTERM';
 }

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -14,12 +14,31 @@ import type { AgentId } from '../docker/agent-adapter.js';
 import type { SessionMode } from './types.js';
 import { detectAuthMethod, preflightCredentialSources, type CredentialSources } from '../docker/oauth-credentials.js';
 import { resolveApiKeyForProvider } from '../config/model-provider.js';
-import { isObjectWithProp } from '../utils/is-plain-object.js';
+import { isExecError, isExecTimeout } from '../utils/exec-error.js';
 
 const execFile = promisify(execFileCb);
 
-const DOCKER_TIMEOUT_MS = 5_000;
+/**
+ * Per-attempt timeout for `docker info`. The daemon call can be slow under
+ * load (cold daemon, busy machine), so we use a generous timeout and retry
+ * on timeout-class failures rather than tightening the bound.
+ */
+const DOCKER_PROBE_TIMEOUT_MS = 10_000;
+
+/** Maximum number of additional attempts after the first one. */
+const DOCKER_PROBE_MAX_RETRIES = 2;
+
 const DOCKER_UNAVAILABLE_REASON = 'Docker not available';
+
+/**
+ * Function signature for `execFile` injection in tests. Matches the shape of
+ * `promisify(child_process.execFile)` for the subset of options we use.
+ */
+export type ProbeExecFileFn = (
+  cmd: string,
+  args: readonly string[],
+  opts: { timeout: number },
+) => Promise<{ stdout: string; stderr: string }>;
 
 /**
  * Thrown when explicit --agent prerequisites are not met, or when
@@ -50,35 +69,68 @@ export interface PreflightOptions {
   credentialSources?: CredentialSources;
 }
 
+function describeProbeFailure(err: unknown, fallback: string): string {
+  if (!isExecError(err)) return fallback;
+
+  if (err.code === 'ENOENT') {
+    return 'The "docker" command was not found in your PATH. Is Docker installed?';
+  }
+
+  const stderr = err.stderr.trim();
+  if (stderr.length === 0) return fallback;
+  if (stderr.includes('permission denied')) {
+    return 'Permission denied while connecting to the Docker daemon socket.\nIs your user in the "docker" group?';
+  }
+  if (stderr.includes('Cannot connect to the Docker daemon')) {
+    return (
+      'Cannot connect to the Docker daemon.\n' +
+      'Is the Docker service running? On macOS/Windows, ensure Docker Desktop is started.'
+    );
+  }
+  return stderr;
+}
+
 /**
- * Checks whether the Docker daemon is responsive.
- * Returns detailed diagnostic information if it fails.
+ * Single canonical "is Docker available?" probe for the entire codebase. Other
+ * modules MUST call this rather than re-implementing `docker info`.
+ *
+ * `docker info` can blow past a tight timeout on a cold/busy daemon, so we use
+ * a generous 10s per attempt and retry on timeout-class failures. We do NOT
+ * retry on deterministic failures (ENOENT, permission denied, "Cannot connect
+ * to the Docker daemon") — those won't change between attempts and the
+ * user-visible failure path should be fast.
+ *
+ * @param execFileFn Optional `execFile` implementation for tests.
  */
-export async function checkDockerAvailable(): Promise<DockerAvailability> {
-  try {
-    await execFile('docker', ['info'], { timeout: DOCKER_TIMEOUT_MS });
-    return { available: true };
-  } catch (err: unknown) {
-    let detailedMessage = err instanceof Error ? err.message : String(err);
-    const errCode = isObjectWithProp(err, 'code') ? err.code : undefined;
-    const errStderr = isObjectWithProp(err, 'stderr') ? err.stderr : undefined;
-    if (errCode === 'ENOENT') {
-      detailedMessage = 'The "docker" command was not found in your PATH. Is Docker installed?';
-    } else if (typeof errStderr === 'string' && errStderr.length > 0) {
-      const stderr = errStderr.trim();
-      if (stderr.includes('permission denied')) {
-        detailedMessage =
-          'Permission denied while connecting to the Docker daemon socket.\n' + 'Is your user in the "docker" group?';
-      } else if (stderr.includes('Cannot connect to the Docker daemon')) {
-        detailedMessage =
-          'Cannot connect to the Docker daemon.\n' +
-          'Is the Docker service running? On macOS/Windows, ensure Docker Desktop is started.';
-      } else {
-        detailedMessage = stderr;
+export async function checkDockerAvailable(execFileFn: ProbeExecFileFn = execFile): Promise<DockerAvailability> {
+  const totalAttempts = DOCKER_PROBE_MAX_RETRIES + 1;
+  let lastErr: unknown;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    try {
+      await execFileFn('docker', ['info'], { timeout: DOCKER_PROBE_TIMEOUT_MS });
+      return { available: true };
+    } catch (err: unknown) {
+      lastErr = err;
+      if (!isExecError(err) || !isExecTimeout(err)) {
+        return {
+          available: false,
+          reason: DOCKER_UNAVAILABLE_REASON,
+          detailedMessage: describeProbeFailure(err, err instanceof Error ? err.message : String(err)),
+        };
       }
     }
-    return { available: false, reason: DOCKER_UNAVAILABLE_REASON, detailedMessage };
   }
+
+  const baseMessage = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  const timeoutSeconds = DOCKER_PROBE_TIMEOUT_MS / 1000;
+  return {
+    available: false,
+    reason: DOCKER_UNAVAILABLE_REASON,
+    detailedMessage:
+      `Docker daemon did not respond within ${timeoutSeconds}s after ${totalAttempts} attempts. ` +
+      `The daemon may be overloaded or starting up. Original error: ${baseMessage}`,
+  };
 }
 
 /**

--- a/src/signal/setup-signal.ts
+++ b/src/signal/setup-signal.ts
@@ -12,10 +12,8 @@
  */
 
 import { randomInt } from 'node:crypto';
-import { exec as execCb } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { promisify } from 'node:util';
 import * as p from '@clack/prompts';
 import { createDockerManager } from '../docker/docker-manager.js';
 import { saveUserConfig, loadUserConfig } from '../config/user-config.js';
@@ -25,9 +23,7 @@ import {
   type SignalContainerConfig,
 } from './signal-container.js';
 import { SIGNAL_DEFAULTS, resolveSignalConfig, getSignalDataDir } from './signal-config.js';
-import type { DockerManager } from '../docker/types.js';
-
-const execAsync = promisify(execCb);
+import { checkDockerAvailable } from '../session/preflight.js';
 
 // ---- Cancel handling ------------------------------------------------
 
@@ -54,28 +50,25 @@ export function validatePhoneNumber(value: string | undefined): string | undefin
 
 // ---- Docker validation ----------------------------------------------
 
-async function validateDocker(docker: DockerManager): Promise<void> {
+// We deliberately skip docker.preflight() here: that also requires the
+// signal-cli image to exist, but in this wizard we pull/build it ourselves
+// afterwards. We only need to confirm the daemon is reachable.
+async function validateDocker(): Promise<void> {
   const spinner = p.spinner();
   spinner.start('Checking Docker...');
 
-  try {
-    await docker.preflight(SIGNAL_DEFAULTS.image);
+  const status = await checkDockerAvailable();
+  if (status.available) {
     spinner.stop('Docker is available');
-  } catch {
-    // preflight checks both docker info and image -- we only need docker info here
-    try {
-      // Check if Docker daemon is reachable at all
-      await execAsync('docker info', { timeout: 10_000 });
-      spinner.stop('Docker is available');
-    } catch {
-      spinner.stop('Docker is not available');
-      p.log.error(
-        'Docker is not available. Start Docker and try again.\n\n' +
-          'Install Docker: https://docs.docker.com/get-docker/',
-      );
-      process.exit(1);
-    }
+    return;
   }
+
+  spinner.stop('Docker is not available');
+  p.log.error(
+    `Docker is not available. Start Docker and try again.\n\n${status.detailedMessage}\n\n` +
+      'Install Docker: https://docs.docker.com/get-docker/',
+  );
+  process.exit(1);
 }
 
 // ---- Container setup ------------------------------------------------
@@ -464,8 +457,8 @@ export async function runSignalSetup(options?: { reTrust?: boolean }): Promise<v
   }
 
   // Step 1: Docker check
+  await validateDocker();
   const docker = createDockerManager();
-  await validateDocker(docker);
 
   // Step 2: Pull image and start container
   const containerConfig = resolveContainerConfig();

--- a/src/utils/exec-error.ts
+++ b/src/utils/exec-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared types and helpers for failures produced by `child_process.execFile`
+ * (and `promisify(execFile)`).
+ *
+ * `code` carries different shapes depending on the failure mode: a numeric
+ * process exit code for non-zero exits, a Node errno string (e.g. `'ENOENT'`)
+ * for spawn failures, or `null` when the process was signal-killed (including
+ * timeouts, where `killed === true` and `signal === 'SIGTERM'`).
+ */
+
+export interface ExecError {
+  code: number | string | null;
+  stdout: string;
+  stderr: string;
+  killed?: boolean;
+  signal?: string;
+  message?: string;
+}
+
+export function isExecError(err: unknown): err is ExecError {
+  return typeof err === 'object' && err !== null && 'stdout' in err;
+}
+
+export function isExecTimeout(err: ExecError): boolean {
+  return err.killed === true && err.signal === 'SIGTERM';
+}

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createDockerManager, buildCreateArgs, type ExecFileFn } from '../src/docker/docker-manager.js';
 import type { DockerContainerConfig } from '../src/docker/types.js';
 
@@ -203,24 +203,45 @@ describe('DockerManager', () => {
   describe('preflight', () => {
     it('succeeds when Docker is available and image exists', async () => {
       mock.setResponse('');
-      const manager = createDockerManager(mock.mockExec);
+      const probe = vi.fn().mockResolvedValue({ available: true });
+      const manager = createDockerManager(mock.mockExec, probe);
 
       await expect(manager.preflight('test-image:latest')).resolves.toBeUndefined();
-      expect(mock.calls).toHaveLength(2);
-      expect(mock.calls[0].args).toEqual(['info']);
-      expect(mock.calls[1].args).toEqual(['image', 'inspect', 'test-image:latest']);
+      // Daemon reachability flows through the canonical probe; only the image
+      // inspect call lands on `mock.mockExec`.
+      expect(probe).toHaveBeenCalledTimes(1);
+      expect(mock.calls).toHaveLength(1);
+      expect(mock.calls[0].args).toEqual(['image', 'inspect', 'test-image:latest']);
     });
 
     it('throws when Docker daemon is not available', async () => {
-      mock.setError(1, '', 'Cannot connect to the Docker daemon');
-      const manager = createDockerManager(mock.mockExec);
+      const probe = vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'Docker not available',
+        detailedMessage: 'Cannot connect to the Docker daemon.\nIs the Docker service running?',
+      });
+      const manager = createDockerManager(mock.mockExec, probe);
 
       await expect(manager.preflight('test-image:latest')).rejects.toThrow('Docker is not available');
+      // Image inspect is skipped when the daemon is unreachable.
+      expect(mock.calls).toHaveLength(0);
+    });
+
+    it('surfaces the detailed message when Docker is unavailable', async () => {
+      const probe = vi.fn().mockResolvedValue({
+        available: false,
+        reason: 'Docker not available',
+        detailedMessage: 'Permission denied while connecting to the Docker daemon socket.',
+      });
+      const manager = createDockerManager(mock.mockExec, probe);
+
+      await expect(manager.preflight('test-image:latest')).rejects.toThrow(/Permission denied/);
     });
 
     it('throws when image is not found', async () => {
-      mock.setSequence([{ stdout: '' }, { error: true, code: 1, stderr: 'No such image' }]);
-      const manager = createDockerManager(mock.mockExec);
+      mock.setError(1, '', 'No such image');
+      const probe = vi.fn().mockResolvedValue({ available: true });
+      const manager = createDockerManager(mock.mockExec, probe);
 
       await expect(manager.preflight('missing-image:latest')).rejects.toThrow('Docker image not found');
     });

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { resolveSessionMode, PreflightError, type DockerAvailability } from '../src/session/preflight.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveSessionMode,
+  checkDockerAvailable,
+  PreflightError,
+  type DockerAvailability,
+  type ProbeExecFileFn,
+} from '../src/session/preflight.js';
 import type { IronCurtainConfig } from '../src/config/types.js';
 import type { AgentId } from '../src/docker/agent-adapter.js';
 import type { CredentialSources } from '../src/docker/oauth-credentials.js';
@@ -260,5 +266,126 @@ describe('resolveSessionMode', () => {
         await expect(promise).rejects.toThrow(/Docker/);
       });
     });
+  });
+});
+
+// ---- Helpers for checkDockerAvailable tests --------------------------
+
+/**
+ * Builds the error shape Node's `execFile` produces on `timeout`. We don't
+ * call the real `child_process.execFile` from these tests so we have to
+ * synthesize the expected shape.
+ */
+function makeTimeoutError(): Error {
+  return Object.assign(new Error('Command timed out'), {
+    code: null,
+    killed: true,
+    signal: 'SIGTERM',
+    stdout: '',
+    stderr: '',
+  });
+}
+
+function makeEnoentError(): Error {
+  return Object.assign(new Error('spawn docker ENOENT'), {
+    code: 'ENOENT',
+    stdout: '',
+    stderr: '',
+  });
+}
+
+function makePermissionDeniedError(): Error {
+  return Object.assign(new Error('Command failed'), {
+    code: 1,
+    stdout: '',
+    stderr: 'Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock',
+  });
+}
+
+describe('checkDockerAvailable', () => {
+  it('returns available:true on the first attempt when docker info succeeds', async () => {
+    const execFileFn: ProbeExecFileFn = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+
+    const result = await checkDockerAvailable(execFileFn);
+
+    expect(result).toEqual({ available: true });
+    expect(execFileFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers on the second attempt after a single timeout', async () => {
+    const execFileFn = vi
+      .fn<ProbeExecFileFn>()
+      .mockRejectedValueOnce(makeTimeoutError())
+      .mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    const result = await checkDockerAvailable(execFileFn);
+
+    expect(result).toEqual({ available: true });
+    expect(execFileFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts all attempts on persistent timeouts and reports a timeout-flavored error', async () => {
+    const execFileFn = vi.fn<ProbeExecFileFn>().mockRejectedValue(makeTimeoutError());
+
+    const result = await checkDockerAvailable(execFileFn);
+
+    // 1 initial attempt + 2 retries = 3 total attempts
+    expect(execFileFn).toHaveBeenCalledTimes(3);
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.reason).toBe('Docker not available');
+      expect(result.detailedMessage).toMatch(/did not respond/);
+      expect(result.detailedMessage).toMatch(/3 attempts/);
+    }
+  });
+
+  it('does not retry when docker binary is missing (ENOENT)', async () => {
+    const execFileFn = vi.fn<ProbeExecFileFn>().mockRejectedValue(makeEnoentError());
+
+    const result = await checkDockerAvailable(execFileFn);
+
+    expect(execFileFn).toHaveBeenCalledTimes(1);
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.detailedMessage).toMatch(/not found in your PATH/);
+    }
+  });
+
+  it('does not retry on permission denied', async () => {
+    const execFileFn = vi.fn<ProbeExecFileFn>().mockRejectedValue(makePermissionDeniedError());
+
+    const result = await checkDockerAvailable(execFileFn);
+
+    expect(execFileFn).toHaveBeenCalledTimes(1);
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.detailedMessage).toMatch(/Permission denied/);
+    }
+  });
+
+  it('does not retry when daemon is unreachable (deterministic stderr)', async () => {
+    const execFileFn = vi.fn<ProbeExecFileFn>().mockRejectedValue(
+      Object.assign(new Error('Command failed'), {
+        code: 1,
+        stdout: '',
+        stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+      }),
+    );
+
+    const result = await checkDockerAvailable(execFileFn);
+
+    expect(execFileFn).toHaveBeenCalledTimes(1);
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.detailedMessage).toMatch(/Cannot connect to the Docker daemon/);
+    }
+  });
+
+  it('uses a 10 second per-attempt timeout', async () => {
+    const execFileFn = vi.fn<ProbeExecFileFn>().mockResolvedValue({ stdout: '', stderr: '' });
+
+    await checkDockerAvailable(execFileFn);
+
+    expect(execFileFn).toHaveBeenCalledWith('docker', ['info'], { timeout: 10_000 });
   });
 });

--- a/test/signal/setup-signal.test.ts
+++ b/test/signal/setup-signal.test.ts
@@ -25,10 +25,8 @@ vi.mock('@clack/prompts', () => ({
   },
 }));
 
-vi.mock('node:child_process', () => ({
-  exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: Error | null) => void) => {
-    cb(null);
-  }),
+vi.mock('../../src/session/preflight.js', () => ({
+  checkDockerAvailable: vi.fn().mockResolvedValue({ available: true }),
 }));
 
 vi.mock('node:crypto', async () => {


### PR DESCRIPTION
## Summary

- Consolidates three duplicate `docker info` probes (in `src/session/preflight.ts`, `src/docker/docker-manager.ts`, `src/signal/setup-signal.ts`) into a single canonical `checkDockerAvailable()`. Previously each probe had its own timeout (5s / 10s / 10s) and inconsistent error handling.
- Raises the per-attempt timeout to 10s and retries up to 2 additional times on timeout-class failures (Node's `killed === true && signal === 'SIGTERM'` signature). Deterministic failures (ENOENT, permission denied, "cannot connect to the Docker daemon") bail immediately — they won't change between attempts.
- Extracts `ExecError` / `isExecError` / `isExecTimeout` from `docker-manager.ts` (where they were file-private) into a shared `src/utils/exec-error.ts` so both the manager and the preflight probe use the same typed error helpers.
- Removes a `child_process.exec()` shell-string call in `src/signal/setup-signal.ts` (CLAUDE.md requires `execFile` with argument arrays).

## Why

Bishop Fox testing reported that `ironcurtain start` non-deterministically alternated between `Mode: docker (Docker available, OAuth detected)` and `Mode: builtin (Docker not available)` across back-to-back runs with no environmental change. Root cause: `docker info` is a heavy daemon call that can blow past a tight 5s timeout on cold/busy daemons, and the probe gave up after a single attempt and silently fell back to builtin (forcing the API-key path even when OAuth credentials were available). Three separate copies of the probe with different timeouts compounded the flakiness.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 4254 root tests pass + 338 web-ui tests pass
- [x] New tests in `test/preflight.test.ts` cover: success on first attempt, recovery after one timeout, exhaustion after 3 attempts, no-retry on ENOENT / permission denied / "cannot connect", and 10s per-attempt timeout assertion
- [x] `test/docker-manager.test.ts` updated to inject the canonical probe via DI
- [x] `test/signal/setup-signal.test.ts` simplified to mock the named seam (`checkDockerAvailable`) instead of reaching into `node:child_process`