### PR TITLE
Extract getListMatcher into src/trusted-process/list-matcher.ts

### DIFF
--- a/src/pipeline/dynamic-list-types.ts
+++ b/src/pipeline/dynamic-list-types.ts
@@ -4,11 +4,12 @@
  * Each type determines:
  * - How values are validated during resolution
  * - What format guidance is appended to the generation prompt
- * - How values are matched against tool call arguments at evaluation time
+ *
+ * Runtime value/pattern matching lives in `src/trusted-process/list-matcher.ts`
+ * so the policy engine does not depend on the offline pipeline layer.
  */
 
 import type { ListType } from './types.js';
-import { domainMatchesAllowlist } from '../trusted-process/domain-utils.js';
 
 export interface ListTypeDef {
   readonly description: string;
@@ -78,18 +79,3 @@ export const LIST_TYPE_REGISTRY: ReadonlyMap<ListType, ListTypeDef> = new Map<Li
     },
   ],
 ]);
-
-/**
- * Returns a matcher function for the given list type.
- * The matcher checks whether a value matches a pattern from the allowed list.
- */
-export function getListMatcher(type: ListType): (value: string, pattern: string) => boolean {
-  switch (type) {
-    case 'domains':
-      return (v, p) => domainMatchesAllowlist(v, [p]);
-    case 'emails':
-      return (v, p) => v.toLowerCase() === p.toLowerCase();
-    case 'identifiers':
-      return (v, p) => v === p;
-  }
-}

--- a/src/trusted-process/list-matcher.ts
+++ b/src/trusted-process/list-matcher.ts
@@ -25,5 +25,9 @@ export function getListMatcher(type: ListType): (value: string, pattern: string)
       return (v, p) => v.toLowerCase() === p.toLowerCase();
     case 'identifiers':
       return (v, p) => v === p;
+    default: {
+      const _exhaustive: never = type;
+      throw new Error(`Unknown list type: ${String(_exhaustive)}`);
+    }
   }
 }

--- a/src/trusted-process/list-matcher.ts
+++ b/src/trusted-process/list-matcher.ts
@@ -1,0 +1,29 @@
+/**
+ * List matcher -- runtime value/pattern matching for dynamic list types.
+ *
+ * Used by the PolicyEngine when evaluating `ListCondition` rules: given a
+ * `ListType`, returns a comparator that tests whether a tool-call argument
+ * value matches an entry from the resolved allow list.
+ *
+ * Lives in the trusted-process layer (not the offline pipeline) because it
+ * runs on the policy hot path. The compile-time concerns (validators,
+ * format guidance, the type registry) stay in `src/pipeline/dynamic-list-types.ts`.
+ */
+
+import type { ListType } from '../pipeline/types.js';
+import { domainMatchesAllowlist } from './domain-utils.js';
+
+/**
+ * Returns a matcher function for the given list type.
+ * The matcher checks whether a value matches a pattern from the allowed list.
+ */
+export function getListMatcher(type: ListType): (value: string, pattern: string) => boolean {
+  switch (type) {
+    case 'domains':
+      return (v, p) => domainMatchesAllowlist(v, [p]);
+    case 'emails':
+      return (v, p) => v.toLowerCase() === p.toLowerCase();
+    case 'identifiers':
+      return (v, p) => v === p;
+  }
+}

--- a/src/trusted-process/policy-engine.ts
+++ b/src/trusted-process/policy-engine.ts
@@ -42,7 +42,7 @@ import {
   resolveDefaultGitRemote,
   extractDomainForRole,
 } from './domain-utils.js';
-import { getListMatcher } from '../pipeline/dynamic-list-types.js';
+import { getListMatcher } from './list-matcher.js';
 
 /**
  * Extracts string values from arguments based on annotation roles.

--- a/test/dynamic-lists.test.ts
+++ b/test/dynamic-lists.test.ts
@@ -12,7 +12,8 @@ import {
   validateCompiledRules,
   type CompilerConfig,
 } from '../src/pipeline/constitution-compiler.js';
-import { LIST_TYPE_REGISTRY, getListMatcher } from '../src/pipeline/dynamic-list-types.js';
+import { LIST_TYPE_REGISTRY } from '../src/pipeline/dynamic-list-types.js';
+import { getListMatcher } from '../src/trusted-process/list-matcher.js';
 import { resolveList, resolveAllLists, type ListResolverConfig } from '../src/pipeline/list-resolver.js';
 import { buildGeneratorSystemPrompt, formatDynamicListsSection } from '../src/pipeline/scenario-generator.js';
 import { buildJudgeSystemPrompt } from '../src/pipeline/policy-verifier.js';


### PR DESCRIPTION
## Summary

The `PolicyEngine` runtime-imported `getListMatcher` from `src/pipeline/dynamic-list-types.ts`, crossing from the security kernel into the offline pipeline layer. The file mixed two independent concerns:

- **Compile-time** (validators, `LIST_TYPE_REGISTRY`, `ListTypeDef`) — used by `src/pipeline/list-resolver.ts` during artifact generation. Stays in `dynamic-list-types.ts`.
- **Runtime** (`getListMatcher`) — only consumer is `PolicyEngine`. Moves to `src/trusted-process/list-matcher.ts`, naturally aligned with its dependency `domainMatchesAllowlist` (already a sibling in the trusted-process layer).

Pure move — no behavior change, no signature change. The new file uses a type-only import from `../pipeline/types.js` for `ListType`, which is acceptable per the existing layer-audit conventions (pipeline/types is treated as schema-shape and many other trusted-process files already do this).

Updates the single runtime importer (`policy-engine.ts:45`), the test file (`test/dynamic-lists.test.ts`), drops the now-unused `domainMatchesAllowlist` import from `dynamic-list-types.ts`, and refreshes its file-header JSDoc to point at the new home.

Part of the layer-violation refactor backlog (item #3).

## Test plan

- [x] `grep -n "from '\.\./pipeline/" src/trusted-process/list-matcher.ts` — only the type-only `ListType` import remains
- [x] `grep -n "from '\.\./pipeline/dynamic-list-types" src/` — empty (runtime import path gone)
- [x] `grep -n "domainMatchesAllowlist" src/pipeline/dynamic-list-types.ts` — empty (import removed)
- [x] `grep -rn "getListMatcher" src/ test/` — definition in new file, single import + single call site in `policy-engine.ts`, plus the existing test consumer now pointing at the new path
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` — 4283 passed / 53 skipped / 1 todo (200 files); web UI: 338 passed (18 files)