### PR TITLE
Remove silent fallback to builtin agent (explicit preferredMode)

### DIFF
--- a/docs/designs/explicit-agent-mode.md
+++ b/docs/designs/explicit-agent-mode.md
@@ -1,0 +1,300 @@
+# Explicit Agent Mode (no silent fallback)
+
+## Motivation
+
+Bishop Fox testers Aaron and Ben spent significant time debugging the wrong session mode because IronCurtain silently fell back from Docker to the builtin V8 sandbox when Docker detection failed. PR #213 already eliminated transient Docker-probe flakiness (10s per-attempt timeout, up to 2 retries). The remaining behavioral fix is to stop the silent fallback itself: builtin must be a deliberate choice, not a degraded default.
+
+This design replaces auto-detect with an explicit `preferredMode` config field. The Docker path is the default; if Docker is unavailable, the session errors out with a remediation hint instead of dropping into builtin.
+
+## Decisions (already settled, do not re-debate)
+
+- Drop silent fallback. No `'auto'` mode.
+- New `preferredMode: 'docker' | 'builtin'` in `UserConfig`. Default `'docker'`.
+- `--agent` CLI flag wins over `preferredMode`.
+- `preferredDockerAgent` (`'claude-code' | 'goose'`) continues to gate which Docker agent runs.
+- No backward-compatibility carve-outs — single user, accepts churn.
+
+## Naming
+
+`preferredMode` is preferred over alternatives like `defaultAgent`, `runtimeMode`, or `sessionMode` because:
+
+- It composes cleanly with the existing `preferredDockerAgent`. Reading the config, "preferred mode = docker, preferred docker agent = claude-code" parses left-to-right.
+- "Mode" matches the existing `Mode: ...` print line and the `SessionMode` discriminated union in `src/session/types.ts`. The config field name and the runtime concept share vocabulary.
+- "Preferred" telegraphs intent (this is the user's preference) without implying fallback semantics — important now that we've removed silent fallback. If Docker is unavailable, the preference is unmet and we error; we do not silently substitute.
+
+## Control flow
+
+`resolveSessionMode()` keeps its current top-level shape. Only `resolveAutoDetect()` changes: rename to `resolveDefaultMode()` (no auto-detection happens anymore) and dispatch on `preferredMode`.
+
+```ts
+async function resolveSessionMode(options: PreflightOptions): Promise<PreflightResult> {
+  const { config, requestedAgent, credentialSources } = options;
+  const isDockerAvailable = options.isDockerAvailable ?? checkDockerAvailable;
+
+  if (requestedAgent !== undefined) {
+    return resolveExplicit(requestedAgent, config, isDockerAvailable, credentialSources);
+  }
+
+  return resolveDefaultMode(config, isDockerAvailable, credentialSources);
+}
+
+async function resolveDefaultMode(
+  config: IronCurtainConfig,
+  isDockerAvailable: () => Promise<DockerAvailability>,
+  credentialSources?: CredentialSources,
+): Promise<PreflightResult> {
+  const { preferredMode, preferredDockerAgent } = config.userConfig;
+
+  if (preferredMode === 'builtin') {
+    // Builtin requires an Anthropic API key; OAuth is unusable here.
+    const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
+    if (apiKey.length === 0) {
+      throw new PreflightError(builtinNeedsApiKeyMessage());
+    }
+    return { mode: { kind: 'builtin' }, reason: 'preferredMode = builtin' };
+  }
+
+  // preferredMode === 'docker' — the default branch.
+  const dockerStatus = await isDockerAvailable();
+  if (!dockerStatus.available) {
+    throw new PreflightError(dockerUnavailableMessage(dockerStatus.detailedMessage));
+  }
+
+  const credKind = await detectCredentials(preferredDockerAgent, config, credentialSources);
+  if (credKind === null) {
+    throw new PreflightError(
+      credentialErrorMessageForPreferredMode(preferredDockerAgent, config, credentialSources),
+    );
+  }
+
+  return {
+    mode: { kind: 'docker', agent: preferredDockerAgent, authKind: credKind },
+    reason: `${preferredDockerAgent} (${credKind === 'oauth' ? 'OAuth' : 'API key'})`,
+  };
+}
+```
+
+The OAuth-only-without-Docker special case at `preflight.ts:244-250` collapses into the general `preferredMode === 'docker'` branch: Docker unavailable now errors unconditionally regardless of which credentials the user holds. The OAuth message becomes one variant of `dockerUnavailableMessage()` content rather than a separately-thrown branch.
+
+`resolveExplicit()` is unchanged — explicit `--agent` already errors on missing prerequisites, and continues to call the existing `credentialErrorMessageForExplicit()` (renamed from `credentialErrorMessage`) so its `--agent ${agentId} requires authentication...` wording stays correct.
+
+## `UserConfig` schema change
+
+Field: `preferredMode: 'docker' | 'builtin'`, default `'docker'`. Lives in `src/config/user-config.ts` alongside `preferredDockerAgent`.
+
+```ts
+export const SESSION_MODES = ['docker', 'builtin'] as const;
+export type SessionModeKind = (typeof SESSION_MODES)[number];
+
+// In userConfigSchema:
+preferredMode: z.enum(SESSION_MODES).optional(),
+
+// In USER_CONFIG_DEFAULTS:
+preferredMode: 'docker',
+
+// In ResolvedUserConfig:
+readonly preferredMode: SessionModeKind;
+
+// In mergeWithDefaults:
+preferredMode: config.preferredMode ?? USER_CONFIG_DEFAULTS.preferredMode,
+```
+
+The `SESSION_MODES` tuple deliberately mirrors the `DOCKER_AGENTS` / `GOOSE_PROVIDERS` pattern already used in this file — readable for the config editor, derivable as a Zod enum, exported for tests.
+
+All touch-points the implementer must hit when adding `preferredMode` (omitting any of these breaks the field silently):
+
+1. `SESSION_MODES` const tuple (new export at top of file).
+2. `SessionModeKind` type alias derived from the tuple.
+3. `userConfigSchema` Zod field — `preferredMode: z.enum(SESSION_MODES).optional()`.
+4. `USER_CONFIG_DEFAULTS` value — `preferredMode: 'docker'`.
+5. `ResolvedUserConfig` field — `readonly preferredMode: SessionModeKind`.
+6. `mergeWithDefaults` merge line (around the `preferredDockerAgent` sibling, currently ~line 639) — `preferredMode: config.preferredMode ?? USER_CONFIG_DEFAULTS.preferredMode`.
+7. `computeDiff` — extend the `topLevelKeys` tuple in `src/config/config-command.ts` so `preferredMode` is included when diffing pending changes against resolved config.
+
+## Print-line behavior
+
+On success, the existing `Mode: ...` line in `src/index.ts:127` continues to render with the `reason` field from `PreflightResult`. The reason strings change to reflect explicit selection. The line already starts with `Mode: <kind>`, so the parenthetical no longer needs to repeat the mode — instead we surface the agent (useful for PTY-mode users):
+
+- `Mode: docker / claude-code (OAuth)`
+- `Mode: docker / claude-code (API key)`
+- `Mode: docker / goose (API key)`
+- `Mode: builtin` (no parenthetical)
+
+The corresponding `reason` strings produced by `resolveDefaultMode` (and consumed by the print formatter):
+
+- Docker branch: `reason = "${preferredDockerAgent} (${credKind === 'oauth' ? 'OAuth' : 'API key'})"` — formatter renders `Mode: docker / ${reason}`.
+- Builtin branch: `reason = "preferredMode = builtin"` — formatter detects builtin kind and prints just `Mode: builtin`.
+
+`resolveExplicit()` should keep its current `reason` shape; the formatter is the only place that decides whether to append the parenthetical.
+
+On `PreflightError`, no `Mode:` line is printed. The CLI catches the error in its top-level handler, writes the error message to stderr, and exits 1. (This is already the behavior for explicit `--agent` failures — the auto-detect path now joins it.)
+
+## Error wording
+
+All four error messages must be self-explanatory: include the failure cause, the one-shot CLI escape, and the permanent config escape.
+
+### `dockerUnavailableMessage(detailedMessage: string)`
+
+```
+Cannot start IronCurtain.
+preferredMode is "docker" but Docker is not available:
+
+<dockerStatus.detailedMessage indented or rendered as-is>
+
+To run this session in builtin mode, pass:
+  --agent builtin
+
+To make builtin the default permanently, run:
+  ironcurtain config
+and set Session Mode > Preferred mode to "builtin".
+
+Run `ironcurtain doctor` for a full diagnostic.
+```
+
+### `builtinNeedsApiKeyMessage()`
+
+```
+Cannot start IronCurtain.
+preferredMode is "builtin" but no ANTHROPIC_API_KEY is configured.
+Builtin mode talks to Anthropic directly using an API key — Claude OAuth credentials are not usable in builtin mode.
+
+To run this session in Docker mode, pass:
+  --agent claude-code
+
+To make Docker the default permanently, run:
+  ironcurtain config
+and set Session Mode > Preferred mode to "docker".
+
+Set ANTHROPIC_API_KEY in your environment, or run `ironcurtain config`.
+```
+
+### `credentialErrorMessageForPreferredMode(agentId, config, credentialSources)`
+
+A new variant that reads symmetric with the two helpers above. The existing helper hard-codes `--agent ${agentId} requires authentication...`, which mis-attributes the cause when the user never passed `--agent`. Splitting into two helpers keeps each call site honest:
+
+- `credentialErrorMessageForExplicit(agentId, config)` — current wording, used only by `resolveExplicit()`.
+- `credentialErrorMessageForPreferredMode(agentId, config, credentialSources)` — new, used by `resolveDefaultMode()`.
+
+The preferred-mode variant:
+
+```
+Cannot start IronCurtain.
+preferredMode is "docker" but no credentials are configured for "<agentId>".
+
+<provider-specific guidance — e.g., 'Set ANTHROPIC_API_KEY' for claude-code,
+ 'Set <provider>_API_KEY' for goose>
+
+To run this session in builtin mode, pass:
+  --agent builtin
+
+To make builtin the default permanently, run:
+  ironcurtain config
+and set Session Mode > Preferred mode to "builtin".
+```
+
+### Goose + OAuth-only addendum
+
+When `preferredDockerAgent === 'goose'` and the only Anthropic credentials present are OAuth (no API key), the base message says `requires an API key for provider "anthropic". Set ANTHROPIC_API_KEY...` — which leaves a tester who just ran `claude login` wondering why their auth doesn't help. `credentialErrorMessageForPreferredMode` (and the explicit variant for symmetry) inspects `credentialSources` and, when goose is the agent and Anthropic OAuth is present, appends one extra line:
+
+```
+OAuth credentials are not usable with goose; provider "anthropic" requires an API key.
+```
+
+This is purely additive — the rest of the message is unchanged.
+
+(The old `credentialErrorMessage()` helper is renamed to `credentialErrorMessageForExplicit()`; both call sites — old and new — are updated in the same patch.)
+
+## Edge cases
+
+| Scenario | Outcome |
+| --- | --- |
+| `--agent builtin` + `preferredMode: 'docker'` | CLI wins. `resolveExplicit('builtin', ...)` returns builtin without checking Docker or the API key (current behavior). Documented in the test plan to lock the gap in. |
+| `--agent claude-code` + `preferredMode: 'builtin'` | CLI wins. `resolveExplicit('claude-code', ...)` checks Docker and errors with the existing message if unavailable. |
+| `preferredMode: 'docker'` + `preferredDockerAgent: 'goose'` + only Anthropic OAuth credentials | `detectCredentials('goose', ...)` looks at the goose provider's API key, finds none, returns `null` → `credentialErrorMessageForPreferredMode('goose', config, credentialSources)` fires. The message names goose's provider explicitly and appends the "OAuth not usable with goose" line because Anthropic OAuth was detected. |
+| `preferredMode: 'builtin'` + only OAuth (no `ANTHROPIC_API_KEY`) | New explicit check at the top of the builtin branch errors with `builtinNeedsApiKeyMessage()` before any Docker probe. Fast failure — no 10s docker probe wasted. |
+| `preferredMode: 'docker'` + Docker available + `ANTHROPIC_API_KEY` set + OAuth credentials present | Unchanged from today: `detectAuthMethod()` prefers OAuth; session runs Docker mode with OAuth. |
+
+## Interactive config editor
+
+Add a top-level menu entry `Session Mode (<hint>)` between `Memory` and `Docker Agent`. Submenu has one prompt: "Preferred mode" with `Docker (recommended)` and `Builtin (V8 sandbox)` options.
+
+```ts
+{ value: 'sessionMode', label: `Session Mode (${sessionModeHint(resolved, pending)})` }
+```
+
+`sessionModeHint` returns `'Docker'` or `'Builtin'`. Implementation mirrors the existing `handleDockerAgent` shape (single-field submenu with a Back option). The new `preferredMode` field also joins the `topLevelKeys` array in `computeDiff()` (see schema touch-point #7).
+
+The Docker Agent submenu remains a peer — `preferredDockerAgent` is still meaningful when `preferredMode === 'builtin'` because `--agent claude-code` overrides only mode, not which Docker agent.
+
+## Doctor command impact
+
+Two changes in `src/doctor/`:
+
+1. **Surface the resolved preferred mode and treat declared-but-unmet preferences as failures.** Add `checkPreferredMode(config: IronCurtainConfig, dockerResult: CheckResult)` to the `Configuration` section, called immediately after `checkConfigLoad` so it consumes the already-loaded config (mirrors `checkPolicyArtifacts(config)` shape — no re-load, no second probe).
+
+   The function reuses the prior `dockerResult` so Docker is probed exactly once per `doctor` run, and then maps the (preferredMode × dockerResult × api-key-presence) tuple to a status:
+
+   | `preferredMode` | `dockerResult` | API key present | `checkPreferredMode` status |
+   | --- | --- | --- | --- |
+   | `docker` | `ok` | (any) | `ok` — `Preferred mode: docker` |
+   | `docker` | `warn` (unavailable) | (any) | `fail` — `Preferred mode: docker, but Docker is unavailable. Sessions will refuse to start.` |
+   | `builtin` | (any) | yes | `ok` — `Preferred mode: builtin` |
+   | `builtin` | (any) | no | `warn` — `Preferred mode: builtin, but no ANTHROPIC_API_KEY configured. Sessions will fail.` |
+
+   Doctor's overall exit code is the worst status across all checks, so a `fail` here makes `ironcurtain doctor` exit 1 in exactly the cases where a session would refuse to start. This is a deliberate change from the prior behavior — under deny-fallback semantics, a declared-but-unmet preference is a real diagnostic problem, not advisory.
+
+2. **`checkDocker` itself is unchanged.** It continues to return `warn` (not `fail`) on unavailability — the contextual interpretation (`warn` is bad if `preferredMode === 'docker'`, fine if `preferredMode === 'builtin'`) is moved entirely into `checkPreferredMode`. Keeping `checkDocker` semantically agnostic preserves its reusability and concentrates the policy decision in one place.
+
+(Optional DI seam: `checkPreferredMode` may also accept an `isDockerAvailable` injection for tests that want to drive both checks from a single fake. Not required if the doctor command always runs `checkDocker` first and threads the result.)
+
+No changes to `--check-api`, MCP liveness probes, or the credential checks.
+
+## Test plan
+
+In `test/preflight.test.ts`, replace the auto-detect block with a `resolveDefaultMode` block covering:
+
+- `preferredMode: 'docker'` + Docker available + Anthropic API key → `mode.kind === 'docker'`, agent `claude-code`, authKind `apikey`.
+- `preferredMode: 'docker'` + Docker available + OAuth (no API key) → mode docker, authKind `oauth`.
+- `preferredMode: 'docker'` + Docker available + `preferredDockerAgent: 'goose'` + goose provider key set → mode docker, agent `goose`.
+- `preferredMode: 'docker'` + Docker available + `preferredDockerAgent: 'goose'` + only Anthropic OAuth → throws PreflightError matching `goose` credential message AND containing the `OAuth credentials are not usable with goose` line.
+- `preferredMode: 'docker'` + Docker unavailable → throws PreflightError matching `Docker is not available`, includes `--agent builtin` hint and `ironcurtain config` hint.
+- `preferredMode: 'docker'` + Docker available + no credentials at all → throws PreflightError from `credentialErrorMessageForPreferredMode` (NOT the explicit-mode helper — assert the message does not contain `--agent claude-code requires authentication`).
+- `preferredMode: 'builtin'` + Anthropic API key → mode builtin, no Docker probe attempted (verify probe is never called).
+- `preferredMode: 'builtin'` + OAuth only → throws PreflightError matching `no ANTHROPIC_API_KEY`.
+- `preferredMode: 'builtin'` + nothing configured → same PreflightError as OAuth-only.
+- `--agent builtin` + `preferredMode: 'docker'` → mode builtin (CLI overrides config).
+- `--agent builtin` + `preferredMode: 'builtin'` + no API key → mode builtin returned successfully (the API-key check is intentionally skipped on the explicit path; agent loop fails later on the actual API call). This test exists to lock the asymmetry in — anyone "tightening" `resolveExplicit` to mirror the default path's API-key check should have to delete this test on purpose.
+- `--agent claude-code` + `preferredMode: 'builtin'` + Docker unavailable → throws (existing explicit-mode message — assert it still uses `credentialErrorMessageForExplicit`'s `--agent claude-code requires...` wording).
+
+Add one assertion-level test for `userConfigSchema`: rejects `preferredMode: 'auto'` with a clear message.
+
+For the config editor (if it has tests), assert that toggling `preferredMode` lands a `preferredMode` field in the saved partial.
+
+For `src/doctor/`, add tests covering `checkPreferredMode`:
+
+- `preferredMode: 'docker'` + `dockerResult.status === 'warn'` → `checkPreferredMode` returns `fail`; full doctor run exits 1.
+- `preferredMode: 'docker'` + `dockerResult.status === 'ok'` → `checkPreferredMode` returns `ok`.
+- `preferredMode: 'builtin'` + no API key → `checkPreferredMode` returns `warn`; full doctor run still exits 0 (warn alone doesn't fail).
+- `preferredMode: 'builtin'` + API key present → `checkPreferredMode` returns `ok`.
+
+## Files touched
+
+- `src/config/user-config.ts` — add `SESSION_MODES`/`SessionModeKind`, schema field, default, resolved field, merge (touch-points 1–6 in the schema section).
+- `src/config/config-command.ts` — new `Session Mode` menu entry, handler, hint, and `topLevelKeys` update (touch-point 7).
+- `src/session/preflight.ts` — rename `resolveAutoDetect` → `resolveDefaultMode`, replace body, drop OAuth-only special case, add `dockerUnavailableMessage` / `builtinNeedsApiKeyMessage` helpers, rename `credentialErrorMessage` → `credentialErrorMessageForExplicit`, add `credentialErrorMessageForPreferredMode` (with goose+OAuth addendum).
+- `src/index.ts` (or wherever the `Mode:` print line lives) — update the formatter to render `Mode: <kind> / <reason>` for docker and `Mode: builtin` for builtin.
+- `src/doctor/checks.ts` — new `checkPreferredMode(config, dockerResult)` function.
+- `src/doctor/doctor-command.ts` — call `checkPreferredMode` in the `Configuration` section, threading the prior `dockerResult`.
+- `test/preflight.test.ts` — replace auto-detect cases per the test plan above; add the `--agent builtin` no-API-key lock-in test and the goose+OAuth message-content test.
+- `test/user-config.test.ts` (or equivalent) — add `preferredMode` schema assertions.
+- `test/doctor.test.ts` (or equivalent) — add `checkPreferredMode` tests including the `docker-required-but-down → exit 1` case.
+
+## Out of scope
+
+- Auditing Docker detection technique. PR #213 already addressed flakiness; this design only changes what we do with the result.
+- Adding a third `preferredMode` value (e.g., `'auto'`, `'pty'`). The whole point is to remove ambiguity.
+- Changing `--agent` semantics. The flag continues to override config and to skip auto-selection logic entirely.
+- Migrating existing config files. The user-base accepts churn; missing `preferredMode` resolves to the `'docker'` default automatically via `mergeWithDefaults`, which is the same as the prior auto-detect behavior on a Docker-up host.
+- Cross-cutting changes to `ironcurtain doctor` exit codes beyond the targeted change in `checkPreferredMode`. Other checks' `warn`/`fail` semantics are unchanged.
+- Tightening the `--agent builtin` explicit path to require an API key. Today `resolveExplicit('builtin', ...)` succeeds without an API-key check and the agent loop fails later on the actual API call; the test plan locks this gap in deliberately so a future "symmetry" refactor doesn't silently regress it. If that asymmetry needs to go, it's a separate design.
+- Removing `preferredDockerAgent` or merging it into `preferredMode`. The agent dimension (which Docker agent) is orthogonal to the mode dimension (Docker vs builtin); collapsing them into a single `preferredAgent: 'docker-claude-code' | 'docker-goose' | 'builtin'` would re-introduce the ambiguity this design is meant to remove.

--- a/src/config/config-command.ts
+++ b/src/config/config-command.ts
@@ -21,11 +21,13 @@ import {
   WEB_SEARCH_PROVIDER_URLS,
   GOOSE_PROVIDERS,
   DOCKER_AGENTS,
+  SESSION_MODES,
   type UserConfig,
   type ResolvedUserConfig,
   type WebSearchProvider,
   type GooseProvider,
   type DockerAgent,
+  type SessionModeKind,
 } from './user-config.js';
 import { getUserConfigPath } from './paths.js';
 import type { MCPServerConfig } from './types.js';
@@ -108,6 +110,7 @@ export function computeDiff(resolved: ResolvedUserConfig, pending: UserConfig): 
     'gooseProvider',
     'gooseModel',
     'preferredDockerAgent',
+    'preferredMode',
   ] as const;
   for (const key of topLevelKeys) {
     if (key in pending && pending[key] !== undefined && pending[key] !== resolved[key]) {
@@ -714,6 +717,59 @@ async function handleServerCredentials(resolved: ResolvedUserConfig, pending: Us
   }
 }
 
+// ─── Session Mode ─────────────────────────────────────────────
+
+/** Human-readable labels for session modes. */
+const SESSION_MODE_LABELS: Readonly<Record<SessionModeKind, string>> = {
+  docker: 'Docker (recommended)',
+  builtin: 'Builtin (V8 sandbox)',
+};
+
+/** Short labels used in hints (no parenthetical). */
+const SESSION_MODE_SHORT_LABELS: Readonly<Record<SessionModeKind, string>> = {
+  docker: 'Docker',
+  builtin: 'Builtin',
+};
+
+async function handleSessionMode(resolved: ResolvedUserConfig, pending: UserConfig): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- interactive loop exited via return
+  while (true) {
+    const currentMode = pending.preferredMode ?? resolved.preferredMode;
+
+    const field = await p.select({
+      message: 'Session Mode',
+      options: [
+        {
+          value: 'preferredMode',
+          label: 'Preferred mode',
+          hint: SESSION_MODE_LABELS[currentMode],
+        },
+        { value: 'back', label: 'Back' },
+      ],
+    });
+    if (isCancelled(field) || field === 'back') return;
+
+    if (field === 'preferredMode') {
+      const modeOptions = SESSION_MODES.map((mode) => ({
+        value: mode,
+        label: SESSION_MODE_LABELS[mode],
+        hint: mode === currentMode ? '(current)' : undefined,
+      }));
+
+      const selected = await p.select({
+        message: 'Select preferred session mode:',
+        options: modeOptions,
+        initialValue: currentMode,
+      });
+      if (isCancelled(selected)) continue;
+      const mode = selected as SessionModeKind;
+      if (mode !== currentMode) {
+        pending.preferredMode = mode;
+      }
+    }
+  }
+}
+
 // ─── Docker Agent Settings ────────────────────────────────────
 
 /** Human-readable labels for Goose providers. */
@@ -888,6 +944,10 @@ function dockerAgentHint(resolved: ResolvedUserConfig, pending: UserConfig): str
   return DOCKER_AGENT_LABELS[pending.preferredDockerAgent ?? resolved.preferredDockerAgent];
 }
 
+function sessionModeHint(resolved: ResolvedUserConfig, pending: UserConfig): string {
+  return SESSION_MODE_SHORT_LABELS[pending.preferredMode ?? resolved.preferredMode];
+}
+
 function changeCount(resolved: ResolvedUserConfig, pending: UserConfig): string {
   const diffs = computeDiff(resolved, pending);
   if (diffs.length === 0) return 'no changes';
@@ -931,6 +991,7 @@ export async function runConfigCommand(): Promise<void> {
         { value: 'websearch', label: `Web Search (${webSearchHint(resolved, pending)})` },
         { value: 'credentials', label: `Server Credentials (${serverCredentialsHint(resolved, pending)})` },
         { value: 'memory', label: `Memory (${memoryHint(resolved, pending)})` },
+        { value: 'sessionMode', label: `Session Mode (${sessionModeHint(resolved, pending)})` },
         { value: 'dockerAgent', label: `Docker Agent (${dockerAgentHint(resolved, pending)})` },
         { value: 'save', label: 'Save & Exit', hint: changeCount(resolved, pending) },
         { value: 'cancel', label: 'Cancel', hint: 'discard all changes' },
@@ -962,6 +1023,9 @@ export async function runConfigCommand(): Promise<void> {
         break;
       case 'memory':
         await handleMemory(resolved, pending);
+        break;
+      case 'sessionMode':
+        await handleSessionMode(resolved, pending);
         break;
       case 'dockerAgent':
         await handleDockerAgent(resolved, pending);

--- a/src/config/user-config.ts
+++ b/src/config/user-config.ts
@@ -39,6 +39,7 @@ export const USER_CONFIG_DEFAULTS = {
   auditRedaction: {
     enabled: true,
   },
+  preferredMode: 'docker',
 } as const;
 
 export const ESCALATION_TIMEOUT_MIN = 30;
@@ -204,6 +205,9 @@ export type GooseProvider = (typeof GOOSE_PROVIDERS)[number];
 export const DOCKER_AGENTS = ['claude-code', 'goose'] as const;
 export type DockerAgent = (typeof DOCKER_AGENTS)[number];
 
+export const SESSION_MODES = ['docker', 'builtin'] as const;
+export type SessionModeKind = (typeof SESSION_MODES)[number];
+
 export const userConfigSchema = z.object({
   agentModelId: qualifiedModelId.optional(),
   policyModelId: qualifiedModelId.optional(),
@@ -231,6 +235,7 @@ export const userConfigSchema = z.object({
   gooseProvider: z.enum(GOOSE_PROVIDERS).optional(),
   gooseModel: z.string().min(1).optional(),
   preferredDockerAgent: z.enum(DOCKER_AGENTS).optional(),
+  preferredMode: z.enum(SESSION_MODES).optional(),
   packageInstall: packageInstallSchema,
 });
 
@@ -316,6 +321,8 @@ export interface ResolvedUserConfig {
   readonly gooseModel: string;
   /** Preferred Docker agent for auto-detection. */
   readonly preferredDockerAgent: DockerAgent;
+  /** Preferred session mode: 'docker' (default) or 'builtin'. */
+  readonly preferredMode: SessionModeKind;
   /** Package installation proxy configuration. */
   readonly packageInstall: ResolvedPackageInstallConfig;
 }
@@ -358,6 +365,7 @@ const DEFAULT_CONFIG_CONTENT =
       autoCompact: USER_CONFIG_DEFAULTS.autoCompact,
       autoApprove: USER_CONFIG_DEFAULTS.autoApprove,
       auditRedaction: USER_CONFIG_DEFAULTS.auditRedaction,
+      preferredMode: USER_CONFIG_DEFAULTS.preferredMode,
     },
     null,
     2,
@@ -637,6 +645,7 @@ function mergeWithDefaults(config: UserConfig): ResolvedUserConfig {
     gooseProvider: config.gooseProvider ?? 'anthropic',
     gooseModel: config.gooseModel ?? 'claude-sonnet-4-20250514',
     preferredDockerAgent: config.preferredDockerAgent ?? 'claude-code',
+    preferredMode: config.preferredMode ?? USER_CONFIG_DEFAULTS.preferredMode,
     packageInstall: {
       enabled: config.packageInstall?.enabled ?? true,
       quarantineDays: config.packageInstall?.quarantineDays ?? 2,

--- a/src/cron/job-commands.ts
+++ b/src/cron/job-commands.ts
@@ -589,10 +589,10 @@ export async function runJobCommand(jobIdStr: string): Promise<void> {
   const job = loadJobOrExit(jobIdStr);
 
   console.error(`Running job "${job.name}"...`);
-  const { resolveSessionMode } = await import('../session/preflight.js');
+  const { resolveSessionMode, formatModeLine } = await import('../session/preflight.js');
   const { loadConfig } = await import('../config/index.js');
   const preflight = await resolveSessionMode({ config: loadConfig() });
-  console.error(`Mode: ${preflight.mode.kind} (${preflight.reason})`);
+  console.error(formatModeLine(preflight));
   const { IronCurtainDaemon } = await import('../daemon/ironcurtain-daemon.js');
   const daemon = new IronCurtainDaemon({ mode: preflight.mode, noSignal: true });
   const record = await daemon.runJobNow(job.id);

--- a/src/cron/job-commands.ts
+++ b/src/cron/job-commands.ts
@@ -592,7 +592,7 @@ export async function runJobCommand(jobIdStr: string): Promise<void> {
   const { resolveSessionMode, formatModeLine } = await import('../session/preflight.js');
   const { loadConfig } = await import('../config/index.js');
   const preflight = await resolveSessionMode({ config: loadConfig() });
-  console.error(formatModeLine(preflight));
+  process.stderr.write(`${formatModeLine(preflight)}\n`);
   const { IronCurtainDaemon } = await import('../daemon/ironcurtain-daemon.js');
   const daemon = new IronCurtainDaemon({ mode: preflight.mode, noSignal: true });
   const record = await daemon.runJobNow(job.id);

--- a/src/daemon/daemon-command.ts
+++ b/src/daemon/daemon-command.ts
@@ -116,7 +116,7 @@ export async function runDaemonCommand(argv: string[]): Promise<void> {
     requestedAgent: values.agent ? (values.agent as AgentId) : undefined,
   });
   const mode = preflight.mode;
-  console.error(formatModeLine(preflight));
+  process.stderr.write(`${formatModeLine(preflight)}\n`);
 
   if (!subcommand) {
     // Start the daemon

--- a/src/daemon/daemon-command.ts
+++ b/src/daemon/daemon-command.ts
@@ -109,14 +109,14 @@ export async function runDaemonCommand(argv: string[]): Promise<void> {
   const subcommand = positionals[0];
 
   // Resolve session mode (same as `start` command)
-  const { resolveSessionMode } = await import('../session/preflight.js');
+  const { resolveSessionMode, formatModeLine } = await import('../session/preflight.js');
   const { loadConfig } = await import('../config/index.js');
   const preflight = await resolveSessionMode({
     config: loadConfig(),
     requestedAgent: values.agent ? (values.agent as AgentId) : undefined,
   });
   const mode = preflight.mode;
-  console.error(`Mode: ${mode.kind} (${preflight.reason})`);
+  console.error(formatModeLine(preflight));
 
   if (!subcommand) {
     // Start the daemon

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -107,7 +107,7 @@ export async function checkDocker(
  *   - preferredMode: 'docker' + Docker ok          -> ok
  *   - preferredMode: 'docker' + Docker unavailable -> fail (sessions will refuse to start)
  *   - preferredMode: 'builtin' + API key present   -> ok
- *   - preferredMode: 'builtin' + no API key        -> warn (sessions will fail later)
+ *   - preferredMode: 'builtin' + no API key        -> warn (sessions will fail to start by default)
  */
 export function checkPreferredMode(config: IronCurtainConfig, dockerResult: CheckResult): CheckResult {
   const preferredMode = config.userConfig.preferredMode;

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -77,10 +77,10 @@ export async function checkSandbox(): Promise<CheckResult> {
 }
 
 /**
- * Reports Docker daemon status. Returns `warn` (not `fail`) on unavailability
- * because the builtin agent runs without Docker — doctor doesn't know whether
- * the user intends to run Docker mode, so it surfaces the issue without
- * forcing a non-zero exit.
+ * Reports Docker daemon status. Returns `warn` (not `fail`) on unavailability —
+ * `checkPreferredMode` decides whether the warn is fatal based on the
+ * user's `preferredMode`. Keeping this check semantically agnostic lets it
+ * be reused in contexts that don't care about preferred mode.
  */
 export async function checkDocker(
   probe: () => Promise<DockerAvailability> = checkDockerAvailable,
@@ -94,6 +94,46 @@ export async function checkDocker(
     status: 'warn',
     message: 'unavailable',
     hint: status.detailedMessage,
+  };
+}
+
+/**
+ * Reports whether the user's `preferredMode` is satisfiable on this host.
+ *
+ * Reuses the prior `dockerResult` from `checkDocker` so Docker is probed
+ * exactly once per `doctor` run. Maps the (preferredMode × dockerResult ×
+ * api-key-presence) tuple to a status:
+ *
+ *   - preferredMode: 'docker' + Docker ok          -> ok
+ *   - preferredMode: 'docker' + Docker unavailable -> fail (sessions will refuse to start)
+ *   - preferredMode: 'builtin' + API key present   -> ok
+ *   - preferredMode: 'builtin' + no API key        -> warn (sessions will fail later)
+ */
+export function checkPreferredMode(config: IronCurtainConfig, dockerResult: CheckResult): CheckResult {
+  const preferredMode = config.userConfig.preferredMode;
+
+  if (preferredMode === 'docker') {
+    if (dockerResult.status === 'ok') {
+      return { name: 'Preferred mode', status: 'ok', message: 'docker' };
+    }
+    return {
+      name: 'Preferred mode',
+      status: 'fail',
+      message: 'docker, but Docker is unavailable. Sessions will refuse to start.',
+      hint: 'Start Docker, or run `ironcurtain config` and set Session Mode > Preferred mode to "builtin".',
+    };
+  }
+
+  // preferredMode === 'builtin'
+  const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
+  if (apiKey.length > 0) {
+    return { name: 'Preferred mode', status: 'ok', message: 'builtin' };
+  }
+  return {
+    name: 'Preferred mode',
+    status: 'warn',
+    message: 'builtin, but no ANTHROPIC_API_KEY configured. Sessions will fail.',
+    hint: 'Set ANTHROPIC_API_KEY in your environment, or run `ironcurtain config`.',
   };
 }
 

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -21,6 +21,7 @@ import {
   checkMcpServerLiveness,
   checkNodeVersion,
   checkPolicyArtifacts,
+  checkPreferredMode,
   checkSandbox,
   checkServerCredentials,
   collectDeclaredEnvVars,
@@ -117,6 +118,14 @@ export async function runDoctorCommand(argv: string[], deps: DoctorDeps = {}): P
     exitWithStatus(collected);
   }
   const config = configCheck.config;
+
+  // Reuse the dockerResult from the Environment section so Docker is
+  // probed at most once per doctor run. checkPreferredMode upgrades the
+  // earlier warn to a fail when preferredMode is "docker", because in that
+  // configuration Docker unavailability means sessions refuse to start.
+  const preferredModeResult = checkPreferredMode(config, dockerResult);
+  printCheck(preferredModeResult);
+  collected.push(preferredModeResult);
 
   const policyCheck = checkPolicyArtifacts(config);
   for (const r of policyCheck.results) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { checkHelp, type CommandSpec } from './cli-help.js';
 import * as logger from './logger.js';
 import { CliTransport } from './session/cli-transport.js';
 import { createStandaloneSession } from './session/index.js';
-import { resolveSessionMode } from './session/preflight.js';
+import { formatModeLine, resolveSessionMode } from './session/preflight.js';
 import { validateWorkspacePath } from './session/workspace-validation.js';
 import { shouldAutoSaveMemory } from './memory/auto-save.js';
 import type { AgentId } from './docker/agent-adapter.js';
@@ -122,13 +122,9 @@ export async function main(args?: string[]): Promise<void> {
     requestedAgent: agentName ? (agentName as AgentId) : undefined,
   });
 
-  // Log the resolved mode (skip when --agent was explicit -- the user
-  // already knows what they asked for). Docker mode prints the agent and
-  // auth kind from the resolver's reason field; builtin mode is a single
-  // word with no parenthetical.
+  // Skip when --agent was explicit -- the user already knows what they asked for.
   if (!agentName) {
-    const line = preflight.mode.kind === 'docker' ? `Mode: docker / ${preflight.reason}` : 'Mode: builtin';
-    process.stderr.write(chalk.dim(`${line}\n`));
+    process.stderr.write(chalk.dim(`${formatModeLine(preflight)}\n`));
   }
 
   const mode = preflight.mode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,6 @@ export async function main(args?: string[]): Promise<void> {
     requestedAgent: agentName ? (agentName as AgentId) : undefined,
   });
 
-  // Skip when --agent was explicit -- the user already knows what they asked for.
   if (!agentName) {
     process.stderr.write(chalk.dim(`${formatModeLine(preflight)}\n`));
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,9 +122,13 @@ export async function main(args?: string[]): Promise<void> {
     requestedAgent: agentName ? (agentName as AgentId) : undefined,
   });
 
-  // Log auto-selection reason (skip for explicit --agent)
+  // Log the resolved mode (skip when --agent was explicit -- the user
+  // already knows what they asked for). Docker mode prints the agent and
+  // auth kind from the resolver's reason field; builtin mode is a single
+  // word with no parenthetical.
   if (!agentName) {
-    process.stderr.write(chalk.dim(`Mode: ${preflight.mode.kind} (${preflight.reason})\n`));
+    const line = preflight.mode.kind === 'docker' ? `Mode: docker / ${preflight.reason}` : 'Mode: builtin';
+    process.stderr.write(chalk.dim(`${line}\n`));
   }
 
   const mode = preflight.mode;

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -136,47 +136,68 @@ export async function checkDockerAvailable(execFileFn: ProbeExecFileFn = execFil
 }
 
 /**
- * Checks whether credentials (OAuth or API key) are available for the given agent.
- * Returns the auth kind if available, or null if no credentials found.
- *
- * Includes macOS Keychain lookup and token refresh for expired credentials.
+ * Result of credential detection for a given agent. `anthropicOAuthOnly`
+ * is only meaningful for goose: it records whether Anthropic OAuth
+ * credentials are present (and would have helped a claude-code session)
+ * so the goose error message can tell a tester that OAuth is unusable
+ * with goose. Combining it into a single struct lets us probe
+ * `detectAuthMethod` once and share the result across the credential
+ * decision and the error-message construction.
  */
-async function detectCredentials(
+interface CredentialState {
+  credKind: 'oauth' | 'apikey' | null;
+  anthropicOAuthOnly: boolean;
+}
+
+async function detectCredentialState(
   agentId: AgentId,
   config: IronCurtainConfig,
   sources?: CredentialSources,
-): Promise<'oauth' | 'apikey' | null> {
-  // Goose uses provider-specific API keys, not Anthropic OAuth.
+): Promise<CredentialState> {
   if (agentId === 'goose') {
     const provider = config.userConfig.gooseProvider;
     const key = resolveApiKeyForProvider(provider, config.userConfig);
-    return key ? 'apikey' : null;
+    if (key) return { credKind: 'apikey', anthropicOAuthOnly: false };
+
+    const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
+    return {
+      credKind: null,
+      anthropicOAuthOnly:
+        auth.kind === 'oauth' && resolveApiKeyForProvider('anthropic', config.userConfig).length === 0,
+    };
   }
 
-  // Default path: Anthropic OAuth + API key detection (Claude Code and others).
-  // Uses preflightCredentialSources, which may refresh expired tokens and update credential storage.
   const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
-  if (auth.kind === 'none') return null;
-  return auth.kind === 'oauth' ? 'oauth' : 'apikey';
+  if (auth.kind === 'none') return { credKind: null, anthropicOAuthOnly: false };
+  return { credKind: auth.kind === 'oauth' ? 'oauth' : 'apikey', anthropicOAuthOnly: false };
 }
 
 /**
- * Returns true when Anthropic OAuth credentials are present (file or
- * Keychain) but no `ANTHROPIC_API_KEY` is configured. Used to surface a
- * goose-specific addendum: a tester who just ran `claude login` deserves
- * to know that OAuth is unusable with goose.
+ * Renders the "switch to <other mode>" remediation footer shared by every
+ * preflight error message. Centralized so the wording can't drift between
+ * the docker-unavailable, builtin-needs-key, and credential-missing paths.
  */
-async function hasAnthropicOAuthOnly(config: IronCurtainConfig, sources?: CredentialSources): Promise<boolean> {
-  const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
-  if (auth.kind !== 'oauth') return false;
-  return resolveApiKeyForProvider('anthropic', config.userConfig).length === 0;
+function formatModeRemediation(targetMode: 'docker' | 'builtin'): string[] {
+  if (targetMode === 'builtin') {
+    return [
+      'To run this session in builtin mode, pass:',
+      '  --agent builtin',
+      '',
+      'To make builtin the default permanently, run:',
+      '  ironcurtain config',
+      'and set Session Mode > Preferred mode to "builtin".',
+    ];
+  }
+  return [
+    'To run this session in Docker mode, pass:',
+    '  --agent claude-code',
+    '',
+    'To make Docker the default permanently, run:',
+    '  ironcurtain config',
+    'and set Session Mode > Preferred mode to "docker".',
+  ];
 }
 
-/**
- * Returns the error message for missing credentials when `--agent` is
- * explicit. Wording leads with `--agent ${agentId} requires...` since the
- * user typed that flag.
- */
 function credentialErrorMessageForExplicit(agentId: AgentId, config: IronCurtainConfig, oauthOnly: boolean): string {
   if (agentId === 'goose') {
     const provider = config.userConfig.gooseProvider;
@@ -192,21 +213,16 @@ function credentialErrorMessageForExplicit(agentId: AgentId, config: IronCurtain
   return `--agent ${agentId} requires authentication. Log in with \`claude login\` (OAuth) or set ANTHROPIC_API_KEY.`;
 }
 
-/**
- * Returns the error message for missing credentials when the session mode
- * was selected via `preferredMode`. Wording leads with `preferredMode is
- * "docker"...` so the user understands the cause and can change either the
- * one-shot (`--agent builtin`) or the permanent default (`ironcurtain config`).
- */
 function credentialErrorMessageForPreferredMode(
   agentId: AgentId,
   config: IronCurtainConfig,
   oauthOnly: boolean,
 ): string {
-  const lines: string[] = [];
-  lines.push('Cannot start IronCurtain.');
-  lines.push(`preferredMode is "docker" but no credentials are configured for "${agentId}".`);
-  lines.push('');
+  const lines: string[] = [
+    'Cannot start IronCurtain.',
+    `preferredMode is "docker" but no credentials are configured for "${agentId}".`,
+    '',
+  ];
   if (agentId === 'goose') {
     const provider = config.userConfig.gooseProvider;
     lines.push(
@@ -220,24 +236,14 @@ function credentialErrorMessageForPreferredMode(
     }
   } else {
     lines.push(
-      `Authentication is required for "${agentId}". ` + 'Log in with `claude login` (OAuth) or set ANTHROPIC_API_KEY.',
+      `Authentication is required for "${agentId}". Log in with \`claude login\` (OAuth) or set ANTHROPIC_API_KEY.`,
     );
   }
   lines.push('');
-  lines.push('To run this session in builtin mode, pass:');
-  lines.push('  --agent builtin');
-  lines.push('');
-  lines.push('To make builtin the default permanently, run:');
-  lines.push('  ironcurtain config');
-  lines.push('and set Session Mode > Preferred mode to "builtin".');
+  lines.push(...formatModeRemediation('builtin'));
   return lines.join('\n');
 }
 
-/**
- * Error message for `preferredMode === 'docker'` but the Docker daemon
- * cannot be reached. Includes the underlying probe diagnostic plus both
- * the one-shot and permanent escapes.
- */
 function dockerUnavailableMessage(detailedMessage: string): string {
   return [
     'Cannot start IronCurtain.',
@@ -245,35 +251,31 @@ function dockerUnavailableMessage(detailedMessage: string): string {
     '',
     detailedMessage,
     '',
-    'To run this session in builtin mode, pass:',
-    '  --agent builtin',
-    '',
-    'To make builtin the default permanently, run:',
-    '  ironcurtain config',
-    'and set Session Mode > Preferred mode to "builtin".',
+    ...formatModeRemediation('builtin'),
   ].join('\n');
 }
 
-/**
- * Error message for `preferredMode === 'builtin'` but no Anthropic API key
- * is configured. Builtin mode talks to Anthropic directly and Claude OAuth
- * tokens are not usable on that path.
- */
 function builtinNeedsApiKeyMessage(): string {
   return [
     'Cannot start IronCurtain.',
     'preferredMode is "builtin" but no ANTHROPIC_API_KEY is configured.',
     'Builtin mode talks to Anthropic directly using an API key — Claude OAuth credentials are not usable in builtin mode.',
     '',
-    'To run this session in Docker mode, pass:',
-    '  --agent claude-code',
-    '',
-    'To make Docker the default permanently, run:',
-    '  ironcurtain config',
-    'and set Session Mode > Preferred mode to "docker".',
+    ...formatModeRemediation('docker'),
     '',
     'Set ANTHROPIC_API_KEY in your environment, or run `ironcurtain config`.',
   ].join('\n');
+}
+
+/**
+ * Renders the user-facing `Mode: ...` banner shown at session startup.
+ * Single source of truth so `ironcurtain start`, the daemon, and cron
+ * jobs all print identically. Docker mode includes the agent + auth
+ * kind via `reason`; builtin has no parenthetical.
+ */
+export function formatModeLine(preflight: PreflightResult): string {
+  if (preflight.mode.kind === 'builtin') return 'Mode: builtin';
+  return `Mode: docker / ${preflight.reason}`;
 }
 
 /**
@@ -308,7 +310,11 @@ async function resolveExplicit(
     };
   }
 
-  const dockerStatus = await isDockerAvailable();
+  const [dockerStatus, credState] = await Promise.all([
+    isDockerAvailable(),
+    detectCredentialState(agent, config, credentialSources),
+  ]);
+
   if (!dockerStatus.available) {
     throw new PreflightError(
       `--agent ${agent} requires Docker, but it is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
@@ -316,15 +322,13 @@ async function resolveExplicit(
     );
   }
 
-  const credKind = await detectCredentials(agent, config, credentialSources);
-  if (credKind === null) {
-    const oauthOnly = agent === 'goose' && (await hasAnthropicOAuthOnly(config, credentialSources));
-    throw new PreflightError(credentialErrorMessageForExplicit(agent, config, oauthOnly));
+  if (credState.credKind === null) {
+    throw new PreflightError(credentialErrorMessageForExplicit(agent, config, credState.anthropicOAuthOnly));
   }
 
   return {
-    mode: { kind: 'docker', agent, authKind: credKind },
-    reason: `Explicit --agent selection (${credKind === 'oauth' ? 'OAuth' : 'API key'})`,
+    mode: { kind: 'docker', agent, authKind: credState.credKind },
+    reason: `Explicit --agent selection (${credState.credKind === 'oauth' ? 'OAuth' : 'API key'})`,
   };
 }
 
@@ -336,7 +340,8 @@ async function resolveDefaultMode(
   const { preferredMode, preferredDockerAgent } = config.userConfig;
 
   if (preferredMode === 'builtin') {
-    // Fail before any Docker probe so the user gets fast feedback.
+    // Order matters: fail before the Docker probe on the builtin path. Lock-in
+    // at test/preflight.test.ts "Builtin path must not probe Docker".
     const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
     if (apiKey.length === 0) {
       throw new PreflightError(builtinNeedsApiKeyMessage());
@@ -344,21 +349,22 @@ async function resolveDefaultMode(
     return { mode: { kind: 'builtin' }, reason: 'preferredMode = builtin' };
   }
 
-  // preferredMode === 'docker' — the default branch.
   const agent = preferredDockerAgent as AgentId;
-  const dockerStatus = await isDockerAvailable();
+  const [dockerStatus, credState] = await Promise.all([
+    isDockerAvailable(),
+    detectCredentialState(agent, config, credentialSources),
+  ]);
+
   if (!dockerStatus.available) {
     throw new PreflightError(dockerUnavailableMessage(dockerStatus.detailedMessage));
   }
 
-  const credKind = await detectCredentials(agent, config, credentialSources);
-  if (credKind === null) {
-    const oauthOnly = preferredDockerAgent === 'goose' && (await hasAnthropicOAuthOnly(config, credentialSources));
-    throw new PreflightError(credentialErrorMessageForPreferredMode(agent, config, oauthOnly));
+  if (credState.credKind === null) {
+    throw new PreflightError(credentialErrorMessageForPreferredMode(agent, config, credState.anthropicOAuthOnly));
   }
 
   return {
-    mode: { kind: 'docker', agent, authKind: credKind },
-    reason: `${preferredDockerAgent} (${credKind === 'oauth' ? 'OAuth' : 'API key'})`,
+    mode: { kind: 'docker', agent, authKind: credState.credKind },
+    reason: `${preferredDockerAgent} (${credState.credKind === 'oauth' ? 'OAuth' : 'API key'})`,
   };
 }

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -303,11 +303,10 @@ async function resolveExplicit(
     };
   }
 
-  const [dockerStatus, credState] = await Promise.all([
-    isDockerAvailable(),
-    detectCredentialState(agent, config, credentialSources),
-  ]);
-
+  // Probe Docker first; credential detection can refresh OAuth tokens
+  // (rotating the refresh token) and we don't want that side effect on a
+  // failure path.
+  const dockerStatus = await isDockerAvailable();
   if (!dockerStatus.available) {
     throw new PreflightError(
       `--agent ${agent} requires Docker, but it is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
@@ -315,6 +314,7 @@ async function resolveExplicit(
     );
   }
 
+  const credState = await detectCredentialState(agent, config, credentialSources);
   if (credState.credKind === null) {
     throw new PreflightError(credentialErrorMessageForExplicit(agent, config, credState.anthropicOAuthOnly));
   }
@@ -342,15 +342,16 @@ async function resolveDefaultMode(
   }
 
   const agent = preferredDockerAgent as AgentId;
-  const [dockerStatus, credState] = await Promise.all([
-    isDockerAvailable(),
-    detectCredentialState(agent, config, credentialSources),
-  ]);
 
+  // Probe Docker first; credential detection can refresh OAuth tokens
+  // (rotating the refresh token) and we don't want that side effect on a
+  // failure path.
+  const dockerStatus = await isDockerAvailable();
   if (!dockerStatus.available) {
     throw new PreflightError(dockerUnavailableMessage(dockerStatus.detailedMessage));
   }
 
+  const credState = await detectCredentialState(agent, config, credentialSources);
   if (credState.credKind === null) {
     throw new PreflightError(credentialErrorMessageForPreferredMode(agent, config, credState.anthropicOAuthOnly));
   }

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -13,7 +13,12 @@ import { promisify } from 'node:util';
 import type { IronCurtainConfig } from '../config/types.js';
 import type { AgentId } from '../docker/agent-adapter.js';
 import type { SessionMode } from './types.js';
-import { detectAuthMethod, preflightCredentialSources, type CredentialSources } from '../docker/oauth-credentials.js';
+import {
+  detectAuthMethod,
+  preflightCredentialSources,
+  readOnlyCredentialSources,
+  type CredentialSources,
+} from '../docker/oauth-credentials.js';
 import { resolveApiKeyForProvider } from '../config/model-provider.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
 
@@ -145,14 +150,14 @@ interface CredentialState {
 async function detectCredentialState(
   agentId: AgentId,
   config: IronCurtainConfig,
-  sources?: CredentialSources,
+  sources: CredentialSources,
 ): Promise<CredentialState> {
   if (agentId === 'goose') {
     const provider = config.userConfig.gooseProvider;
     const key = resolveApiKeyForProvider(provider, config.userConfig);
     if (key) return { credKind: 'apikey', anthropicOAuthOnly: false };
 
-    const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
+    const auth = await detectAuthMethod(config, sources);
     return {
       credKind: null,
       anthropicOAuthOnly:
@@ -160,9 +165,45 @@ async function detectCredentialState(
     };
   }
 
-  const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
+  const auth = await detectAuthMethod(config, sources);
   if (auth.kind === 'none') return { credKind: null, anthropicOAuthOnly: false };
   return { credKind: auth.kind === 'oauth' ? 'oauth' : 'apikey', anthropicOAuthOnly: false };
+}
+
+/**
+ * Resolves Docker availability and credential presence concurrently, then —
+ * only on the success path — triggers a proactive OAuth-refresh round-trip.
+ *
+ * The phase split is what gives us both speed AND clean failure semantics:
+ *   - Phase 1 (parallel): Docker probe + read-only credential check.
+ *     No side effects. If either fails we throw without ever touching the
+ *     refresh path, so a Docker-unavailable run can't burn an OAuth refresh
+ *     token.
+ *   - Phase 2 (post-confirm): if both passed and the credential is OAuth,
+ *     re-run detection with `preflightCredentialSources` so a near-expired
+ *     token is rotated before the first MCP call.
+ *
+ * Tests that inject `credentialSources` get phase-1-only behavior with
+ * their fixture — the injection encodes the test's chosen semantics, so
+ * rerunning with refresh-capable sources would defeat the override.
+ */
+async function probeDockerAndCredentials(
+  agent: AgentId,
+  config: IronCurtainConfig,
+  isDockerAvailable: () => Promise<DockerAvailability>,
+  credentialSources: CredentialSources | undefined,
+): Promise<{ dockerStatus: DockerAvailability; credState: CredentialState }> {
+  const phase1Sources = credentialSources ?? readOnlyCredentialSources;
+  const [dockerStatus, credState] = await Promise.all([
+    isDockerAvailable(),
+    detectCredentialState(agent, config, phase1Sources),
+  ]);
+
+  if (!credentialSources && dockerStatus.available && credState.credKind === 'oauth') {
+    await detectAuthMethod(config, preflightCredentialSources);
+  }
+
+  return { dockerStatus, credState };
 }
 
 /**
@@ -303,10 +344,13 @@ async function resolveExplicit(
     };
   }
 
-  // Probe Docker first; credential detection can refresh OAuth tokens
-  // (rotating the refresh token) and we don't want that side effect on a
-  // failure path.
-  const dockerStatus = await isDockerAvailable();
+  const { dockerStatus, credState } = await probeDockerAndCredentials(
+    agent,
+    config,
+    isDockerAvailable,
+    credentialSources,
+  );
+
   if (!dockerStatus.available) {
     throw new PreflightError(
       `--agent ${agent} requires Docker, but it is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
@@ -314,7 +358,6 @@ async function resolveExplicit(
     );
   }
 
-  const credState = await detectCredentialState(agent, config, credentialSources);
   if (credState.credKind === null) {
     throw new PreflightError(credentialErrorMessageForExplicit(agent, config, credState.anthropicOAuthOnly));
   }
@@ -343,15 +386,17 @@ async function resolveDefaultMode(
 
   const agent = preferredDockerAgent as AgentId;
 
-  // Probe Docker first; credential detection can refresh OAuth tokens
-  // (rotating the refresh token) and we don't want that side effect on a
-  // failure path.
-  const dockerStatus = await isDockerAvailable();
+  const { dockerStatus, credState } = await probeDockerAndCredentials(
+    agent,
+    config,
+    isDockerAvailable,
+    credentialSources,
+  );
+
   if (!dockerStatus.available) {
     throw new PreflightError(dockerUnavailableMessage(dockerStatus.detailedMessage));
   }
 
-  const credState = await detectCredentialState(agent, config, credentialSources);
   if (credState.credKind === null) {
     throw new PreflightError(credentialErrorMessageForPreferredMode(agent, config, credState.anthropicOAuthOnly));
   }

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -135,15 +135,8 @@ export async function checkDockerAvailable(execFileFn: ProbeExecFileFn = execFil
   };
 }
 
-/**
- * Result of credential detection for a given agent. `anthropicOAuthOnly`
- * is only meaningful for goose: it records whether Anthropic OAuth
- * credentials are present (and would have helped a claude-code session)
- * so the goose error message can tell a tester that OAuth is unusable
- * with goose. Combining it into a single struct lets us probe
- * `detectAuthMethod` once and share the result across the credential
- * decision and the error-message construction.
- */
+/** `anthropicOAuthOnly` is only meaningful for goose: it lets the goose
+ *  error message tell a tester that present OAuth credentials are unusable. */
 interface CredentialState {
   credKind: 'oauth' | 'apikey' | null;
   anthropicOAuthOnly: boolean;
@@ -340,8 +333,7 @@ async function resolveDefaultMode(
   const { preferredMode, preferredDockerAgent } = config.userConfig;
 
   if (preferredMode === 'builtin') {
-    // Order matters: fail before the Docker probe on the builtin path. Lock-in
-    // at test/preflight.test.ts "Builtin path must not probe Docker".
+    // Fail before the Docker probe — fast feedback for missing keys.
     const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
     if (apiKey.length === 0) {
       throw new PreflightError(builtinNeedsApiKeyMessage());

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -1,10 +1,11 @@
 /**
- * Pre-flight checks and automatic session mode selection.
+ * Pre-flight checks and explicit session mode selection.
  *
- * When --agent is explicit, validates prerequisites and fails fast.
- * When no --agent is given, auto-detects the best mode (Docker preferred,
- * builtin fallback) without ever throwing, EXCEPT when the user has OAuth
- * credentials but no API key (which strictly requires Docker).
+ * When `--agent` is explicit, validates prerequisites and fails fast.
+ * When no `--agent` is given, dispatches on the user's `preferredMode`
+ * (`'docker'` or `'builtin'`) — there is no silent fallback. If the
+ * preferred mode's prerequisites are unmet, a `PreflightError` is raised
+ * with remediation hints and the session refuses to start.
  */
 
 import { execFile as execFileCb } from 'node:child_process';
@@ -41,8 +42,9 @@ export type ProbeExecFileFn = (
 ) => Promise<{ stdout: string; stderr: string }>;
 
 /**
- * Thrown when explicit --agent prerequisites are not met, or when
- * auto-detect finds an unresolvable constraint (e.g. OAuth-only without Docker).
+ * Thrown when explicit `--agent` prerequisites are not met, or when the
+ * user's `preferredMode` cannot be honored (Docker unavailable while
+ * preferring docker, missing API key while preferring builtin, etc.).
  */
 export class PreflightError extends Error {
   constructor(message: string) {
@@ -61,7 +63,7 @@ export type DockerAvailability = { available: true } | { available: false; reaso
 
 export interface PreflightOptions {
   config: IronCurtainConfig;
-  /** The --agent flag value. undefined = auto-detect. */
+  /** The --agent flag value. undefined = use preferredMode from config. */
   requestedAgent?: AgentId;
   /** Dependency injection for tests. Defaults to real Docker check. */
   isDockerAvailable?: () => Promise<DockerAvailability>;
@@ -159,26 +161,128 @@ async function detectCredentials(
 }
 
 /**
- * Returns the error message for missing credentials, tailored to the agent.
+ * Returns true when Anthropic OAuth credentials are present (file or
+ * Keychain) but no `ANTHROPIC_API_KEY` is configured. Used to surface a
+ * goose-specific addendum: a tester who just ran `claude login` deserves
+ * to know that OAuth is unusable with goose.
  */
-function credentialErrorMessage(agentId: AgentId, config: IronCurtainConfig): string {
+async function hasAnthropicOAuthOnly(config: IronCurtainConfig, sources?: CredentialSources): Promise<boolean> {
+  const auth = await detectAuthMethod(config, sources ?? preflightCredentialSources);
+  if (auth.kind !== 'oauth') return false;
+  return resolveApiKeyForProvider('anthropic', config.userConfig).length === 0;
+}
+
+/**
+ * Returns the error message for missing credentials when `--agent` is
+ * explicit. Wording leads with `--agent ${agentId} requires...` since the
+ * user typed that flag.
+ */
+function credentialErrorMessageForExplicit(agentId: AgentId, config: IronCurtainConfig, oauthOnly: boolean): string {
   if (agentId === 'goose') {
     const provider = config.userConfig.gooseProvider;
-    return (
+    const base =
       `--agent goose requires an API key for provider "${provider}". ` +
       'Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY, ' +
-      'or configure via `ironcurtain config`.'
-    );
+      'or configure via `ironcurtain config`.';
+    if (provider === 'anthropic' && oauthOnly) {
+      return `${base}\n\nOAuth credentials are not usable with goose; provider "anthropic" requires an API key.`;
+    }
+    return base;
   }
   return `--agent ${agentId} requires authentication. Log in with \`claude login\` (OAuth) or set ANTHROPIC_API_KEY.`;
 }
 
 /**
- * Resolves the session mode based on explicit --agent flag or auto-detection.
+ * Returns the error message for missing credentials when the session mode
+ * was selected via `preferredMode`. Wording leads with `preferredMode is
+ * "docker"...` so the user understands the cause and can change either the
+ * one-shot (`--agent builtin`) or the permanent default (`ironcurtain config`).
+ */
+function credentialErrorMessageForPreferredMode(
+  agentId: AgentId,
+  config: IronCurtainConfig,
+  oauthOnly: boolean,
+): string {
+  const lines: string[] = [];
+  lines.push('Cannot start IronCurtain.');
+  lines.push(`preferredMode is "docker" but no credentials are configured for "${agentId}".`);
+  lines.push('');
+  if (agentId === 'goose') {
+    const provider = config.userConfig.gooseProvider;
+    lines.push(
+      `Goose requires an API key for provider "${provider}". ` +
+        'Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY, ' +
+        'or configure via `ironcurtain config`.',
+    );
+    if (provider === 'anthropic' && oauthOnly) {
+      lines.push('');
+      lines.push('OAuth credentials are not usable with goose; provider "anthropic" requires an API key.');
+    }
+  } else {
+    lines.push(
+      `Authentication is required for "${agentId}". ` + 'Log in with `claude login` (OAuth) or set ANTHROPIC_API_KEY.',
+    );
+  }
+  lines.push('');
+  lines.push('To run this session in builtin mode, pass:');
+  lines.push('  --agent builtin');
+  lines.push('');
+  lines.push('To make builtin the default permanently, run:');
+  lines.push('  ironcurtain config');
+  lines.push('and set Session Mode > Preferred mode to "builtin".');
+  return lines.join('\n');
+}
+
+/**
+ * Error message for `preferredMode === 'docker'` but the Docker daemon
+ * cannot be reached. Includes the underlying probe diagnostic plus both
+ * the one-shot and permanent escapes.
+ */
+function dockerUnavailableMessage(detailedMessage: string): string {
+  return [
+    'Cannot start IronCurtain.',
+    'preferredMode is "docker" but Docker is not available:',
+    '',
+    detailedMessage,
+    '',
+    'To run this session in builtin mode, pass:',
+    '  --agent builtin',
+    '',
+    'To make builtin the default permanently, run:',
+    '  ironcurtain config',
+    'and set Session Mode > Preferred mode to "builtin".',
+  ].join('\n');
+}
+
+/**
+ * Error message for `preferredMode === 'builtin'` but no Anthropic API key
+ * is configured. Builtin mode talks to Anthropic directly and Claude OAuth
+ * tokens are not usable on that path.
+ */
+function builtinNeedsApiKeyMessage(): string {
+  return [
+    'Cannot start IronCurtain.',
+    'preferredMode is "builtin" but no ANTHROPIC_API_KEY is configured.',
+    'Builtin mode talks to Anthropic directly using an API key — Claude OAuth credentials are not usable in builtin mode.',
+    '',
+    'To run this session in Docker mode, pass:',
+    '  --agent claude-code',
+    '',
+    'To make Docker the default permanently, run:',
+    '  ironcurtain config',
+    'and set Session Mode > Preferred mode to "docker".',
+    '',
+    'Set ANTHROPIC_API_KEY in your environment, or run `ironcurtain config`.',
+  ].join('\n');
+}
+
+/**
+ * Resolves the session mode based on the explicit `--agent` flag or the
+ * user's `preferredMode`.
  *
  * - Explicit agent: validates prerequisites; throws PreflightError on failure.
- * - Auto-detect: prefers Docker when available; falls back to builtin, but throws if
- *   OAuth is the only available credential (since builtin requires an API key).
+ * - Default path: dispatches on `preferredMode`. There is no silent
+ *   fallback — Docker unavailability or missing credentials throw.
  */
 export async function resolveSessionMode(options: PreflightOptions): Promise<PreflightResult> {
   const { config, requestedAgent, credentialSources } = options;
@@ -188,7 +292,7 @@ export async function resolveSessionMode(options: PreflightOptions): Promise<Pre
     return resolveExplicit(requestedAgent, config, isDockerAvailable, credentialSources);
   }
 
-  return resolveAutoDetect(config, isDockerAvailable, credentialSources);
+  return resolveDefaultMode(config, isDockerAvailable, credentialSources);
 }
 
 async function resolveExplicit(
@@ -214,7 +318,8 @@ async function resolveExplicit(
 
   const credKind = await detectCredentials(agent, config, credentialSources);
   if (credKind === null) {
-    throw new PreflightError(credentialErrorMessage(agent, config));
+    const oauthOnly = agent === 'goose' && (await hasAnthropicOAuthOnly(config, credentialSources));
+    throw new PreflightError(credentialErrorMessageForExplicit(agent, config, oauthOnly));
   }
 
   return {
@@ -223,47 +328,37 @@ async function resolveExplicit(
   };
 }
 
-async function resolveAutoDetect(
+async function resolveDefaultMode(
   config: IronCurtainConfig,
   isDockerAvailable: () => Promise<DockerAvailability>,
   credentialSources?: CredentialSources,
 ): Promise<PreflightResult> {
-  const defaultAgent = config.userConfig.preferredDockerAgent as AgentId;
-  const [dockerStatus, credKind, authMethod] = await Promise.all([
-    isDockerAvailable(),
-    detectCredentials(defaultAgent, config, credentialSources),
-    detectAuthMethod(config, credentialSources ?? preflightCredentialSources),
-  ]);
+  const { preferredMode, preferredDockerAgent } = config.userConfig;
 
-  if (!dockerStatus.available) {
-    // Check Anthropic OAuth presence directly, independent of the preferred agent.
-    // detectCredentials only probes Anthropic OAuth on the Claude Code path; when the
-    // preferred agent is goose it reports credKind based on the goose provider key and
-    // never looks at Anthropic OAuth. Call detectAuthMethod explicitly so we catch the
-    // OAuth-only-no-Docker failure even for goose-preferred configs.
-    if (authMethod.kind === 'oauth' && resolveApiKeyForProvider('anthropic', config.userConfig).length === 0) {
-      throw new PreflightError(
-        `Cannot start IronCurtain. You have Claude OAuth credentials, which require Docker mode, ` +
-          `but Docker is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
-          `To run without Docker, you must provide an ANTHROPIC_API_KEY.`,
-      );
+  if (preferredMode === 'builtin') {
+    // Fail before any Docker probe so the user gets fast feedback.
+    const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
+    if (apiKey.length === 0) {
+      throw new PreflightError(builtinNeedsApiKeyMessage());
     }
-
-    return {
-      mode: { kind: 'builtin' },
-      reason: DOCKER_UNAVAILABLE_REASON,
-    };
+    return { mode: { kind: 'builtin' }, reason: 'preferredMode = builtin' };
   }
 
+  // preferredMode === 'docker' — the default branch.
+  const agent = preferredDockerAgent as AgentId;
+  const dockerStatus = await isDockerAvailable();
+  if (!dockerStatus.available) {
+    throw new PreflightError(dockerUnavailableMessage(dockerStatus.detailedMessage));
+  }
+
+  const credKind = await detectCredentials(agent, config, credentialSources);
   if (credKind === null) {
-    return {
-      mode: { kind: 'builtin' },
-      reason: 'No credentials (OAuth or API key)',
-    };
+    const oauthOnly = preferredDockerAgent === 'goose' && (await hasAnthropicOAuthOnly(config, credentialSources));
+    throw new PreflightError(credentialErrorMessageForPreferredMode(agent, config, oauthOnly));
   }
 
   return {
-    mode: { kind: 'docker', agent: defaultAgent, authKind: credKind },
-    reason: `Docker available, ${credKind === 'oauth' ? 'OAuth' : 'API key'} detected`,
+    mode: { kind: 'docker', agent, authKind: credKind },
+    reason: `${preferredDockerAgent} (${credKind === 'oauth' ? 'OAuth' : 'API key'})`,
   };
 }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -539,10 +539,7 @@ describe('runDoctorCommand', () => {
   });
 
   it('prints a Preferred mode line in the Configuration section', async () => {
-    // The new checkPreferredMode wiring should surface its result to
-    // stdout under the Configuration heading. We don't assert pass/fail
-    // here because Docker availability varies by test environment; we
-    // only assert the line is present and labeled correctly.
+    // Docker availability varies by env; only assert the line is labeled.
     const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
     const probeStub = vi.fn(async (): Promise<ProbeResult> => ({ status: 'ok', toolCount: 1, elapsedMs: 10 }));
     const { output } = await captureOutput(() => runDoctorCommand([], { probeMcpServer: probeStub }));

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -42,6 +42,7 @@ import {
   checkDocker,
   checkMcpServerLiveness,
   checkNodeVersion,
+  checkPreferredMode,
   checkServerCredentials,
   collectDeclaredEnvVars,
   type CheckResult,
@@ -133,6 +134,7 @@ function buildConfig(overrides: Partial<IronCurtainConfig> = {}): IronCurtainCon
     gooseProvider: 'anthropic' as const,
     gooseModel: 'claude',
     preferredDockerAgent: 'claude-code' as const,
+    preferredMode: 'docker' as const,
     packageInstall: { enabled: true, quarantineDays: 2, allowedPackages: [], deniedPackages: [] },
   };
   return {
@@ -195,6 +197,58 @@ describe('checkDocker', () => {
     }));
     expect(result.status).toBe('warn');
     expect(result.hint).toBe('docker: command not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkPreferredMode
+// ---------------------------------------------------------------------------
+
+describe('checkPreferredMode', () => {
+  const dockerOk: CheckResult = { name: 'Docker', status: 'ok', message: 'running' };
+  const dockerWarn: CheckResult = {
+    name: 'Docker',
+    status: 'warn',
+    message: 'unavailable',
+    hint: 'docker: command not found',
+  };
+
+  function configWithMode(mode: 'docker' | 'builtin', anthropicApiKey = '') {
+    return buildConfig({
+      userConfig: { ...buildConfig().userConfig, preferredMode: mode, anthropicApiKey },
+    });
+  }
+
+  it('preferredMode=docker + Docker ok -> ok', () => {
+    const r = checkPreferredMode(configWithMode('docker', 'sk-test'), dockerOk);
+    expect(r.status).toBe('ok');
+    expect(r.message).toBe('docker');
+  });
+
+  it('preferredMode=docker + Docker unavailable -> fail', () => {
+    const r = checkPreferredMode(configWithMode('docker', 'sk-test'), dockerWarn);
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/Docker is unavailable/);
+    expect(r.hint).toMatch(/Start Docker/);
+  });
+
+  it('preferredMode=builtin + API key present -> ok', () => {
+    const r = checkPreferredMode(configWithMode('builtin', 'sk-test'), dockerWarn);
+    expect(r.status).toBe('ok');
+    expect(r.message).toBe('builtin');
+  });
+
+  it('preferredMode=builtin + no API key -> warn (warn alone does not fail doctor)', () => {
+    const r = checkPreferredMode(configWithMode('builtin', ''), dockerOk);
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/no ANTHROPIC_API_KEY/);
+    expect(r.hint).toMatch(/ANTHROPIC_API_KEY/);
+  });
+
+  it('preferredMode=builtin status is independent of Docker availability', () => {
+    // dockerWarn must not turn a builtin-mode user's status into fail.
+    const r = checkPreferredMode(configWithMode('builtin', 'sk-test'), dockerWarn);
+    expect(r.status).toBe('ok');
   });
 });
 
@@ -482,6 +536,17 @@ describe('runDoctorCommand', () => {
     const { output, exitCode } = await captureOutput(() => runDoctorCommand(['--bogus']));
     expect(output).toMatch(/--bogus/i);
     expect(exitCode).toBe(1);
+  });
+
+  it('prints a Preferred mode line in the Configuration section', async () => {
+    // The new checkPreferredMode wiring should surface its result to
+    // stdout under the Configuration heading. We don't assert pass/fail
+    // here because Docker availability varies by test environment; we
+    // only assert the line is present and labeled correctly.
+    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
+    const probeStub = vi.fn(async (): Promise<ProbeResult> => ({ status: 'ok', toolCount: 1, elapsedMs: 10 }));
+    const { output } = await captureOutput(() => runDoctorCommand([], { probeMcpServer: probeStub }));
+    expect(output).toContain('Preferred mode');
   });
 });
 

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -269,26 +269,24 @@ describe('resolveSessionMode', () => {
         expect(isDockerAvailable).not.toHaveBeenCalled();
       });
 
-      it('throws when only OAuth is configured (no ANTHROPIC_API_KEY)', async () => {
+      it('throws without probing OAuth or Docker when no ANTHROPIC_API_KEY is set', async () => {
+        // Two cases that both hit the same `apiKey.length === 0` check before
+        // any auth or Docker probe. Spied sources prove the shortcut.
+        const dockerSpy = vi.fn(dockerAvailable);
+        const loadFromFile = vi.fn(() => null);
+        const loadFromKeychain = vi.fn(() => null);
+
         const promise = resolveSessionMode({
           config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
-          isDockerAvailable: dockerAvailable,
-          credentialSources: oauthOnlySources,
+          isDockerAvailable: dockerSpy,
+          credentialSources: { loadFromFile, loadFromKeychain },
         });
 
         await expect(promise).rejects.toThrow(PreflightError);
         await expect(promise).rejects.toThrow(/no ANTHROPIC_API_KEY/);
-      });
-
-      it('throws when nothing is configured (same message as OAuth-only)', async () => {
-        const promise = resolveSessionMode({
-          config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
-          isDockerAvailable: dockerAvailable,
-          credentialSources: noOAuthSources,
-        });
-
-        await expect(promise).rejects.toThrow(PreflightError);
-        await expect(promise).rejects.toThrow(/no ANTHROPIC_API_KEY/);
+        expect(dockerSpy).not.toHaveBeenCalled();
+        expect(loadFromFile).not.toHaveBeenCalled();
+        expect(loadFromKeychain).not.toHaveBeenCalled();
       });
     });
 
@@ -306,11 +304,8 @@ describe('resolveSessionMode', () => {
       });
 
       it('--agent builtin succeeds even with preferredMode = builtin and no API key', async () => {
-        // Lock-in: resolveExplicit('builtin', ...) intentionally does NOT
-        // check the API key. The agent loop fails later on the actual API
-        // call. If a future "symmetry" refactor tightens this path, it
-        // should have to delete this test on purpose — see the design's
-        // out-of-scope notes.
+        // resolveExplicit('builtin', ...) intentionally does not check the API
+        // key — the agent loop fails later on the actual API call.
         const dockerSpy = vi.fn().mockResolvedValue({ available: true });
         const result = await resolveSessionMode({
           config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
@@ -321,9 +316,6 @@ describe('resolveSessionMode', () => {
 
         expect(result.mode).toEqual({ kind: 'builtin' });
         expect(result.reason).toBe('Explicit --agent builtin');
-        // Explicit-builtin path skips the Docker probe — only resolveExplicit
-        // produces this combination; the bare `mode === 'builtin'` assertion
-        // alone would also pass the prior auto-detect code.
         expect(dockerSpy).not.toHaveBeenCalled();
       });
 

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -18,7 +18,9 @@ const noOAuthSources: CredentialSources = {
   loadFromKeychain: () => null,
 };
 
-function createTestConfig(overrides: { anthropicApiKey?: string } = {}): IronCurtainConfig {
+function createTestConfig(
+  overrides: { anthropicApiKey?: string; preferredMode?: 'docker' | 'builtin' } = {},
+): IronCurtainConfig {
   return {
     auditLogPath: './audit.jsonl',
     allowedDirectory: TEST_SANDBOX_DIR,
@@ -56,6 +58,7 @@ function createTestConfig(overrides: { anthropicApiKey?: string } = {}): IronCur
       gooseProvider: 'anthropic',
       gooseModel: 'claude-sonnet-4-20250514',
       preferredDockerAgent: 'claude-code',
+      preferredMode: overrides.preferredMode ?? 'docker',
     },
   };
 }
@@ -149,73 +152,8 @@ describe('resolveSessionMode', () => {
       expect(result.mode).toEqual({ kind: 'docker', agent: 'claude-code', authKind: 'oauth' });
       expect(result.reason).toBe('Explicit --agent selection (OAuth)');
     });
-  });
 
-  describe('auto-detect (no --agent)', () => {
-    it('selects Docker when both Docker and API key are available', async () => {
-      const result = await resolveSessionMode({
-        config: createTestConfig(),
-        isDockerAvailable: dockerAvailable,
-        credentialSources: noOAuthSources,
-      });
-
-      expect(result.mode).toEqual({ kind: 'docker', agent: 'claude-code', authKind: 'apikey' });
-      expect(result.reason).toBe('Docker available, API key detected');
-    });
-
-    it('selects Docker with OAuth when available', async () => {
-      const oauthSources: CredentialSources = {
-        loadFromFile: () => ({
-          accessToken: 'sk-ant-oat01-test',
-          refreshToken: 'sk-ant-ort01-test',
-          expiresAt: Date.now() + 3_600_000,
-        }),
-        loadFromKeychain: () => null,
-      };
-
-      const result = await resolveSessionMode({
-        config: createTestConfig({ anthropicApiKey: '' }),
-        isDockerAvailable: dockerAvailable,
-        credentialSources: oauthSources,
-      });
-
-      expect(result.mode).toEqual({ kind: 'docker', agent: 'claude-code', authKind: 'oauth' });
-      expect(result.reason).toBe('Docker available, OAuth detected');
-    });
-
-    it('falls back to builtin when Docker is unavailable', async () => {
-      const result = await resolveSessionMode({
-        config: createTestConfig(),
-        isDockerAvailable: dockerUnavailable,
-        credentialSources: noOAuthSources,
-      });
-
-      expect(result.mode).toEqual({ kind: 'builtin' });
-      expect(result.reason).toBe('Docker not available');
-    });
-
-    it('falls back to builtin when no credentials are available', async () => {
-      const result = await resolveSessionMode({
-        config: createTestConfig({ anthropicApiKey: '' }),
-        isDockerAvailable: dockerAvailable,
-        credentialSources: noOAuthSources,
-      });
-
-      expect(result.mode).toEqual({ kind: 'builtin' });
-      expect(result.reason).toBe('No credentials (OAuth or API key)');
-    });
-
-    it('falls back to builtin when both Docker and credentials are missing', async () => {
-      const result = await resolveSessionMode({
-        config: createTestConfig({ anthropicApiKey: '' }),
-        isDockerAvailable: dockerUnavailable,
-        credentialSources: noOAuthSources,
-      });
-
-      expect(result.mode).toEqual({ kind: 'builtin' });
-    });
-
-    describe('OAuth-only without Docker', () => {
+    it('--agent goose surfaces the OAuth-not-usable-with-goose addendum on OAuth-only', async () => {
       const oauthOnlySources: CredentialSources = {
         loadFromFile: () => ({
           accessToken: 'sk-ant-oat01-test',
@@ -225,45 +163,193 @@ describe('resolveSessionMode', () => {
         loadFromKeychain: () => null,
       };
 
-      it('throws PreflightError when Docker is unavailable and only OAuth is configured', async () => {
-        const promise = resolveSessionMode({
-          config: createTestConfig({ anthropicApiKey: '' }),
-          isDockerAvailable: dockerUnavailable,
-          credentialSources: oauthOnlySources,
-        });
+      const config = createTestConfig({ anthropicApiKey: '' });
+      config.userConfig.preferredDockerAgent = 'goose';
+      config.userConfig.gooseProvider = 'anthropic';
 
-        await expect(promise).rejects.toThrow(PreflightError);
-        await expect(promise).rejects.toThrow(/Docker/);
+      const promise = resolveSessionMode({
+        config,
+        requestedAgent: 'goose' as AgentId,
+        isDockerAvailable: dockerAvailable,
+        credentialSources: oauthOnlySources,
       });
 
-      it('falls back to builtin when Docker is unavailable but an API key is also configured', async () => {
+      await expect(promise).rejects.toThrow(/OAuth credentials are not usable with goose/);
+    });
+  });
+
+  describe('default mode (no --agent)', () => {
+    const oauthOnlySources: CredentialSources = {
+      loadFromFile: () => ({
+        accessToken: 'sk-ant-oat01-test',
+        refreshToken: 'sk-ant-ort01-test',
+        expiresAt: Date.now() + 3_600_000,
+      }),
+      loadFromKeychain: () => null,
+    };
+
+    describe('preferredMode = docker', () => {
+      it('selects Docker (claude-code, API key) when both Docker and API key are available', async () => {
         const result = await resolveSessionMode({
-          config: createTestConfig({ anthropicApiKey: 'sk-ant-test-fallback' }),
-          isDockerAvailable: dockerUnavailable,
+          config: createTestConfig(),
+          isDockerAvailable: dockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        expect(result.mode).toEqual({ kind: 'docker', agent: 'claude-code', authKind: 'apikey' });
+        expect(result.reason).toBe('claude-code (API key)');
+      });
+
+      it('selects Docker (claude-code, OAuth) when only OAuth is configured', async () => {
+        const result = await resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: '' }),
+          isDockerAvailable: dockerAvailable,
           credentialSources: oauthOnlySources,
         });
 
-        expect(result.mode).toEqual({ kind: 'builtin' });
-        expect(result.reason).toBe('Docker not available');
+        expect(result.mode).toEqual({ kind: 'docker', agent: 'claude-code', authKind: 'oauth' });
+        expect(result.reason).toBe('claude-code (OAuth)');
       });
 
-      it('throws PreflightError when preferredDockerAgent is goose but Anthropic OAuth is the only credential', async () => {
-        // Regression: previously, detectCredentials on the goose path only probed the
-        // goose provider's API key and never looked at Anthropic OAuth, so OAuth-only
-        // users with preferredDockerAgent=goose silently fell back to builtin (which
-        // then failed without an API key). authMethod must be checked directly.
+      it('selects Docker (goose) when preferredDockerAgent=goose and goose provider key is set', async () => {
+        const config = createTestConfig();
+        config.userConfig.preferredDockerAgent = 'goose';
+        config.userConfig.gooseProvider = 'anthropic';
+
+        const result = await resolveSessionMode({
+          config,
+          isDockerAvailable: dockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        expect(result.mode).toEqual({ kind: 'docker', agent: 'goose', authKind: 'apikey' });
+        expect(result.reason).toBe('goose (API key)');
+      });
+
+      it('throws with goose+OAuth-only and includes the goose-OAuth-not-usable addendum', async () => {
         const config = createTestConfig({ anthropicApiKey: '' });
         config.userConfig.preferredDockerAgent = 'goose';
         config.userConfig.gooseProvider = 'anthropic';
 
         const promise = resolveSessionMode({
           config,
-          isDockerAvailable: dockerUnavailable,
+          isDockerAvailable: dockerAvailable,
           credentialSources: oauthOnlySources,
         });
 
         await expect(promise).rejects.toThrow(PreflightError);
-        await expect(promise).rejects.toThrow(/Docker/);
+        await expect(promise).rejects.toThrow(/goose/);
+        await expect(promise).rejects.toThrow(/OAuth credentials are not usable with goose/);
+      });
+
+      it('throws when Docker is unavailable, with --agent builtin and ironcurtain config hints', async () => {
+        const promise = resolveSessionMode({
+          config: createTestConfig(),
+          isDockerAvailable: dockerUnavailable,
+          credentialSources: noOAuthSources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        await expect(promise).rejects.toThrow(/Docker is not available/);
+        await expect(promise).rejects.toThrow(/--agent builtin/);
+        await expect(promise).rejects.toThrow(/ironcurtain config/);
+      });
+
+      it('throws via the preferred-mode helper (not the explicit-mode helper) when no credentials are configured', async () => {
+        const promise = resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: '' }),
+          isDockerAvailable: dockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        // The preferred-mode helper leads with "preferredMode is" and offers
+        // both the one-shot and permanent escapes. The explicit-mode helper
+        // would say "--agent claude-code requires authentication" instead.
+        await expect(promise).rejects.toThrow(/preferredMode is "docker"/);
+        await expect(promise).rejects.not.toThrow(/--agent claude-code requires authentication/);
+      });
+    });
+
+    describe('preferredMode = builtin', () => {
+      it('selects builtin when an Anthropic API key is configured', async () => {
+        const isDockerAvailable = vi.fn(dockerAvailable);
+        const result = await resolveSessionMode({
+          config: createTestConfig({ preferredMode: 'builtin' }),
+          isDockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        expect(result.mode).toEqual({ kind: 'builtin' });
+        expect(result.reason).toBe('preferredMode = builtin');
+        // Builtin path must not probe Docker — fast feedback for missing keys.
+        expect(isDockerAvailable).not.toHaveBeenCalled();
+      });
+
+      it('throws when only OAuth is configured (no ANTHROPIC_API_KEY)', async () => {
+        const promise = resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
+          isDockerAvailable: dockerAvailable,
+          credentialSources: oauthOnlySources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        await expect(promise).rejects.toThrow(/no ANTHROPIC_API_KEY/);
+      });
+
+      it('throws when nothing is configured (same message as OAuth-only)', async () => {
+        const promise = resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
+          isDockerAvailable: dockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        await expect(promise).rejects.toThrow(/no ANTHROPIC_API_KEY/);
+      });
+    });
+
+    describe('--agent overrides preferredMode', () => {
+      it('--agent builtin wins when preferredMode = docker', async () => {
+        const result = await resolveSessionMode({
+          config: createTestConfig({ preferredMode: 'docker' }),
+          requestedAgent: 'builtin' as AgentId,
+          isDockerAvailable: dockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        expect(result.mode).toEqual({ kind: 'builtin' });
+        expect(result.reason).toBe('Explicit --agent builtin');
+      });
+
+      it('--agent builtin succeeds even with preferredMode = builtin and no API key', async () => {
+        // Lock-in: resolveExplicit('builtin', ...) intentionally does NOT
+        // check the API key. The agent loop fails later on the actual API
+        // call. If a future "symmetry" refactor tightens this path, it
+        // should have to delete this test on purpose — see the design's
+        // out-of-scope notes.
+        const result = await resolveSessionMode({
+          config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
+          requestedAgent: 'builtin' as AgentId,
+          isDockerAvailable: dockerAvailable,
+          credentialSources: noOAuthSources,
+        });
+
+        expect(result.mode).toEqual({ kind: 'builtin' });
+      });
+
+      it('--agent claude-code with Docker unavailable throws the explicit-mode message', async () => {
+        const promise = resolveSessionMode({
+          config: createTestConfig({ preferredMode: 'builtin' }),
+          requestedAgent: 'claude-code' as AgentId,
+          isDockerAvailable: dockerUnavailable,
+          credentialSources: noOAuthSources,
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        // The explicit-mode message preserves its existing wording so the
+        // error is attributed to the flag the user typed.
+        await expect(promise).rejects.toThrow(/--agent claude-code requires Docker/);
       });
     });
   });

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -18,6 +18,16 @@ const noOAuthSources: CredentialSources = {
   loadFromKeychain: () => null,
 };
 
+/** OAuth credentials present (file), no API key — covers the OAuth-only paths. */
+const oauthOnlySources: CredentialSources = {
+  loadFromFile: () => ({
+    accessToken: 'sk-ant-oat01-test',
+    refreshToken: 'sk-ant-ort01-test',
+    expiresAt: Date.now() + 3_600_000,
+  }),
+  loadFromKeychain: () => null,
+};
+
 function createTestConfig(
   overrides: { anthropicApiKey?: string; preferredMode?: 'docker' | 'builtin' } = {},
 ): IronCurtainConfig {
@@ -133,20 +143,11 @@ describe('resolveSessionMode', () => {
     });
 
     it('succeeds with OAuth credentials and no API key', async () => {
-      const oauthSources: CredentialSources = {
-        loadFromFile: () => ({
-          accessToken: 'sk-ant-oat01-test',
-          refreshToken: 'sk-ant-ort01-test',
-          expiresAt: Date.now() + 3_600_000,
-        }),
-        loadFromKeychain: () => null,
-      };
-
       const result = await resolveSessionMode({
         config: createTestConfig({ anthropicApiKey: '' }),
         requestedAgent: 'claude-code' as AgentId,
         isDockerAvailable: dockerAvailable,
-        credentialSources: oauthSources,
+        credentialSources: oauthOnlySources,
       });
 
       expect(result.mode).toEqual({ kind: 'docker', agent: 'claude-code', authKind: 'oauth' });
@@ -154,15 +155,6 @@ describe('resolveSessionMode', () => {
     });
 
     it('--agent goose surfaces the OAuth-not-usable-with-goose addendum on OAuth-only', async () => {
-      const oauthOnlySources: CredentialSources = {
-        loadFromFile: () => ({
-          accessToken: 'sk-ant-oat01-test',
-          refreshToken: 'sk-ant-ort01-test',
-          expiresAt: Date.now() + 3_600_000,
-        }),
-        loadFromKeychain: () => null,
-      };
-
       const config = createTestConfig({ anthropicApiKey: '' });
       config.userConfig.preferredDockerAgent = 'goose';
       config.userConfig.gooseProvider = 'anthropic';
@@ -179,15 +171,6 @@ describe('resolveSessionMode', () => {
   });
 
   describe('default mode (no --agent)', () => {
-    const oauthOnlySources: CredentialSources = {
-      loadFromFile: () => ({
-        accessToken: 'sk-ant-oat01-test',
-        refreshToken: 'sk-ant-ort01-test',
-        expiresAt: Date.now() + 3_600_000,
-      }),
-      loadFromKeychain: () => null,
-    };
-
     describe('preferredMode = docker', () => {
       it('selects Docker (claude-code, API key) when both Docker and API key are available', async () => {
         const result = await resolveSessionMode({
@@ -328,14 +311,20 @@ describe('resolveSessionMode', () => {
         // call. If a future "symmetry" refactor tightens this path, it
         // should have to delete this test on purpose — see the design's
         // out-of-scope notes.
+        const dockerSpy = vi.fn().mockResolvedValue({ available: true });
         const result = await resolveSessionMode({
           config: createTestConfig({ anthropicApiKey: '', preferredMode: 'builtin' }),
           requestedAgent: 'builtin' as AgentId,
-          isDockerAvailable: dockerAvailable,
+          isDockerAvailable: dockerSpy,
           credentialSources: noOAuthSources,
         });
 
         expect(result.mode).toEqual({ kind: 'builtin' });
+        expect(result.reason).toBe('Explicit --agent builtin');
+        // Explicit-builtin path skips the Docker probe — only resolveExplicit
+        // produces this combination; the bare `mode === 'builtin'` assertion
+        // alone would also pass the prior auto-detect code.
+        expect(dockerSpy).not.toHaveBeenCalled();
       });
 
       it('--agent claude-code with Docker unavailable throws the explicit-mode message', async () => {

--- a/test/user-config.test.ts
+++ b/test/user-config.test.ts
@@ -740,6 +740,61 @@ describe('saveUserConfig', () => {
   }
 });
 
+describe('preferredMode field', () => {
+  let testHome: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    testHome = mkdtempSync(resolve(tmpdir(), 'ironcurtain-prefmode-'));
+    for (const key of ENV_VARS_TO_ISOLATE) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.IRONCURTAIN_HOME = testHome;
+  });
+
+  afterEach(() => {
+    for (const key of ENV_VARS_TO_ISOLATE) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  function writeConfigFile(config: Record<string, unknown>): void {
+    mkdirSync(testHome, { recursive: true });
+    writeFileSync(resolve(testHome, 'config.json'), JSON.stringify(config, null, 2));
+  }
+
+  it('defaults to "docker" when not set', () => {
+    const config = loadUserConfig();
+    expect(config.preferredMode).toBe('docker');
+  });
+
+  it('accepts "docker"', () => {
+    writeConfigFile({ preferredMode: 'docker' });
+    expect(loadUserConfig().preferredMode).toBe('docker');
+  });
+
+  it('accepts "builtin"', () => {
+    writeConfigFile({ preferredMode: 'builtin' });
+    expect(loadUserConfig().preferredMode).toBe('builtin');
+  });
+
+  it('rejects "auto" with a clear schema error', () => {
+    writeConfigFile({ preferredMode: 'auto' });
+    expect(() => loadUserConfig()).toThrow(/preferredMode/);
+  });
+
+  it('rejects unrelated string values', () => {
+    writeConfigFile({ preferredMode: 'pty' });
+    expect(() => loadUserConfig()).toThrow(/preferredMode/);
+  });
+});
+
 describe('validateModelId', () => {
   it('returns undefined for valid model IDs', () => {
     expect(validateModelId('anthropic:claude-sonnet-4-6')).toBeUndefined();


### PR DESCRIPTION
## Summary

- Removes silent fallback to the builtin V8 sandbox during session-startup mode resolution. Builtin is now opt-in, not a degraded default.
- Adds `preferredMode: 'docker' | 'builtin'` to `UserConfig`, default `'docker'`. If `preferredMode === 'docker'` and Docker is unavailable, the session refuses to start with remediation hints instead of silently dropping into builtin.
- `--agent` CLI flag continues to win over config. Goose covered via the existing `preferredDockerAgent` field — `preferredMode: 'docker'` with `preferredDockerAgent: 'goose'` requires goose-provider credentials and surfaces an "OAuth not usable with goose" addendum when only Anthropic OAuth is present.
- `ironcurtain doctor` now treats declared-but-unmet preferences as failures: `preferredMode: 'docker'` + Docker unavailable causes `doctor` to exit 1, matching the actual session-startup contract.
- Includes a design doc at `docs/designs/explicit-agent-mode.md` capturing the control flow, edge cases, and test plan.

## Why

Bishop Fox testing surfaced the silent-fallback behavior as harmful: testers got stuck in builtin mode for hours without realizing it because the only signal was a single dim stderr line they could miss. PR #213 (already merged) fixed transient Docker-probe flakiness with timeout + retries; this PR fixes the *policy* of what to do when the probe legitimately reports unavailable.

## Architectural notes

- `resolveAutoDetect` renamed to `resolveDefaultMode` (no auto-detection happens anymore — the user's `preferredMode` is consulted directly). The OAuth-only-without-Docker special case collapses into the general docker-unavailable path.
- New `detectCredentialState` consolidates `detectCredentials` + the prior `hasAnthropicOAuthOnly` helper into a single `detectAuthMethod` round-trip per resolution.
- `Promise.all` runs the Docker probe and credential detection in parallel on the docker happy path (preserved from the prior auto-detect shape).
- New `formatModeLine(preflight)` and `formatModeRemediation(targetMode)` helpers ensure the print banner and the "switch to <other mode>" footer don't drift across `start`, `daemon`, and cron-job entry points.

## Out of scope (explicit, see design doc)

- Auditing the Docker detection technique itself — PR #213 addressed flakiness.
- Adding a third `preferredMode` value (`'auto'`, `'pty'`, etc.) — the entire point is to remove ambiguity.
- Changing `--agent` flag semantics.
- Tightening `--agent builtin` to require an API key — locked in with a regression test so a future "symmetry" refactor doesn't silently change it.
- Migrating existing config files — missing `preferredMode` resolves to the `'docker'` default via `mergeWithDefaults`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 4299 root tests pass + 338 web-ui tests pass
- [x] New `resolveDefaultMode` cases in `test/preflight.test.ts`: docker + API key, docker + OAuth, docker + goose + provider key, docker + goose + OAuth-only addendum content, docker unavailable error wording (asserts `--agent builtin` and `ironcurtain config` hints), no credentials at all (asserts preferred-mode helper is used, not the explicit-mode helper)
- [x] `preferredMode: 'builtin'` cases: success with API key, fast-fail without API key (asserts `isDockerAvailable` is never called)
- [x] `--agent` overrides: builtin + preferredMode docker, builtin + preferredMode builtin + no API key (lock-in for the explicit-path API-key skip), claude-code + preferredMode builtin + Docker unavailable (existing explicit message preserved), goose + OAuth-only addendum
- [x] Schema rejection of `preferredMode: 'auto'`
- [x] `checkPreferredMode` table cases in `test/doctor.test.ts`: docker + ok → ok, docker + warn → fail, builtin + key → ok, builtin + no-key → warn
- [x] Three commits on the branch — initial implementation, /simplify pass (restored Promise.all, helper extraction, fixture hoisting), cleanliness pass (comment trims, test consolidation). All pre-commit-clean.