### PR TITLE
Move session error hierarchy from session/ to types/

### DIFF
--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -30,7 +30,7 @@ import { loadAllJobs, loadJob, saveJob, deleteJob, saveRunRecord, loadRecentRuns
 import { compileTaskPolicy } from '../cron/compile-task-policy.js';
 import type { JobDefinition, JobId, RunRecord, RunOutcome } from '../cron/types.js';
 import { CRON_BUDGET_DEFAULTS } from '../cron/types.js';
-import { BudgetExhaustedError } from '../session/errors.js';
+import { BudgetExhaustedError } from '../types/errors.js';
 import { validateWorkspacePath } from '../session/workspace-validation.js';
 import * as logger from '../logger.js';
 import { getDaemonLogPath } from '../config/paths.js';

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -47,7 +47,7 @@ import type { IronCurtainConfig } from '../config/types.js';
 import type { DockerInfrastructure } from './docker-infrastructure.js';
 import { destroyDockerInfrastructure } from './docker-infrastructure.js';
 import { AuditLogTailer } from './audit-log-tailer.js';
-import { SessionNotReadyError, SessionClosedError } from '../session/errors.js';
+import { SessionNotReadyError, SessionClosedError } from '../types/errors.js';
 import { createEscalationWatcher, atomicWriteJsonSync } from '../escalation/escalation-watcher.js';
 import type { EscalationWatcher } from '../escalation/escalation-watcher.js';
 import * as logger from '../logger.js';

--- a/src/memory/auto-save.ts
+++ b/src/memory/auto-save.ts
@@ -9,7 +9,7 @@ import type { Session, ConversationTurn } from '../session/types.js';
 import type { IronCurtainConfig } from '../config/types.js';
 import type { PersonaDefinition } from '../persona/types.js';
 import type { JobDefinition } from '../cron/types.js';
-import { BudgetExhaustedError } from '../session/errors.js';
+import { BudgetExhaustedError } from '../types/errors.js';
 import { isMemoryEnabledFor } from './memory-policy.js';
 import { loadPersona } from '../persona/resolve.js';
 import { createPersonaName } from '../persona/types.js';

--- a/src/session/agent-session.ts
+++ b/src/session/agent-session.ts
@@ -26,7 +26,7 @@ import { createLlmLoggingMiddleware, type LlmLogContext } from '../observability
 import type { IronCurtainConfig } from '../config/types.js';
 import * as logger from '../logger.js';
 import type { Sandbox } from '../sandbox/index.js';
-import { SessionNotReadyError, SessionClosedError, BudgetExhaustedError } from './errors.js';
+import { SessionNotReadyError, SessionClosedError, BudgetExhaustedError } from '../types/errors.js';
 import { MessageCompactor } from './message-compactor.js';
 import { createCacheStrategy, type PromptCacheStrategy } from './prompt-cache.js';
 import { buildSystemPrompt, type ServerListing } from './prompts.js';

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -39,7 +39,7 @@ import type { PersonaDefinition } from '../persona/types.js';
 import { createJobId } from '../cron/types.js';
 import { loadJob } from '../cron/job-store.js';
 import { AgentSession } from './agent-session.js';
-import { SessionError } from './errors.js';
+import { SessionError } from '../types/errors.js';
 import { saveSessionMetadata, saveSessionMetadataTo, loadSessionMetadata } from './session-metadata.js';
 import { createAgentConversationId, createSessionId } from './types.js';
 import type {
@@ -683,6 +683,6 @@ export type {
   BudgetStatus,
 } from './types.js';
 export type { Transport } from './transport.js';
-export { SessionError, SessionNotReadyError, SessionClosedError, BudgetExhaustedError } from './errors.js';
+export { SessionError, SessionNotReadyError, SessionClosedError, BudgetExhaustedError } from '../types/errors.js';
 export { resolveSessionMode, PreflightError } from './preflight.js';
 export type { PreflightResult, PreflightOptions } from './preflight.js';

--- a/src/signal/signal-bot-daemon.ts
+++ b/src/signal/signal-bot-daemon.ts
@@ -36,7 +36,7 @@ import {
   type JobListEntry,
   type SessionListEntry,
 } from './format.js';
-import { BudgetExhaustedError } from '../session/errors.js';
+import { BudgetExhaustedError } from '../types/errors.js';
 import * as logger from '../logger.js';
 
 /** How often to proactively verify the recipient's identity key (ms). */

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,6 +1,12 @@
 /**
- * Base class for session-related errors. Uses a discriminant
- * `code` field for programmatic handling without instanceof checks.
+ * Session error class hierarchy. Lives in `src/types/` rather than
+ * `src/session/` so that domain modules (e.g., `memory/auto-save.ts`)
+ * can catch session-thrown errors without importing back into the
+ * composition layer. Errors are throw-from-anywhere / catch-anywhere
+ * by nature, so the leaf position is the natural home.
+ *
+ * Uses a discriminant `code` field for programmatic handling without
+ * instanceof checks.
  */
 export class SessionError extends Error {
   constructor(

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -21,7 +21,7 @@ import { WebSessionTransport } from '../web-session-transport.js';
 import { loadConfig } from '../../config/index.js';
 import { createStandaloneSession } from '../../session/index.js';
 import { shouldAutoSaveMemory } from '../../memory/auto-save.js';
-import { BudgetExhaustedError } from '../../session/errors.js';
+import { BudgetExhaustedError } from '../../types/errors.js';
 import { getTokenStreamBus } from '../../docker/token-stream-bus.js';
 import * as logger from '../../logger.js';
 

--- a/test/auto-save-memory.test.ts
+++ b/test/auto-save-memory.test.ts
@@ -13,7 +13,7 @@ import { saveSessionMemory, shouldAutoSaveMemory } from '../src/memory/auto-save
 import type { IronCurtainConfig } from '../src/config/types.js';
 import type { Session, SessionInfo, ConversationTurn } from '../src/session/types.js';
 import type { PersonaDefinition, PersonaName } from '../src/persona/types.js';
-import { BudgetExhaustedError } from '../src/session/errors.js';
+import { BudgetExhaustedError } from '../src/types/errors.js';
 
 /** Minimal persona scope for the auto-save gate (persona present => eligible for memory when not opted out). */
 function makePersonaScope(): { persona: PersonaDefinition } {

--- a/test/policy-dir-validation.test.ts
+++ b/test/policy-dir-validation.test.ts
@@ -38,7 +38,7 @@ describe('policyDir containment validation', () => {
     }));
 
     const { createSession } = await import('../src/session/index.js');
-    const { SessionError } = await import('../src/session/errors.js');
+    const { SessionError } = await import('../src/types/errors.js');
     const { loadConfig } = await import('../src/config/index.js');
 
     const config = loadConfig();


### PR DESCRIPTION
## Summary

- `src/memory/auto-save.ts` (a domain module) imported `BudgetExhaustedError` from `src/session/errors.ts` (a composition-layer module). That was the only real layer violation in a small architectural audit pass.
- Errors are throw-from-anywhere / catch-anywhere by nature, so moving the entire hierarchy (`SessionError`, `SessionErrorCode`, `SessionNotReadyError`, `SessionClosedError`, `BudgetExhaustedError`) to `src/types/` -- the existing leaf-shaped home for shared types -- removes the violation cleanly without weakening the typing of any catch site.
- The public re-export from `src/session/index.ts` is preserved (just repointed at `../types/errors.js`), so callers that imported via the session barrel (including `test/session.test.ts`) keep working unchanged.

Pure move plus import-path updates. No API changes, no behavior changes. Names and shapes of all five exports are identical.

## Files touched

- New: `src/types/errors.ts` (rename target; updated header doc explains the leaf-position rationale).
- Deleted: `src/session/errors.ts`.
- Repathed: `src/session/index.ts` (both the internal import and the public re-export), `src/session/agent-session.ts`, `src/daemon/ironcurtain-daemon.ts`, `src/signal/signal-bot-daemon.ts`, `src/docker/docker-agent-session.ts`, `src/memory/auto-save.ts` (the actual layer-violation fix), `src/web-ui/dispatch/session-dispatch.ts`, `test/auto-save-memory.test.ts`, `test/policy-dir-validation.test.ts` (dynamic `await import(...)` string).

## Test plan

- [x] `grep -rn "session/errors" src/ test/ packages/` returns no matches
- [x] `npm run format` clean
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` -- 4283 passed / 53 skipped / 1 todo across 196 main-suite files, plus 338 web UI tests across 18 files