### PR TITLE
fix(docker): harden spawn-with-idle-timeout against edge cases

### DIFF
--- a/src/docker/spawn-with-idle-timeout.ts
+++ b/src/docker/spawn-with-idle-timeout.ts
@@ -69,10 +69,30 @@ export function spawnWithIdleTimeout(
   } = options;
 
   return new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn(cmd, [...args], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: env ? { ...process.env, ...env } : process.env,
-    });
+    let child: ChildProcess;
+    try {
+      child = spawn(cmd, [...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: env ? { ...process.env, ...env } : process.env,
+      });
+    } catch (err: unknown) {
+      // `spawn()` can throw synchronously on invalid options/args (the
+      // async `error` event handles the ENOENT-class failures). Reformat
+      // with the operation label so callers get a consistent error shape.
+      rejectPromise(new Error(`${operation} failed to spawn: ${err instanceof Error ? err.message : String(err)}`));
+      return;
+    }
+
+    const safeKill = (signal: NodeJS.Signals): void => {
+      try {
+        child.kill(signal);
+      } catch {
+        // kill() returns false (doesn't throw) on ESRCH per Node's docs;
+        // a throw here would only come from an invalid signal name or an
+        // unexpectedly torn-down child handle. Either way the timeout
+        // callback should never crash the process.
+      }
+    };
 
     let stderrTail = '';
     let settled = false;
