### PR TITLE
feat(docker): collapse docker pull/build flood into single updating line

### DIFF
--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -28,7 +28,13 @@ import type { DockerAuthKind, IronCurtainConfig } from '../config/types.js';
 import { getBundleRuntimeRoot } from '../config/paths.js';
 import { getBundleShortId, type BundleId, type SessionId, type SessionMode } from '../session/types.js';
 import { DEFAULT_CONTAINER_SCOPE, type WorkflowId } from '../workflow/types.js';
-import { CONTAINER_WORKSPACE_DIR, type AgentAdapter, type ConversationStateConfig } from './agent-adapter.js';
+import {
+  CONTAINER_WORKSPACE_DIR,
+  type AgentAdapter,
+  type AgentId,
+  type ConversationStateConfig,
+} from './agent-adapter.js';
+import type { ResolvedUserConfig } from '../config/user-config.js';
 import type { DockerProxy } from './code-mode-proxy.js';
 import type { MitmProxy } from './mitm-proxy.js';
 import type { CertificateAuthority } from './ca.js';
@@ -1055,6 +1061,32 @@ export function prepareConversationStateDir(sessionDir: string, config: Conversa
   }
 
   return stateDir;
+}
+
+/**
+ * Public pre-flight: resolves the adapter for `agentId`, makes sure the CA
+ * and Docker manager are in place, and runs the same `ensureImage` work
+ * that `prepareDockerInfrastructure` would do later.
+ *
+ * Why expose this: image pull/build streams progress to the parent
+ * terminal (via the progress sink), and the CLI normally wraps session
+ * init in an `ora` spinner. Running this BEFORE the spinner starts keeps
+ * the two renderers from fighting for the same line. The inner
+ * `ensureImage` call inside `prepareDockerInfrastructure` is content-hash
+ * cached, so a second call from the session-init path is a cheap no-op.
+ */
+export async function ensureDockerImage(agentId: AgentId, userConfig: ResolvedUserConfig): Promise<void> {
+  const { registerBuiltinAdapters, getAgent } = await import('./agent-registry.js');
+  const { loadOrCreateCA } = await import('./ca.js');
+  const { createDockerManager } = await import('./docker-manager.js');
+  const { getIronCurtainHome } = await import('../config/paths.js');
+
+  await registerBuiltinAdapters(userConfig);
+  const adapter = getAgent(agentId);
+  const image = await adapter.getImage();
+  const docker = createDockerManager();
+  const ca = loadOrCreateCA(resolve(getIronCurtainHome(), 'ca'));
+  await ensureImage(image, docker, ca);
 }
 
 /**

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -13,6 +13,11 @@ import * as logger from '../logger.js';
 import { checkDockerAvailable, type DockerAvailability } from '../session/preflight.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
 import { spawnWithIdleTimeout, type SpawnFn } from './spawn-with-idle-timeout.js';
+import {
+  createDockerProgressSink,
+  type CreateDockerProgressSinkOptions,
+  type DockerProgressSink,
+} from './docker-progress-sink.js';
 
 /** Async exec function signature matching promisified execFile. */
 export type ExecFileFn = (
@@ -157,6 +162,12 @@ export interface CreateDockerManagerOptions {
   spawn?: SpawnFn;
   stdoutSink?: NodeJS.WritableStream;
   stderrSink?: NodeJS.WritableStream;
+  /**
+   * Override the progress-sink factory (tests). When `stdoutSink` /
+   * `stderrSink` are provided explicitly the progress sink is bypassed
+   * regardless of this option.
+   */
+  progressSinkFactory?: (opts: CreateDockerProgressSinkOptions) => DockerProgressSink;
 }
 
 export function createDockerManager(
@@ -169,6 +180,39 @@ export function createDockerManager(
     spawn: spawnOpts?.spawn,
     stdoutSink: spawnOpts?.stdoutSink,
     stderrSink: spawnOpts?.stderrSink,
+  };
+  const progressSinkFactory = spawnOpts?.progressSinkFactory ?? createDockerProgressSink;
+
+  // Runs a `docker pull` / `docker build` invocation with the streaming
+  // idle-timeout primitive, wrapped in a progress sink that collapses the
+  // raw output flood into a single updating status line (TTY) or
+  // verbatim pass-through (non-TTY). When the test seam provides explicit
+  // sinks we honor them and skip the wrapper.
+  const runStreamed = async (params: {
+    operation: 'docker pull' | 'docker build';
+    args: readonly string[];
+    idleTimeoutMs: number;
+    env?: NodeJS.ProcessEnv;
+  }): Promise<void> => {
+    const hasInjectedSinks = streamOpts.stdoutSink !== undefined && streamOpts.stderrSink !== undefined;
+    const progress: DockerProgressSink | undefined = hasInjectedSinks
+      ? undefined
+      : progressSinkFactory({ operation: params.operation });
+    try {
+      await spawnWithIdleTimeout('docker', params.args, {
+        idleTimeoutMs: params.idleTimeoutMs,
+        operation: params.operation,
+        env: params.env,
+        spawn: streamOpts.spawn,
+        stdoutSink: streamOpts.stdoutSink ?? progress?.stdout,
+        stderrSink: streamOpts.stderrSink ?? progress?.stderr,
+      });
+      progress?.finish(true);
+    } catch (err) {
+      progress?.finish(false);
+      progress?.dumpRecent();
+      throw err;
+    }
   };
 
   return {
@@ -295,11 +339,11 @@ export function createDockerManager(
         }
       }
       args.push(contextDir);
-      await spawnWithIdleTimeout('docker', args, {
-        idleTimeoutMs: BUILD_IDLE_TIMEOUT_MS,
+      await runStreamed({
         operation: 'docker build',
+        args,
+        idleTimeoutMs: BUILD_IDLE_TIMEOUT_MS,
         env: { DOCKER_BUILDKIT: '1' },
-        ...streamOpts,
       });
     },
 
@@ -354,14 +398,15 @@ export function createDockerManager(
     },
 
     async pullImage(image: string): Promise<void> {
-      // Streamed via spawn (not execFile) so the user sees per-layer
-      // progress and the watchdog can reset on every heartbeat. Large
-      // images like devcontainers/universal (~5 GB) on slow links
-      // legitimately take an hour or more; only true silence kills.
-      await spawnWithIdleTimeout('docker', ['pull', image], {
-        idleTimeoutMs: PULL_IDLE_TIMEOUT_MS,
+      // Streamed via spawn (not execFile) so the watchdog can reset on
+      // every heartbeat. Large images like devcontainers/universal
+      // (~5 GB) on slow links legitimately take an hour or more; only
+      // true silence kills. The progress sink collapses the per-layer
+      // chatter into a single updating status line.
+      await runStreamed({
         operation: 'docker pull',
-        ...streamOpts,
+        args: ['pull', image],
+        idleTimeoutMs: PULL_IDLE_TIMEOUT_MS,
       });
     },
 

--- a/src/docker/docker-progress-sink.ts
+++ b/src/docker/docker-progress-sink.ts
@@ -60,23 +60,13 @@ export function createDockerProgressSink(opts: CreateDockerProgressSinkOptions):
   const now = opts.now ?? Date.now;
 
   // Non-TTY fast path: behave like the pre-sink `process.stderr` so CI logs
-  // keep their full transcript and dumpRecent / finish are no-ops.
+  // keep their full transcript. finish/dumpRecent are no-ops because the
+  // raw transcript is already on screen.
   if (!isTTY) {
-    const passthroughBuffer: string[] = [];
-    const recordPassthroughLines = (text: string): void => {
-      for (const line of text.split('\n')) {
-        const trimmed = line.replace(/\r$/g, '').trimEnd();
-        if (!trimmed) continue;
-        passthroughBuffer.push(trimmed);
-        if (passthroughBuffer.length > bufferSize) passthroughBuffer.shift();
-      }
-    };
     const makeStream = (): NodeJS.WritableStream =>
       new Writable({
         write(chunk: Buffer | string, _encoding, cb) {
-          const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
-          recordPassthroughLines(text);
-          output.write(text);
+          output.write(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
           cb();
         },
       });
@@ -84,9 +74,7 @@ export function createDockerProgressSink(opts: CreateDockerProgressSinkOptions):
       stdout: makeStream(),
       stderr: makeStream(),
       finish: () => {},
-      dumpRecent: () => {
-        /* raw lines are already on screen */
-      },
+      dumpRecent: () => {},
     };
   }
 

--- a/src/docker/docker-progress-sink.ts
+++ b/src/docker/docker-progress-sink.ts
@@ -1,0 +1,341 @@
+/**
+ * Single-line progress renderer for `docker pull` / `docker build` streams.
+ *
+ * `spawnWithIdleTimeout` (PR #250) restored real-time visibility into image
+ * pulls/builds by piping the child's stdout/stderr verbatim to the parent's
+ * terminal — fixing silent hangs but flooding the user with thousands of
+ * lines of BuildKit / per-layer chatter. This sink replaces that verbatim
+ * dump in the interactive (TTY) case with a single status line that
+ * updates in place, while still feeding every chunk to the watchdog (the
+ * heartbeat detection in `spawnWithIdleTimeout` runs before the chunk
+ * reaches the sink — see `forward()` in that file).
+ *
+ * On non-TTY stderr (CI, redirected logs) the sink passes chunks through
+ * verbatim, matching the pre-existing behavior and keeping CI logs useful.
+ *
+ * On failure, `dumpRecent()` flushes the last ~200 raw lines so the user
+ * gets a real diagnostic — the 4 KB stderr-tail quoted in the rejection
+ * message from `spawnWithIdleTimeout` is often too short to capture an
+ * earlier RUN step that actually went wrong.
+ */
+
+import { Writable } from 'node:stream';
+import chalk from 'chalk';
+
+export type DockerProgressOperation = 'docker pull' | 'docker build';
+
+export interface DockerProgressSink {
+  /** Writable that the child's stdout pipes into. */
+  stdout: NodeJS.WritableStream;
+  /** Writable that the child's stderr pipes into. */
+  stderr: NodeJS.WritableStream;
+  /** Commit the in-place line (TTY) or emit a final summary (non-TTY). */
+  finish(success: boolean): void;
+  /** Flush the rolling raw-line buffer; intended for the failure path. */
+  dumpRecent(): void;
+}
+
+export interface CreateDockerProgressSinkOptions {
+  operation: DockerProgressOperation;
+  /** Underlying writable. Defaults to `process.stderr`. */
+  output?: NodeJS.WritableStream;
+  /** Override TTY detection (used by tests). */
+  isTTY?: boolean;
+  /** Max raw lines retained for failure dump. Defaults to 200. */
+  bufferSize?: number;
+  /** Override clock for elapsed timers (used by tests). */
+  now?: () => number;
+}
+
+const DEFAULT_BUFFER_LINES = 200;
+const PENDING_BUFFER_HARD_CAP = 8 * 1024;
+
+export function createDockerProgressSink(opts: CreateDockerProgressSinkOptions): DockerProgressSink {
+  const output: NodeJS.WritableStream = opts.output ?? process.stderr;
+  // `process.stderr` is typed as `WriteStream` (with `isTTY: true | undefined`);
+  // a generic `WritableStream` may not have the property at all. Cast to a
+  // shape that admits either so ESLint does not flag the comparison.
+  const isTTY = opts.isTTY ?? (output as { isTTY?: unknown }).isTTY === true;
+  const bufferSize = opts.bufferSize ?? DEFAULT_BUFFER_LINES;
+  const now = opts.now ?? Date.now;
+
+  // Non-TTY fast path: behave like the pre-sink `process.stderr` so CI logs
+  // keep their full transcript and dumpRecent / finish are no-ops.
+  if (!isTTY) {
+    const passthroughBuffer: string[] = [];
+    const recordPassthroughLines = (text: string): void => {
+      for (const line of text.split('\n')) {
+        const trimmed = line.replace(/\r$/g, '').trimEnd();
+        if (!trimmed) continue;
+        passthroughBuffer.push(trimmed);
+        if (passthroughBuffer.length > bufferSize) passthroughBuffer.shift();
+      }
+    };
+    const makeStream = (): NodeJS.WritableStream =>
+      new Writable({
+        write(chunk: Buffer | string, _encoding, cb) {
+          const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+          recordPassthroughLines(text);
+          output.write(text);
+          cb();
+        },
+      });
+    return {
+      stdout: makeStream(),
+      stderr: makeStream(),
+      finish: () => {},
+      dumpRecent: () => {
+        /* raw lines are already on screen */
+      },
+    };
+  }
+
+  const parser = opts.operation === 'docker pull' ? createPullParser(now) : createBuildParser(now);
+  const ringBuffer: string[] = [];
+  const startTime = now();
+
+  let pendingStdout = '';
+  let pendingStderr = '';
+  // Empty string means no in-place line is currently on screen.
+  let lastRendered = '';
+  let finished = false;
+
+  const record = (line: string): void => {
+    if (!line) return;
+    ringBuffer.push(line);
+    if (ringBuffer.length > bufferSize) ringBuffer.shift();
+  };
+
+  const render = (): void => {
+    if (finished) return;
+    const summary = parser.summary();
+    if (summary === lastRendered) return;
+    lastRendered = summary;
+    output.write(`\r\x1B[2K${summary}`);
+  };
+
+  const processChunk = (chunk: Buffer | string, isStderr: boolean): void => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+    let pending = (isStderr ? pendingStderr : pendingStdout) + text;
+    // Docker pull uses `\r` (not `\n`) to update its progress meter in place;
+    // we treat both as line boundaries so each transient state is parsed.
+    const splitter = /[^\r\n]*[\r\n]/g;
+    let lastIdx = 0;
+    let match: RegExpExecArray | null;
+    while ((match = splitter.exec(pending)) !== null) {
+      const segment = match[0];
+      const line = segment.replace(/[\r\n]+$/, '').trimEnd();
+      if (line) {
+        record(line);
+        try {
+          parser.feed(line);
+        } catch {
+          // Parser bugs MUST NOT propagate — the streaming pipeline relies
+          // on the sink consuming bytes without error so the watchdog stays
+          // armed.
+        }
+      }
+      lastIdx = splitter.lastIndex;
+    }
+    pending = pending.slice(lastIdx);
+    // Guard against pathological no-newline output (e.g. a malicious image
+    // streaming a giant binary blob to stderr). Keep only the trailing half
+    // of the cap so we don't OOM on the pending buffer.
+    if (pending.length > PENDING_BUFFER_HARD_CAP) {
+      pending = pending.slice(-PENDING_BUFFER_HARD_CAP / 2);
+    }
+    if (isStderr) pendingStderr = pending;
+    else pendingStdout = pending;
+    render();
+  };
+
+  const makeWritable = (isStderr: boolean): NodeJS.WritableStream =>
+    new Writable({
+      write(chunk: Buffer | string, _encoding, cb) {
+        try {
+          processChunk(chunk, isStderr);
+        } catch {
+          // see comment above — never throw from the write path
+        }
+        cb();
+      },
+    });
+
+  const flushPending = (): void => {
+    for (const pending of [pendingStdout, pendingStderr]) {
+      const trimmed = pending.replace(/[\r\n]+$/, '').trimEnd();
+      if (!trimmed) continue;
+      record(trimmed);
+      try {
+        parser.feed(trimmed);
+      } catch {
+        /* swallow */
+      }
+    }
+    pendingStdout = '';
+    pendingStderr = '';
+  };
+
+  return {
+    stdout: makeWritable(false),
+    stderr: makeWritable(true),
+    finish(success) {
+      if (finished) return;
+      finished = true;
+      flushPending();
+      const elapsed = ((now() - startTime) / 1000).toFixed(1);
+      const summary = parser.summary();
+      const tag = success ? chalk.green(`${opts.operation} done`) : chalk.red(`${opts.operation} failed`);
+      const line = `${tag}  ${chalk.dim(`(${elapsed}s)`)}  ${chalk.dim(summary)}`;
+      if (lastRendered) {
+        output.write(`\r\x1B[2K${line}\n`);
+      } else {
+        output.write(`${line}\n`);
+      }
+      lastRendered = '';
+    },
+    dumpRecent() {
+      if (ringBuffer.length === 0) return;
+      if (lastRendered) {
+        // Make sure our dump starts on a fresh line.
+        output.write('\r\x1B[2K');
+        lastRendered = '';
+      }
+      output.write(chalk.dim(`--- last ${ringBuffer.length} lines from ${opts.operation} ---`) + '\n');
+      for (const line of ringBuffer) {
+        output.write(line + '\n');
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+interface ProgressParser {
+  feed(line: string): void;
+  summary(): string;
+}
+
+type PullPhase = 'pending' | 'downloading' | 'verifying' | 'downloaded' | 'extracting' | 'done' | 'exists';
+
+function createPullParser(now: () => number): ProgressParser {
+  const layers = new Map<string, PullPhase>();
+  let statusLine = '';
+  const startTime = now();
+
+  return {
+    feed(line) {
+      const clean = stripAnsi(line).trim();
+      // Layer-scoped messages: `<id>: <message>` where id is a short hex
+      // digest or a tag name in the case of the first line.
+      const layerMatch = clean.match(/^([0-9a-f]{8,}|[A-Za-z][\w.-]*):\s+(.+?)\s*$/);
+      if (layerMatch) {
+        const [, id, msg] = layerMatch;
+        if (/^Pulling fs layer$/i.test(msg) || /^Waiting$/i.test(msg)) {
+          if (!layers.has(id)) layers.set(id, 'pending');
+        } else if (/^Downloading/i.test(msg)) {
+          layers.set(id, 'downloading');
+        } else if (/^Verifying Checksum/i.test(msg)) {
+          layers.set(id, 'verifying');
+        } else if (/^Download complete/i.test(msg)) {
+          layers.set(id, 'downloaded');
+        } else if (/^Extracting/i.test(msg)) {
+          layers.set(id, 'extracting');
+        } else if (/^Pull complete/i.test(msg)) {
+          layers.set(id, 'done');
+        } else if (/^Already exists/i.test(msg)) {
+          layers.set(id, 'exists');
+        } else if (/^Pulling from /i.test(msg)) {
+          statusLine = clean;
+        }
+        return;
+      }
+      if (/^Status:|^Digest:/i.test(clean) || /Pulling from /i.test(clean)) {
+        statusLine = clean;
+      }
+    },
+    summary() {
+      const total = layers.size;
+      const phases = [...layers.values()];
+      const done = phases.filter((p) => p === 'done' || p === 'exists').length;
+      const downloading = phases.filter((p) => p === 'downloading').length;
+      const extracting = phases.filter((p) => p === 'extracting').length;
+      const elapsed = ((now() - startTime) / 1000).toFixed(0);
+
+      const parts: string[] = [chalk.cyan('docker pull')];
+      if (total === 0) {
+        parts.push(chalk.dim(statusLine || 'starting...'));
+      } else {
+        parts.push(chalk.dim(`${done}/${total} layers`));
+        if (downloading > 0) parts.push(chalk.yellow(`${downloading} downloading`));
+        if (extracting > 0) parts.push(chalk.blue(`${extracting} extracting`));
+      }
+      parts.push(chalk.dim(`(${elapsed}s)`));
+      return parts.join('  ');
+    },
+  };
+}
+
+function createBuildParser(now: () => number): ProgressParser {
+  let currentStep: number | undefined;
+  let totalSteps: number | undefined;
+  let currentDesc: string | undefined;
+  let lastBracket: string | undefined;
+  const startTime = now();
+
+  return {
+    feed(line) {
+      const clean = stripAnsi(line);
+      // BuildKit `--progress=plain` format. Step headers look like:
+      //   #5 [stage 2/8] RUN apt-get install -y curl
+      //   #4 [internal] load build definition from Dockerfile
+      //   #6 [build 3/5] COPY . /workspace
+      // We pull the `N/M` out of the bracket when present so the summary
+      // can show progress; otherwise we fall back to the bracket label.
+      const stepHeader = clean.match(/^#\d+\s+\[([^\]]+)\]\s+(.+?)\s*$/);
+      if (stepHeader) {
+        const [, bracket, desc] = stepHeader;
+        const numbered = bracket.match(/(\d+)\/(\d+)/);
+        if (numbered) {
+          currentStep = Number.parseInt(numbered[1], 10);
+          totalSteps = Number.parseInt(numbered[2], 10);
+        }
+        lastBracket = bracket;
+        currentDesc = truncate(desc, 80);
+      }
+      // Step continuation lines (`#5 0.234 ...output...`) and DONE markers
+      // intentionally don't update the summary — they'd just flicker the
+      // line. Their job is to advance the watchdog, which already happens
+      // before the sink is reached.
+    },
+    summary() {
+      const elapsed = ((now() - startTime) / 1000).toFixed(0);
+      const parts: string[] = [chalk.cyan('docker build')];
+      if (currentStep !== undefined && totalSteps !== undefined) {
+        parts.push(chalk.dim(`step ${currentStep}/${totalSteps}`));
+      } else if (lastBracket) {
+        parts.push(chalk.dim(lastBracket));
+      } else {
+        parts.push(chalk.dim('starting...'));
+      }
+      if (currentDesc) parts.push(currentDesc);
+      parts.push(chalk.dim(`(${elapsed}s)`));
+      return parts.join('  ');
+    },
+  };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
+// CSI sequence: ESC [ <params> <intermediate> <final>. Strips colors and
+// cursor-control codes BuildKit/docker may embed in line output.
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_PATTERN, '');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,21 @@ export async function main(args?: string[]): Promise<void> {
   checkConstitutionFreshness(compiledPolicy, config.constitutionPath);
   checkAnnotationFreshness(toolAnnotations, config.mcpServers);
 
+  // Pre-flight the Docker image before starting the init spinner: the
+  // progress sink and the spinner both render to stderr, so they fight for
+  // the same line if they run concurrently. The inner ensureImage call
+  // during session init is content-hash cached, so it's a cheap no-op.
+  if (mode.kind === 'docker') {
+    const { ensureDockerImage } = await import('./docker/docker-infrastructure.js');
+    try {
+      await ensureDockerImage(mode.agent, config.userConfig);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`\n${chalk.red('Docker image setup failed:')} ${message}\n`);
+      process.exit(1);
+    }
+  }
+
   // PTY mode: attach terminal directly to Claude Code in a Docker container
   if (values.pty) {
     if (mode.kind !== 'docker') {

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -9,6 +9,7 @@ import {
   type ExecFileFn,
 } from '../src/docker/docker-manager.js';
 import { spawnWithIdleTimeout, type SpawnFn } from '../src/docker/spawn-with-idle-timeout.js';
+import type { CreateDockerProgressSinkOptions, DockerProgressSink } from '../src/docker/docker-progress-sink.js';
 import type { DockerContainerConfig } from '../src/docker/types.js';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 
@@ -166,6 +167,45 @@ function createMockSpawn(): MockSpawn {
 /** Silent writable so tests don't spew docker output into the test runner. */
 function nullSink(): NodeJS.WritableStream {
   return new PassThrough();
+}
+
+interface SpyProgressSinkHandle {
+  factory: (opts: CreateDockerProgressSinkOptions) => DockerProgressSink;
+  /** Each created sink, in construction order. */
+  sinks: Array<{
+    operation: CreateDockerProgressSinkOptions['operation'];
+    finishCalls: boolean[];
+    dumpRecentCalls: number;
+  }>;
+}
+
+/**
+ * Builds a `progressSinkFactory` that records calls to `finish` and
+ * `dumpRecent` on each constructed sink. The sink itself is just a
+ * pair of `PassThrough` streams so the streaming pipeline can drain
+ * normally.
+ */
+function createSpyProgressSink(): SpyProgressSinkHandle {
+  const sinks: SpyProgressSinkHandle['sinks'] = [];
+  const factory = (opts: CreateDockerProgressSinkOptions): DockerProgressSink => {
+    const entry = {
+      operation: opts.operation,
+      finishCalls: [] as boolean[],
+      dumpRecentCalls: 0,
+    };
+    sinks.push(entry);
+    return {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      finish: (success: boolean) => {
+        entry.finishCalls.push(success);
+      },
+      dumpRecent: () => {
+        entry.dumpRecentCalls += 1;
+      },
+    };
+  };
+  return { factory, sinks };
 }
 
 const sampleConfig: DockerContainerConfig = {
@@ -669,6 +709,89 @@ describe('DockerManager', () => {
       spawnMock.handles[0].spawnError(new Error('spawn docker ENOENT'));
 
       await expect(promise).rejects.toThrow(/docker pull failed to spawn: spawn docker ENOENT/);
+    });
+  });
+
+  // The default code path (no `stdoutSink`/`stderrSink` injected) wraps
+  // pullImage/buildImage in the progress sink: success → finish(true);
+  // failure → finish(false) + dumpRecent(). These tests guard the
+  // dispatch via an injected spy factory so a future regression in
+  // runStreamed can't silently bypass the failure-context dump.
+  describe('progress sink dispatch', () => {
+    it('calls finish(true) and skips dumpRecent on a clean pullImage', async () => {
+      const spawnMock = createMockSpawn();
+      const spy = createSpyProgressSink();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        progressSinkFactory: spy.factory,
+      });
+
+      const promise = manager.pullImage('alpine:latest');
+      await Promise.resolve();
+      spawnMock.handles[0].exit(0);
+      await promise;
+
+      expect(spy.sinks).toHaveLength(1);
+      expect(spy.sinks[0].operation).toBe('docker pull');
+      expect(spy.sinks[0].finishCalls).toEqual([true]);
+      expect(spy.sinks[0].dumpRecentCalls).toBe(0);
+    });
+
+    it('calls finish(false) then dumpRecent when buildImage exits non-zero', async () => {
+      const spawnMock = createMockSpawn();
+      const spy = createSpyProgressSink();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        progressSinkFactory: spy.factory,
+      });
+
+      const promise = manager.buildImage('img:latest', '/Dockerfile', '/ctx');
+      await Promise.resolve();
+      spawnMock.handles[0].emitStderr('ERROR: bad step\n');
+      await new Promise((r) => setImmediate(r));
+      spawnMock.handles[0].exit(1);
+
+      await expect(promise).rejects.toThrow(/docker build .*exited with code 1/);
+      expect(spy.sinks).toHaveLength(1);
+      expect(spy.sinks[0].operation).toBe('docker build');
+      expect(spy.sinks[0].finishCalls).toEqual([false]);
+      expect(spy.sinks[0].dumpRecentCalls).toBe(1);
+    });
+
+    it('also flushes dumpRecent when spawn itself errors', async () => {
+      const spawnMock = createMockSpawn();
+      const spy = createSpyProgressSink();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        progressSinkFactory: spy.factory,
+      });
+
+      const promise = manager.pullImage('alpine:latest');
+      await Promise.resolve();
+      spawnMock.handles[0].spawnError(new Error('spawn docker ENOENT'));
+
+      await expect(promise).rejects.toThrow(/docker pull failed to spawn/);
+      expect(spy.sinks[0].finishCalls).toEqual([false]);
+      expect(spy.sinks[0].dumpRecentCalls).toBe(1);
+    });
+
+    it('skips the progress sink when stdoutSink/stderrSink are injected', async () => {
+      const spawnMock = createMockSpawn();
+      const spy = createSpyProgressSink();
+      const manager = createDockerManager(mock.mockExec, undefined, {
+        spawn: spawnMock.spawn,
+        stdoutSink: nullSink(),
+        stderrSink: nullSink(),
+        progressSinkFactory: spy.factory,
+      });
+
+      const promise = manager.pullImage('alpine:latest');
+      await Promise.resolve();
+      spawnMock.handles[0].exit(0);
+      await promise;
+
+      // Test seam wins: the factory was never called.
+      expect(spy.sinks).toHaveLength(0);
     });
   });
 

--- a/test/docker-progress-sink.test.ts
+++ b/test/docker-progress-sink.test.ts
@@ -1,0 +1,181 @@
+import { Writable } from 'node:stream';
+import { describe, it, expect } from 'vitest';
+import { createDockerProgressSink, type DockerProgressOperation } from '../src/docker/docker-progress-sink.js';
+
+/** In-memory writable that records every chunk it receives. */
+function captureStream(): { stream: NodeJS.WritableStream; chunks: string[]; text: () => string } {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk: Buffer | string, _enc, cb) {
+      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+      cb();
+    },
+  });
+  return { stream, chunks, text: () => chunks.join('') };
+}
+
+/** Strips ANSI escapes so assertions don't depend on chalk output. */
+function plain(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, '');
+}
+
+function makeSink(operation: DockerProgressOperation, opts: { isTTY: boolean; now?: () => number } = { isTTY: true }) {
+  const out = captureStream();
+  const sink = createDockerProgressSink({
+    operation,
+    output: out.stream,
+    isTTY: opts.isTTY,
+    now: opts.now ?? (() => 0),
+  });
+  return { sink, out };
+}
+
+describe('createDockerProgressSink', () => {
+  describe('TTY mode', () => {
+    it('renders an in-place line for docker pull layer transitions', () => {
+      const { sink, out } = makeSink('docker pull', { isTTY: true });
+      sink.stdout.write('latest: Pulling from library/alpine\n');
+      sink.stdout.write('abc123def: Pulling fs layer\n');
+      sink.stdout.write('beefcafe1: Pulling fs layer\n');
+      sink.stdout.write('abc123def: Downloading [====>] 1MB/3MB\r');
+      sink.stdout.write('abc123def: Pull complete\n');
+      sink.stdout.write('beefcafe1: Already exists\n');
+
+      const rendered = plain(out.text());
+      // Every redraw is preceded by \r\x1B[2K — same-line update only.
+      expect(out.text().split('\n').length).toBe(1);
+      expect(rendered).toContain('docker pull');
+      expect(rendered).toContain('2/2 layers');
+    });
+
+    it('renders step number from BuildKit --progress=plain output', () => {
+      const { sink, out } = makeSink('docker build', { isTTY: true });
+      sink.stderr.write('#1 [internal] load build definition from Dockerfile\n');
+      sink.stderr.write('#1 DONE 0.0s\n');
+      sink.stderr.write('#5 [2/8] RUN apt-get update && apt-get install -y curl\n');
+      sink.stderr.write('#5 0.234 Reading package lists...\n');
+      sink.stderr.write('#5 1.456 ...lots of noise...\n');
+      sink.stderr.write('#5 DONE 12.3s\n');
+
+      const rendered = plain(out.text());
+      expect(rendered).toContain('docker build');
+      expect(rendered).toContain('step 2/8');
+      expect(rendered).toContain('RUN apt-get update');
+      // Continuation lines should NOT have produced a separate visible
+      // entry (they only feed the watchdog).
+      expect(rendered).not.toContain('0.234');
+      expect(rendered).not.toContain('1.456');
+    });
+
+    it('finish(true) commits a "done" summary line', () => {
+      const { sink, out } = makeSink('docker pull', { isTTY: true });
+      sink.stdout.write('abc123: Pulling fs layer\n');
+      sink.stdout.write('abc123: Pull complete\n');
+      sink.finish(true);
+
+      const final = plain(out.text());
+      expect(final).toContain('docker pull done');
+      // After finish() the line ends with a newline so subsequent output
+      // doesn't clobber it.
+      expect(out.text().endsWith('\n')).toBe(true);
+    });
+
+    it('finish(false) marks the line failed', () => {
+      const { sink, out } = makeSink('docker build', { isTTY: true });
+      sink.stderr.write('#3 [1/4] FROM ubuntu:latest\n');
+      sink.finish(false);
+
+      expect(plain(out.text())).toContain('docker build failed');
+    });
+
+    it('dumpRecent emits the rolling raw buffer on failure', () => {
+      const { sink, out } = makeSink('docker build', { isTTY: true });
+      sink.stderr.write('#3 [1/4] FROM ubuntu:latest\n');
+      sink.stderr.write('#3 0.123 fetching metadata\n');
+      sink.stderr.write('#3 ERROR: failed to resolve source\n');
+      sink.finish(false);
+      sink.dumpRecent();
+
+      const dumped = plain(out.text());
+      expect(dumped).toContain('last');
+      expect(dumped).toContain('lines from docker build');
+      expect(dumped).toContain('ERROR: failed to resolve source');
+    });
+
+    it('caps the dump buffer at bufferSize', () => {
+      const out = captureStream();
+      const sink = createDockerProgressSink({
+        operation: 'docker build',
+        output: out.stream,
+        isTTY: true,
+        bufferSize: 3,
+        now: () => 0,
+      });
+      for (let i = 0; i < 10; i++) {
+        sink.stderr.write(`#1 raw line ${i}\n`);
+      }
+      sink.dumpRecent();
+
+      const dumped = plain(out.text());
+      expect(dumped).toContain('raw line 9');
+      expect(dumped).toContain('raw line 8');
+      expect(dumped).toContain('raw line 7');
+      expect(dumped).not.toContain('raw line 6');
+    });
+
+    it('handles carriage-return-separated progress updates as line boundaries', () => {
+      // docker pull uses `\r` (not `\n`) to update the downloading meter
+      // in place. The sink has to split on it or the progress phase never
+      // gets observed.
+      const { sink, out } = makeSink('docker pull', { isTTY: true });
+      sink.stdout.write('abc123: Pulling fs layer\n');
+      sink.stdout.write('abc123: Downloading [=>      ] 1MB/100MB\r');
+      sink.stdout.write('abc123: Downloading [==>     ] 2MB/100MB\r');
+      sink.stdout.write('abc123: Downloading [===>    ] 3MB/100MB\r');
+
+      expect(plain(out.text())).toContain('1 downloading');
+    });
+  });
+
+  describe('non-TTY mode', () => {
+    it('passes raw bytes straight through to the underlying stream', () => {
+      const { sink, out } = makeSink('docker build', { isTTY: false });
+      sink.stderr.write('#1 [internal] load Dockerfile\n');
+      sink.stderr.write('#1 DONE 0.0s\n');
+
+      // Non-TTY path must preserve full transcript so CI logs are useful.
+      expect(out.text()).toBe('#1 [internal] load Dockerfile\n#1 DONE 0.0s\n');
+    });
+
+    it('finish() and dumpRecent() are no-ops on non-TTY', () => {
+      const { sink, out } = makeSink('docker pull', { isTTY: false });
+      sink.stdout.write('abc: Pulling fs layer\n');
+      const beforeFinish = out.text();
+      sink.finish(true);
+      sink.dumpRecent();
+
+      // Nothing extra was written after the raw lines.
+      expect(out.text()).toBe(beforeFinish);
+    });
+  });
+
+  describe('parser elapsed time', () => {
+    it('uses the injected clock for the (Xs) suffix', () => {
+      let t = 1000;
+      const out = captureStream();
+      const sink = createDockerProgressSink({
+        operation: 'docker pull',
+        output: out.stream,
+        isTTY: true,
+        now: () => t,
+      });
+      sink.stdout.write('abc: Pulling fs layer\n');
+      t = 6000; // five seconds later
+      // Trigger a re-render by pushing another line.
+      sink.stdout.write('abc: Pull complete\n');
+
+      expect(plain(out.text())).toContain('(5s)');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/docker/docker-progress-sink.ts`: a TTY-aware sink that consumes `docker pull` / `docker build` output and renders one status line that updates in place (`docker pull  4/12 layers  2 downloading`; `docker build  step 5/14  RUN apt-get install -y curl  (8s)`). On non-TTY stderr (CI / redirected logs) it passes the raw transcript through unchanged.
- Wires the sink into `pullImage` and `buildImage` in `docker-manager.ts` via a new internal `runStreamed` helper. The test seam (explicit `stdoutSink`/`stderrSink` on `createDockerManager`) bypasses the sink, so existing tests keep their behavior.
- On failure the sink dumps the last ~200 raw lines so the user gets a real diagnostic; this complements (does not replace) the 4 KB stderr-tail that `spawnWithIdleTimeout` already quotes in its rejection.
- Adds an `ensureDockerImage(agentId, userConfig)` helper exported from `docker-infrastructure.ts` and calls it from `src/index.ts` BEFORE the init `ora` spinner starts. Without this, the spinner and the sink would fight for the same line on stderr. The second `ensureImage` call deep inside session init is content-hash cached, so it short-circuits.

## Motivation

PR #250 traded "silent docker hang" for "real-time streamed output," but the per-layer pull chatter and BuildKit `--progress=plain` step output combined to flood the terminal with hundreds-to-thousands of lines per session start. This change keeps the watchdog heartbeat (every byte still flows through the sink before `resetIdleTimer()`) but replaces the visible flood with a single updating summary.

## Implementation notes

- The sink splits incoming chunks on both `\n` and `\r` because `docker pull` uses `\r` (not `\n`) to update its `Downloading [====>] X/Y` progress meter in place. Without that, layer download state would never be observed.
- `--progress=plain` is line-oriented, so the build parser keys off step headers (`#N [stage X/Y] DESC`) and ignores per-step continuation lines (`#5 0.234 ...`) — they still feed the watchdog but don't update the summary, which would otherwise flicker.
- The sink keeps a rolling 200-line raw buffer; `dumpRecent()` flushes it on the failure path.
- Parser bugs in either pull/build parsing are caught and swallowed inside the write path — the streaming pipeline must never throw from a write, or the watchdog would stop being fed and the operation would falsely time out.

## Test plan

- [x] `npm test -- test/docker-manager.test.ts test/docker-progress-sink.test.ts` — 69/69 pass (59 existing + 10 new covering pull/build parsing, `\r`-separated progress meter, non-TTY passthrough, `finish` success/failure, `dumpRecent` buffer behavior, buffer cap, injected clock)
- [x] `npm run lint` / `npm run format:check` — clean
- [ ] Manual: run `ironcurtain start --agent claude-code "..."` against a cold image cache and confirm the terminal shows one updating progress line instead of the flood
- [ ] Manual: redirect stderr to a file (`2> /tmp/log`) and confirm the file still contains the full verbatim transcript (CI path)
- [ ] Manual: deliberately break the Dockerfile and confirm the failure path dumps the recent buffer with the error context above the rejection message

## Out of scope

- Same collision logic applies in `daemon` mode, but the daemon does not run an `ora` spinner during session init (it serves a web UI), so no change needed there.
- Workflow shared-container runs go through `createWorkflowInfrastructure`, not `createStandaloneSession` — no spinner today, so no pre-flight needed. We can wire it through later if a similar collision is reported.