### PR TITLE
fix(workflow): anchor agent_status block on final response

### DIFF
--- a/src/workflow/status-parser.ts
+++ b/src/workflow/status-parser.ts
@@ -116,13 +116,15 @@ export function stripStatusBlock(responseText: string): string {
 
 /** Base informational status block lines (verdict does not affect routing). */
 const INFORMATIONAL_STATUS_LINES: readonly string[] = [
-  'When you have completed your work, include the following YAML block at the end of your response inside a fenced code block:',
+  'When all your work is finished and you are ready to exit, include the following YAML block as the LAST content of your FINAL response, inside a fenced code block. Do not run any further tool calls after emitting it:',
   '',
   '```',
   'agent_status:',
   '  verdict: completed',
   '  notes: "brief summary of what was done"',
   '```',
+  '',
+  'Only the agent_status block in your final response is parsed. Blocks emitted earlier (e.g. as progress checkpoints) are ignored — do not use this block to "check in" mid-task.',
   '',
   'Use EXACTLY these field names (`verdict`, `notes`). Do NOT add additional fields, rename fields, or use synonyms (e.g. `status`, `result`, `scope`, `artifacts`) — any deviation is a hard error and will force the workflow to reject your response. If you want to include more context, put it in the `notes` string.',
   '',
@@ -186,13 +188,15 @@ function buildVerdictRoutedInstructions(
   const verdictList = verdictValues.map((v) => `\`${v}\``).join(', ');
 
   const lines = [
-    'When you have completed your work, include the following YAML block at the end of your response inside a fenced code block:',
+    'When all your work is finished and you are ready to exit, include the following YAML block as the LAST content of your FINAL response, inside a fenced code block. Do not run any further tool calls after emitting it:',
     '',
     '```',
     'agent_status:',
     `  verdict: ${verdictExample}`,
     '  notes: "brief summary of what was done"',
     '```',
+    '',
+    'Only the agent_status block in your final response is parsed. Blocks emitted earlier (e.g. as progress checkpoints) are ignored — do not use this block to "check in" mid-task.',
     '',
     'Fields:',
     `- verdict: determines what happens next. Set this to exactly one of: ${verdictList}`,
@@ -239,9 +243,16 @@ export function buildStatusBlockReprompt(statusInstructions?: string, parseError
     ? [
         'Your previous response had a malformed `agent_status` block and could not be parsed.',
         `Parse error: ${parseError.message}`,
-        'Please emit a new block using exactly the fields shown below.',
+        '',
+        'Emit a new block as the LAST content of your FINAL response, after all work is complete and before you exit. Use exactly the fields shown below.',
       ]
-    : ['Your response is missing the required agent_status block.', 'Please include it at the end of your response.'];
+    : [
+        'Your final response did not include the required agent_status block.',
+        '',
+        'The block must be the LAST content of your FINAL response — emitted after all work is complete and immediately before you exit. Only the closing block of your final message is parsed; any agent_status blocks you may have emitted earlier in this conversation are ignored.',
+        '',
+        'If your work is finished: stop calling tools and emit a single final message ending with the YAML block below. If you still have work to do, complete it first, then emit the block as your closing content.',
+      ];
 
   return [...header, '', statusInstructions ?? MINIMAL_STATUS_INSTRUCTIONS].join('\n');
 }

--- a/test/workflow/status-parser.test.ts
+++ b/test/workflow/status-parser.test.ts
@@ -277,9 +277,19 @@ describe('buildStatusBlockReprompt', () => {
     expect(prompt).toContain('agent_status:');
   });
 
-  it('mentions the missing block', () => {
+  it('signals that the agent_status block was absent', () => {
     const prompt = buildStatusBlockReprompt();
-    expect(prompt).toContain('missing');
+    expect(prompt).toMatch(/did not include the required agent_status block/);
+  });
+
+  it('anchors the block on the final response, not just any response', () => {
+    const prompt = buildStatusBlockReprompt();
+    expect(prompt).toMatch(/LAST content of your FINAL response/);
+  });
+
+  it('warns that intermediate agent_status blocks are ignored', () => {
+    const prompt = buildStatusBlockReprompt();
+    expect(prompt).toMatch(/blocks you may have emitted earlier .* are ignored/);
   });
 
   it('uses the minimal format with verdict and notes', () => {
@@ -304,7 +314,7 @@ describe('buildStatusBlockReprompt', () => {
 
   it('uses missing-block wording when no parse error is supplied', () => {
     const prompt = buildStatusBlockReprompt();
-    expect(prompt).toContain('missing the required agent_status block');
+    expect(prompt).toMatch(/did not include the required agent_status block/);
     expect(prompt).not.toContain('malformed');
   });
 });


### PR DESCRIPTION
## Summary

The `buildStatusBlockReprompt` retry message previously told the agent to "include [the agent_status block] at the end of your response." A vuln-discovery `harness_build` agent in a long-running state interpreted this as "at the end of *any* response" and emitted four `agent_status` blocks mid-conversation as progress checkpoints, then closed with a prose summary that omitted the block.

Claude Code's `-p` JSON output only returns the **last** assistant text turn, so the orchestrator never saw the intermediate blocks and aborted the workflow after several hours of work that had actually succeeded (1,260-LoC harness built, fuzz burst hit `cov=9129`, ASan clean).

This patch tightens the wording in three places:

- **`INFORMATIONAL_STATUS_LINES`** (base template used by the original prompt for unconditional / guard-only states) now anchors the block on the **LAST** content of the **FINAL** response and warns that earlier blocks are not parsed.
- **`buildVerdictRoutedInstructions`** (template used when transitions have `when:` clauses) carries the same anchoring + warning, kept in sync.
- **`buildStatusBlockReprompt`** header (the retry message itself) gives an even more explicit branch — *"If your work is finished: stop calling tools and emit a single final message ending with the YAML block. If you still have work to do, complete it first, then emit the block as your closing content."*

Wording-only change. No parsing or behavior change.

## Test plan

- [x] `npm test -- test/workflow/status-parser.test.ts` — 54 pass (2 brittle substring assertions relaxed to match new wording; 2 new assertions pin the final-message anchoring contract)
- [x] `npm test -- test/workflow/` — 490 pass
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean