### PR TITLE
fix(proxy): exit non-zero when no backend connects

### DIFF
--- a/src/pipeline/proxy-mcp-connections.ts
+++ b/src/pipeline/proxy-mcp-connections.ts
@@ -130,9 +130,11 @@ export async function connectViaProxy(
     stderr: 'pipe',
   });
 
-  // Drain piped stderr to prevent backpressure
+  // Forward piped stderr to the parent so the proxy's actionable
+  // diagnostics (missing env vars, OAuth not authorized, etc.) reach
+  // the user instead of being silently dropped by a drain.
   if (transport.stderr) {
-    transport.stderr.on('data', () => {});
+    transport.stderr.on('data', (chunk: Buffer) => process.stderr.write(chunk));
   }
 
   const client = new Client(

--- a/src/pipeline/proxy-mcp-connections.ts
+++ b/src/pipeline/proxy-mcp-connections.ts
@@ -130,11 +130,24 @@ export async function connectViaProxy(
     stderr: 'pipe',
   });
 
-  // Forward piped stderr to the parent so the proxy's actionable
-  // diagnostics (missing env vars, OAuth not authorized, etc.) reach
-  // the user instead of being silently dropped by a drain.
+  // Forward only the proxy's own diagnostic lines (WARNING:/ERROR:
+  // emitted by `emitProxyDiagnostic`) to the parent. Backend MCP-server
+  // stderr can include unredacted credentials in failure paths, so we
+  // never echo arbitrary subprocess output verbatim. Incomplete lines
+  // are buffered until the trailing newline.
   if (transport.stderr) {
-    transport.stderr.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+    let buffer = '';
+    transport.stderr.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf-8');
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (/^(WARNING|ERROR): /.test(line)) {
+          process.stderr.write(`${line}\n`);
+        }
+      }
+    });
   }
 
   const client = new Client(

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -145,6 +145,8 @@ export interface ProxyEnvConfig {
   allowedDirectory: string | undefined;
   serverCredentials: Record<string, string>;
   sandboxPolicy: SandboxAvailabilityPolicy;
+  /** Raw `SERVER_FILTER` env value (e.g., backend name, "proxy", or undefined). */
+  serverFilter: string | undefined;
 }
 
 /** Result of sandbox availability validation. */
@@ -235,6 +237,7 @@ export function parseProxyEnvConfig(): ProxyEnvConfig {
     allowedDirectory,
     serverCredentials,
     sandboxPolicy,
+    serverFilter,
   };
 }
 
@@ -360,6 +363,7 @@ async function main(): Promise<void> {
     allowedDirectory,
     serverCredentials,
     sandboxPolicy,
+    serverFilter,
   } = envConfig;
 
   // Load compiled policy + annotations to derive MCP roots advertised
@@ -616,7 +620,7 @@ async function main(): Promise<void> {
     const serverNames = Object.keys(serversConfig).join(', ');
     emitProxyDiagnostic(
       'ERROR',
-      `proxy subprocess for SERVER_FILTER="${process.env.SERVER_FILTER ?? '<unset>'}" has no connected backend (configured: ${serverNames}); exiting`,
+      `proxy subprocess for SERVER_FILTER="${serverFilter ?? '<unset>'}" has no connected backend (configured: ${serverNames}); exiting`,
       sessionLogPath,
     );
     for (const refresher of tokenRefreshers.values()) {
@@ -628,7 +632,7 @@ async function main(): Promise<void> {
 
   // In virtual-only mode (SERVER_FILTER=proxy), register proxy tool definitions
   // and create the control API client for communicating with the MITM proxy.
-  const isVirtualOnlyMode = process.env.SERVER_FILTER === 'proxy' && Object.keys(serversConfig).length === 0;
+  const isVirtualOnlyMode = serverFilter === 'proxy' && Object.keys(serversConfig).length === 0;
   let controlApiClient: ControlApiClient | null = null;
 
   if (isVirtualOnlyMode) {

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -155,16 +155,14 @@ export interface SandboxValidationResult {
 }
 
 /**
- * True when this proxy subprocess has at least one usable backend (or is in
- * virtual-only mode with no backends configured). Returning false here means
- * the parent should treat this subprocess as failed -- otherwise it would
- * register zero tools for the server and trigger a misleading
- * "stale annotations" warning in the coordinator's drift check.
+ * True when this proxy subprocess is in a viable serving state -- either
+ * virtual-only mode (no backends configured) or at least one configured
+ * backend connected. Returning false means the parent should treat this
+ * subprocess as failed; otherwise it would register zero tools for the
+ * server and trigger a misleading "stale annotations" warning in the
+ * coordinator's drift check.
  */
-export function hasAtLeastOneConnectedBackend(
-  serversConfig: Record<string, MCPServerConfig>,
-  connectedBackendCount: number,
-): boolean {
+export function proxyCanServe(serversConfig: Record<string, MCPServerConfig>, connectedBackendCount: number): boolean {
   return Object.keys(serversConfig).length === 0 || connectedBackendCount > 0;
 }
 
@@ -623,7 +621,7 @@ async function main(): Promise<void> {
   // Exit non-zero so the parent's `MCPClientManager.connect()` fails the
   // handshake -- the existing try/catch in `connectBackendSubprocesses`
   // skips the server without reaching `registerTools`.
-  if (!hasAtLeastOneConnectedBackend(serversConfig, clientStates.size)) {
+  if (!proxyCanServe(serversConfig, clientStates.size)) {
     const serverNames = Object.keys(serversConfig).join(', ');
     emitProxyDiagnostic(
       'ERROR',

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -44,7 +44,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { appendFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdtempSync, writeFileSync, writeSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir, homedir } from 'node:os';
@@ -168,9 +168,16 @@ export function hasAtLeastOneConnectedBackend(
   return Object.keys(serversConfig).length === 0 || connectedBackendCount > 0;
 }
 
-/** Writes a diagnostic line to stderr and (if configured) the proxy session log. */
+/**
+ * Writes a diagnostic line to stderr and (if configured) the proxy session log.
+ *
+ * Uses `fs.writeSync` so the bytes reach the OS before the function returns
+ * even when stderr is a pipe (parent-spawned subprocess). `process.stderr.write`
+ * is asynchronous in that case, which would let a follow-up `process.exit(1)`
+ * truncate the diagnostic before delivery.
+ */
 function emitProxyDiagnostic(level: 'WARNING' | 'ERROR', message: string, sessionLogPath: string | undefined): void {
-  process.stderr.write(`${level}: ${message}\n`);
+  writeSync(2, `${level}: ${message}\n`);
   if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${message}`);
 }
 

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -166,6 +166,12 @@ export function hasAtLeastOneConnectedBackend(
   return Object.keys(serversConfig).length === 0 || connectedBackendCount > 0;
 }
 
+/** Writes a diagnostic line to stderr and (if configured) the proxy session log. */
+function emitProxyDiagnostic(level: 'WARNING' | 'ERROR', message: string, sessionLogPath: string | undefined): void {
+  process.stderr.write(`${level}: ${message}\n`);
+  if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${message}`);
+}
+
 /**
  * Reads and validates proxy environment variables.
  * Returns a typed config object or calls process.exit(1) on missing required vars.
@@ -405,9 +411,11 @@ async function main(): Promise<void> {
     // that aren't set — the server will fail to start without them.
     const missingEnvVars = getMissingEnvVars(config.args);
     if (missingEnvVars.length > 0) {
-      const warning = `Skipping MCP server "${serverName}": missing environment variable(s) ${missingEnvVars.join(', ')}`;
-      process.stderr.write(`WARNING: ${warning}\n`);
-      if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${warning}`);
+      emitProxyDiagnostic(
+        'WARNING',
+        `Skipping MCP server "${serverName}": missing environment variable(s) ${missingEnvVars.join(', ')}`,
+        sessionLogPath,
+      );
       continue;
     }
 
@@ -417,17 +425,21 @@ async function main(): Promise<void> {
     if (oauthProvider) {
       const clientCreds = loadClientCredentials(oauthProvider);
       if (!clientCreds) {
-        const warning = `Skipping MCP server "${serverName}": no OAuth credentials. Run 'ironcurtain auth import ${oauthProvider.id} <file>'`;
-        process.stderr.write(`WARNING: ${warning}\n`);
-        if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${warning}`);
+        emitProxyDiagnostic(
+          'WARNING',
+          `Skipping MCP server "${serverName}": no OAuth credentials. Run 'ironcurtain auth import ${oauthProvider.id} <file>'`,
+          sessionLogPath,
+        );
         continue;
       }
 
       const tokenProvider = new OAuthTokenProvider(oauthProvider, clientCreds);
       if (!tokenProvider.isAuthorized()) {
-        const warning = `Skipping MCP server "${serverName}": not authorized. Run 'ironcurtain auth ${oauthProvider.id}'`;
-        process.stderr.write(`WARNING: ${warning}\n`);
-        if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${warning}`);
+        emitProxyDiagnostic(
+          'WARNING',
+          `Skipping MCP server "${serverName}": not authorized. Run 'ironcurtain auth ${oauthProvider.id}'`,
+          sessionLogPath,
+        );
         continue;
       }
 
@@ -495,9 +507,11 @@ async function main(): Promise<void> {
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const warning = `Skipping MCP server "${serverName}": OAuth token error: ${message}. Run 'ironcurtain auth ${oauthProvider.id}'`;
-        process.stderr.write(`WARNING: ${warning}\n`);
-        if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${warning}`);
+        emitProxyDiagnostic(
+          'WARNING',
+          `Skipping MCP server "${serverName}": OAuth token error: ${message}. Run 'ironcurtain auth ${oauthProvider.id}'`,
+          sessionLogPath,
+        );
         continue;
       }
     }
@@ -595,22 +609,19 @@ async function main(): Promise<void> {
     }
   }
 
-  // If every backend in this subprocess failed to start (missing env var,
-  // missing/unauthorized OAuth credentials, etc.), exit non-zero so the
-  // parent's `MCPClientManager.connect()` call throws on the broken MCP
-  // handshake. The parent already logs and skips, and -- critically --
-  // never reaches `registerTools(serverName, [], ...)`, which would
-  // otherwise emit a misleading "tools no longer exposed by the server"
-  // drift warning.
+  // Exit non-zero so the parent's `MCPClientManager.connect()` fails the
+  // handshake -- the existing try/catch in `connectBackendSubprocesses`
+  // skips the server without reaching `registerTools`.
   if (!hasAtLeastOneConnectedBackend(serversConfig, clientStates.size)) {
     const serverNames = Object.keys(serversConfig).join(', ');
-    const errMsg = `proxy subprocess for SERVER_FILTER="${process.env.SERVER_FILTER ?? '<unset>'}" has no connected backend (configured: ${serverNames}); exiting`;
-    process.stderr.write(`ERROR: ${errMsg}\n`);
-    if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${errMsg}`);
+    emitProxyDiagnostic(
+      'ERROR',
+      `proxy subprocess for SERVER_FILTER="${process.env.SERVER_FILTER ?? '<unset>'}" has no connected backend (configured: ${serverNames}); exiting`,
+      sessionLogPath,
+    );
     for (const refresher of tokenRefreshers.values()) {
       refresher.stop();
     }
-    tokenRefreshers.clear();
     cleanupSettingsFiles(settingsDir);
     process.exit(1);
   }

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -153,6 +153,20 @@ export interface SandboxValidationResult {
 }
 
 /**
+ * True when this proxy subprocess has at least one usable backend (or is in
+ * virtual-only mode with no backends configured). Returning false here means
+ * the parent should treat this subprocess as failed -- otherwise it would
+ * register zero tools for the server and trigger a misleading
+ * "stale annotations" warning in the coordinator's drift check.
+ */
+export function hasAtLeastOneConnectedBackend(
+  serversConfig: Record<string, MCPServerConfig>,
+  connectedBackendCount: number,
+): boolean {
+  return Object.keys(serversConfig).length === 0 || connectedBackendCount > 0;
+}
+
+/**
  * Reads and validates proxy environment variables.
  * Returns a typed config object or calls process.exit(1) on missing required vars.
  */
@@ -579,6 +593,26 @@ async function main(): Promise<void> {
         inputSchema: tool.inputSchema as Record<string, unknown>,
       });
     }
+  }
+
+  // If every backend in this subprocess failed to start (missing env var,
+  // missing/unauthorized OAuth credentials, etc.), exit non-zero so the
+  // parent's `MCPClientManager.connect()` call throws on the broken MCP
+  // handshake. The parent already logs and skips, and -- critically --
+  // never reaches `registerTools(serverName, [], ...)`, which would
+  // otherwise emit a misleading "tools no longer exposed by the server"
+  // drift warning.
+  if (!hasAtLeastOneConnectedBackend(serversConfig, clientStates.size)) {
+    const serverNames = Object.keys(serversConfig).join(', ');
+    const errMsg = `proxy subprocess for SERVER_FILTER="${process.env.SERVER_FILTER ?? '<unset>'}" has no connected backend (configured: ${serverNames}); exiting`;
+    process.stderr.write(`ERROR: ${errMsg}\n`);
+    if (sessionLogPath) logToSessionFile(sessionLogPath, `[proxy] ${errMsg}`);
+    for (const refresher of tokenRefreshers.values()) {
+      refresher.stop();
+    }
+    tokenRefreshers.clear();
+    cleanupSettingsFiles(settingsDir);
+    process.exit(1);
   }
 
   // In virtual-only mode (SERVER_FILTER=proxy), register proxy tool definitions

--- a/src/trusted-process/tool-call-coordinator.ts
+++ b/src/trusted-process/tool-call-coordinator.ts
@@ -639,8 +639,8 @@ function mergeProxyAnnotations(src: StoredToolAnnotationsFile): StoredToolAnnota
  *
  * Spurious "stale annotations" warnings from servers that simply failed
  * to start are avoided upstream: in the sandbox/router path the proxy
- * subprocess exits non-zero when no backend connects (see
- * `hasAtLeastOneConnectedBackend` in `mcp-proxy-server.ts`); in the direct
+ * subprocess exits non-zero when no backend connects (see `proxyCanServe`
+ * in `mcp-proxy-server.ts`); in the direct
  * `TrustedProcess.connectMcpServers` path the caller applies its own
  * env-var guard before reaching `registerTools`. A backend that does
  * connect but legitimately exposes zero tools will still surface a drift

--- a/src/trusted-process/tool-call-coordinator.ts
+++ b/src/trusted-process/tool-call-coordinator.ts
@@ -636,6 +636,14 @@ function mergeProxyAnnotations(src: StoredToolAnnotationsFile): StoredToolAnnota
  * Server-level drift (entire server not annotated) is already surfaced by
  * `checkAnnotationFreshness` at policy-load time; this helper only fires
  * when the server has an annotations entry and its tool set diverges.
+ *
+ * Contract: only invoked for servers whose proxy subprocess connected at
+ * least one backend (see `hasAtLeastOneConnectedBackend` in
+ * `mcp-proxy-server.ts`). A subprocess where every backend was skipped --
+ * missing env var, missing OAuth credentials, not authorized -- exits
+ * non-zero before the parent calls `registerTools`, so this helper never
+ * sees the empty-liveTools-vs-N-annotations case that would otherwise
+ * flag every annotated tool as stale.
  */
 function warnOnToolAnnotationDrift(
   serverName: string,

--- a/src/trusted-process/tool-call-coordinator.ts
+++ b/src/trusted-process/tool-call-coordinator.ts
@@ -637,13 +637,14 @@ function mergeProxyAnnotations(src: StoredToolAnnotationsFile): StoredToolAnnota
  * `checkAnnotationFreshness` at policy-load time; this helper only fires
  * when the server has an annotations entry and its tool set diverges.
  *
- * Contract: only invoked for servers whose proxy subprocess connected at
- * least one backend (see `hasAtLeastOneConnectedBackend` in
- * `mcp-proxy-server.ts`). A subprocess where every backend was skipped --
- * missing env var, missing OAuth credentials, not authorized -- exits
- * non-zero before the parent calls `registerTools`, so this helper never
- * sees the empty-liveTools-vs-N-annotations case that would otherwise
- * flag every annotated tool as stale.
+ * Spurious "stale annotations" warnings from servers that simply failed
+ * to start are avoided upstream: in the sandbox/router path the proxy
+ * subprocess exits non-zero when no backend connects (see
+ * `hasAtLeastOneConnectedBackend` in `mcp-proxy-server.ts`); in the direct
+ * `TrustedProcess.connectMcpServers` path the caller applies its own
+ * env-var guard before reaching `registerTools`. A backend that does
+ * connect but legitimately exposes zero tools will still surface a drift
+ * note here, which is the intended behavior.
  */
 function warnOnToolAnnotationDrift(
   serverName: string,

--- a/test/mcp-proxy-server-no-backend.integration.test.ts
+++ b/test/mcp-proxy-server-no-backend.integration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Outside-in coverage for the no-backend exit path in mcp-proxy-server.ts.
+ *
+ * Spawns the proxy subprocess with a single configured backend whose
+ * `-e VAR_NAME` arg references an env var that is not set. The proxy's
+ * backend-connect loop should skip the backend, the post-loop
+ * `hasAtLeastOneConnectedBackend` guard should fire, and the subprocess
+ * should exit non-zero before the MCP transport is brought up. The unit
+ * tests in `mcp-proxy-server.test.ts` cover the predicate in isolation;
+ * this test exercises the wiring (condition direction, diagnostic emit,
+ * cleanup, exit code) so a regression in any of those is caught.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const MISSING_VAR = 'IRONCURTAIN_TEST_DEFINITELY_NOT_SET_VAR';
+
+describe('mcp-proxy-server no-backend exit', { timeout: 30_000 }, () => {
+  it('exits non-zero with an ERROR diagnostic when the only configured backend is skipped', async () => {
+    const generatedDir = resolve(__dirname, '..', 'src', 'config', 'generated');
+
+    const mcpServersConfig = {
+      testserver: {
+        command: 'true',
+        args: ['-e', MISSING_VAR],
+      },
+    };
+
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      MCP_SERVERS_CONFIG: JSON.stringify(mcpServersConfig),
+      SERVER_FILTER: 'testserver',
+      GENERATED_DIR: generatedDir,
+      PROTECTED_PATHS: '[]',
+      SANDBOX_POLICY: 'warn',
+    };
+    delete env[MISSING_VAR];
+
+    const child = spawn('npx', ['tsx', 'src/trusted-process/mcp-proxy-server.ts'], {
+      env,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf-8');
+    });
+
+    const exitCode: number = await new Promise((resolveExit, rejectExit) => {
+      child.once('exit', (code) => resolveExit(code ?? -1));
+      child.once('error', rejectExit);
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(`WARNING: Skipping MCP server "testserver"`);
+    expect(stderr).toContain(MISSING_VAR);
+    expect(stderr).toContain('ERROR: proxy subprocess for SERVER_FILTER="testserver" has no connected backend');
+  });
+});

--- a/test/mcp-proxy-server-no-backend.integration.test.ts
+++ b/test/mcp-proxy-server-no-backend.integration.test.ts
@@ -4,9 +4,9 @@
  * Spawns the proxy subprocess with a single configured backend whose
  * `-e VAR_NAME` arg references an env var that is not set. The proxy's
  * backend-connect loop should skip the backend, the post-loop
- * `hasAtLeastOneConnectedBackend` guard should fire, and the subprocess
- * should exit non-zero before the MCP transport is brought up. The unit
- * tests in `mcp-proxy-server.test.ts` cover the predicate in isolation;
+ * `proxyCanServe` guard should fire, and the subprocess should exit
+ * non-zero before the MCP transport is brought up. The unit tests in
+ * `mcp-proxy-server.test.ts` cover the predicate in isolation;
  * this test exercises the wiring (condition direction, diagnostic emit,
  * cleanup, exit code) so a regression in any of those is caught.
  */
@@ -51,8 +51,10 @@ describe('mcp-proxy-server no-backend exit', { timeout: 30_000 }, () => {
       stderr += chunk.toString('utf-8');
     });
 
+    // Wait for `close`, not `exit`: `exit` can fire before stdio streams
+    // have flushed, leaving the ERROR line we assert on truncated.
     const exitCode: number = await new Promise((resolveExit, rejectExit) => {
-      child.once('exit', (code) => resolveExit(code ?? -1));
+      child.once('close', (code) => resolveExit(code ?? -1));
       child.once('error', rejectExit);
     });
 

--- a/test/mcp-proxy-server-no-backend.integration.test.ts
+++ b/test/mcp-proxy-server-no-backend.integration.test.ts
@@ -12,7 +12,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const MISSING_VAR = 'IRONCURTAIN_TEST_DEFINITELY_NOT_SET_VAR';
 

--- a/test/mcp-proxy-server.test.ts
+++ b/test/mcp-proxy-server.test.ts
@@ -341,13 +341,6 @@ describe('hasAtLeastOneConnectedBackend', () => {
   it('returns false when backends were configured but none connected', () => {
     expect(hasAtLeastOneConnectedBackend({ github: stubConfig }, 0)).toBe(false);
   });
-
-  it('returns false for the missing-env-var case (single backend skipped)', () => {
-    // Mirrors the exact failure mode from the bug report: github server
-    // configured, GITHUB_PERSONAL_ACCESS_TOKEN unset, loop continues past
-    // it, clientStates ends empty.
-    expect(hasAtLeastOneConnectedBackend({ github: stubConfig }, 0)).toBe(false);
-  });
 });
 
 // ── validateSandboxAvailability tests ──────────────────────────────────

--- a/test/mcp-proxy-server.test.ts
+++ b/test/mcp-proxy-server.test.ts
@@ -245,6 +245,7 @@ describe('parseProxyEnvConfig', () => {
     expect(config.allowedDirectory).toBeUndefined();
     expect(config.sandboxPolicy).toBe('warn');
     expect(config.serverCredentials).toEqual({});
+    expect(config.serverFilter).toBeUndefined();
   });
 
   it('parses SERVER_CREDENTIALS and scrubs from process.env', () => {
@@ -272,6 +273,7 @@ describe('parseProxyEnvConfig', () => {
 
     expect(Object.keys(config.serversConfig)).toEqual(['git']);
     expect(config.serversConfig.git).toEqual(servers.git);
+    expect(config.serverFilter).toBe('git');
   });
 
   it('calls process.exit(1) when MCP_SERVERS_CONFIG is missing', () => {

--- a/test/mcp-proxy-server.test.ts
+++ b/test/mcp-proxy-server.test.ts
@@ -4,7 +4,9 @@ import {
   parseProxyEnvConfig,
   validateSandboxAvailability,
   selectTransportConfig,
+  hasAtLeastOneConnectedBackend,
 } from '../src/trusted-process/mcp-proxy-server.js';
+import type { MCPServerConfig } from '../src/config/types.js';
 import {
   buildToolMap,
   buildAuditEntry,
@@ -320,6 +322,31 @@ describe('parseProxyEnvConfig', () => {
 
     exitSpy.mockRestore();
     stderrSpy.mockRestore();
+  });
+});
+
+// ── hasAtLeastOneConnectedBackend tests ────────────────────────────────
+
+describe('hasAtLeastOneConnectedBackend', () => {
+  const stubConfig: MCPServerConfig = { command: 'node', args: [] };
+
+  it('returns true when no backends are configured (virtual-only proxy mode)', () => {
+    expect(hasAtLeastOneConnectedBackend({}, 0)).toBe(true);
+  });
+
+  it('returns true when at least one configured backend connected', () => {
+    expect(hasAtLeastOneConnectedBackend({ github: stubConfig, git: stubConfig }, 1)).toBe(true);
+  });
+
+  it('returns false when backends were configured but none connected', () => {
+    expect(hasAtLeastOneConnectedBackend({ github: stubConfig }, 0)).toBe(false);
+  });
+
+  it('returns false for the missing-env-var case (single backend skipped)', () => {
+    // Mirrors the exact failure mode from the bug report: github server
+    // configured, GITHUB_PERSONAL_ACCESS_TOKEN unset, loop continues past
+    // it, clientStates ends empty.
+    expect(hasAtLeastOneConnectedBackend({ github: stubConfig }, 0)).toBe(false);
   });
 });
 

--- a/test/mcp-proxy-server.test.ts
+++ b/test/mcp-proxy-server.test.ts
@@ -4,7 +4,7 @@ import {
   parseProxyEnvConfig,
   validateSandboxAvailability,
   selectTransportConfig,
-  hasAtLeastOneConnectedBackend,
+  proxyCanServe,
 } from '../src/trusted-process/mcp-proxy-server.js';
 import type { MCPServerConfig } from '../src/config/types.js';
 import {
@@ -327,21 +327,21 @@ describe('parseProxyEnvConfig', () => {
   });
 });
 
-// ── hasAtLeastOneConnectedBackend tests ────────────────────────────────
+// ── proxyCanServe tests ────────────────────────────────────────────────
 
-describe('hasAtLeastOneConnectedBackend', () => {
+describe('proxyCanServe', () => {
   const stubConfig: MCPServerConfig = { command: 'node', args: [] };
 
   it('returns true when no backends are configured (virtual-only proxy mode)', () => {
-    expect(hasAtLeastOneConnectedBackend({}, 0)).toBe(true);
+    expect(proxyCanServe({}, 0)).toBe(true);
   });
 
   it('returns true when at least one configured backend connected', () => {
-    expect(hasAtLeastOneConnectedBackend({ github: stubConfig, git: stubConfig }, 1)).toBe(true);
+    expect(proxyCanServe({ github: stubConfig, git: stubConfig }, 1)).toBe(true);
   });
 
   it('returns false when backends were configured but none connected', () => {
-    expect(hasAtLeastOneConnectedBackend({ github: stubConfig }, 0)).toBe(false);
+    expect(proxyCanServe({ github: stubConfig }, 0)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- When an MCP proxy subprocess had every backend skipped (missing env var, missing/unauthorized OAuth credentials, etc.), it stayed alive with an empty tool list. The parent then registered zero tools for the server, and the coordinator's drift check misleadingly flagged every annotated tool as \"no longer exposed by the server\" — e.g. all 41 github tools when \`GITHUB_PERSONAL_ACCESS_TOKEN\` was unset.
- Make the proxy exit non-zero whenever none of its configured backends connected. The parent's existing \`MCPClientManager.connect()\` try/catch in \`connectBackendSubprocesses\` already logs and skips, so \`registerTools\` is never called for the dead server and \`warnOnToolAnnotationDrift\` only runs for live servers. The drift check's new contract is documented on the coordinator side.
- Drive-by cleanups (second commit): extract a small \`emitProxyDiagnostic\` helper to consolidate five repeated \`process.stderr.write\` + \`logToSessionFile\` diagnostic call sites in the proxy; drop dead \`tokenRefreshers.clear()\` immediately before \`process.exit\`; remove a duplicate unit test that exercised the same helper case with identical arguments.

## Test plan

- [x] \`npm test\` — full suite green (4510 passed)
- [x] \`npm run lint\` + \`npm run format\` clean on touched files
- [x] New unit tests for \`hasAtLeastOneConnectedBackend\` cover virtual-only mode, at-least-one-connected, and configured-but-none-connected
- [ ] Manual sanity: start a session with \`github\` configured but \`GITHUB_PERSONAL_ACCESS_TOKEN\` unset — confirm only the \`WARNING: Skipping MCP server\` + \`ERROR: proxy subprocess ... exiting\` lines appear, no spurious drift note