### PR TITLE
Extract llm-logger from pipeline/ to observability/

### DIFF
--- a/src/observability/llm-logger.ts
+++ b/src/observability/llm-logger.ts
@@ -1,10 +1,15 @@
 /**
- * LLM Interaction Logger -- AI SDK middleware that captures all LLM
- * prompts and responses during the policy compilation pipeline.
+ * LLM Interaction Logger -- AI SDK middleware that captures LLM
+ * prompts and responses to a JSONL file.
+ *
+ * Used by any AI SDK call site that wants to record LLM interactions:
+ * the offline policy compilation pipeline (per-phase, full-prompt logging)
+ * as well as runtime call sites such as the sandbox and the agent session
+ * (long-running conversations, delta logging).
  *
  * Uses `wrapLanguageModel()` with a custom middleware that intercepts
  * every `doGenerate` call. The caller sets `context.stepName` before
- * each pipeline phase so logs are labeled without changing module APIs.
+ * each phase so logs are labeled without changing module APIs.
  *
  * Writes a single JSONL file with one entry per LLM call.
  */

--- a/src/pipeline/pipeline-runner.ts
+++ b/src/pipeline/pipeline-runner.ts
@@ -54,7 +54,7 @@ import {
 import { filterInvalidSchemaScenarios } from './scenario-schema-validator.js';
 import { buildGeneratorSystemPrompt, generateScenarios, repairScenarios } from './scenario-generator.js';
 import { prefilterServers } from './server-prefilter.js';
-import type { LlmLogContext } from './llm-logger.js';
+import type { LlmLogContext } from '../observability/llm-logger.js';
 import type { PromptCacheStrategy } from '../session/prompt-cache.js';
 import { connectViaProxy, type ProxyConnection } from './proxy-mcp-connections.js';
 import type {

--- a/src/pipeline/pipeline-shared.ts
+++ b/src/pipeline/pipeline-shared.ts
@@ -27,7 +27,7 @@ import type { MCPServerConfig } from '../config/types.js';
 import { loadUserConfig } from '../config/user-config.js';
 import type { CompiledRule, ToolAnnotationsFile, StoredToolAnnotationsFile } from './types.js';
 import { resolveRealPath, resolveStoredAnnotationsFile } from '../types/argument-roles.js';
-import { createLlmLoggingMiddleware, type LlmLogContext } from './llm-logger.js';
+import { createLlmLoggingMiddleware, type LlmLogContext } from '../observability/llm-logger.js';
 import { createCacheStrategy, type PromptCacheStrategy } from '../session/prompt-cache.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -35,7 +35,7 @@ import {
 } from './ironcurtain-protocol.js';
 import * as logger from '../logger.js';
 import { wrapLanguageModel } from 'ai';
-import { createLlmLoggingMiddleware } from '../pipeline/llm-logger.js';
+import { createLlmLoggingMiddleware } from '../observability/llm-logger.js';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 
 // Workaround: UTCP creates MCP SDK Client instances without setting a per-request

--- a/src/session/agent-session.ts
+++ b/src/session/agent-session.ts
@@ -22,7 +22,7 @@ import {
 } from 'ai';
 import { z } from 'zod';
 import { createLanguageModel } from '../config/model-provider.js';
-import { createLlmLoggingMiddleware, type LlmLogContext } from '../pipeline/llm-logger.js';
+import { createLlmLoggingMiddleware, type LlmLogContext } from '../observability/llm-logger.js';
 import type { IronCurtainConfig } from '../config/types.js';
 import * as logger from '../logger.js';
 import type { Sandbox } from '../sandbox/index.js';

--- a/test/llm-logger.test.ts
+++ b/test/llm-logger.test.ts
@@ -4,7 +4,7 @@ import { wrapLanguageModel, generateText, Output } from 'ai';
 import { z } from 'zod';
 import { readFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { createLlmLoggingMiddleware, type LlmLogContext, type LlmLogEntry } from '../src/pipeline/llm-logger.js';
+import { createLlmLoggingMiddleware, type LlmLogContext, type LlmLogEntry } from '../src/observability/llm-logger.js';
 
 const TEST_DIR = resolve('/tmp', `llm-logger-test-${process.pid}`);
 const LOG_PATH = resolve(TEST_DIR, 'test-interactions.jsonl');


### PR DESCRIPTION
## Summary

- `src/pipeline/` is offline tooling (the policy compiler). Runtime modules `sandbox/` and `session/` were importing `createLlmLoggingMiddleware` from there, which is a layer violation in the same vein as the recent `getListMatcher` extraction (#219).
- Move `llm-logger.ts` to a new `src/observability/` directory. The new home leaves room for future structured-runtime-data utilities (metric counters, audit-stream tailers, etc.) without crowding the top level or `pipeline/`.
- Pure file move plus import path updates -- no API or behavior changes. The file's JSDoc header was updated to reflect that it serves both the pipeline and runtime AI SDK call sites.

## Files moved / updated

- `src/pipeline/llm-logger.ts` -> `src/observability/llm-logger.ts` (rename, 91% similarity per git)
- Import path updates in: `src/pipeline/pipeline-runner.ts`, `src/pipeline/pipeline-shared.ts`, `src/sandbox/index.ts`, `src/session/agent-session.ts`, `test/llm-logger.test.ts`

## Test plan

- [x] `grep -rn "pipeline/llm-logger"` returns no matches
- [x] `npm run format` clean
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` -- 196 test files passed (4283 tests passed, 53 skipped, 1 todo); web UI 18 files / 338 tests passed