### PR TITLE
feat(mux): run Docker preflight before entering fullscreen

### DIFF
--- a/src/mux/mux-command.ts
+++ b/src/mux/mux-command.ts
@@ -12,24 +12,38 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 import { getPtyRegistryDir } from '../config/paths.js';
-import { loadUserConfig } from '../config/user-config.js';
+import type { ResolvedUserConfig } from '../config/user-config.js';
 import { parseModelId, resolveApiKeyForProvider } from '../config/model-provider.js';
 import { loadConfig } from '../config/index.js';
 import { checkHelp, type CommandSpec } from '../cli-help.js';
-import { createMuxApp } from './mux-app.js';
+import {
+  resolveSessionMode as defaultResolveSessionMode,
+  formatModeLine,
+  PreflightError,
+} from '../session/preflight.js';
+import type { PreflightOptions, PreflightResult } from '../session/preflight.js';
+import type { AgentId } from '../docker/agent-adapter.js';
+import { createMuxApp, type MuxApp, type MuxAppOptions } from './mux-app.js';
 
 const muxSpec: CommandSpec = {
   name: 'ironcurtain mux',
   description: 'Terminal multiplexer for PTY sessions (requires node-pty)',
   usage: ['ironcurtain mux [options]'],
   options: [
-    { flag: 'agent', short: 'a', description: 'Agent mode (default: claude-code)', placeholder: '<name>' },
+    { flag: 'agent', short: 'a', description: 'Agent mode (default: from config)', placeholder: '<name>' },
     { flag: 'model', short: 'm', description: 'Override the agent model ID', placeholder: '<model>' },
   ],
 };
 
-export async function main(args?: string[]): Promise<void> {
-  // Check for optional mux dependencies
+/** Test injection points; production callers pass nothing. */
+export interface MuxMainDeps {
+  readonly resolveSessionMode?: (options: PreflightOptions) => Promise<PreflightResult>;
+  readonly createMuxApp?: (options: MuxAppOptions) => MuxApp;
+  readonly skipNativeProbes?: boolean;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+async function probeNativeDependencies(): Promise<void> {
   try {
     await import('node-pty');
   } catch {
@@ -65,6 +79,7 @@ export async function main(args?: string[]): Promise<void> {
       // its own error if spawning fails.
     }
   }
+
   try {
     await import('terminal-kit');
   } catch {
@@ -73,6 +88,33 @@ export async function main(args?: string[]): Promise<void> {
         'Install it with: npm install terminal-kit\n',
     );
     process.exit(1);
+  }
+}
+
+/** Returns true if a warning was emitted (caller should pause before fullscreen). */
+function emitAutoApproveWarning(userConfig: ResolvedUserConfig): boolean {
+  if (!userConfig.autoApprove.enabled) return false;
+
+  const { provider } = parseModelId(userConfig.autoApprove.modelId);
+  const apiKey = resolveApiKeyForProvider(provider, userConfig);
+  if (apiKey) return false;
+
+  process.stderr.write(
+    chalk.yellow(
+      `Warning: auto-approve is enabled but no API key found for provider "${provider}".\n` +
+        'Auto-approve will be silently disabled. Set the API key in your environment or config.\n',
+    ),
+  );
+  return true;
+}
+
+export async function main(args?: string[], deps: MuxMainDeps = {}): Promise<void> {
+  const resolveSessionMode = deps.resolveSessionMode ?? defaultResolveSessionMode;
+  const createApp = deps.createMuxApp ?? createMuxApp;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  if (!deps.skipNativeProbes) {
+    await probeNativeDependencies();
   }
 
   // Parse args
@@ -89,8 +131,47 @@ export async function main(args?: string[]): Promise<void> {
 
   if (checkHelp(values as { help?: boolean }, muxSpec)) return;
 
-  const agent = (values.agent as string | undefined) ?? 'claude-code';
+  const requestedAgentRaw = values.agent as string | undefined;
   const model = values.model as string | undefined;
+
+  const config = loadConfig();
+
+  // Preflight runs before the autoApprove sleep so a fatal preflight does not wait 3 seconds.
+  let preflight: PreflightResult;
+  try {
+    preflight = await resolveSessionMode({
+      config,
+      requestedAgent: requestedAgentRaw ? (requestedAgentRaw as AgentId) : undefined,
+    });
+  } catch (err) {
+    if (err instanceof PreflightError) {
+      process.stderr.write(chalk.red(err.message) + '\n');
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  process.stderr.write(chalk.dim(formatModeLine(preflight)) + '\n');
+
+  // Builtin mode does not have a `--agent` flag to pass to the child PTY,
+  // and the PTY child requires Docker mode anyway. Refuse cleanly here so
+  // the user gets a single coherent message rather than per-tab failures.
+  if (preflight.mode.kind !== 'docker') {
+    process.stderr.write(
+      chalk.red(
+        'ironcurtain mux requires Docker agent mode.\n' +
+          'Pass --agent claude-code, or set Session Mode > Preferred mode to "docker" in `ironcurtain config`.\n',
+      ),
+    );
+    process.exit(1);
+  }
+  const resolvedAgent = preflight.mode.agent;
+
+  const hasWarnings = emitAutoApproveWarning(config.userConfig);
+  if (hasWarnings) {
+    process.stderr.write(chalk.dim('\nStarting in 3 seconds...\n'));
+    await sleep(3000);
+  }
 
   // Generate a unique mux instance ID for session ownership
   const muxId = `mux-${randomBytes(4).toString('hex')}`;
@@ -99,45 +180,11 @@ export async function main(args?: string[]): Promise<void> {
   const registryDir = getPtyRegistryDir();
   mkdirSync(registryDir, { recursive: true, mode: 0o700 });
 
-  // Pre-flight warnings (shown before fullscreen takes over)
-  let hasWarnings = false;
-  try {
-    const userConfig = loadUserConfig({ readOnly: true });
-    if (userConfig.autoApprove.enabled) {
-      const { provider } = parseModelId(userConfig.autoApprove.modelId);
-      const apiKey = resolveApiKeyForProvider(provider, userConfig);
-      if (!apiKey) {
-        process.stderr.write(
-          chalk.yellow(
-            `Warning: auto-approve is enabled but no API key found for provider "${provider}".\n` +
-              'Auto-approve will be silently disabled. Set the API key in your environment or config.\n',
-          ),
-        );
-        hasWarnings = true;
-      }
-    }
-  } catch {
-    // Config load failure is not fatal here -- the child sessions will report it.
-  }
-
-  if (hasWarnings) {
-    process.stderr.write(chalk.dim('\nStarting in 3 seconds...\n'));
-    await new Promise((r) => setTimeout(r, 3000));
-  }
-
-  // Load config once for workspace validation
-  let protectedPaths: string[] = [];
-  try {
-    protectedPaths = loadConfig().protectedPaths;
-  } catch {
-    // Config load failure is not fatal; child sessions will report it.
-  }
-
-  const app = createMuxApp({
-    agent,
+  const app = createApp({
+    agent: resolvedAgent,
     model,
     autoSpawn: false,
-    protectedPaths,
+    protectedPaths: config.protectedPaths,
     muxId,
     muxPid: process.pid,
   });

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -312,6 +312,41 @@ export function formatModeLine(preflight: PreflightResult): string {
   return `Mode: docker / ${preflight.reason}`;
 }
 
+/** Per-call-site message strategy for `resolveDockerAgent`. */
+interface DockerAgentMessages {
+  dockerUnavailable: (detailedMessage: string) => string;
+  credentialsMissing: (anthropicOAuthOnly: boolean) => string;
+  successReason: (authKind: 'oauth' | 'apikey') => string;
+}
+
+async function resolveDockerAgent(
+  agent: AgentId,
+  config: IronCurtainConfig,
+  isDockerAvailable: () => Promise<DockerAvailability>,
+  credentialSources: CredentialSources | undefined,
+  messages: DockerAgentMessages,
+): Promise<PreflightResult> {
+  const { dockerStatus, credState } = await probeDockerAndCredentials(
+    agent,
+    config,
+    isDockerAvailable,
+    credentialSources,
+  );
+
+  if (!dockerStatus.available) {
+    throw new PreflightError(messages.dockerUnavailable(dockerStatus.detailedMessage));
+  }
+
+  if (credState.credKind === null) {
+    throw new PreflightError(messages.credentialsMissing(credState.anthropicOAuthOnly));
+  }
+
+  return {
+    mode: { kind: 'docker', agent, authKind: credState.credKind },
+    reason: messages.successReason(credState.credKind),
+  };
+}
+
 /**
  * Resolves the session mode based on the explicit `--agent` flag or the
  * user's `preferredMode`.
@@ -344,28 +379,13 @@ async function resolveExplicit(
     };
   }
 
-  const { dockerStatus, credState } = await probeDockerAndCredentials(
-    agent,
-    config,
-    isDockerAvailable,
-    credentialSources,
-  );
-
-  if (!dockerStatus.available) {
-    throw new PreflightError(
-      `--agent ${agent} requires Docker, but it is not available:\n\n${dockerStatus.detailedMessage}\n\n` +
-        'Please fix your Docker installation or use the builtin agent.',
-    );
-  }
-
-  if (credState.credKind === null) {
-    throw new PreflightError(credentialErrorMessageForExplicit(agent, config, credState.anthropicOAuthOnly));
-  }
-
-  return {
-    mode: { kind: 'docker', agent, authKind: credState.credKind },
-    reason: `Explicit --agent selection (${credState.credKind === 'oauth' ? 'OAuth' : 'API key'})`,
-  };
+  return resolveDockerAgent(agent, config, isDockerAvailable, credentialSources, {
+    dockerUnavailable: (detailedMessage) =>
+      `--agent ${agent} requires Docker, but it is not available:\n\n${detailedMessage}\n\n` +
+      'Please fix your Docker installation or use the builtin agent.',
+    credentialsMissing: (oauthOnly) => credentialErrorMessageForExplicit(agent, config, oauthOnly),
+    successReason: (authKind) => `Explicit --agent selection (${authKind === 'oauth' ? 'OAuth' : 'API key'})`,
+  });
 }
 
 async function resolveDefaultMode(
@@ -386,23 +406,9 @@ async function resolveDefaultMode(
 
   const agent = preferredDockerAgent as AgentId;
 
-  const { dockerStatus, credState } = await probeDockerAndCredentials(
-    agent,
-    config,
-    isDockerAvailable,
-    credentialSources,
-  );
-
-  if (!dockerStatus.available) {
-    throw new PreflightError(dockerUnavailableMessage(dockerStatus.detailedMessage));
-  }
-
-  if (credState.credKind === null) {
-    throw new PreflightError(credentialErrorMessageForPreferredMode(agent, config, credState.anthropicOAuthOnly));
-  }
-
-  return {
-    mode: { kind: 'docker', agent, authKind: credState.credKind },
-    reason: `${preferredDockerAgent} (${credState.credKind === 'oauth' ? 'OAuth' : 'API key'})`,
-  };
+  return resolveDockerAgent(agent, config, isDockerAvailable, credentialSources, {
+    dockerUnavailable: dockerUnavailableMessage,
+    credentialsMissing: (oauthOnly) => credentialErrorMessageForPreferredMode(agent, config, oauthOnly),
+    successReason: (authKind) => `${preferredDockerAgent} (${authKind === 'oauth' ? 'OAuth' : 'API key'})`,
+  });
 }

--- a/test/mux-command.test.ts
+++ b/test/mux-command.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `ironcurtain mux`'s preflight integration.
+ *
+ * These tests verify the contract introduced when preflight was added to
+ * the mux command:
+ *   1. Successful preflight prints the mode line to stderr and proceeds
+ *      to construct the MuxApp.
+ *   2. PreflightError is caught, printed in red, and exits with code 1
+ *      WITHOUT constructing the MuxApp (i.e., never enters fullscreen).
+ *   3. When `--agent` is omitted, `resolveSessionMode` is called with
+ *      `requestedAgent: undefined` so `userConfig.preferredMode` is honored.
+ *   4. When `--agent <name>` is provided, that value is passed through.
+ *   5. Preflight runs BEFORE the autoApprove 3-second warning sleep
+ *      (fail-fast semantics).
+ *
+ * The mux module is imported once and uses the dependency-injection seam
+ * (`MuxMainDeps`) to substitute the real `resolveSessionMode`, `createMuxApp`,
+ * and the autoApprove sleep. Native-deps probing (node-pty / terminal-kit)
+ * is skipped via `skipNativeProbes: true` so the test does not require those
+ * optional packages.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { IronCurtainConfig } from '../src/config/types.js';
+import type { PreflightOptions, PreflightResult } from '../src/session/preflight.js';
+import { PreflightError } from '../src/session/preflight.js';
+import type { MuxApp, MuxAppOptions } from '../src/mux/mux-app.js';
+
+// --- Module mocks (hoisted) ---
+// `loadConfig()` is mocked so the test does not require a real
+// `~/.ironcurtain/config.json` or `mcp-servers.json` on disk.
+
+const mockConfig: IronCurtainConfig = {
+  auditLogPath: './audit.jsonl',
+  allowedDirectory: join(tmpdir(), 'mux-test-sandbox'),
+  mcpServers: {},
+  protectedPaths: ['/protected/path'],
+  generatedDir: join(tmpdir(), 'mux-test-generated'),
+  constitutionPath: join(tmpdir(), 'mux-test-constitution.md'),
+  agentModelId: 'anthropic:claude-sonnet-4-6',
+  escalationTimeoutSeconds: 300,
+  userConfig: {
+    agentModelId: 'anthropic:claude-sonnet-4-6',
+    policyModelId: 'anthropic:claude-sonnet-4-6',
+    anthropicApiKey: 'test-api-key',
+    googleApiKey: '',
+    openaiApiKey: '',
+    escalationTimeoutSeconds: 300,
+    resourceBudget: {
+      maxTotalTokens: 1_000_000,
+      maxSteps: 200,
+      maxSessionSeconds: 1800,
+      maxEstimatedCostUsd: 5.0,
+      warnThresholdPercent: 80,
+    },
+    autoCompact: {
+      enabled: false,
+      thresholdTokens: 80_000,
+      keepRecentMessages: 10,
+      summaryModelId: 'anthropic:claude-haiku-4-5',
+    },
+    autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
+    auditRedaction: { enabled: true },
+    serverCredentials: {},
+    gooseProvider: 'anthropic',
+    gooseModel: 'claude-sonnet-4-20250514',
+    preferredDockerAgent: 'claude-code',
+    preferredMode: 'docker',
+  },
+};
+
+vi.mock('../src/config/index.js', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => mockConfig),
+  };
+});
+
+// Point the PTY registry into a temp dir so the `mkdirSync(registryDir, ...)`
+// call doesn't touch the user's real `~/.ironcurtain/`.
+vi.mock('../src/config/paths.js', async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    getPtyRegistryDir: vi.fn(() => join(tmpdir(), `mux-test-registry-${process.pid}`)),
+  };
+});
+
+// --- Imports (after mocks) ---
+
+import { main as muxMain } from '../src/mux/mux-command.js';
+
+// --- Helpers ---
+
+function makePreflightSuccess(agent: 'claude-code' | 'goose' = 'claude-code'): PreflightResult {
+  return {
+    mode: { kind: 'docker', agent, authKind: 'apikey' },
+    reason: `${agent} (API key)`,
+  };
+}
+
+/** Builds a fake `MuxApp` whose `start()` immediately resolves. */
+function makeFakeMuxApp(): MuxApp {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Captures stderr writes during `main()` so tests can assert on them. */
+function captureStderr(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = (chunk: any) => {
+    if (typeof chunk === 'string') lines.push(chunk);
+    else if (Buffer.isBuffer(chunk)) lines.push(chunk.toString('utf8'));
+    return true;
+  };
+  return {
+    lines,
+    restore: () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stderr as any).write = original;
+    },
+  };
+}
+
+/**
+ * Replaces `process.exit` with one that throws a tagged error. The mux command
+ * uses `process.exit(1)` on PreflightError; without this stub the test process
+ * would actually exit. The thrown error is caught at the test's `await`.
+ */
+function stubProcessExit(): { restore: () => void } {
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`process.exit:${code ?? 0}`);
+  }) as never);
+  return { restore: () => exitSpy.mockRestore() };
+}
+
+describe('ironcurtain mux preflight integration', () => {
+  let stderr: ReturnType<typeof captureStderr>;
+  let exitStub: ReturnType<typeof stubProcessExit>;
+
+  beforeEach(async () => {
+    stderr = captureStderr();
+    exitStub = stubProcessExit();
+    // Reset the loadConfig mock so tests that override it don't leak.
+    const configModule = await import('../src/config/index.js');
+    vi.mocked(configModule.loadConfig).mockReturnValue(mockConfig);
+  });
+
+  afterEach(() => {
+    stderr.restore();
+    exitStub.restore();
+    vi.restoreAllMocks();
+  });
+
+  it('successful preflight prints the mode line and constructs the MuxApp', async () => {
+    const fakeApp = makeFakeMuxApp();
+    const resolveSessionMode = vi.fn().mockResolvedValue(makePreflightSuccess('claude-code'));
+    const createMuxApp = vi.fn(() => fakeApp);
+
+    await muxMain([], {
+      resolveSessionMode,
+      createMuxApp,
+      skipNativeProbes: true,
+    });
+
+    expect(resolveSessionMode).toHaveBeenCalledOnce();
+    expect(createMuxApp).toHaveBeenCalledOnce();
+    expect(fakeApp.start).toHaveBeenCalledOnce();
+    // Mode line must reach stderr in the same shape as `start`/`daemon`/`bot`.
+    const stderrText = stderr.lines.join('');
+    expect(stderrText).toMatch(/Mode: docker \/ claude-code \(API key\)/);
+  });
+
+  it('PreflightError is printed in red and exits with code 1; MuxApp is NOT constructed', async () => {
+    const resolveSessionMode = vi.fn().mockRejectedValue(new PreflightError('Docker is not available'));
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await expect(
+      muxMain([], {
+        resolveSessionMode,
+        createMuxApp,
+        skipNativeProbes: true,
+      }),
+    ).rejects.toThrow('process.exit:1');
+
+    expect(resolveSessionMode).toHaveBeenCalledOnce();
+    expect(createMuxApp).not.toHaveBeenCalled();
+    const stderrText = stderr.lines.join('');
+    // The error message itself reaches stderr (chalk.red wraps it; the
+    // message body is plain so we can match on the literal).
+    expect(stderrText).toMatch(/Docker is not available/);
+    expect(stderrText).toMatch(/Run `ironcurtain doctor` for a full diagnostic/);
+  });
+
+  it('omitting --agent passes requestedAgent: undefined so preferredMode is honored', async () => {
+    const resolveSessionMode = vi.fn().mockResolvedValue(makePreflightSuccess('claude-code'));
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await muxMain([], {
+      resolveSessionMode,
+      createMuxApp,
+      skipNativeProbes: true,
+    });
+
+    expect(resolveSessionMode).toHaveBeenCalledOnce();
+    const callArg = resolveSessionMode.mock.calls[0][0] as PreflightOptions;
+    expect(callArg.requestedAgent).toBeUndefined();
+  });
+
+  it('explicit --agent claude-code is forwarded to resolveSessionMode', async () => {
+    const resolveSessionMode = vi.fn().mockResolvedValue(makePreflightSuccess('claude-code'));
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await muxMain(['--agent', 'claude-code'], {
+      resolveSessionMode,
+      createMuxApp,
+      skipNativeProbes: true,
+    });
+
+    expect(resolveSessionMode).toHaveBeenCalledOnce();
+    const callArg = resolveSessionMode.mock.calls[0][0] as PreflightOptions;
+    expect(callArg.requestedAgent).toBe('claude-code');
+  });
+
+  it('preflight runs BEFORE the autoApprove warning sleep (fail-fast)', async () => {
+    // Arrange: enable autoApprove with no API key so the warning would fire,
+    // and have preflight reject so we can prove we never reached the sleep.
+    const configWithBadAutoApprove: IronCurtainConfig = {
+      ...mockConfig,
+      userConfig: {
+        ...mockConfig.userConfig,
+        autoApprove: { enabled: true, modelId: 'anthropic:claude-haiku-4-5' },
+        anthropicApiKey: '',
+        googleApiKey: '',
+        openaiApiKey: '',
+      },
+    };
+    const configModule = await import('../src/config/index.js');
+    vi.mocked(configModule.loadConfig).mockReturnValue(configWithBadAutoApprove);
+
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const resolveSessionMode = vi.fn().mockRejectedValue(new PreflightError('preflight failed'));
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await expect(
+      muxMain([], {
+        resolveSessionMode,
+        createMuxApp,
+        skipNativeProbes: true,
+        sleep,
+      }),
+    ).rejects.toThrow('process.exit:1');
+
+    // The 3-second sleep MUST NOT have been triggered — preflight short-
+    // circuits before the autoApprove warning block runs.
+    expect(sleep).not.toHaveBeenCalled();
+    expect(createMuxApp).not.toHaveBeenCalled();
+  });
+
+  it('builtin mode is rejected with a clean error (mux requires Docker)', async () => {
+    // If preferredMode resolves to builtin, the mux child PTY can't run.
+    // Fail fast with a single coherent message rather than per-tab spam.
+    const resolveSessionMode = vi.fn().mockResolvedValue({
+      mode: { kind: 'builtin' },
+      reason: 'preferredMode = builtin',
+    } as PreflightResult);
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await expect(
+      muxMain([], {
+        resolveSessionMode,
+        createMuxApp,
+        skipNativeProbes: true,
+      }),
+    ).rejects.toThrow('process.exit:1');
+
+    expect(createMuxApp).not.toHaveBeenCalled();
+    const stderrText = stderr.lines.join('');
+    expect(stderrText).toMatch(/ironcurtain mux requires Docker agent mode/);
+  });
+
+  it('uses the resolved preflight agent (not the raw --agent value) when constructing the MuxApp', async () => {
+    // When --agent is omitted, the resolved agent must come from preflight
+    // (driven by preferredDockerAgent), not from a hardcoded default.
+    const resolveSessionMode = vi.fn().mockResolvedValue(makePreflightSuccess('goose'));
+    const captured: MuxAppOptions[] = [];
+    const createMuxApp = vi.fn((opts: MuxAppOptions) => {
+      captured.push(opts);
+      return makeFakeMuxApp();
+    });
+
+    await muxMain([], {
+      resolveSessionMode,
+      createMuxApp,
+      skipNativeProbes: true,
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].agent).toBe('goose');
+  });
+});


### PR DESCRIPTION
## Summary
- Run preflight (Docker probe + credential detection + OAuth refresh) once in the `ironcurtain mux` parent process, before fullscreen takes over. Failures now surface as a clean red error with exit 1, instead of being swallowed when each PTY child runs its own preflight and dies (`mux-app` removes the failed tab and discards its xterm buffer, so the child's stderr is gone).
- When `--agent` is omitted, `requestedAgent: undefined` is passed through so `userConfig.preferredMode` is honored, matching the `start` / `daemon` / `bot` callers. Builtin mode is rejected at the parent — the PTY child requires Docker by construction, so failing once is friendlier than N identical per-tab failures.
- De-dup `resolveExplicit` and `resolveDefaultMode` in `src/session/preflight.ts` via a shared `resolveDockerAgent` helper that owns the Docker probe, credential check, OAuth refresh, and result shape. Per-call-site text is supplied via a `DockerAgentMessages` strategy object. The existing 25 preflight tests pass unchanged, which is the contract that the refactor is behavior-preserving.

## Notable behavior changes
- `loadConfig()` failure in `mux` is now fatal (was best-effort for `protectedPaths`). Every PTY child would hit the same failure anyway, so a single clean error is better than N identical ones.
- Bare `ironcurtain mux` no longer hard-codes `agent = 'claude-code'`; it now honors `preferredMode` / `preferredDockerAgent` from `~/.ironcurtain/config.json`, consistent with other entry points.

## Follow-up (not in this PR)
- Child-side `PreflightError` from PTY tabs is still invisible to the user when the mux is already running and a new tab is opened later (e.g., Docker dies between launch and second tab). Fix idea: capture the last N kB of the xterm buffer in `pty-bridge` on exit and surface it via `showMessage` when exit code ≠ 0.

## Test plan
- [x] `npm test -- test/preflight.test.ts` — 25/25 pass (refactor is behavior-preserving)
- [x] `npm test -- test/mux-command.test.ts` — 7 new tests pass (success path, PreflightError → exit 1 + no MuxApp, `--agent` omitted forwards `undefined`, explicit `--agent` forwarded, fail-fast before 3s sleep, builtin rejected, resolved agent flows to `MuxApp`)
- [x] `npm test` — full suite green, no regressions
- [x] `npm run lint`, `npm run format:check`, `npm run build` — all clean
- [ ] Manual: `ironcurtain mux` with Docker running — should show `Mode: docker / claude-code (...)` and enter fullscreen
- [ ] Manual: `ironcurtain mux` with Docker stopped — should print red error and exit 1 *before* fullscreen
- [ ] Manual: `ironcurtain mux --agent builtin` — should print "mux requires Docker agent mode" and exit 1