### PR TITLE
fix(docker): remap codespace UID/GID to host on Linux (#232)

### DIFF
--- a/docker/entrypoint-claude-code.sh
+++ b/docker/entrypoint-claude-code.sh
@@ -4,6 +4,34 @@
 # Non-PTY mode: CMD is "sleep infinity" (agent commands arrive via docker exec).
 # PTY mode: CMD is the socat PTY command from buildPtyCommand().
 
+# Runtime UID remap (Linux only).
+#
+# Issue #232: when the host UID is not 1000, bind-mounted directories
+# (e.g., the conversation-state dir) appear inside the container owned
+# by the host UID, and the baked codespace user (UID 1000) cannot write
+# to them. The host-side launcher passes `--user 0:0` plus the host
+# UID/GID via IRONCURTAIN_AGENT_UID / IRONCURTAIN_AGENT_GID so this
+# block (running as root) can renumber the codespace account to match
+# the host before dropping privileges. On macOS, Docker Desktop's
+# VirtioFS translates UIDs transparently and the env vars are not set,
+# so this block is skipped.
+if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
+  if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
+    # Renumber the codespace user/group to the host UID/GID, then fix
+    # ownership on the baked home dir and workspace mount so the
+    # remapped codespace user can read/write them. Bind-mounted
+    # subdirectories (conversation state, sockets, orientation) keep
+    # their host-side ownership, which now matches codespace.
+    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace
+    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace
+    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace
+  fi
+  # Re-exec the entrypoint as the (possibly remapped) codespace user.
+  # The remainder of this script runs under codespace, so $HOME and
+  # sudoers (which keys on the username) resolve correctly.
+  exec runuser -u codespace -- "$0" "$@"
+fi
+
 # Bridge UDS to local TCP so HTTPS_PROXY works
 MITM_SOCK="/run/ironcurtain/mitm-proxy.sock"
 PROXY_PORT=18080

--- a/docker/entrypoint-claude-code.sh
+++ b/docker/entrypoint-claude-code.sh
@@ -22,9 +22,27 @@ if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN
     # remapped codespace user can read/write them. Bind-mounted
     # subdirectories (conversation state, sockets, orientation) keep
     # their host-side ownership, which now matches codespace.
-    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace
-    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace
-    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace
+    #
+    # FAIL HARD on remap errors. Previously these commands ran without
+    # return-code checks: if `usermod -u $HOST_UID codespace` collided
+    # with an existing image user (plausible for system UIDs like 33
+    # `www-data` or 100 `systemd-network`), the entrypoint would
+    # silently continue, then `chown` and `runuser -u codespace`
+    # would operate on the still-UID-1000 codespace — recreating the
+    # original issue #232 bug with no diagnostic. Abort with an explicit
+    # error instead so the operator sees what went wrong.
+    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace || {
+      echo "[ironcurtain] groupmod failed: cannot remap codespace group to GID $IRONCURTAIN_AGENT_GID (already in use?)" >&2
+      exit 1
+    }
+    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace || {
+      echo "[ironcurtain] usermod failed: cannot remap codespace user to UID $IRONCURTAIN_AGENT_UID (already in use?)" >&2
+      exit 1
+    }
+    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace || {
+      echo "[ironcurtain] chown failed: cannot reset ownership of /home/codespace and /workspace to $IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" >&2
+      exit 1
+    }
   fi
   # Re-exec the entrypoint as the (possibly remapped) codespace user.
   # The remainder of this script runs under codespace, so $HOME and

--- a/docker/entrypoint-goose.sh
+++ b/docker/entrypoint-goose.sh
@@ -2,6 +2,18 @@
 # IronCurtain entrypoint for Goose containers.
 # Sets up proxy bridges, writes Goose config, then hands off to CMD.
 
+# Runtime UID remap (Linux only). See entrypoint-claude-code.sh for the
+# full rationale (issue #232). Skipped on macOS where Docker Desktop
+# translates UIDs and the env vars are not set.
+if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
+  if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
+    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace
+    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace
+    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace
+  fi
+  exec runuser -u codespace -- "$0" "$@"
+fi
+
 # 1. Bridge MITM proxy UDS to local TCP (same as Claude Code entrypoint)
 MITM_SOCK="/run/ironcurtain/mitm-proxy.sock"
 PROXY_PORT=18080

--- a/docker/entrypoint-goose.sh
+++ b/docker/entrypoint-goose.sh
@@ -7,9 +7,22 @@
 # translates UIDs and the env vars are not set.
 if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
   if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
-    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace
-    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace
-    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace
+    # Fail hard on remap errors — see entrypoint-claude-code.sh for the
+    # full rationale. Without explicit checks, a UID collision (host UID
+    # already in use by a system user baked into the image) silently
+    # recreates the original issue #232 bug.
+    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace || {
+      echo "[ironcurtain] groupmod failed: cannot remap codespace group to GID $IRONCURTAIN_AGENT_GID (already in use?)" >&2
+      exit 1
+    }
+    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace || {
+      echo "[ironcurtain] usermod failed: cannot remap codespace user to UID $IRONCURTAIN_AGENT_UID (already in use?)" >&2
+      exit 1
+    }
+    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace || {
+      echo "[ironcurtain] chown failed: cannot reset ownership of /home/codespace and /workspace to $IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" >&2
+      exit 1
+    }
   fi
   exec runuser -u codespace -- "$0" "$@"
 fi

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -686,6 +686,39 @@ export function buildBundleLabels(core: Pick<PreContainerInfrastructure, 'bundle
   return { bundleLabel: core.bundleId };
 }
 
+/**
+ * Returns the `user` override and env vars needed for runtime UID
+ * remapping on Linux (issue #232). When the host UID is not 1000, the
+ * baked codespace user (UID 1000) cannot write to bind-mounted
+ * directories owned by the host UID. To fix this without committing to
+ * a hardcoded UID in the image, the host launches the container as
+ * `0:0` and passes `IRONCURTAIN_AGENT_UID` / `IRONCURTAIN_AGENT_GID`
+ * so the entrypoint (running as root) can renumber the codespace
+ * account before dropping privileges via `runuser`.
+ *
+ * On macOS (`useTcp === true`), Docker Desktop's VirtioFS handles UID
+ * translation transparently and `--user 0:0` would defeat it; this
+ * function returns an empty mapping there, leaving the container to
+ * run as the baked `codespace` user from the Dockerfile.
+ *
+ * Exported for testability.
+ */
+export function buildAgentUidRemap(useTcp: boolean): {
+  readonly user: string | undefined;
+  readonly env: Record<string, string>;
+} {
+  if (useTcp) return { user: undefined, env: {} };
+  const uid = process.getuid?.() ?? 1000;
+  const gid = process.getgid?.() ?? 1000;
+  return {
+    user: '0:0',
+    env: {
+      IRONCURTAIN_AGENT_UID: String(uid),
+      IRONCURTAIN_AGENT_GID: String(gid),
+    },
+  };
+}
+
 /** Container-level resources layered on top of the pre-container bundle. */
 export interface ContainerResources {
   readonly containerId: string;
@@ -849,12 +882,21 @@ export async function createSessionContainers(
       mounts.push({ source: core.skillsMount.hostDir, target: core.skillsMount.target, readonly: true });
     }
 
+    // Linux-only UID-remap wiring (issue #232). On Linux, run the
+    // container as root and pass the host UID/GID via env so the
+    // entrypoint can renumber codespace before dropping privileges.
+    // On macOS (useTcp), VirtioFS translates UIDs transparently —
+    // passing `--user 0:0` would actually break that translation,
+    // so we leave the container running as the baked codespace user
+    // and skip the env vars entirely.
+    const uidRemap = buildAgentUidRemap(core.useTcp);
     mainContainerId = await core.docker.create({
       image: core.image,
       name: mainContainerName,
       network: network ?? 'none',
       mounts,
-      env,
+      env: { ...env, ...uidRemap.env },
+      user: uidRemap.user,
       command: ['sleep', 'infinity'],
       ...bundleLabels,
       resources: { memoryMb: 8192, cpus: 4 },

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -120,6 +120,14 @@ export function buildCreateArgs(config: DockerContainerConfig): string[] {
     args.push('-t');
   }
 
+  // Linux-only: when set (typically to '0:0'), runs the entrypoint as
+  // root so it can renumber the codespace user before dropping
+  // privileges. macOS skips this (VirtioFS handles UID translation).
+  // See `DockerContainerConfig.user` JSDoc.
+  if (config.user !== undefined) {
+    args.push('--user', config.user);
+  }
+
   args.push(config.image);
   args.push(...config.command);
 
@@ -159,7 +167,15 @@ export function createDockerManager(
     async exec(nameOrId: string, command: readonly string[], timeoutMs?: number): Promise<DockerExecResult> {
       const timeout = timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
       try {
-        const { stdout, stderr } = await exec('docker', ['exec', nameOrId, ...command], {
+        // Always pin the exec user to `codespace`. On Linux, agent
+        // containers are created with `--user 0:0` (see issue #232) so
+        // the entrypoint can renumber the codespace user; without an
+        // explicit `--user codespace` here, every exec would land as
+        // root and bypass the sudoers / $HOME setup the agent expects.
+        // On macOS, `--user 0:0` is not passed and the Dockerfile
+        // `USER codespace` directive already takes effect, but
+        // re-asserting `codespace` is a harmless no-op.
+        const { stdout, stderr } = await exec('docker', ['exec', '--user', 'codespace', nameOrId, ...command], {
           timeout,
           maxBuffer: 50 * 1024 * 1024,
         });

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -164,18 +164,29 @@ export function createDockerManager(
       await exec('docker', ['start', nameOrId], { timeout: 30_000 });
     },
 
-    async exec(nameOrId: string, command: readonly string[], timeoutMs?: number): Promise<DockerExecResult> {
+    async exec(
+      nameOrId: string,
+      command: readonly string[],
+      timeoutMs?: number,
+      execUser?: string | null,
+    ): Promise<DockerExecResult> {
       const timeout = timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
+      // Resolve the `--user` flag (see DockerManager.exec JSDoc):
+      //   undefined → 'codespace' (default for agent containers)
+      //   string    → override
+      //   null      → skip the flag entirely (non-agent containers
+      //               without a codespace account, e.g. signal-cli)
+      // On Linux, agent containers are created with `--user 0:0` (see
+      // issue #232) so the entrypoint can renumber the codespace user;
+      // without an explicit `--user codespace` here, every exec would
+      // land as root and bypass the sudoers / $HOME setup the agent
+      // expects. On macOS, `--user 0:0` is not passed and the
+      // Dockerfile `USER codespace` directive already takes effect,
+      // but re-asserting `codespace` is a harmless no-op.
+      const resolvedUser = execUser === undefined ? 'codespace' : execUser;
+      const userArgs = resolvedUser === null ? [] : (['--user', resolvedUser] as const);
       try {
-        // Always pin the exec user to `codespace`. On Linux, agent
-        // containers are created with `--user 0:0` (see issue #232) so
-        // the entrypoint can renumber the codespace user; without an
-        // explicit `--user codespace` here, every exec would land as
-        // root and bypass the sudoers / $HOME setup the agent expects.
-        // On macOS, `--user 0:0` is not passed and the Dockerfile
-        // `USER codespace` directive already takes effect, but
-        // re-asserting `codespace` is a harmless no-op.
-        const { stdout, stderr } = await exec('docker', ['exec', '--user', 'codespace', nameOrId, ...command], {
+        const { stdout, stderr } = await exec('docker', ['exec', ...userArgs, nameOrId, ...command], {
           timeout,
           maxBuffer: 50 * 1024 * 1024,
         });

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -34,6 +34,7 @@ import * as logger from '../logger.js';
 import { buildDockerClaudeMd } from './claude-md-seed.js';
 import { getInternalNetworkName } from './platform.js';
 import { cleanupContainers } from './container-lifecycle.js';
+import { buildAgentUidRemap } from './docker-infrastructure.js';
 
 export interface PtySessionOptions {
   readonly config: IronCurtainConfig;
@@ -491,13 +492,20 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       env.IRONCURTAIN_RESUME_FLAGS = conversationStateConfig.resumeFlags.join(' ');
     }
 
+    // Linux-only UID-remap wiring (issue #232). Matches the parallel
+    // setup in `docker-infrastructure.ts::createSessionContainers`;
+    // when adding fields here, mirror the change there. macOS skips
+    // the remap because VirtioFS translates UIDs transparently.
+    const uidRemap = buildAgentUidRemap(useTcp);
+
     // Create and start container with PTY command and TTY
     containerId = await docker.create({
       image,
       name: mainContainerName,
       network: network ?? 'none',
       mounts,
-      env,
+      env: { ...env, ...uidRemap.env },
+      user: uidRemap.user,
       command: ptyCommand,
       // PTY sessions are standalone (no workflow/scope), so only the
       // bundle label is emitted. See docs/designs/workflow-session-identity.md §7.
@@ -761,7 +769,20 @@ function attachPtyOnce(options: PtyProxyOptions): Promise<number> {
           isFirstResize = false;
           execFile(
             'docker',
-            ['exec', options.containerId, '/etc/ironcurtain/resize-pty.sh', String(columns), String(rows)],
+            [
+              'exec',
+              // The container may be running as root (Linux UID-remap path,
+              // issue #232) or as codespace (macOS). Pinning the exec user
+              // to codespace works in both cases — codespace is the baked
+              // user (renumbered, but the username is unchanged) and
+              // re-asserting it under macOS is a no-op.
+              '--user',
+              'codespace',
+              options.containerId,
+              '/etc/ironcurtain/resize-pty.sh',
+              String(columns),
+              String(rows),
+            ],
             { timeout: 5000 },
             (err, _stdout, stderr) => {
               if (err) {
@@ -869,7 +890,9 @@ function checkPtySize(containerId: string): Promise<{ rows: number; cols: number
   return new Promise((resolve) => {
     execFile(
       'docker',
-      ['exec', containerId, '/etc/ironcurtain/check-pty-size.sh'],
+      // `--user codespace` mirrors DockerManager.exec; see the resize
+      // callsite above for the issue #232 rationale.
+      ['exec', '--user', 'codespace', containerId, '/etc/ironcurtain/check-pty-size.sh'],
       { timeout: 5000 },
       (err, stdout) => {
         if (err) {
@@ -918,7 +941,16 @@ async function verifyInitialPtySize(
     await new Promise<void>((resolve) => {
       execFile(
         'docker',
-        ['exec', containerId, '/etc/ironcurtain/resize-pty.sh', String(expectedCols), String(expectedRows)],
+        // `--user codespace` mirrors DockerManager.exec; see issue #232.
+        [
+          'exec',
+          '--user',
+          'codespace',
+          containerId,
+          '/etc/ironcurtain/resize-pty.sh',
+          String(expectedCols),
+          String(expectedRows),
+        ],
         { timeout: 5000 },
         () => resolve(),
       );

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -70,6 +70,16 @@ export interface PtyProxyOptions {
 /** Maximum time to wait for the PTY socket to appear (ms). */
 const PTY_READINESS_TIMEOUT_MS = 30_000;
 
+/**
+ * Extended PTY readiness timeout for the Linux UID-remap path. The
+ * universal-image entrypoint does `usermod -u`, `groupmod -g`, and a
+ * recursive `chown` of `/home/codespace` (Conda, NVM, Hugo, etc.) and
+ * `/workspace` before exec'ing the agent, which is what eventually
+ * runs socat and creates the UDS. On slower disks the chown alone can
+ * take 25–30s; budget 90s so non-1000 hosts don't flap during startup.
+ */
+const PTY_READINESS_TIMEOUT_REMAP_MS = 90_000;
+
 /** Poll interval when waiting for PTY socket (ms). */
 const PTY_READINESS_POLL_MS = 200;
 
@@ -554,7 +564,13 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     }
 
     if (!useTcp) {
-      await waitForPtyReady(ptyTarget);
+      // When `uidRemap.user` is set (Linux non-1000 host, issue #232) the
+      // entrypoint runs usermod/groupmod and a recursive chown before
+      // exec'ing the agent, so socat — and therefore the UDS — appears
+      // 25–30s later than the no-remap case. Stretch the readiness
+      // budget so PTY sessions on non-1000 hosts don't flap.
+      const readinessTimeoutMs = uidRemap.user ? PTY_READINESS_TIMEOUT_REMAP_MS : PTY_READINESS_TIMEOUT_MS;
+      await waitForPtyReady(ptyTarget, readinessTimeoutMs);
       logger.info('PTY readiness check passed');
     }
 
@@ -991,20 +1007,20 @@ async function verifyInitialPtySize(
  * directory at the path is not "ready", since the Linux/UDS attach path
  * does not retry on connect failure.
  */
-export async function waitForPtyReady(target: PtyTarget): Promise<void> {
+export async function waitForPtyReady(target: PtyTarget, timeoutMs: number = PTY_READINESS_TIMEOUT_MS): Promise<void> {
   if (typeof target !== 'string') {
     // macOS TCP path is guarded out at the call site (pty-session.ts ~534);
     // this branch exists only as a defensive no-op so the helper stays total.
     return;
   }
 
-  const deadline = Date.now() + PTY_READINESS_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (isSocketPath(target)) return;
     await new Promise((r) => setTimeout(r, PTY_READINESS_POLL_MS));
   }
 
-  throw new Error(`PTY socket did not become ready within ${PTY_READINESS_TIMEOUT_MS / 1000}s`);
+  throw new Error(`PTY socket did not become ready within ${timeoutMs / 1000}s`);
 }
 
 /**

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -99,6 +99,25 @@ export interface DockerContainerConfig {
    * Optional. Defaults to false (no TTY allocated).
    */
   readonly tty?: boolean;
+
+  /**
+   * Override the container's effective user at creation time.
+   * Maps to `docker create --user <value>` (formats: `uid`, `uid:gid`,
+   * or `name[:group]`).
+   *
+   * Used on Linux to start the agent container as `0:0` so the
+   * entrypoint can renumber the baked codespace user to match the
+   * host UID/GID before dropping privileges (see issue #232 and
+   * `docker/entrypoint-claude-code.sh`). Must be omitted on macOS,
+   * where Docker Desktop's VirtioFS translates UIDs transparently and
+   * passing `--user 0:0` would defeat that translation.
+   *
+   * When this is set to anything other than `codespace`, every
+   * `docker exec` against the container must pass `--user codespace`
+   * explicitly — Docker treats this field as the default exec user,
+   * overriding the Dockerfile `USER` directive.
+   */
+  readonly user?: string;
 }
 
 /** A volume mount for a Docker container. */

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -159,8 +159,22 @@ export interface DockerManager {
    * Returns when the command exits. Both stdout and stderr are captured.
    *
    * @param timeoutMs - kill the exec process after this many ms.
+   * @param execUser - override the exec user via `docker exec --user <value>`.
+   *   - `undefined` (default): pins `--user codespace`, the correct behavior
+   *     for agent containers (which on Linux are created with `--user 0:0`
+   *     so the entrypoint can renumber the baked codespace user — every
+   *     subsequent exec must opt back into codespace explicitly).
+   *   - A string: passes that value as `--user`.
+   *   - `null`: skip the `--user` flag entirely. Required for non-agent
+   *     containers that have no `codespace` account (e.g. the
+   *     `bbernhard/signal-cli-rest-api` image).
    */
-  exec(nameOrId: string, command: readonly string[], timeoutMs?: number): Promise<DockerExecResult>;
+  exec(
+    nameOrId: string,
+    command: readonly string[],
+    timeoutMs?: number,
+    execUser?: string | null,
+  ): Promise<DockerExecResult>;
 
   /** Stop a running container (SIGTERM, then SIGKILL after grace period). */
   stop(nameOrId: string): Promise<void>;

--- a/src/signal/signal-container.ts
+++ b/src/signal/signal-container.ts
@@ -61,7 +61,13 @@ function sleep(ms: number): Promise<void> {
  */
 async function hasStaleBindMount(docker: DockerManager, containerName: string): Promise<boolean> {
   try {
-    const result = await docker.exec(containerName, ['test', '-d', `${SIGNAL_CLI_DATA_DIR}/data`], 5_000);
+    // Pass `execUser: null` to skip `--user codespace`: the
+    // bbernhard/signal-cli-rest-api image has no codespace account, and
+    // pinning it would cause `docker exec` to fail with a confusing
+    // "unable to find user codespace" error — which the catch below
+    // would swallow, silently returning false and breaking stale-mount
+    // detection on WSL/Windows reboots.
+    const result = await docker.exec(containerName, ['test', '-d', `${SIGNAL_CLI_DATA_DIR}/data`], 5_000, null);
     return result.exitCode !== 0;
   } catch {
     return false; // Can't tell — assume OK

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { DockerInfrastructure, PreContainerInfrastructure } from '../src/docker/docker-infrastructure.js';
 import {
+  buildAgentUidRemap,
   prepareConversationStateDir,
   createSessionContainers,
   destroyDockerInfrastructure,
@@ -145,6 +146,25 @@ describe('DockerInfrastructure interface', () => {
     const udsAddr: DockerInfrastructure['mitmAddr'] = { socketPath: '/tmp/mitm.sock' };
     expect(udsAddr.socketPath).toBe('/tmp/mitm.sock');
     expect(udsAddr.port).toBeUndefined();
+  });
+});
+
+describe('buildAgentUidRemap (issue #232)', () => {
+  it('returns empty mapping on macOS (useTcp=true)', () => {
+    // VirtioFS handles UID translation transparently; passing
+    // `--user 0:0` would break that. macOS path must be a pure no-op.
+    const remap = buildAgentUidRemap(true);
+    expect(remap.user).toBeUndefined();
+    expect(remap.env).toEqual({});
+  });
+
+  it('returns 0:0 + host UID/GID env on Linux (useTcp=false)', () => {
+    const remap = buildAgentUidRemap(false);
+    expect(remap.user).toBe('0:0');
+    // The entrypoint reads these to renumber codespace before
+    // dropping privileges via runuser.
+    expect(remap.env.IRONCURTAIN_AGENT_UID).toBe(String(process.getuid?.() ?? 1000));
+    expect(remap.env.IRONCURTAIN_AGENT_GID).toBe(String(process.getgid?.() ?? 1000));
   });
 });
 
@@ -412,6 +432,13 @@ describe('createSessionContainers', () => {
 
     // Only one docker.create call in UDS mode: the main container.
     expect(createCalls).toHaveLength(1);
+
+    // Issue #232: Linux UDS mode runs the container as 0:0 and passes
+    // the host UID/GID via env so the entrypoint can renumber codespace.
+    expect(createCalls[0].user).toBe('0:0');
+    expect(createCalls[0].env.IRONCURTAIN_AGENT_UID).toBe(String(process.getuid?.() ?? 1000));
+    expect(createCalls[0].env.IRONCURTAIN_AGENT_GID).toBe(String(process.getgid?.() ?? 1000));
+
     const mounts = createCalls[0].mounts;
 
     // Defense-in-depth: /run/ironcurtain must map to sockets/ only, so the
@@ -461,6 +488,28 @@ describe('createSessionContainers', () => {
   it('omits the skills mount entirely when core.skillsMount is undefined', async () => {
     const mounts = await runSkillsMountScenario({});
     expect(mounts.some((m) => m.target === TEST_SKILLS_CONTAINER_PATH)).toBe(false);
+  });
+
+  // --- UID remap (issue #232) ---
+  it('does NOT pass --user 0:0 or UID env in TCP (macOS) mode', async () => {
+    // On macOS, VirtioFS handles UID translation and `--user 0:0` would
+    // break it; the agent container must run as the baked codespace user.
+    // We construct a TCP-mode core but bypass the connectivity check by
+    // returning exitCode 0 from the mocked exec.
+    const { docker, createCalls } = makeMockDocker({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    const core = makeMockCore({ tempDir, useTcp: true, docker });
+    await createSessionContainers(core, makeMockConfig());
+
+    // Two creates in TCP mode: [0] sidecar, [1] main container.
+    expect(createCalls).toHaveLength(2);
+    const mainCreate = createCalls[1];
+    expect(mainCreate.user).toBeUndefined();
+    expect(mainCreate.env.IRONCURTAIN_AGENT_UID).toBeUndefined();
+    expect(mainCreate.env.IRONCURTAIN_AGENT_GID).toBeUndefined();
   });
 
   it('mounts an empty skills directory when set (workflow-mode invariant)', async () => {

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -208,6 +208,22 @@ describe('DockerManager', () => {
 
       expect(args).toContain('--add-host=host.docker.internal:host-gateway');
     });
+
+    it('emits --user when config.user is set (issue #232 Linux UID remap)', () => {
+      const config: DockerContainerConfig = {
+        ...sampleConfig,
+        user: '0:0',
+      };
+      const args = buildCreateArgs(config);
+      expect(args).toContain('--user');
+      expect(args[args.indexOf('--user') + 1]).toBe('0:0');
+    });
+
+    it('omits --user when config.user is undefined (macOS path)', () => {
+      // sampleConfig has no `user` field, so --user must be absent.
+      const args = buildCreateArgs(sampleConfig);
+      expect(args).not.toContain('--user');
+    });
   });
 
   describe('preflight', () => {
@@ -278,7 +294,31 @@ describe('DockerManager', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toBe('task completed');
       expect(result.stderr).toBe('');
-      expect(mock.calls[0].args).toEqual(['exec', 'container-id', 'claude', '--continue', '-p', 'Hello']);
+      // `--user codespace` is always injected: agent containers are
+      // created with `--user 0:0` on Linux for the UID-remap entrypoint
+      // (issue #232), so every subsequent exec must opt back into the
+      // codespace user explicitly.
+      expect(mock.calls[0].args).toEqual([
+        'exec',
+        '--user',
+        'codespace',
+        'container-id',
+        'claude',
+        '--continue',
+        '-p',
+        'Hello',
+      ]);
+    });
+
+    it('always passes --user codespace (issue #232)', async () => {
+      mock.setResponse('ok');
+      const manager = createDockerManager(mock.mockExec);
+
+      await manager.exec('container-id', ['anything']);
+      const args = mock.calls[0].args;
+      expect(args[0]).toBe('exec');
+      expect(args[1]).toBe('--user');
+      expect(args[2]).toBe('codespace');
     });
 
     it('returns non-zero exit code without throwing', async () => {

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -321,6 +321,31 @@ describe('DockerManager', () => {
       expect(args[2]).toBe('codespace');
     });
 
+    it('skips --user when execUser is null (non-agent containers)', async () => {
+      // signal-cli-rest-api has no codespace account; pinning it would
+      // make `docker exec` fail with "unable to find user codespace" and
+      // break stale-bind-mount detection. `execUser: null` opts out.
+      mock.setResponse('ok');
+      const manager = createDockerManager(mock.mockExec);
+
+      await manager.exec('signal-cli', ['test', '-d', '/data'], 5_000, null);
+      const args = mock.calls[0].args;
+      expect(args[0]).toBe('exec');
+      expect(args).not.toContain('--user');
+      expect(args).toEqual(['exec', 'signal-cli', 'test', '-d', '/data']);
+    });
+
+    it('honors a custom execUser override (string value)', async () => {
+      mock.setResponse('ok');
+      const manager = createDockerManager(mock.mockExec);
+
+      await manager.exec('container-id', ['cmd'], undefined, 'root');
+      const args = mock.calls[0].args;
+      expect(args[0]).toBe('exec');
+      expect(args[1]).toBe('--user');
+      expect(args[2]).toBe('root');
+    });
+
     it('returns non-zero exit code without throwing', async () => {
       mock.setError(1, 'error output', 'stderr output');
       const manager = createDockerManager(mock.mockExec);

--- a/test/uid-remap.goose.integration.test.ts
+++ b/test/uid-remap.goose.integration.test.ts
@@ -88,29 +88,27 @@ const COLLIDING_UID = 33;
  * the entrypoint is still running after `timeoutMs` — that indicates a
  * hang, not normal slowness.
  */
-async function waitForEntrypointHandoff(containerId: string, timeoutMs: number): Promise<void> {
+async function waitForRemapComplete(containerId: string, expectedUid: number, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
+  // Poll on `/workspace`'s owner UID rather than on the absence of
+  // `usermod`/`groupmod` processes. The entrypoint runs `chown -R
+  // "$UID:$GID" /home/codespace /workspace` after usermod/groupmod; a
+  // process-presence poll could return while `chown -R` is still
+  // walking the bind mount, and the `stat`-based assertions below
+  // would flake. `/workspace` is processed last in the chown arg list
+  // (after `/home/codespace`), so seeing its UID flip is a sufficient
+  // signal that the full remap chain is done.
   while (Date.now() < deadline) {
-    // `pgrep -c X` prints the count and exits non-zero when 0, which
-    // would make `dockerExecAs` report failure; the explicit `; true`
-    // neutralises that.
-    const result = await dockerExecAs(
-      containerId,
-      '0:0',
-      'sh',
-      '-c',
-      'pgrep -c usermod || true; pgrep -c groupmod || true',
-    );
+    const result = await dockerExecAs(containerId, '0:0', 'stat', '-c', '%u', '/workspace');
     if (result.exitCode !== 0) {
       // Container gone or exec broken — bail so assertions produce a
       // meaningful error rather than silent looping.
       return;
     }
-    const counts = result.stdout.trim().split(/\s+/);
-    if (counts.length >= 2 && counts.every((c) => c === '0')) return;
+    if (result.stdout.trim() === String(expectedUid)) return;
     await new Promise((r) => setTimeout(r, 500));
   }
-  throw new Error(`Entrypoint did not finish remap within ${timeoutMs}ms`);
+  throw new Error(`Entrypoint did not complete remap to UID ${expectedUid} within ${timeoutMs}ms`);
 }
 
 /** Runs `cmd` inside `containerId` as the given user. */
@@ -215,9 +213,12 @@ describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #
         { timeout: 30_000 },
       );
 
-      // Wait for the entrypoint to finish the remap before reading state.
-      // See `waitForEntrypointHandoff` for the timing rationale.
-      await waitForEntrypointHandoff(containerName, 90_000);
+      // Wait for the entrypoint to finish the full remap (including the
+      // recursive chown of /workspace) before reading state. Polling on
+      // /workspace ownership is strictly stronger than polling on the
+      // usermod/groupmod processes: it observes the final post-condition
+      // every subsequent assertion depends on.
+      await waitForRemapComplete(containerName, REMAP_UID, 90_000);
 
       // `id codespace` reflects the renumbered passwd entry.
       const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
@@ -248,20 +249,27 @@ describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #
       const runuserName = await dockerExecAs(containerName, 'codespace', 'whoami');
       observations.runuserUid = runuserUid.stdout.trim();
       observations.runuserName = runuserName.stdout.trim();
-
-      // Restore workspace ownership BEFORE the container is torn down.
-      // The entrypoint's `chown -R ${REMAP_UID} /workspace` propagates
-      // through the bind mount; without this restore, the host tempdir
-      // would be left owned by UID 1500 and the afterAll `rmSync` would
-      // either EACCES or leak files.
-      await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
     }, 120_000);
 
     afterAll(async () => {
-      try {
-        await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
-      } catch {
-        /* container already gone */
+      if (containerName) {
+        // Restore workspace ownership BEFORE the container is torn down.
+        // The entrypoint's `chown -R ${REMAP_UID} /workspace` propagates
+        // through the bind mount; without this restore, the host tempdir
+        // would be left owned by UID 1500 and the `rmSync` below would
+        // either EACCES or leak files. Best-effort: if `beforeAll` threw
+        // before the chown landed, or the container is already gone,
+        // there is nothing to restore.
+        try {
+          await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
+        } catch {
+          /* container gone or chown failed */
+        }
+        try {
+          await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+        } catch {
+          /* container already gone */
+        }
       }
       if (homeDir) rmSync(homeDir, { recursive: true, force: true });
     });

--- a/test/uid-remap.goose.integration.test.ts
+++ b/test/uid-remap.goose.integration.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Integration test: runtime UID/GID remap in the Goose agent container
+ * entrypoint (issue #232 — Goose mirror of `uid-remap.integration.test.ts`).
+ *
+ * Background. `docker/entrypoint-goose.sh` carries the same remap block as
+ * `docker/entrypoint-claude-code.sh` (the block was copied to both
+ * entrypoints when the issue #232 fix landed). PR #245 covers the Claude
+ * Code adapter; this file is the Goose mirror so a future regression in
+ * one entrypoint cannot pass CI by relying only on the other adapter's
+ * coverage.
+ *
+ * Design. Identical to the Claude Code test:
+ *
+ *   - Direct `docker run` against the prebuilt `ironcurtain-goose:latest`
+ *     image (not `runPtySession`). Rationale: `pty-session.ts` mounts a
+ *     host-side `socketsDir` created with the real host UID into the
+ *     container; once the entrypoint remaps codespace to a synthetic UID,
+ *     the renumbered user cannot bind a socket in that bind-mounted
+ *     directory because the host-side ownership is unchanged. In real
+ *     deployments host UID == IRONCURTAIN_AGENT_UID by construction
+ *     (`buildAgentUidRemap`) so the bind mount works; the mock is what
+ *     creates the divergence. A direct `docker run` keeps the test
+ *     scope tight: we exercise the entrypoint's remap logic, not the PTY
+ *     chain. PTY coverage lives in `pty-entrypoint.integration.test.ts`.
+ *
+ *   - Synthetic UID/GID 1500 forces the remap path. The Goose image is
+ *     built from `ironcurtain-base` (same `mcr.microsoft.com/devcontainers
+ *     /universal:latest` lineage as Claude Code) and bakes users at
+ *     UIDs 0–101, 997–998, 1000, and 65534. UID 1500 has no collision in
+ *     either image. If a future base-image update adds a user at 1500,
+ *     swap to another conflict-free UID and update `REMAP_UID` — all
+ *     assertions reference the constant.
+ *
+ *   - UID 33 (`www-data`) is the collision case. Present in the base
+ *     image; `groupmod -g 33 codespace` fails because gid 33 is already
+ *     taken, so the entrypoint exits non-zero with the
+ *     `[ironcurtain] groupmod failed:` (or `usermod failed:`) diagnostic
+ *     added in commit 2f463f3. The hard-error contract guards against
+ *     silent fall-through to a broken UID mapping.
+ *
+ *   - Cleanup. The entrypoint's `chown -R $UID:$GID /workspace`
+ *     propagates through the bind mount, so the host-side workspace
+ *     tempdir would be left owned by the synthetic UID. Before container
+ *     teardown we re-chown `/workspace` back to the original host UID
+ *     from inside the still-running container so `rmSync` can remove the
+ *     tempdir without leaking files.
+ *
+ *   - CMD is `sleep 180`. We only care about the entrypoint's behaviour;
+ *     keeping the container up long enough for `docker exec` to inspect
+ *     post-remap state is sufficient.
+ *
+ * Linux-only (`!useTcpTransport()`): macOS uses Docker Desktop's VirtioFS
+ * which translates UIDs transparently. `buildAgentUidRemap` returns an
+ * empty mapping there, so the entrypoint never enters the remap branch.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { useTcpTransport } from '../src/docker/platform.js';
+import { isDockerAvailable, isDockerImageAvailable } from './helpers/docker-available.js';
+
+const execFile = promisify(execFileCb);
+
+const IMAGE = 'ironcurtain-goose:latest';
+
+/**
+ * Synthetic UID/GID used to force the remap path. The Goose image inherits
+ * `ironcurtain-base`, which is built on `mcr.microsoft.com/devcontainers/
+ * universal:latest`; the base bakes users at UIDs 0–101, 997–998, 1000,
+ * and 65534. 1500 has no collision. If a future image update adds a user
+ * at 1500, swap to another conflict-free UID and update this constant.
+ */
+const REMAP_UID = 1500;
+
+/** A UID known to collide with a baked image user (`www-data`). */
+const COLLIDING_UID = 33;
+
+/**
+ * Polls until the entrypoint has finished running `usermod`/`groupmod`/`chown`
+ * and has exec'd the CMD. The universal devcontainer image has a large
+ * `/home/codespace` (Conda, NVM, Hugo, etc.) that `usermod -u` scans for
+ * ownership references, so the remap can take ~25–30 seconds. Throws if
+ * the entrypoint is still running after `timeoutMs` — that indicates a
+ * hang, not normal slowness.
+ */
+async function waitForEntrypointHandoff(containerId: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    // `pgrep -c X` prints the count and exits non-zero when 0, which
+    // would make `dockerExecAs` report failure; the explicit `; true`
+    // neutralises that.
+    const result = await dockerExecAs(
+      containerId,
+      '0:0',
+      'sh',
+      '-c',
+      'pgrep -c usermod || true; pgrep -c groupmod || true',
+    );
+    if (result.exitCode !== 0) {
+      // Container gone or exec broken — bail so assertions produce a
+      // meaningful error rather than silent looping.
+      return;
+    }
+    const counts = result.stdout.trim().split(/\s+/);
+    if (counts.length >= 2 && counts.every((c) => c === '0')) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Entrypoint did not finish remap within ${timeoutMs}ms`);
+}
+
+/** Runs `cmd` inside `containerId` as the given user. */
+async function dockerExecAs(
+  containerId: string,
+  user: string,
+  ...cmd: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const { stdout, stderr } = await execFile('docker', ['exec', '--user', user, containerId, ...cmd], {
+      timeout: 15_000,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', exitCode: e.code ?? 1 };
+  }
+}
+
+/**
+ * Same CA-discovery helper as the Claude Code remap test. The presence of
+ * the developer's CA tells us the prebuilt image was built against it; if
+ * not, we skip rather than force a multi-minute rebuild.
+ */
+function findHostCaDir(): string | null {
+  const home = process.env.IRONCURTAIN_HOME ?? join(homedir(), '.ironcurtain');
+  const ca = join(home, 'ca');
+  return existsSync(ca) ? ca : null;
+}
+
+const hostCaDir = findHostCaDir();
+const gooseDockerReady =
+  !useTcpTransport() && isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+
+interface RemapObservations {
+  idCodespaceUid?: string;
+  idCodespaceGid?: string;
+  passwdUid?: string;
+  homeStatUid?: string;
+  runuserUid?: string;
+  runuserName?: string;
+  workspaceStatUid?: string;
+}
+
+describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #232)', () => {
+  /**
+   * Success path: a non-1000 UID forces the entrypoint to execute usermod /
+   * groupmod / chown. Driven via a direct `docker run --user 0:0 -e
+   * IRONCURTAIN_AGENT_UID=N` against the prebuilt Goose image — the
+   * smallest exercise of the remap logic itself.
+   */
+  describe('forced remap to a non-baked UID', () => {
+    let homeDir: string;
+    let workspaceDir: string;
+    let containerName: string;
+    let originalUid: number;
+    let originalGid: number;
+    const observations: RemapObservations = {};
+
+    beforeAll(async () => {
+      // Capture the real UID/GID for the workspace chown-back during cleanup.
+      originalUid = process.getuid?.() ?? 1000;
+      originalGid = process.getgid?.() ?? 1000;
+
+      homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-uidremap-goose-test-'));
+      workspaceDir = join(homeDir, 'workspace');
+      mkdirSync(workspaceDir, { recursive: true });
+      containerName = `ironcurtain-uidremap-goose-success-${process.pid}-${Date.now()}`;
+
+      // Run the entrypoint as root with the synthetic UID/GID. CMD is
+      // `sleep 180` so the container stays up long enough for `docker
+      // exec` to inspect the post-remap state.
+      //
+      // Mounting only `/workspace` (not `/run/ironcurtain` or the
+      // orientation dir) is intentional: the entrypoint's remap touches
+      // `/home/codespace` and `/workspace`. The other mounts are part of
+      // the broader proxy/orientation plumbing and aren't relevant to
+      // the remap contract.
+      await execFile(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '-d',
+          '--name',
+          containerName,
+          '--user',
+          '0:0',
+          '-e',
+          `IRONCURTAIN_AGENT_UID=${REMAP_UID}`,
+          '-e',
+          `IRONCURTAIN_AGENT_GID=${REMAP_UID}`,
+          '-v',
+          `${workspaceDir}:/workspace`,
+          IMAGE,
+          // CMD must outlive the entrypoint remap (~25–30s on the
+          // universal image) plus the test's `docker exec` calls.
+          // 180s is comfortable.
+          'sleep',
+          '180',
+        ],
+        { timeout: 30_000 },
+      );
+
+      // Wait for the entrypoint to finish the remap before reading state.
+      // See `waitForEntrypointHandoff` for the timing rationale.
+      await waitForEntrypointHandoff(containerName, 90_000);
+
+      // `id codespace` reflects the renumbered passwd entry.
+      const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
+      observations.idCodespaceUid = /uid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
+      observations.idCodespaceGid = /gid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
+
+      // /etc/passwd is the canonical source: if usermod silently failed,
+      // `id codespace` could resolve via nsswitch but passwd would still
+      // show 1000. We assert against passwd directly to catch that.
+      const passwdOut = await dockerExecAs(containerName, '0:0', 'sh', '-c', 'getent passwd codespace | cut -d: -f3');
+      observations.passwdUid = passwdOut.stdout.trim();
+
+      // chown -R should have flipped /home/codespace to the new UID.
+      const homeStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/home/codespace');
+      observations.homeStatUid = homeStat.stdout.trim();
+
+      // chown -R should also have flipped /workspace (the bind mount).
+      // This is the property issue #232 reports: without the remap, the
+      // agent (UID 1000 in the container) cannot write to /workspace
+      // owned by a non-1000 host UID.
+      const wsStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/workspace');
+      observations.workspaceStatUid = wsStat.stdout.trim();
+
+      // `--user codespace` resolves the name against the (renumbered)
+      // passwd entry, so this is functionally equivalent to dropping
+      // privileges via `runuser -u codespace` in the entrypoint.
+      const runuserUid = await dockerExecAs(containerName, 'codespace', 'id', '-u');
+      const runuserName = await dockerExecAs(containerName, 'codespace', 'whoami');
+      observations.runuserUid = runuserUid.stdout.trim();
+      observations.runuserName = runuserName.stdout.trim();
+
+      // Restore workspace ownership BEFORE the container is torn down.
+      // The entrypoint's `chown -R ${REMAP_UID} /workspace` propagates
+      // through the bind mount; without this restore, the host tempdir
+      // would be left owned by UID 1500 and the afterAll `rmSync` would
+      // either EACCES or leak files.
+      await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
+    }, 120_000);
+
+    afterAll(async () => {
+      try {
+        await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+      } catch {
+        /* container already gone */
+      }
+      if (homeDir) rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it(`renumbered codespace user to UID ${REMAP_UID} (usermod path)`, () => {
+      expect(observations.idCodespaceUid).toBe(String(REMAP_UID));
+      expect(observations.passwdUid).toBe(String(REMAP_UID));
+    });
+
+    it(`renumbered codespace group to GID ${REMAP_UID} (groupmod path)`, () => {
+      expect(observations.idCodespaceGid).toBe(String(REMAP_UID));
+    });
+
+    it(`chown -R reset /home/codespace ownership to ${REMAP_UID}`, () => {
+      expect(observations.homeStatUid).toBe(String(REMAP_UID));
+    });
+
+    it(`chown -R reset /workspace ownership to ${REMAP_UID}`, () => {
+      // The property issue #232 is about: the workspace bind mount must
+      // end up owned by the renumbered codespace user so the agent can
+      // read/write it after `runuser -u codespace`.
+      expect(observations.workspaceStatUid).toBe(String(REMAP_UID));
+    });
+
+    it('dropping privileges via runuser/--user codespace lands on the remapped UID', () => {
+      expect(observations.runuserUid).toBe(String(REMAP_UID));
+      expect(observations.runuserName).toBe('codespace');
+    });
+  });
+
+  /**
+   * Failure-diagnostic path: a UID collision (33 == `www-data` in the base
+   * image) makes `groupmod`/`usermod` fail. The entrypoint must exit
+   * non-zero and emit the `[ironcurtain] {usermod,groupmod} failed:`
+   * diagnostic so operators see what went wrong instead of silently
+   * running with a broken UID mapping.
+   */
+  describe('UID collision is reported as a hard error', () => {
+    let containerName: string;
+
+    beforeAll(() => {
+      containerName = `ironcurtain-uidremap-goose-fail-${process.pid}-${Date.now()}`;
+    });
+
+    afterAll(async () => {
+      // Best-effort: `docker run --rm` should have already removed it,
+      // but belt-and-braces in case the run was interrupted.
+      try {
+        await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+      } catch {
+        /* container already gone */
+      }
+    });
+
+    it(`entrypoint exits non-zero and logs a diagnostic when UID ${COLLIDING_UID} collides with a baked user`, async () => {
+      // Run the entrypoint as root (`--user 0:0`) with a colliding
+      // IRONCURTAIN_AGENT_UID. `groupmod` runs first; gid 33 also
+      // belongs to `www-data`, so the diagnostic will be `groupmod
+      // failed:` (the entrypoint fails on the first collision). Either
+      // error proves the hard-error contract: silent fall-through is
+      // the regression we're guarding against.
+      let result: { stdout: string; stderr: string; exitCode: number };
+      try {
+        const ok = await execFile(
+          'docker',
+          [
+            'run',
+            '--rm',
+            '--name',
+            containerName,
+            '--user',
+            '0:0',
+            '-e',
+            `IRONCURTAIN_AGENT_UID=${COLLIDING_UID}`,
+            '-e',
+            `IRONCURTAIN_AGENT_GID=${COLLIDING_UID}`,
+            IMAGE,
+            'true',
+          ],
+          { timeout: 30_000 },
+        );
+        result = { stdout: ok.stdout, stderr: ok.stderr, exitCode: 0 };
+      } catch (err: unknown) {
+        const e = err as { stdout?: string; stderr?: string; code?: number };
+        result = { stdout: e.stdout ?? '', stderr: e.stderr ?? '', exitCode: e.code ?? 1 };
+      }
+
+      // Container must exit non-zero. The entrypoint script uses `exit 1`
+      // explicitly on each failure branch.
+      expect(result.exitCode).not.toBe(0);
+      // Stderr must contain one of the diagnostic lines — we accept
+      // either `usermod failed:` or `groupmod failed:` because groupmod
+      // runs first and gid 33 also collides with www-data.
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).toMatch(/\[ironcurtain\] (usermod|groupmod) failed:/);
+    }, 60_000);
+  });
+});

--- a/test/uid-remap.goose.integration.test.ts
+++ b/test/uid-remap.goose.integration.test.ts
@@ -101,9 +101,17 @@ async function waitForRemapComplete(containerId: string, expectedUid: number, ti
   while (Date.now() < deadline) {
     const result = await dockerExecAs(containerId, '0:0', 'stat', '-c', '%u', '/workspace');
     if (result.exitCode !== 0) {
-      // Container gone or exec broken — bail so assertions produce a
-      // meaningful error rather than silent looping.
-      return;
+      // Don't silently return: a non-zero exit here means the container
+      // is gone, exec is broken, or /workspace doesn't exist yet. Bailing
+      // with `return` would let the downstream assertions fail with
+      // confusing "expected undefined toBe ..." messages that hide the
+      // real cause. Throw with the captured stdio so the failure points
+      // straight at the underlying problem.
+      throw new Error(
+        `docker exec failed while polling /workspace ownership ` +
+          `(exit=${result.exitCode}); stdout=${JSON.stringify(result.stdout)} ` +
+          `stderr=${JSON.stringify(result.stderr)}`,
+      );
     }
     if (result.stdout.trim() === String(expectedUid)) return;
     await new Promise((r) => setTimeout(r, 500));

--- a/test/uid-remap.integration.test.ts
+++ b/test/uid-remap.integration.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Integration test: runtime UID/GID remap in the agent container entrypoint
+ * (issue #232).
+ *
+ * The existing PTY/skills integration tests do NOT exercise the remap block:
+ * they inherit `process.getuid()` from the host (typically 1000), which equals
+ * the baked codespace UID, so the entrypoint guard
+ *   if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || ... ; then
+ * skips `usermod` / `groupmod` / `chown` entirely. Those tests prove `runuser`
+ * drops correctly but not that the remap itself works.
+ *
+ * This file forces the remap by spawning the agent image with
+ * `IRONCURTAIN_AGENT_UID` / `IRONCURTAIN_AGENT_GID` overridden to a synthetic
+ * value not present in the universal devcontainer image (`/etc/passwd` of
+ * `ironcurtain-claude-code:latest` was inspected to pick a conflict-free UID).
+ * The test then asserts inside the live container that:
+ *
+ *   - the codespace account was renumbered to the synthetic UID,
+ *   - `/home/codespace` is owned by the synthetic UID after `chown -R`,
+ *   - `runuser -u codespace` (the same drop-privileges call the entrypoint
+ *     makes before `exec "$@"`) lands on the synthetic UID, so the workspace
+ *     bind mount is writable from the agent.
+ *
+ * The success path drives a direct `docker run` against the image rather than
+ * `runPtySession`. Driving through `runPtySession` would require mocking
+ * `process.getuid` to inject the synthetic UID, but `pty-session.ts` mounts a
+ * host-side `socketsDir` (created with the *real* host UID) into the container
+ * at `/run/ironcurtain`. After remap, the renumbered codespace user cannot
+ * bind a PTY socket in that bind-mounted directory because its host-side
+ * ownership doesn't match the mocked UID. In real deployments these match
+ * (host UID == IRONCURTAIN_AGENT_UID by construction in `buildAgentUidRemap`)
+ * and the bind mount works naturally; the mock is what creates the
+ * divergence. A direct `docker run` keeps the test scope tight: we're
+ * exercising the entrypoint's remap logic, not the PTY chain. The PTY chain
+ * itself is already covered by `pty-entrypoint.integration.test.ts`.
+ *
+ * A separate test forces a UID collision (33 = `www-data`, present in the
+ * base image) and asserts the entrypoint exits non-zero with the
+ * `[ironcurtain] {usermod,groupmod} failed:` diagnostic added in commit
+ * 2f463f3 — the regression guard for silent fall-through to a broken
+ * UID mapping.
+ *
+ * Cleanup: the entrypoint's `chown -R $UID:$GID /workspace` propagates
+ * through the bind mount, so after the run completes the host-side workspace
+ * tempdir would be left owned by the synthetic UID. Before container
+ * teardown the test re-chowns the workspace back to the original host UID
+ * from inside the still-running container so `rmSync` can remove the tempdir
+ * without leaking files.
+ *
+ * Linux-only (`!useTcpTransport()`): macOS uses Docker Desktop's VirtioFS,
+ * which handles UID translation transparently. `buildAgentUidRemap` returns
+ * an empty mapping there, so the entrypoint never enters the remap branch.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { useTcpTransport } from '../src/docker/platform.js';
+import { isDockerAvailable, isDockerImageAvailable } from './helpers/docker-available.js';
+
+const execFile = promisify(execFileCb);
+
+const IMAGE = 'ironcurtain-claude-code:latest';
+
+/**
+ * Synthetic UID/GID used to force the remap path. The universal devcontainer
+ * image (`mcr.microsoft.com/devcontainers/universal:latest`) bakes users at
+ * UIDs 0–101, 997–998, 1000, and 65534; 1500 has no collision. If a future
+ * base-image update adds a user at 1500, swap to another conflict-free UID
+ * (e.g. 1501, 1600) and update this constant — all assertions below reference
+ * REMAP_UID so a single edit suffices.
+ */
+const REMAP_UID = 1500;
+
+/** A UID known to collide with a baked image user (`www-data`). */
+const COLLIDING_UID = 33;
+
+/**
+ * Polls until the entrypoint has finished running `usermod`/`groupmod`/`chown`
+ * and has exec'd the CMD. The universal devcontainer image has a large
+ * `/home/codespace` (Conda, NVM, Hugo, etc.) that `usermod -u` scans for
+ * ownership references, so the remap can take ~25–30 seconds; a fixed
+ * `setTimeout` would be either flaky or wasteful. Throws if the entrypoint
+ * is still running after `timeoutMs` — that indicates a hang, not normal
+ * slowness, and the test should fail loud rather than wait indefinitely.
+ */
+async function waitForEntrypointHandoff(containerId: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    // Run pgrep inside a shell that always exits 0; we read counts from
+    // stdout. `pgrep -c X` prints the count and exits non-zero when 0,
+    // which would make `dockerExecAs` report failure; the explicit
+    // `; true` here neutralises that.
+    const result = await dockerExecAs(
+      containerId,
+      '0:0',
+      'sh',
+      '-c',
+      'pgrep -c usermod || true; pgrep -c groupmod || true',
+    );
+    if (result.exitCode !== 0) {
+      // The container is gone or exec is broken — bail so the assertions
+      // below produce a meaningful error rather than us looping silently.
+      return;
+    }
+    const counts = result.stdout.trim().split(/\s+/);
+    if (counts.length >= 2 && counts.every((c) => c === '0')) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Entrypoint did not finish remap within ${timeoutMs}ms`);
+}
+
+/** Runs `cmd` inside `containerId` as the given user. */
+async function dockerExecAs(
+  containerId: string,
+  user: string,
+  ...cmd: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const { stdout, stderr } = await execFile('docker', ['exec', '--user', user, containerId, ...cmd], {
+      timeout: 15_000,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', exitCode: e.code ?? 1 };
+  }
+}
+
+/**
+ * Same CA-discovery helper as `pty-entrypoint.integration.test.ts`. The
+ * presence of the developer's CA tells us the prebuilt image was built
+ * against it; if not, we skip rather than force a multi-minute rebuild.
+ */
+function findHostCaDir(): string | null {
+  const home = process.env.IRONCURTAIN_HOME ?? join(homedir(), '.ironcurtain');
+  const ca = join(home, 'ca');
+  return existsSync(ca) ? ca : null;
+}
+
+const hostCaDir = findHostCaDir();
+const dockerReady = !useTcpTransport() && isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+
+interface RemapObservations {
+  idCodespaceUid?: string;
+  idCodespaceGid?: string;
+  passwdUid?: string;
+  homeStatUid?: string;
+  runuserUid?: string;
+  runuserName?: string;
+  workspaceStatUid?: string;
+}
+
+describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () => {
+  /**
+   * Success path: a non-1000 UID forces the entrypoint to execute usermod /
+   * groupmod / chown. Driven via a direct `docker run --user 0:0 -e
+   * IRONCURTAIN_AGENT_UID=N` against the same image used by `runPtySession`,
+   * which is the smallest exercise of the remap logic itself.
+   */
+  describe('forced remap to a non-baked UID', () => {
+    let homeDir: string;
+    let workspaceDir: string;
+    let containerName: string;
+    let originalUid: number;
+    let originalGid: number;
+    const observations: RemapObservations = {};
+
+    beforeAll(async () => {
+      // Capture the real UID/GID for the workspace chown-back during cleanup.
+      originalUid = process.getuid?.() ?? 1000;
+      originalGid = process.getgid?.() ?? 1000;
+
+      homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-uidremap-test-'));
+      workspaceDir = join(homeDir, 'workspace');
+      mkdirSync(workspaceDir, { recursive: true });
+      containerName = `ironcurtain-uidremap-success-${process.pid}-${Date.now()}`;
+
+      // Run the entrypoint as root with the synthetic UID/GID. CMD is
+      // `sleep 30` so the container stays up long enough for `docker exec`
+      // to inspect the post-remap state.
+      //
+      // Mounting only `/workspace` (not `/run/ironcurtain` or the
+      // orientation dir) is intentional: the entrypoint's remap touches
+      // `/home/codespace` and `/workspace`. The other mounts are part of
+      // the broader PTY plumbing and aren't relevant to the remap contract.
+      await execFile(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '-d',
+          '--name',
+          containerName,
+          '--user',
+          '0:0',
+          '-e',
+          `IRONCURTAIN_AGENT_UID=${REMAP_UID}`,
+          '-e',
+          `IRONCURTAIN_AGENT_GID=${REMAP_UID}`,
+          '-v',
+          `${workspaceDir}:/workspace`,
+          IMAGE,
+          // CMD must outlive the entrypoint remap (~25–30s on the universal
+          // image) plus the test's `docker exec` calls. 180s is comfortable.
+          'sleep',
+          '180',
+        ],
+        { timeout: 30_000 },
+      );
+
+      // Wait for the entrypoint to finish the remap before reading state.
+      // `usermod -u N codespace` on the universal devcontainer image takes
+      // ~25s because the home directory is massive (Conda, NVM, Hugo, ...)
+      // and `usermod` scans it. We poll on the entrypoint having exec'd
+      // away — once `pgrep usermod` reports no match AND CMD `sleep` is
+      // the running PID 1 child, the remap is complete.
+      await waitForEntrypointHandoff(containerName, 90_000);
+
+      // `id codespace` reflects the renumbered passwd entry.
+      const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
+      observations.idCodespaceUid = /uid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
+      observations.idCodespaceGid = /gid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
+
+      // /etc/passwd is the canonical source: if usermod silently failed,
+      // `id codespace` could resolve via nsswitch but passwd would still
+      // show 1000. We assert against passwd directly to catch that.
+      const passwdOut = await dockerExecAs(containerName, '0:0', 'sh', '-c', 'getent passwd codespace | cut -d: -f3');
+      observations.passwdUid = passwdOut.stdout.trim();
+
+      // chown -R should have flipped /home/codespace to the new UID.
+      const homeStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/home/codespace');
+      observations.homeStatUid = homeStat.stdout.trim();
+
+      // chown -R should also have flipped /workspace (the bind mount). This
+      // is the property issue #232 reports: without the remap, the agent
+      // (UID 1000 in the container) cannot write to /workspace owned by a
+      // non-1000 host UID. The remap fixes that by aligning the container
+      // codespace UID with the host UID.
+      const wsStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/workspace');
+      observations.workspaceStatUid = wsStat.stdout.trim();
+
+      // `--user codespace` resolves the name against the (renumbered) passwd
+      // entry, so this is functionally equivalent to dropping privileges via
+      // `runuser -u codespace` in the entrypoint.
+      const runuserUid = await dockerExecAs(containerName, 'codespace', 'id', '-u');
+      const runuserName = await dockerExecAs(containerName, 'codespace', 'whoami');
+      observations.runuserUid = runuserUid.stdout.trim();
+      observations.runuserName = runuserName.stdout.trim();
+
+      // Restore workspace ownership BEFORE the container is torn down. The
+      // entrypoint's `chown -R ${REMAP_UID} /workspace` propagates through
+      // the bind mount; without this restore, the host tempdir would be
+      // left owned by UID 1500 and the afterAll `rmSync` would either
+      // EACCES or leak files.
+      await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
+    }, 120_000);
+
+    afterAll(async () => {
+      try {
+        await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+      } catch {
+        /* container already gone */
+      }
+      if (homeDir) rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it(`renumbered codespace user to UID ${REMAP_UID} (usermod path)`, () => {
+      expect(observations.idCodespaceUid).toBe(String(REMAP_UID));
+      expect(observations.passwdUid).toBe(String(REMAP_UID));
+    });
+
+    it(`renumbered codespace group to GID ${REMAP_UID} (groupmod path)`, () => {
+      expect(observations.idCodespaceGid).toBe(String(REMAP_UID));
+    });
+
+    it(`chown -R reset /home/codespace ownership to ${REMAP_UID}`, () => {
+      expect(observations.homeStatUid).toBe(String(REMAP_UID));
+    });
+
+    it(`chown -R reset /workspace ownership to ${REMAP_UID}`, () => {
+      // This is the property issue #232 is about: the workspace bind mount
+      // must end up owned by the renumbered codespace user so the agent
+      // can read/write it after `runuser -u codespace`.
+      expect(observations.workspaceStatUid).toBe(String(REMAP_UID));
+    });
+
+    it('dropping privileges via runuser/--user codespace lands on the remapped UID', () => {
+      expect(observations.runuserUid).toBe(String(REMAP_UID));
+      expect(observations.runuserName).toBe('codespace');
+    });
+  });
+
+  /**
+   * Failure-diagnostic path: a UID collision (33 == `www-data` in the base
+   * image) makes `groupmod`/`usermod` fail. The entrypoint must exit
+   * non-zero and emit the `[ironcurtain] {usermod,groupmod} failed:`
+   * diagnostic added in commit 2f463f3 so operators see what went wrong
+   * instead of silently running with a broken UID mapping.
+   */
+  describe('UID collision is reported as a hard error', () => {
+    let containerName: string;
+
+    beforeAll(() => {
+      containerName = `ironcurtain-uidremap-fail-${process.pid}-${Date.now()}`;
+    });
+
+    afterAll(async () => {
+      // Best-effort: `docker run --rm` should have already removed it, but
+      // belt-and-braces in case the run was interrupted.
+      try {
+        await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+      } catch {
+        /* container already gone */
+      }
+    });
+
+    it(`entrypoint exits non-zero and logs a diagnostic when UID ${COLLIDING_UID} collides with a baked user`, async () => {
+      // Run the entrypoint as root (`--user 0:0`) with a colliding
+      // IRONCURTAIN_AGENT_UID. `groupmod` runs first; gid 33 also belongs to
+      // `www-data`, so the diagnostic will be `groupmod failed:` (the
+      // entrypoint fails on the first collision). Either error proves the
+      // hard-error contract: silent fall-through is the regression we're
+      // guarding against.
+      let result: { stdout: string; stderr: string; exitCode: number };
+      try {
+        const ok = await execFile(
+          'docker',
+          [
+            'run',
+            '--rm',
+            '--name',
+            containerName,
+            '--user',
+            '0:0',
+            '-e',
+            `IRONCURTAIN_AGENT_UID=${COLLIDING_UID}`,
+            '-e',
+            `IRONCURTAIN_AGENT_GID=${COLLIDING_UID}`,
+            IMAGE,
+            'true',
+          ],
+          { timeout: 30_000 },
+        );
+        result = { stdout: ok.stdout, stderr: ok.stderr, exitCode: 0 };
+      } catch (err: unknown) {
+        const e = err as { stdout?: string; stderr?: string; code?: number };
+        result = { stdout: e.stdout ?? '', stderr: e.stderr ?? '', exitCode: e.code ?? 1 };
+      }
+
+      // Container must exit non-zero. The entrypoint script uses `exit 1`
+      // explicitly on each failure branch.
+      expect(result.exitCode).not.toBe(0);
+      // Stderr must contain one of the diagnostic lines added in 2f463f3 —
+      // we accept either `usermod failed:` or `groupmod failed:` because
+      // groupmod runs first and gid 33 also collides with www-data.
+      const combined = `${result.stdout}\n${result.stderr}`;
+      expect(combined).toMatch(/\[ironcurtain\] (usermod|groupmod) failed:/);
+    }, 60_000);
+  });
+});

--- a/test/uid-remap.integration.test.ts
+++ b/test/uid-remap.integration.test.ts
@@ -102,9 +102,17 @@ async function waitForRemapComplete(containerId: string, expectedUid: number, ti
   while (Date.now() < deadline) {
     const result = await dockerExecAs(containerId, '0:0', 'stat', '-c', '%u', '/workspace');
     if (result.exitCode !== 0) {
-      // The container is gone or exec is broken — bail so the assertions
-      // below produce a meaningful error rather than us looping silently.
-      return;
+      // Don't silently return: a non-zero exit here means the container
+      // is gone, exec is broken, or /workspace doesn't exist yet. Bailing
+      // with `return` would let the downstream assertions fail with
+      // confusing "expected undefined toBe ..." messages that hide the
+      // real cause. Throw with the captured stdio so the failure points
+      // straight at the underlying problem.
+      throw new Error(
+        `docker exec failed while polling /workspace ownership ` +
+          `(exit=${result.exitCode}); stdout=${JSON.stringify(result.stdout)} ` +
+          `stderr=${JSON.stringify(result.stderr)}`,
+      );
     }
     if (result.stdout.trim() === String(expectedUid)) return;
     await new Promise((r) => setTimeout(r, 500));

--- a/test/uid-remap.integration.test.ts
+++ b/test/uid-remap.integration.test.ts
@@ -88,30 +88,28 @@ const COLLIDING_UID = 33;
  * is still running after `timeoutMs` — that indicates a hang, not normal
  * slowness, and the test should fail loud rather than wait indefinitely.
  */
-async function waitForEntrypointHandoff(containerId: string, timeoutMs: number): Promise<void> {
+async function waitForRemapComplete(containerId: string, expectedUid: number, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
+  // We poll on `/workspace`'s owner UID rather than on the absence of
+  // `usermod`/`groupmod` processes for two reasons. First, the entrypoint
+  // also runs `chown -R "$UID:$GID" /home/codespace /workspace` after the
+  // usermod/groupmod step; a process-presence poll could return as soon
+  // as those two finish, while `chown -R` is still walking the bind
+  // mount — and the assertions below `stat`-check ownership, so they'd
+  // flake. Second, `/workspace` is processed last in the chown arg list
+  // (after `/home/codespace`), so seeing its UID flip is a sufficient
+  // signal that the full remap chain is done.
   while (Date.now() < deadline) {
-    // Run pgrep inside a shell that always exits 0; we read counts from
-    // stdout. `pgrep -c X` prints the count and exits non-zero when 0,
-    // which would make `dockerExecAs` report failure; the explicit
-    // `; true` here neutralises that.
-    const result = await dockerExecAs(
-      containerId,
-      '0:0',
-      'sh',
-      '-c',
-      'pgrep -c usermod || true; pgrep -c groupmod || true',
-    );
+    const result = await dockerExecAs(containerId, '0:0', 'stat', '-c', '%u', '/workspace');
     if (result.exitCode !== 0) {
       // The container is gone or exec is broken — bail so the assertions
       // below produce a meaningful error rather than us looping silently.
       return;
     }
-    const counts = result.stdout.trim().split(/\s+/);
-    if (counts.length >= 2 && counts.every((c) => c === '0')) return;
+    if (result.stdout.trim() === String(expectedUid)) return;
     await new Promise((r) => setTimeout(r, 500));
   }
-  throw new Error(`Entrypoint did not finish remap within ${timeoutMs}ms`);
+  throw new Error(`Entrypoint did not complete remap to UID ${expectedUid} within ${timeoutMs}ms`);
 }
 
 /** Runs `cmd` inside `containerId` as the given user. */
@@ -216,10 +214,9 @@ describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () =
       // Wait for the entrypoint to finish the remap before reading state.
       // `usermod -u N codespace` on the universal devcontainer image takes
       // ~25s because the home directory is massive (Conda, NVM, Hugo, ...)
-      // and `usermod` scans it. We poll on the entrypoint having exec'd
-      // away — once `pgrep usermod` reports no match AND CMD `sleep` is
-      // the running PID 1 child, the remap is complete.
-      await waitForEntrypointHandoff(containerName, 90_000);
+      // and `usermod` scans it. We poll on `/workspace` ownership rather
+      // than process names so `chown -R` completion is captured too.
+      await waitForRemapComplete(containerName, REMAP_UID, 90_000);
 
       // `id codespace` reflects the renumbered passwd entry.
       const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
@@ -251,20 +248,30 @@ describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () =
       const runuserName = await dockerExecAs(containerName, 'codespace', 'whoami');
       observations.runuserUid = runuserUid.stdout.trim();
       observations.runuserName = runuserName.stdout.trim();
-
-      // Restore workspace ownership BEFORE the container is torn down. The
-      // entrypoint's `chown -R ${REMAP_UID} /workspace` propagates through
-      // the bind mount; without this restore, the host tempdir would be
-      // left owned by UID 1500 and the afterAll `rmSync` would either
-      // EACCES or leak files.
-      await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
     }, 120_000);
 
     afterAll(async () => {
-      try {
-        await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
-      } catch {
-        /* container already gone */
+      // Restore workspace ownership BEFORE removing the container. The
+      // entrypoint's `chown -R ${REMAP_UID} /workspace` propagates
+      // through the bind mount; without this restore, the host tempdir
+      // is left owned by REMAP_UID and the rmSync below fails with
+      // EACCES. Lives in afterAll (not at the end of beforeAll) so a
+      // beforeAll failure after the entrypoint's chown -R still gets
+      // the bind mount restored. Best-effort: if the container already
+      // exited (e.g., the failure-diagnostic test case --rm'd it, or
+      // beforeAll failed before the remap ran), the exec fails
+      // harmlessly and we continue with teardown.
+      if (containerName) {
+        try {
+          await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
+        } catch {
+          /* container gone or chown failed — proceed with teardown */
+        }
+        try {
+          await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+        } catch {
+          /* container already gone */
+        }
       }
       if (homeDir) rmSync(homeDir, { recursive: true, force: true });
     });


### PR DESCRIPTION
## Summary

Fixes #232.

- Agent containers fail with "Not logged in / Please run /login" when the host UID is not 1000, because bind-mounted state dirs are unwritable by the baked codespace user (UID 1000).
- On Linux, the agent container now starts as root (`--user 0:0`) with the host UID/GID passed via env. The entrypoint runs `usermod`/`groupmod`/`chown` to renumber codespace to match the host, then `exec runuser -u codespace` drops privileges. macOS is unchanged (Docker Desktop's VirtioFS already translates UIDs).
- `DockerManager.exec` defaults to `--user codespace` so the renumbered account is used consistently; callers targeting non-agent containers (e.g. `signal-container.ts`) opt out via `execUser: null`.
- New `buildAgentUidRemap(useTcp)` helper centralizes the Linux-vs-macOS split for both batch-mode (`docker-infrastructure.ts`) and PTY-mode (`pty-session.ts`) container creation; entrypoint changes mirrored across `entrypoint-claude-code.sh` and `entrypoint-goose.sh`. Each remap step emits a `[ironcurtain] ... failed:` diagnostic on failure rather than silently re-creating the original bug.
- Integration test (`test/uid-remap.integration.test.ts`) forces `IRONCURTAIN_AGENT_UID=1500` even on a UID-1000 host so the actual remap code path is exercised end-to-end, and a separate case (UID=33, collision with `www-data`) validates the failure-diagnostic path.

## Test plan

- [ ] `npm test -- --run test/docker-manager.test.ts test/docker-infrastructure.test.ts test/uid-remap.integration.test.ts` — passes
- [ ] `npm test` — full suite green
- [ ] `npm run lint` and `npm run build` — clean
- [ ] Reproduce on a non-1000 host (e.g. WSL with UID 1001): run a workflow and confirm the agent reaches the API and writes to `~/.ironcurtain/sessions/<id>/claude-state/`
- [ ] Verify macOS path unchanged: `docker inspect <agent-container>` shows no `--user` override and no `IRONCURTAIN_AGENT_UID` env