@@ -96,6 +116,11 @@ export function spawnWithIdleTimeout(
     };
 
     const onIdleTimeout = (): void => {
+      // Defensive bail: settle() clears the idle timer synchronously, so a
+      // queued callback should not see settled=true — but if a future edit
+      // ever rearranges the close path, the guard prevents duplicate kills
+      // (and a no-op settle()) from this callback.
+      if (settled || exited) return;
       // Two-phase kill: SIGTERM first, SIGKILL after the grace period for
       // children that ignore SIGTERM. We gate the SIGKILL on our own
       // `exited` flag (set in the `close` handler) rather than on
@@ -104,9 +129,9 @@ export function spawnWithIdleTimeout(
       // here would make SIGKILL unreachable in practice. The grace timer is
       // `.unref()`'d so a dropped promise never keeps the Node event loop
       // alive on it alone.
-      child.kill('SIGTERM');
+      safeKill('SIGTERM');
       setTimeout(() => {
-        if (!exited) child.kill('SIGKILL');
+        if (!exited) safeKill('SIGKILL');
       }, killGraceMs).unref();
 
       settle(() => {

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -681,15 +681,15 @@ describe('DockerManager', () => {
     it('rejects with a labeled error when the child stays silent', async () => {
       const spawnMock = createMockSpawn();
       const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
-        idleTimeoutMs: 20,
+        idleTimeoutMs: 100,
         operation: 'docker pull',
         spawn: spawnMock.spawn,
         stdoutSink: nullSink(),
         stderrSink: nullSink(),
-        killGraceMs: 5,
+        killGraceMs: 20,
       });
 
-      await expect(promise).rejects.toThrow(/docker pull produced no output for 20ms/);
+      await expect(promise).rejects.toThrow(/docker pull produced no output for 100ms/);
       // SIGTERM is sent on watchdog fire.
       expect(spawnMock.handles[0].child.killed).toBe(true);
     });
@@ -697,17 +697,18 @@ describe('DockerManager', () => {
     it('resets the watchdog when the child emits output', async () => {
       const spawnMock = createMockSpawn();
       const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
-        idleTimeoutMs: 40,
+        idleTimeoutMs: 150,
         operation: 'docker pull',
         spawn: spawnMock.spawn,
         stdoutSink: nullSink(),
         stderrSink: nullSink(),
       });
 
-      // Heartbeat every 20ms (under the 40ms idle threshold) for 5
-      // iterations — never silent for long enough to trip the watchdog.
+      // Heartbeat every 50ms (3× under the 150ms idle threshold) for 5
+      // iterations. The slack absorbs event-loop jitter on loaded CI
+      // runners that would otherwise stretch a 20ms timer past 40ms.
       for (let i = 0; i < 5; i++) {
-        await new Promise((r) => setTimeout(r, 20));
+        await new Promise((r) => setTimeout(r, 50));
         spawnMock.handles[0].emitStdout(`chunk ${i}\n`);
       }
       // Now exit cleanly. The watchdog should NOT have fired.
@@ -736,19 +737,19 @@ describe('DockerManager', () => {
       };
 
       const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
-        idleTimeoutMs: 10,
+        idleTimeoutMs: 80,
         operation: 'docker pull',
         spawn: recordingSpawn,
         stdoutSink: nullSink(),
         stderrSink: nullSink(),
-        killGraceMs: 20,
+        killGraceMs: 150,
       });
       // Attach a handler immediately so the eventual rejection is observed.
       const expectation = expect(promise).rejects.toThrow();
 
-      // Wait long enough for both the idle timer (10ms) and the kill
-      // grace (20ms) to elapse.
-      await new Promise((r) => setTimeout(r, 60));
+      // Wait long enough for both the idle timer (80ms) and the kill
+      // grace (150ms) to elapse, with slack for CI jitter.
+      await new Promise((r) => setTimeout(r, 300));
       await expectation;
 
       expect(signals[0]).toBe('SIGTERM');
@@ -775,28 +776,72 @@ describe('DockerManager', () => {
       };
 
       const promise = spawnWithIdleTimeout('docker', ['pull', 'x'], {
-        idleTimeoutMs: 10,
+        idleTimeoutMs: 80,
         operation: 'docker pull',
         spawn: recordingSpawn,
         stdoutSink: nullSink(),
         stderrSink: nullSink(),
-        killGraceMs: 40,
+        killGraceMs: 300,
       });
       const expectation = expect(promise).rejects.toThrow();
 
-      // Wait for the idle timer to fire and SIGTERM to be sent.
-      await new Promise((r) => setTimeout(r, 25));
+      // Wait for the idle timer (80ms) to fire and SIGTERM to be sent.
+      await new Promise((r) => setTimeout(r, 150));
       expect(signals).toEqual(['SIGTERM']);
 
       // Simulate the child honoring SIGTERM and exiting before the grace
       // period expires. The close handler flips `exited = true`.
       inner.handles[0].exit(143, 'SIGTERM');
 
-      // Wait past the kill grace window to confirm SIGKILL was NOT sent.
-      await new Promise((r) => setTimeout(r, 60));
+      // Wait past the kill grace window (300ms) to confirm SIGKILL was NOT sent.
+      await new Promise((r) => setTimeout(r, 400));
       await expectation;
 
       expect(signals).toEqual(['SIGTERM']);
+    });
+
+    it('reformats synchronous spawn() throws with the operation label', async () => {
+      // `spawn()` can throw synchronously on invalid options/args — distinct
+      // from the async `error` event for ENOENT-class failures. The helper
+      // should catch and reformat so callers see a consistent error shape.
+      const throwingSpawn: SpawnFn = () => {
+        throw new Error('Invalid stdio option');
+      };
+
+      await expect(
+        spawnWithIdleTimeout('docker', ['pull', 'x'], {
+          idleTimeoutMs: 60_000,
+          operation: 'docker pull',
+          spawn: throwingSpawn,
+          stdoutSink: nullSink(),
+          stderrSink: nullSink(),
+        }),
+      ).rejects.toThrow(/docker pull failed to spawn: Invalid stdio option/);
+    });
+
+    it('swallows kill() throws so the watchdog still rejects cleanly', async () => {
+      // If `kill()` throws (e.g. invalid signal, torn-down handle), the
+      // helper must not leak the exception into the timer callback. The
+      // promise should still reject with the idle-timeout error message.
+      const inner = createMockSpawn();
+      const throwingKillSpawn: SpawnFn = (cmd, args, options) => {
+        const child = inner.spawn(cmd, args, options) as ChildProcess & { killed: boolean };
+        child.kill = (() => {
+          throw new Error('unexpected kill() failure');
+        }) as ChildProcess['kill'];
+        return child;
+      };
+
+      await expect(
+        spawnWithIdleTimeout('docker', ['pull', 'x'], {
+          idleTimeoutMs: 100,
+          operation: 'docker pull',
+          spawn: throwingKillSpawn,
+          stdoutSink: nullSink(),
+          stderrSink: nullSink(),
+          killGraceMs: 20,
+        }),
+      ).rejects.toThrow(/docker pull produced no output for 100ms/);
     });
 
     it('passes operation label and stderr tail in non-zero exit errors', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #250 addressing three rough corners flagged in a second Copilot review pass:

- **Wrap synchronous `spawn()` in try/catch.** The Promise executor would already convert a synchronous throw to a rejection, but callers would see the raw spawn() error message rather than the `\${operation} failed to spawn: ...` shape that the async `error` event handler already produces. Now consistent.
- **Add `if (settled || exited) return` at the top of `onIdleTimeout`.** `settle()` clears the idle timer synchronously so this guard should be unreachable today, but it prevents duplicate kills if a future edit ever rearranges the close path.
- **Route both `kill()` calls through a `safeKill()` helper that swallows throws.** Node's `kill()` returns `false` (not throw) on ESRCH, but a torn-down child handle or invalid signal name could throw and surface as an unhandled exception inside the kill-grace timer callback.

Also bumps the watchdog tests' timer thresholds (20–40ms → 80–150ms idle, 20ms heartbeats → 50ms) so loaded CI runners have 3× slack against event-loop jitter. Suite cost ~+1s.

## Test plan

- [x] `npm test -- test/docker-manager.test.ts` — 59/59 pass (was 57; +2 covering the synchronous-spawn-throw and kill-throws-mid-watchdog paths)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

## Notes

None of these are correctness bugs in #250 — the helper as merged works in every realistic scenario. This is defensive hardening + CI-stability work flagged by Copilot's second review pass after #250 was already merged.