### PR TITLE
fix(docker): stream image pull/build with idle-timeout watchdog

### DIFF
--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -12,6 +12,7 @@ import type { DockerContainerConfig, DockerExecResult, DockerManager } from './t
 import * as logger from '../logger.js';
 import { checkDockerAvailable, type DockerAvailability } from '../session/preflight.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
+import { spawnWithIdleTimeout, type SpawnFn } from './spawn-with-idle-timeout.js';
 
 /** Async exec function signature matching promisified execFile. */
 export type ExecFileFn = (
@@ -27,6 +28,23 @@ const defaultExecFile: ExecFileFn = async (cmd, args, opts) => {
 
 /** Default timeout for docker exec commands (10 minutes). */
 export const DEFAULT_EXEC_TIMEOUT_MS = 600_000;
+
+/**
+ * Idle (no-stdout/stderr) timeout for `docker pull`. The Docker daemon
+ * heartbeats layer progress every few hundred ms during a healthy pull, so
+ * 2 minutes of silence reliably indicates a hung daemon or dead registry
+ * connection. The total wall-clock can still legitimately be hours for a
+ * slow connection on a large base image like `devcontainers/universal`.
+ */
+export const PULL_IDLE_TIMEOUT_MS = 120_000;
+
+/**
+ * Idle timeout for `docker build`. Builds can have legitimately quiet RUN
+ * steps (e.g. compilers running without output), so we allow longer silence
+ * than for pulls before declaring the build hung. Combined with
+ * `--progress=plain`, BuildKit will still emit per-step progress.
+ */
+export const BUILD_IDLE_TIMEOUT_MS = 300_000;
 
 /** Grace period for docker stop before SIGKILL. */
 const STOP_TIMEOUT_SECONDS = 10;
@@ -134,11 +152,24 @@ export function buildCreateArgs(config: DockerContainerConfig): string[] {
   return args;
 }
 
+/** Test seams for the streaming spawn path used by pull/build. */
+export interface CreateDockerManagerOptions {
+  spawn?: SpawnFn;
+  stdoutSink?: NodeJS.WritableStream;
+  stderrSink?: NodeJS.WritableStream;
+}
+
 export function createDockerManager(
   execFileFn?: ExecFileFn,
   dockerAvailabilityProbe: () => Promise<DockerAvailability> = checkDockerAvailable,
+  spawnOpts?: CreateDockerManagerOptions,
 ): DockerManager {
   const exec = execFileFn ?? defaultExecFile;
+  const streamOpts = {
+    spawn: spawnOpts?.spawn,
+    stdoutSink: spawnOpts?.stdoutSink,
+    stderrSink: spawnOpts?.stderrSink,
+  };
 
   return {
     async preflight(image: string): Promise<void> {
@@ -253,16 +284,22 @@ export function createDockerManager(
       contextDir: string,
       labels?: Record<string, string>,
     ): Promise<void> {
-      const args = ['build', '-t', tag, '-f', dockerfilePath];
+      // `--progress=plain` plus BuildKit gives line-oriented streamed output,
+      // which (a) makes the user-visible "what's happening" question
+      // answerable and (b) provides the per-step heartbeat the idle-timeout
+      // watchdog needs to distinguish a quiet RUN from a hung builder.
+      const args = ['build', '--progress=plain', '-t', tag, '-f', dockerfilePath];
       if (labels) {
         for (const [key, value] of Object.entries(labels)) {
           args.push('--label', `${key}=${value}`);
         }
       }
       args.push(contextDir);
-      await exec('docker', args, {
-        timeout: 600_000,
-        maxBuffer: 50 * 1024 * 1024,
+      await spawnWithIdleTimeout('docker', args, {
+        idleTimeoutMs: BUILD_IDLE_TIMEOUT_MS,
+        operation: 'docker build',
+        env: { DOCKER_BUILDKIT: '1' },
+        ...streamOpts,
       });
     },
 
@@ -317,9 +354,14 @@ export function createDockerManager(
     },
 
     async pullImage(image: string): Promise<void> {
-      await exec('docker', ['pull', image], {
-        timeout: 300_000, // 5 minutes for large images
-        maxBuffer: 50 * 1024 * 1024,
+      // Streamed via spawn (not execFile) so the user sees per-layer
+      // progress and the watchdog can reset on every heartbeat. Large
+      // images like devcontainers/universal (~5 GB) on slow links
+      // legitimately take an hour or more; only true silence kills.
+      await spawnWithIdleTimeout('docker', ['pull', image], {
+        idleTimeoutMs: PULL_IDLE_TIMEOUT_MS,
+        operation: 'docker pull',
+        ...streamOpts,
       });
     },
 

--- a/src/docker/spawn-with-idle-timeout.ts
+++ b/src/docker/spawn-with-idle-timeout.ts
@@ -1,0 +1,159 @@
+/**
+ * Runs a child process with an *idle* timeout: the watchdog resets every time
+ * the child emits stdout or stderr, and only fires when no output has been
+ * seen for `idleTimeoutMs`. This is the right primitive for long-running
+ * Docker operations (pull/build) where total wall-clock can legitimately span
+ * hours, but a genuine hang means the daemon has stopped emitting progress.
+ *
+ * The child's stdout/stderr are also piped to the parent's stdout/stderr so
+ * the user sees layer downloads / build steps in real time. Today's
+ * execFile-based callers buffer everything until exit, which is what makes
+ * pulls feel like silent hangs.
+ */
+
+import { spawn as nodeSpawn } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+
+export type SpawnFn = (cmd: string, args: readonly string[], options?: SpawnOptions) => ChildProcess;
+
+export interface SpawnWithIdleTimeoutOptions {
+  /** Reset-on-output watchdog threshold. Fires SIGTERM (then SIGKILL) when idle. */
+  idleTimeoutMs: number;
+  /**
+   * Label used in error messages so the caller can tell which operation hung
+   * (e.g. `"docker pull"`, `"docker build"`).
+   */
+  operation: string;
+  /** Extra env vars merged on top of `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Stream sink for child stdout. Defaults to `process.stdout`. */
+  stdoutSink?: NodeJS.WritableStream;
+  /** Stream sink for child stderr. Defaults to `process.stderr`. */
+  stderrSink?: NodeJS.WritableStream;
+  /** Override the underlying spawn implementation (used by tests). */
+  spawn?: SpawnFn;
+  /** Grace period after SIGTERM before escalating to SIGKILL. Defaults to 2s. */
+  killGraceMs?: number;
+}
+
+/** Max bytes of stderr we keep around to attach to error messages on failure. */
+const STDERR_TAIL_BYTES = 4096;
+
+const DEFAULT_KILL_GRACE_MS = 2_000;
+
+/**
+ * Spawns `cmd args`, streams stdio to the parent terminal, and enforces an
+ * idle (not wall-clock) timeout. Resolves on clean exit; rejects on
+ * non-zero exit, idle timeout, or spawn error.
+ */
+export function spawnWithIdleTimeout(
+  cmd: string,
+  args: readonly string[],
+  options: SpawnWithIdleTimeoutOptions,
+): Promise<void> {
+  const {
+    idleTimeoutMs,
+    operation,
+    env,
+    stdoutSink = process.stdout,
+    stderrSink = process.stderr,
+    spawn = nodeSpawn,
+    killGraceMs = DEFAULT_KILL_GRACE_MS,
+  } = options;
+
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(cmd, [...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: env ? { ...process.env, ...env } : process.env,
+    });
+
+    let stderrTail = '';
+    let settled = false;
+    let idleTimer: NodeJS.Timeout | null = null;
+
+    const settle = (action: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+      // Detach data listeners so a SIGTERM-resistant child can't keep
+      // spamming the user's terminal (or mutating `stderrTail`) between
+      // the promise rejection and the eventual SIGKILL. The kill-escalation
+      // setTimeout is left to fire on its own schedule.
+      child.stdout?.removeAllListeners('data');
+      child.stderr?.removeAllListeners('data');
+      action();
+    };
+
+    const onIdleTimeout = (): void => {
+      // Two-phase kill: SIGTERM first, SIGKILL after the grace period for
+      // children that ignore SIGTERM. The grace timer is `.unref()`'d so a
+      // dropped promise never keeps the Node event loop alive on it alone.
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!child.killed) child.kill('SIGKILL');
+      }, killGraceMs).unref();
+
+      settle(() => {
+        rejectPromise(
+          new Error(
+            `${operation} produced no output for ${idleTimeoutMs}ms and was killed. ` +
+              `The Docker daemon may be hung or the registry/builder is unresponsive.`,
+          ),
+        );
+      });
+    };
+
+    const resetIdleTimer = (): void => {
+      if (settled) return;
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(onIdleTimeout, idleTimeoutMs);
+      // Match `killTimer.unref()`: don't keep the event loop alive if the
+      // caller drops the promise reference (e.g. a CLI early-exit path).
+      idleTimer.unref();
+    };
+
+    const forward = (chunk: Buffer | string, sink: NodeJS.WritableStream, captureTail: boolean): void => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+      // Best-effort write; ignore backpressure since stdio piping is informational.
+      sink.write(text);
+      if (captureTail) {
+        stderrTail = (stderrTail + text).slice(-STDERR_TAIL_BYTES);
+      }
+      resetIdleTimer();
+    };
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      forward(chunk, stdoutSink, false);
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      forward(chunk, stderrSink, true);
+    });
+
+    child.on('error', (err: Error) => {
+      settle(() => {
+        rejectPromise(new Error(`${operation} failed to spawn: ${err.message}`));
+      });
+    });
+
+    child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+      if (settled) return;
+      if (code === 0 && !signal) {
+        settle(() => resolvePromise());
+        return;
+      }
+      const tail = stderrTail.trim();
+      const tailSuffix = tail ? `: ${tail}` : '';
+      const reason = signal ? `killed by signal ${signal}` : `exited with code ${code ?? 'unknown'}`;
+      settle(() => {
+        rejectPromise(new Error(`${operation} ${reason}${tailSuffix}`));
+      });
+    });
+
+    // Arm the watchdog. If the child produces no output at all, this fires
+    // exactly once at `idleTimeoutMs` from start.
+    resetIdleTimer();
+  });
+}

--- a/src/docker/spawn-with-idle-timeout.ts
+++ b/src/docker/spawn-with-idle-timeout.ts
@@ -36,8 +36,15 @@ export interface SpawnWithIdleTimeoutOptions {
   killGraceMs?: number;
 }
 
-/** Max bytes of stderr we keep around to attach to error messages on failure. */
-const STDERR_TAIL_BYTES = 4096;
+/**
+ * Cap on the rolling stderr tail kept for error messages. Measured in JS
+ * string length (UTF-16 code units), not UTF-8 bytes — for ASCII-only
+ * output (the overwhelming majority of docker stderr) the two are equal;
+ * for multi-byte UTF-8 the retained byte count is up to ~3× this value.
+ * 4096 is comfortably enough headroom for the short stderr blurbs we
+ * actually quote back to the user.
+ */
+const STDERR_TAIL_CHARS = 4096;
 
 const DEFAULT_KILL_GRACE_MS = 2_000;
 
@@ -69,6 +76,7 @@ export function spawnWithIdleTimeout(
 
     let stderrTail = '';
     let settled = false;
+    let exited = false;
     let idleTimer: NodeJS.Timeout | null = null;
 
     const settle = (action: () => void): void => {
@@ -89,11 +97,16 @@ export function spawnWithIdleTimeout(
 
     const onIdleTimeout = (): void => {
       // Two-phase kill: SIGTERM first, SIGKILL after the grace period for
-      // children that ignore SIGTERM. The grace timer is `.unref()`'d so a
-      // dropped promise never keeps the Node event loop alive on it alone.
+      // children that ignore SIGTERM. We gate the SIGKILL on our own
+      // `exited` flag (set in the `close` handler) rather than on
+      // `child.killed`, because Node flips `child.killed` to true the moment
+      // a signal is *sent*, not when the child actually exits — using it
+      // here would make SIGKILL unreachable in practice. The grace timer is
+      // `.unref()`'d so a dropped promise never keeps the Node event loop
+      // alive on it alone.
       child.kill('SIGTERM');
       setTimeout(() => {
-        if (!child.killed) child.kill('SIGKILL');
+        if (!exited) child.kill('SIGKILL');
       }, killGraceMs).unref();
 
       settle(() => {
@@ -120,7 +133,7 @@ export function spawnWithIdleTimeout(
       // Best-effort write; ignore backpressure since stdio piping is informational.
       sink.write(text);
       if (captureTail) {
-        stderrTail = (stderrTail + text).slice(-STDERR_TAIL_BYTES);
+        stderrTail = (stderrTail + text).slice(-STDERR_TAIL_CHARS);
       }
       resetIdleTimer();
     };
@@ -139,6 +152,7 @@ export function spawnWithIdleTimeout(
     });
 
     child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+      exited = true;
       if (settled) return;
       if (code === 0 && !signal) {
         settle(() => resolvePromise());

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -755,6 +755,50 @@ describe('DockerManager', () => {
       expect(signals).toContain('SIGKILL');
     });
 
+    it('skips SIGKILL when the child exits within the grace period', async () => {
+      // Cooperative path: the child receives SIGTERM and emits `close`
+      // before the grace expires. The helper's `exited` flag (set at the
+      // top of the close handler) must keep the grace timer from firing
+      // SIGKILL. Regression test for the original bug — when escalation
+      // was gated on `child.killed`, this case would have sent SIGKILL
+      // anyway because Node flips `killed` to true on signal *send*.
+      const inner = createMockSpawn();
+      const signals: NodeJS.Signals[] = [];
+      const recordingSpawn: SpawnFn = (cmd, args, options) => {
+        const child = inner.spawn(cmd, args, options) as ChildProcess & { killed: boolean };
+        child.kill = ((signal?: NodeJS.Signals | number) => {
+          signals.push(typeof signal === 'string' ? signal : 'SIGTERM');
+          child.killed = true;
+          return true;
+        }) as ChildProcess['kill'];
+        return child;
+      };
+
+      const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
+        idleTimeoutMs: 10,
+        operation: 'docker pull',
+        spawn: recordingSpawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+        killGraceMs: 40,
+      });
+      const expectation = expect(promise).rejects.toThrow();
+
+      // Wait for the idle timer to fire and SIGTERM to be sent.
+      await new Promise((r) => setTimeout(r, 25));
+      expect(signals).toEqual(['SIGTERM']);
+
+      // Simulate the child honoring SIGTERM and exiting before the grace
+      // period expires. The close handler flips `exited = true`.
+      inner.handles[0].exit(143, 'SIGTERM');
+
+      // Wait past the kill grace window to confirm SIGKILL was NOT sent.
+      await new Promise((r) => setTimeout(r, 60));
+      await expectation;
+
+      expect(signals).toEqual(['SIGTERM']);
+    });
+
     it('passes operation label and stderr tail in non-zero exit errors', async () => {
       const spawnMock = createMockSpawn();
       const promise = spawnWithIdleTimeout('docker', ['build'], {

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -1,6 +1,16 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createDockerManager, buildCreateArgs, type ExecFileFn } from '../src/docker/docker-manager.js';
+import {
+  createDockerManager,
+  buildCreateArgs,
+  BUILD_IDLE_TIMEOUT_MS,
+  PULL_IDLE_TIMEOUT_MS,
+  type ExecFileFn,
+} from '../src/docker/docker-manager.js';
+import { spawnWithIdleTimeout, type SpawnFn } from '../src/docker/spawn-with-idle-timeout.js';
 import type { DockerContainerConfig } from '../src/docker/types.js';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
 
 type ExecCall = {
   cmd: string;
@@ -90,6 +100,72 @@ function createMockExec(): {
       state.callIndex = 0;
     },
   };
+}
+
+interface SpawnCall {
+  cmd: string;
+  args: readonly string[];
+  options: SpawnOptions | undefined;
+}
+
+interface FakeChildHandle {
+  child: ChildProcess;
+  emitStdout: (chunk: string) => void;
+  emitStderr: (chunk: string) => void;
+  exit: (code: number | null, signal?: NodeJS.Signals | null) => void;
+  spawnError: (err: Error) => void;
+}
+
+interface MockSpawn {
+  spawn: SpawnFn;
+  calls: SpawnCall[];
+  handles: FakeChildHandle[];
+}
+
+/**
+ * Builds a `SpawnFn`-shaped fake plus handles for driving each spawned child
+ * (emit stdout/stderr chunks, fire the close event, etc.). Lets us exercise
+ * the streaming + idle-timeout path without launching real processes.
+ */
+function createMockSpawn(): MockSpawn {
+  const calls: SpawnCall[] = [];
+  const handles: FakeChildHandle[] = [];
+
+  const spawn: SpawnFn = (cmd, args, options) => {
+    calls.push({ cmd, args, options });
+
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = new EventEmitter() as ChildProcess & { killed: boolean };
+    child.stdout = stdout;
+    child.stderr = stderr;
+    child.killed = false;
+    child.kill = (() => {
+      child.killed = true;
+      return true;
+    }) as ChildProcess['kill'];
+
+    handles.push({
+      child,
+      emitStdout: (chunk: string) => stdout.write(chunk),
+      emitStderr: (chunk: string) => stderr.write(chunk),
+      exit: (code: number | null, signal: NodeJS.Signals | null = null) => {
+        child.emit('close', code, signal);
+      },
+      spawnError: (err: Error) => {
+        child.emit('error', err);
+      },
+    });
+
+    return child;
+  };
+
+  return { spawn, calls, handles };
+}
+
+/** Silent writable so tests don't spew docker output into the test runner. */
+function nullSink(): NodeJS.WritableStream {
+  return new PassThrough();
 }
 
 const sampleConfig: DockerContainerConfig = {
@@ -482,15 +558,26 @@ describe('DockerManager', () => {
 
   describe('buildImage', () => {
     it('passes labels as --label flags', async () => {
-      mock.setResponse('');
-      const manager = createDockerManager(mock.mockExec);
+      const spawnMock = createMockSpawn();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
 
-      await manager.buildImage('my-image:latest', '/path/to/Dockerfile', '/context', {
+      const promise = manager.buildImage('my-image:latest', '/path/to/Dockerfile', '/context', {
         'ironcurtain.build-hash': 'abc123',
         'ironcurtain.ca-hash': 'def456',
       });
 
-      const args = mock.calls[0].args;
+      // Wait a tick for the spawn to be registered, then close cleanly.
+      await Promise.resolve();
+      spawnMock.handles[0].exit(0);
+      await promise;
+
+      const args = spawnMock.calls[0].args;
+      expect(spawnMock.calls[0].cmd).toBe('docker');
+      expect(args[0]).toBe('build');
       expect(args).toContain('--label');
       expect(args).toContain('ironcurtain.build-hash=abc123');
       expect(args).toContain('ironcurtain.ca-hash=def456');
@@ -498,13 +585,198 @@ describe('DockerManager', () => {
     });
 
     it('builds without labels when none provided', async () => {
-      mock.setResponse('');
-      const manager = createDockerManager(mock.mockExec);
+      const spawnMock = createMockSpawn();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
 
-      await manager.buildImage('my-image:latest', '/path/to/Dockerfile', '/context');
+      const promise = manager.buildImage('my-image:latest', '/path/to/Dockerfile', '/context');
+      await Promise.resolve();
+      spawnMock.handles[0].exit(0);
+      await promise;
 
-      const args = mock.calls[0].args;
+      const args = spawnMock.calls[0].args;
       expect(args).not.toContain('--label');
+    });
+
+    it('forces BuildKit and plain progress for streamed heartbeats', async () => {
+      const spawnMock = createMockSpawn();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
+
+      const promise = manager.buildImage('img:latest', '/Dockerfile', '/ctx');
+      await Promise.resolve();
+      spawnMock.handles[0].exit(0);
+      await promise;
+
+      expect(spawnMock.calls[0].args).toContain('--progress=plain');
+      const env = spawnMock.calls[0].options?.env;
+      expect(env?.DOCKER_BUILDKIT).toBe('1');
+    });
+
+    it('surfaces stderr tail when the build exits non-zero', async () => {
+      const spawnMock = createMockSpawn();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
+
+      const promise = manager.buildImage('img:latest', '/Dockerfile', '/ctx');
+      await Promise.resolve();
+      spawnMock.handles[0].emitStderr('ERROR: Dockerfile syntax error on line 3\n');
+      await new Promise((r) => setImmediate(r));
+      spawnMock.handles[0].exit(1);
+
+      await expect(promise).rejects.toThrow(/docker build .*exited with code 1.*Dockerfile syntax error/s);
+    });
+  });
+
+  describe('pullImage', () => {
+    it('streams docker pull and resolves on clean exit', async () => {
+      const spawnMock = createMockSpawn();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
+
+      const promise = manager.pullImage('alpine:latest');
+      await Promise.resolve();
+      spawnMock.handles[0].emitStdout('latest: Pulling from library/alpine\n');
+      spawnMock.handles[0].exit(0);
+      await promise;
+
+      expect(spawnMock.calls[0].cmd).toBe('docker');
+      expect(spawnMock.calls[0].args).toEqual(['pull', 'alpine:latest']);
+    });
+
+    it('rejects when the spawn itself errors (e.g. docker not on PATH)', async () => {
+      const spawnMock = createMockSpawn();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
+
+      const promise = manager.pullImage('alpine:latest');
+      await Promise.resolve();
+      spawnMock.handles[0].spawnError(new Error('spawn docker ENOENT'));
+
+      await expect(promise).rejects.toThrow(/docker pull failed to spawn: spawn docker ENOENT/);
+    });
+  });
+
+  // The watchdog primitive is tested directly with real timers and a
+  // tiny idle threshold so the test runs in milliseconds. Driving it
+  // through `pullImage` would either need the real 2-minute timeout
+  // (impractical) or fake timers (which leak across tests when an
+  // assertion fails mid-test, breaking unrelated suites).
+  describe('spawnWithIdleTimeout', () => {
+    it('rejects with a labeled error when the child stays silent', async () => {
+      const spawnMock = createMockSpawn();
+      const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
+        idleTimeoutMs: 20,
+        operation: 'docker pull',
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+        killGraceMs: 5,
+      });
+
+      await expect(promise).rejects.toThrow(/docker pull produced no output for 20ms/);
+      // SIGTERM is sent on watchdog fire.
+      expect(spawnMock.handles[0].child.killed).toBe(true);
+    });
+
+    it('resets the watchdog when the child emits output', async () => {
+      const spawnMock = createMockSpawn();
+      const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
+        idleTimeoutMs: 40,
+        operation: 'docker pull',
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
+
+      // Heartbeat every 20ms (under the 40ms idle threshold) for 5
+      // iterations — never silent for long enough to trip the watchdog.
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        spawnMock.handles[0].emitStdout(`chunk ${i}\n`);
+      }
+      // Now exit cleanly. The watchdog should NOT have fired.
+      spawnMock.handles[0].exit(0);
+      await promise;
+      expect(spawnMock.handles[0].child.killed).toBe(false);
+    });
+
+    it('escalates from SIGTERM to SIGKILL after the grace period', async () => {
+      const signals: NodeJS.Signals[] = [];
+      // Pre-install a recording `kill` on every spawned child BEFORE the
+      // watchdog can fire, so the SIGTERM that arrives ~10ms after spawn
+      // is captured. We also leave `child.killed` false so the helper's
+      // `if (!child.killed) child.kill('SIGKILL')` path actually runs.
+      const recordingSpawn: SpawnFn = (cmd, args, options) => {
+        const child = createMockSpawn().spawn(cmd, args, options) as ChildProcess & { killed: boolean };
+        child.kill = ((signal?: NodeJS.Signals | number) => {
+          signals.push(typeof signal === 'string' ? signal : 'SIGTERM');
+          return true;
+        }) as ChildProcess['kill'];
+        return child;
+      };
+
+      const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
+        idleTimeoutMs: 10,
+        operation: 'docker pull',
+        spawn: recordingSpawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+        killGraceMs: 20,
+      });
+      // Attach a handler immediately so the eventual rejection is observed.
+      const expectation = expect(promise).rejects.toThrow();
+
+      // Wait long enough for both the idle timer (10ms) and the kill
+      // grace (20ms) to elapse.
+      await new Promise((r) => setTimeout(r, 60));
+      await expectation;
+
+      expect(signals[0]).toBe('SIGTERM');
+      expect(signals).toContain('SIGKILL');
+    });
+
+    it('passes operation label and stderr tail in non-zero exit errors', async () => {
+      const spawnMock = createMockSpawn();
+      const promise = spawnWithIdleTimeout('docker', ['build'], {
+        idleTimeoutMs: 60_000, // generous; we'll exit explicitly
+        operation: 'docker build',
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+      });
+      await Promise.resolve();
+      spawnMock.handles[0].emitStderr('failed to compute cache key\n');
+      await new Promise((r) => setImmediate(r));
+      spawnMock.handles[0].exit(2);
+
+      await expect(promise).rejects.toThrow(/docker build exited with code 2.*failed to compute cache key/s);
+    });
+  });
+
+  describe('idle-timeout primitive', () => {
+    // Sanity check the constants haven't drifted accidentally — they're the
+    // visible contract callers (and bug reports) refer to.
+    it('pull idle timeout is 120s', () => {
+      expect(PULL_IDLE_TIMEOUT_MS).toBe(120_000);
+    });
+    it('build idle timeout is 300s', () => {
+      expect(BUILD_IDLE_TIMEOUT_MS).toBe(300_000);
     });
   });
 

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -720,12 +720,16 @@ describe('DockerManager', () => {
       const signals: NodeJS.Signals[] = [];
       // Pre-install a recording `kill` on every spawned child BEFORE the
       // watchdog can fire, so the SIGTERM that arrives ~10ms after spawn
-      // is captured. We also leave `child.killed` false so the helper's
-      // `if (!child.killed) child.kill('SIGKILL')` path actually runs.
+      // is captured. Mirror Node's real semantics by flipping `child.killed`
+      // to true once a signal is sent — SIGKILL escalation is gated on the
+      // helper's internal `exited` flag (set in the `close` handler), not on
+      // `child.killed`, so leaving the child without ever emitting `close`
+      // is what lets the SIGKILL path fire.
       const recordingSpawn: SpawnFn = (cmd, args, options) => {
         const child = createMockSpawn().spawn(cmd, args, options) as ChildProcess & { killed: boolean };
         child.kill = ((signal?: NodeJS.Signals | number) => {
           signals.push(typeof signal === 'string' ? signal : 'SIGTERM');
+          child.killed = true;
           return true;
         }) as ChildProcess['kill'];
         return child;


### PR DESCRIPTION
## Summary

- Replace the hard wall-clock timeouts on `docker pull` (5 min) and `docker build` (10 min) with an **idle** timeout — total wall-clock can run for hours, only true silence kills the child. Fixes the 1+ hour pulls of large base images (e.g. `devcontainers/universal`) that previously aborted mid-flight (reported in Bishop Fox feedback).
- Stream child stdio to the parent terminal so the user sees per-layer pull progress and per-step build output in real time, instead of a silent hang.
- Introduce a small reusable primitive `spawnWithIdleTimeout` (`src/docker/spawn-with-idle-timeout.ts`) that handles the streaming, watchdog reset, SIGTERM → SIGKILL escalation with `.unref()`'d timers, and stderr-tail capture for error messages.

Caller signatures (`pullImage(image)`, `buildImage(tag, dockerfilePath, contextDir, labels?)`) are unchanged — purely internal refactor.

## Implementation notes

- Idle thresholds are hardcoded constants: `PULL_IDLE_TIMEOUT_MS = 120_000` (2 min, since docker pull heartbeats layer progress every few hundred ms) and `BUILD_IDLE_TIMEOUT_MS = 300_000` (5 min, since builds can have legitimately quiet `RUN` steps). Making these configurable via `~/.ironcurtain/config.json` is a natural follow-up if these defaults prove wrong in practice.
- `docker build` is now invoked with `DOCKER_BUILDKIT=1` + `--progress=plain` so BuildKit emits the line-oriented heartbeats the watchdog needs. BuildKit is the default in Docker 23+, so this is a no-op on modern daemons.
- Both `idleTimer` and the SIGKILL grace `setTimeout` are `.unref()`'d — a dropped promise reference won't keep the Node event loop alive for 2–5 minutes on either timer.
- On settle, stdio `data` listeners are detached so a SIGTERM-resistant child can't keep spamming the parent terminal between rejection and SIGKILL.

## Test plan

- [x] `npm test -- test/docker-manager.test.ts` — 56/56 pass (7 new tests covering the streamed path, BuildKit forcing, stderr-tail capture, idle-timeout firing under real timers, watchdog reset on heartbeats, and SIGTERM→SIGKILL escalation)
- [x] `npm run lint` — clean
- [ ] Manual: trigger a real `docker pull` of a large image to confirm progress streams to the terminal as expected
- [ ] Manual: simulate a hung registry (e.g. point at an unreachable host) to confirm the watchdog fires with the labeled error message after 120s

## Out of scope (worth noting)

- The other `execFile`-with-timeout calls in `docker-manager.ts` (`exec`, `create`, `stop`, `network create`, etc.) still buffer. None are user-facing long-running operations, but the new primitive is reusable if Bishop Fox feedback row 29 ("hardcoded timeouts throughout src/docker/") gets prioritized.
- Pre-warming the base image during `ironcurtain setup` / `doctor` (Bishop Fox feedback option #5) is a worthwhile follow-up that would move this long wait into a context where it's expected.