### PR TITLE
Extract URL normalizers into src/types/url-normalize.ts

### DIFF
--- a/src/trusted-process/domain-utils.ts
+++ b/src/trusted-process/domain-utils.ts
@@ -4,9 +4,13 @@
  * Domain matching (domainMatchesAllowlist, isIpAddress) shared by the
  * PolicyEngine and the list type registry (dynamic-list-types.ts).
  *
- * URL normalization and domain extraction (normalizeUrl, extractDomain,
- * normalizeGitUrl, extractGitDomain, resolveGitRemote) used by the
+ * Domain extraction (extractDomain, extractGitDomain) and git remote
+ * resolution (resolveGitRemote, resolveDefaultGitRemote) used by the
  * policy engine's domain check pipeline and the auto-approver.
+ *
+ * URL canonicalizers (normalizeUrl, normalizeGitUrl) live in
+ * `../types/url-normalize.js` so the ArgumentRole registry can use them
+ * without forming a runtime cycle through this module.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -57,19 +61,8 @@ export function domainMatchesAllowlist(domain: string, allowedDomains: readonly 
 }
 
 // ---------------------------------------------------------------------------
-// URL normalization and domain extraction
+// Domain extraction
 // ---------------------------------------------------------------------------
-
-/** Normalizes an HTTP(S) URL to a canonical form. Returns value as-is on parse failure. */
-export function normalizeUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    if (url.pathname === '/') url.pathname = '';
-    return url.toString().replace(/\/$/, '');
-  } catch {
-    return value;
-  }
-}
 
 /** Extracts the hostname from an HTTP(S) URL. Returns value as-is on parse failure. */
 export function extractDomain(value: string): string {
@@ -78,14 +71,6 @@ export function extractDomain(value: string): string {
   } catch {
     return value;
   }
-}
-
-/** Normalizes a git URL (HTTP or SSH format). SSH URLs are returned as-is. */
-export function normalizeGitUrl(value: string): string {
-  // SSH format: git@host:path -- no further normalization needed
-  const sshMatch = value.match(/^(?:[\w.+-]+@)?([^:]+):/);
-  if (sshMatch && !value.includes('://')) return value;
-  return normalizeUrl(value);
 }
 
 /**

--- a/src/types/argument-roles.ts
+++ b/src/types/argument-roles.ts
@@ -17,7 +17,7 @@
 import { realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { resolve, dirname, basename, join } from 'node:path';
-import { normalizeUrl, normalizeGitUrl } from '../trusted-process/domain-utils.js';
+import { normalizeUrl, normalizeGitUrl } from './url-normalize.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/types/url-normalize.ts
+++ b/src/types/url-normalize.ts
@@ -1,0 +1,31 @@
+/**
+ * URL canonicalizers used by the ArgumentRole registry.
+ *
+ * These pure functions normalize HTTP(S) and git URLs to a canonical form
+ * for security-critical role canonicalization. They live in `src/types/`
+ * (a sink layer) so the registry in `argument-roles.ts` can import them
+ * without creating a runtime cycle through `src/trusted-process/`.
+ *
+ * Domain matching, IP detection, domain extraction, and git remote
+ * resolution remain in `src/trusted-process/domain-utils.ts` because they
+ * are consumed by the policy engine's domain check pipeline.
+ */
+
+/** Normalizes an HTTP(S) URL to a canonical form. Returns value as-is on parse failure. */
+export function normalizeUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.pathname === '/') url.pathname = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return value;
+  }
+}
+
+/** Normalizes a git URL (HTTP or SSH format). SSH URLs are returned as-is. */
+export function normalizeGitUrl(value: string): string {
+  // SSH format: git@host:path -- no further normalization needed
+  const sshMatch = value.match(/^(?:[\w.+-]+@)?([^:]+):/);
+  if (sshMatch && !value.includes('://')) return value;
+  return normalizeUrl(value);
+}

--- a/test/argument-roles.test.ts
+++ b/test/argument-roles.test.ts
@@ -21,11 +21,10 @@ import {
   getUrlRoles,
 } from '../src/types/argument-roles.js';
 import type { ArgumentRole } from '../src/types/argument-roles.js';
+import { normalizeUrl, normalizeGitUrl } from '../src/types/url-normalize.js';
 import {
-  normalizeUrl,
   extractDomain,
   extractDomainForRole,
-  normalizeGitUrl,
   extractGitDomain,
   resolveGitRemote,
 } from '../src/trusted-process/domain-utils.js';


### PR DESCRIPTION
## Summary

- Breaks a runtime import cycle between `src/types/argument-roles.ts` and `src/trusted-process/domain-utils.ts`. The ArgumentRole registry runtime-imported `normalizeUrl` / `normalizeGitUrl` from `trusted-process/`, which in turn type-imports `ArgumentRole` — a runtime cycle through `types/`, the sink layer.
- Moves the two pure URL canonicalizers (`normalizeUrl`, `normalizeGitUrl`) into a new neutral module `src/types/url-normalize.ts`.
- Leaves matchers (`domainMatchesAllowlist`, `isIpAddress`), domain extraction (`extractDomain`, `extractGitDomain`, `extractDomainForRole`), and git remote resolution (`resolveGitRemote`, `resolveDefaultGitRemote`) in `trusted-process/` — they belong with the policy engine's domain check pipeline.
- Pure refactor: no signatures or behavior changed. Addresses an item from the recent layer-violation audit.

## Test plan

- [x] `grep -n "from '\\.\\./types/" src/trusted-process/domain-utils.ts` shows only `import type { ArgumentRole }` (type-only, safe direction)
- [x] `grep -n "from '\\.\\./trusted-process/" src/types/argument-roles.ts` returns nothing
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` — 4283 + 338 passing, 0 failures