### PR TITLE
Generify event bus + move WorkflowManager out of src/web-ui/

### DIFF
--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -719,7 +719,7 @@ export class IronCurtainDaemon {
 
   private async startWebUiServer(): Promise<void> {
     const { WebUiServer } = await import('../web-ui/web-ui-server.js');
-    const { WorkflowManager } = await import('../web-ui/workflow-manager.js');
+    const { WorkflowManager } = await import('../workflow/workflow-manager.js');
     const { TokenStreamBridge } = await import('../web-ui/token-stream-bridge.js');
 
     if (!this.controlRequestHandler) {

--- a/src/event-bus/typed-event-bus.ts
+++ b/src/event-bus/typed-event-bus.ts
@@ -1,0 +1,39 @@
+/**
+ * Generic typed pub/sub event bus.
+ *
+ * Decouples event producers from consumers via a strongly-typed event map.
+ * Each handler receives every emitted event; callers narrow on the event
+ * key. Adding a new event requires updating the consumer's `TMap`, ensuring
+ * all producers and consumers agree on the payload shape at compile time.
+ *
+ * This module is deliberately neutral: it has no dependency on the web UI,
+ * the daemon, or any other consumer. Concrete event maps (e.g. `WebEventMap`)
+ * live alongside their consumers.
+ */
+
+export type EventHandler<TMap> = <K extends keyof TMap & string>(event: K, payload: TMap[K]) => void;
+
+/**
+ * Typed pub/sub bus. Producers call `emit()`; subscribers receive every
+ * event and can narrow on the key to access the typed payload.
+ *
+ * `TMap` is intentionally unconstrained so callers can use ordinary
+ * `interface` declarations (which lack an implicit index signature) for
+ * their event maps.
+ */
+export class TypedEventBus<TMap> {
+  private handlers = new Set<EventHandler<TMap>>();
+
+  subscribe(handler: EventHandler<TMap>): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  emit<K extends keyof TMap & string>(event: K, payload: TMap[K]): void {
+    for (const handler of this.handlers) {
+      handler(event, payload);
+    }
+  }
+}

--- a/src/web-ui/dispatch/workflow-dispatch.ts
+++ b/src/web-ui/dispatch/workflow-dispatch.ts
@@ -27,7 +27,7 @@ import {
   MethodNotFoundError,
   toHumanGateRequestDto,
 } from '../web-ui-types.js';
-import type { PastRunLoadSuccess, WorkflowManager } from '../workflow-manager.js';
+import type { PastRunLoadSuccess, WorkflowManager } from '../../workflow/workflow-manager.js';
 import type { WorkflowId, WorkflowStatus, WorkflowCheckpoint, WorkflowDefinition } from '../../workflow/types.js';
 import type { WorkflowDetail } from '../../workflow/orchestrator.js';
 import { MessageLog, type MessageLogEntry, type StateTransitionEntry } from '../../workflow/message-log.js';

--- a/src/web-ui/dispatch/workflow-dispatch.ts
+++ b/src/web-ui/dispatch/workflow-dispatch.ts
@@ -25,10 +25,15 @@ import {
   type PastRunPhase,
   RpcError,
   MethodNotFoundError,
-  toHumanGateRequestDto,
 } from '../web-ui-types.js';
 import type { PastRunLoadSuccess, WorkflowManager } from '../../workflow/workflow-manager.js';
-import type { WorkflowId, WorkflowStatus, WorkflowCheckpoint, WorkflowDefinition } from '../../workflow/types.js';
+import {
+  toHumanGateRequestDto,
+  type WorkflowId,
+  type WorkflowStatus,
+  type WorkflowCheckpoint,
+  type WorkflowDefinition,
+} from '../../workflow/types.js';
 import type { WorkflowDetail } from '../../workflow/orchestrator.js';
 import { MessageLog, type MessageLogEntry, type StateTransitionEntry } from '../../workflow/message-log.js';
 import {

--- a/src/web-ui/web-event-bus.ts
+++ b/src/web-ui/web-event-bus.ts
@@ -8,13 +8,8 @@
  * broadcasts to all connected WebSocket clients.
  */
 
-import type {
-  SessionDto,
-  BudgetSummaryDto,
-  DaemonStatusDto,
-  EscalationDto,
-  HumanGateRequestDto,
-} from './web-ui-types.js';
+import type { SessionDto, BudgetSummaryDto, DaemonStatusDto, EscalationDto } from './web-ui-types.js';
+import type { HumanGateRequestDto } from '../workflow/types.js';
 import type { DiagnosticEvent } from '../session/types.js';
 import type { RunRecord } from '../cron/types.js';
 import type { TokenStreamEvent } from '../docker/token-stream-types.js';

--- a/src/web-ui/web-event-bus.ts
+++ b/src/web-ui/web-event-bus.ts
@@ -1,9 +1,11 @@
 /**
- * Typed pub/sub event bus for web UI events.
+ * Web UI event map and typed bus.
  *
- * Decouples event producers (daemon internals, transports) from
- * WebSocket consumers. The WebUiServer subscribes and broadcasts
- * to all connected clients.
+ * The transport-neutral pub/sub mechanics live in
+ * {@link ../event-bus/typed-event-bus.js | TypedEventBus}; this file owns
+ * the web-flavored event map and the `WebEventBus` alias used by the
+ * daemon, transports, and dispatch layer. The WebUiServer subscribes and
+ * broadcasts to all connected WebSocket clients.
  */
 
 import type {
@@ -16,6 +18,7 @@ import type {
 import type { DiagnosticEvent } from '../session/types.js';
 import type { RunRecord } from '../cron/types.js';
 import type { TokenStreamEvent } from '../docker/token-stream-types.js';
+import { TypedEventBus, type EventHandler } from '../event-bus/typed-event-bus.js';
 
 /**
  * Typed event map. Each key maps to a specific payload type.
@@ -81,25 +84,12 @@ export interface WebEventMap {
 }
 
 export type WebEventName = keyof WebEventMap;
-export type WebEventHandler = <K extends WebEventName>(event: K, payload: WebEventMap[K]) => void;
+export type WebEventHandler = EventHandler<WebEventMap>;
 
 /**
- * Typed pub/sub bus for web UI events.
- * Producers call emit(); the WebUiServer subscribes and broadcasts to WS clients.
+ * Typed pub/sub bus for web UI events. Thin alias over the generic
+ * {@link TypedEventBus} that fixes the event map to {@link WebEventMap}.
+ * Producers call `emit()`; the WebUiServer subscribes and broadcasts to
+ * WS clients.
  */
-export class WebEventBus {
-  private handlers = new Set<WebEventHandler>();
-
-  subscribe(handler: WebEventHandler): () => void {
-    this.handlers.add(handler);
-    return () => {
-      this.handlers.delete(handler);
-    };
-  }
-
-  emit<K extends WebEventName>(event: K, payload: WebEventMap[K]): void {
-    for (const handler of this.handlers) {
-      handler(event, payload);
-    }
-  }
-}
+export class WebEventBus extends TypedEventBus<WebEventMap> {}

--- a/src/web-ui/web-ui-server.ts
+++ b/src/web-ui/web-ui-server.ts
@@ -21,7 +21,7 @@ import type { TokenStreamBridge } from './token-stream-bridge.js';
 import { WebEventBus } from './web-event-bus.js';
 import { type RequestFrame, type ResponseFrame, type EventFrame, RpcError } from './web-ui-types.js';
 import { dispatch, buildStatusDto, type WorkflowDispatchContext } from './json-rpc-dispatch.js';
-import type { WorkflowManager } from './workflow-manager.js';
+import type { WorkflowManager } from '../workflow/workflow-manager.js';
 import { wsDataToString } from './ws-utils.js';
 import * as logger from '../logger.js';
 

--- a/src/web-ui/web-ui-types.ts
+++ b/src/web-ui/web-ui-types.ts
@@ -6,7 +6,7 @@ import type { SessionSource } from '../session/session-manager.js';
 import type { SessionStatus, DiagnosticEvent, ConversationTurn } from '../session/types.js';
 import type { JobDefinition, RunRecord } from '../cron/types.js';
 import type { WhitelistCandidateIpc } from '../trusted-process/approval-whitelist.js';
-import type { HumanGateRequest, WorkflowId } from '../workflow/types.js';
+import type { WorkflowId, HumanGateRequestDto } from '../workflow/types.js';
 import type { MessageLogEntry } from '../workflow/message-log.js';
 
 // Re-export MessageLogEntry so frontends can import it from the wire-types
@@ -268,34 +268,6 @@ export interface TransitionRecordDto {
   readonly durationMs: number;
   /** Summary of the agent output that produced this transition. */
   readonly agentMessage?: string;
-}
-
-export interface HumanGateRequestDto {
-  readonly gateId: string;
-  readonly workflowId: string;
-  readonly stateName: string;
-  readonly acceptedEvents: readonly string[];
-  /** Artifact names only (not content). */
-  readonly presentedArtifacts: readonly string[];
-  readonly summary: string;
-}
-
-/**
- * Converts a domain HumanGateRequest to the JSON-serializable DTO.
- *
- * HumanGateRequest.presentedArtifacts is a ReadonlyMap<string, string>
- * which does not serialize to JSON. This converter extracts the keys
- * as a plain array.
- */
-export function toHumanGateRequestDto(gate: HumanGateRequest): HumanGateRequestDto {
-  return {
-    gateId: gate.gateId,
-    workflowId: gate.workflowId,
-    stateName: gate.stateName,
-    acceptedEvents: gate.acceptedEvents,
-    presentedArtifacts: Array.from(gate.presentedArtifacts.keys()),
-    summary: gate.summary,
-  };
 }
 
 export interface WorkflowContextDto {

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -452,6 +452,32 @@ export interface HumanGateRequest {
   readonly summary: string;
 }
 
+/**
+ * JSON-serializable view of HumanGateRequest. The domain type's
+ * `presentedArtifacts` is a `ReadonlyMap` which doesn't JSON-encode;
+ * the DTO replaces it with the artifact names as a plain array.
+ */
+export interface HumanGateRequestDto {
+  readonly gateId: string;
+  readonly workflowId: string;
+  readonly stateName: string;
+  readonly acceptedEvents: readonly string[];
+  /** Artifact names only (not content). */
+  readonly presentedArtifacts: readonly string[];
+  readonly summary: string;
+}
+
+export function toHumanGateRequestDto(gate: HumanGateRequest): HumanGateRequestDto {
+  return {
+    gateId: gate.gateId,
+    workflowId: gate.workflowId,
+    stateName: gate.stateName,
+    acceptedEvents: gate.acceptedEvents,
+    presentedArtifacts: Array.from(gate.presentedArtifacts.keys()),
+    summary: gate.summary,
+  };
+}
+
 export interface HumanGateEvent {
   readonly type: HumanGateEventType;
   readonly prompt?: string;

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -17,8 +17,9 @@ import { formatHelp, type CommandSpec } from '../cli-help.js';
 import { FileCheckpointStore } from './checkpoint.js';
 import { discoverWorkflows, resolveWorkflowPath, parseDefinitionFile } from './discovery.js';
 import { discoverWorkflowRuns } from './workflow-discovery.js';
-import { WorkflowManager } from '../web-ui/workflow-manager.js';
-import { WebEventBus } from '../web-ui/web-event-bus.js';
+import { WorkflowManager } from './workflow-manager.js';
+import { TypedEventBus } from '../event-bus/typed-event-bus.js';
+import type { WebEventMap } from '../web-ui/web-event-bus.js';
 import { countBySeverity, lintWorkflow, type Diagnostic } from './lint.js';
 import { defaultLintContext, runPreflight, type LintMode } from './lint-integration.js';
 import { loadDefinition } from './definition-loader.js';
@@ -429,10 +430,13 @@ function runInspect(args: string[]): void {
   // WorkflowManager owns the canonical "load a past run" logic. We point it at
   // the user-supplied baseDir via `baseDirOverride` so the same loader works
   // for both the daemon's home directory and arbitrary `inspect` targets.
-  // The CLI never starts workflows through this manager, so the EventBus is
+  // The CLI never starts workflows through this manager, so the event bus is
   // a no-op sink and the orchestrator created lazily inside the manager is
   // never used to spawn sessions.
-  const manager = new WorkflowManager({ eventBus: new WebEventBus(), baseDirOverride: baseDir });
+  const manager = new WorkflowManager({
+    eventBus: new TypedEventBus<WebEventMap>(),
+    baseDirOverride: baseDir,
+  });
 
   for (const run of runs) {
     const workflowId = run.workflowId;

--- a/src/workflow/workflow-manager.ts
+++ b/src/workflow/workflow-manager.ts
@@ -31,10 +31,15 @@ import { findLatestResumableCheckpoint } from './checkpoint-selection.js';
 import { loadDefinition } from './definition-loader.js';
 import type { TypedEventBus } from '../event-bus/typed-event-bus.js';
 import type { WebEventMap } from '../web-ui/web-event-bus.js';
-import { type HumanGateRequestDto, toHumanGateRequestDto } from '../web-ui/web-ui-types.js';
 import { getIronCurtainHome } from '../config/paths.js';
 import { loadConfig } from '../config/index.js';
-import type { WorkflowId, WorkflowCheckpoint, WorkflowDefinition } from './types.js';
+import {
+  type HumanGateRequestDto,
+  toHumanGateRequestDto,
+  type WorkflowId,
+  type WorkflowCheckpoint,
+  type WorkflowDefinition,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // loadPastRun result types

--- a/src/workflow/workflow-manager.ts
+++ b/src/workflow/workflow-manager.ts
@@ -1,9 +1,18 @@
 /**
- * WorkflowManager -- owns WorkflowOrchestrator instances for the web UI.
+ * WorkflowManager -- owns WorkflowOrchestrator instances for the web UI
+ * and the CLI inspect path.
  *
  * Analogous to SessionManager: the daemon creates one WorkflowManager
  * at startup and passes it into the dispatch context. Lifecycle events
- * from the orchestrator are forwarded to the WebEventBus.
+ * from the orchestrator are forwarded to the supplied event bus, which
+ * the WebUiServer subscribes to.
+ *
+ * Layered under `src/workflow/` (rather than `src/web-ui/`) so that
+ * non-web consumers (CLI, signal bot daemon) can reuse it without
+ * pulling in the web UI module. The event bus parameter is typed
+ * against the generic {@link TypedEventBus} fixed to {@link WebEventMap}
+ * so existing callers can keep passing `WebEventBus` instances; the
+ * `WebEventMap` is a type-only import and adds no runtime coupling.
  */
 
 import { mkdirSync, copyFileSync, existsSync } from 'node:fs';
@@ -15,16 +24,17 @@ import {
   type WorkflowTabHandle,
   type WorkflowLifecycleEvent,
   type WorkflowController,
-} from '../workflow/orchestrator.js';
-import { FileCheckpointStore } from '../workflow/checkpoint.js';
-import { createWorkflowSessionFactory } from '../workflow/cli-support.js';
-import { findLatestResumableCheckpoint } from '../workflow/checkpoint-selection.js';
-import { loadDefinition } from '../workflow/definition-loader.js';
-import type { WebEventBus } from './web-event-bus.js';
-import { type HumanGateRequestDto, toHumanGateRequestDto } from './web-ui-types.js';
+} from './orchestrator.js';
+import { FileCheckpointStore } from './checkpoint.js';
+import { createWorkflowSessionFactory } from './cli-support.js';
+import { findLatestResumableCheckpoint } from './checkpoint-selection.js';
+import { loadDefinition } from './definition-loader.js';
+import type { TypedEventBus } from '../event-bus/typed-event-bus.js';
+import type { WebEventMap } from '../web-ui/web-event-bus.js';
+import { type HumanGateRequestDto, toHumanGateRequestDto } from '../web-ui/web-ui-types.js';
 import { getIronCurtainHome } from '../config/paths.js';
 import { loadConfig } from '../config/index.js';
-import type { WorkflowId, WorkflowCheckpoint, WorkflowDefinition } from '../workflow/types.js';
+import type { WorkflowId, WorkflowCheckpoint, WorkflowDefinition } from './types.js';
 
 // ---------------------------------------------------------------------------
 // loadPastRun result types
@@ -79,7 +89,7 @@ function describeError(err: unknown): string {
 // ---------------------------------------------------------------------------
 
 export interface WorkflowManagerOptions {
-  readonly eventBus: WebEventBus;
+  readonly eventBus: TypedEventBus<WebEventMap>;
   /**
    * Optional override for the base directory under which workflow runs are
    * stored. Defaults to `{getIronCurtainHome()}/workflow-runs`. The CLI
@@ -95,7 +105,7 @@ export interface WorkflowManagerOptions {
 
 export class WorkflowManager {
   private orchestrator: WorkflowOrchestrator | null = null;
-  private readonly eventBus: WebEventBus;
+  private readonly eventBus: TypedEventBus<WebEventMap>;
   private readonly baseDirOverride: string | undefined;
 
   constructor(options: WorkflowManagerOptions) {
@@ -332,7 +342,7 @@ export class WorkflowManager {
     };
   }
 
-  /** Maps WorkflowLifecycleEvent to WebEventBus events. */
+  /** Maps WorkflowLifecycleEvent to web event bus events. */
   private forwardLifecycleEvent(event: WorkflowLifecycleEvent): void {
     switch (event.kind) {
       case 'started':

--- a/test/workflow-dispatch.test.ts
+++ b/test/workflow-dispatch.test.ts
@@ -37,7 +37,7 @@ import type {
   WorkflowDefinition,
 } from '../src/workflow/types.js';
 import type { ControlRequestHandler } from '../src/daemon/control-socket.js';
-import type { PastRunLoadSuccess, WorkflowManager, PastRunLoadResult } from '../src/web-ui/workflow-manager.js';
+import type { PastRunLoadSuccess, WorkflowManager, PastRunLoadResult } from '../src/workflow/workflow-manager.js';
 import type { FileCheckpointStore } from '../src/workflow/checkpoint.js';
 
 // ---------------------------------------------------------------------------

--- a/test/workflow-lint-dispatch.test.ts
+++ b/test/workflow-lint-dispatch.test.ts
@@ -21,7 +21,7 @@ import type { Diagnostic } from '../src/workflow/lint.js';
 import type { WorkflowController } from '../src/workflow/orchestrator.js';
 import type { WorkflowId } from '../src/workflow/types.js';
 import type { ControlRequestHandler } from '../src/daemon/control-socket.js';
-import type { WorkflowManager } from '../src/web-ui/workflow-manager.js';
+import type { WorkflowManager } from '../src/workflow/workflow-manager.js';
 import type { FileCheckpointStore } from '../src/workflow/checkpoint.js';
 
 // ---------------------------------------------------------------------------

--- a/test/workflow-manager.test.ts
+++ b/test/workflow-manager.test.ts
@@ -32,7 +32,7 @@ vi.mock('../src/workflow/cli-support.js', async (importOriginal) => {
   };
 });
 
-import { WorkflowManager } from '../src/web-ui/workflow-manager.js';
+import { WorkflowManager } from '../src/workflow/workflow-manager.js';
 import { WebEventBus } from '../src/web-ui/web-event-bus.js';
 import type { WorkflowId, WorkflowCheckpoint, WorkflowContext, WorkflowDefinition } from '../src/workflow/types.js';
 


### PR DESCRIPTION
## Summary

Pure refactor (no behavior change) — part of the layer-violation backlog.

- **Extract `TypedEventBus`** from `src/web-ui/web-event-bus.ts` into a transport-neutral `src/event-bus/typed-event-bus.ts`. The mechanics had zero web-specific code; only the `WebEventMap` type was web-flavored. The `WebEventBus` class is preserved as a thin alias subclass (`class WebEventBus extends TypedEventBus<WebEventMap> {}`), so every existing call site continues to work unchanged.
- **Move `WorkflowManager`** from `src/web-ui/workflow-manager.ts` to `src/workflow/workflow-manager.ts`. The CLI `workflow inspect` subcommand was reaching into `src/web-ui/` to construct a `WorkflowManager`; the file now lives where it belongs. Its constructor parameter is loosened from `WebEventBus` to `TypedEventBus<WebEventMap>` — the latter is the generic plus a type-only event-map import (zero runtime web-ui coupling).
- The CLI inspect site constructs a no-op `TypedEventBus<WebEventMap>()` directly. The runtime layer violation is gone.

### Motivation

The Signal bot daemon (`src/signal/`) is a near-term consumer that will want to observe workflow/session lifecycle events without pulling in the web UI. Generifying the bus and relocating `WorkflowManager` unblocks that.

## Test plan

- [x] `grep -rn "from '\.\./web-ui/" src/workflow/` — only type-only `WebEventMap` imports + pre-existing `web-ui-types` value imports remain (the original runtime violation in `workflow-command.ts` is gone)
- [x] `grep -rn "WebEventBus" src/ test/` — alias survives at every existing call site (no churn in transports/dispatch/web-ui-server)
- [x] `npx tsc --noEmit` clean
- [x] `npm run format` clean
- [x] `npm run lint` clean
- [x] `npm test` — 4283 passed, 53 skipped, 1 todo (200 test files)

## Notes / follow-ups

- `WorkflowManager` retains a value import of `toHumanGateRequestDto` from `src/web-ui/web-ui-types.js` (pre-existing edge — the file already imported it before relocation; not part of this refactor's scope).
- TypeScript's `class TypedEventBus<TMap>` is invariant on `TMap`, so passing a `TypedEventBus<WebEventMap>` into a slot typed `TypedEventBus<WorkflowEventMap>` is not assignable. The "extract a narrower `WorkflowEventMap`" path was therefore not taken; the spec's easier alternative (keep `WebEventMap`) was used. Narrowing can be a follow-up if needed.