### PR TITLE
fix(workflow): close three failure modes in Docker agent sessions

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -19,6 +19,7 @@ import type {
   AgentResponse,
   ConversationStateConfig,
   OrientationContext,
+  TransientFailureKind,
 } from '../agent-adapter.js';
 import type { DockerAuthKind, IronCurtainConfig } from '../../config/types.js';
 import type { ProviderConfig } from '../provider-config.js';
@@ -278,24 +279,35 @@ exit $STATUS
 
     extractResponse(exitCode: number, stdout: string): AgentResponse {
       if (exitCode !== 0) {
-        // The CLI exits non-zero on 429 (quota) and on the upstream-stall
-        // envelope (`type: 'result'`, `output_tokens=0`,
-        // `stop_reason=null`); both signals must survive the non-zero
-        // exit. Parse stdout once and dispatch to both detectors.
+        // The CLI exits non-zero on 429 (quota), on transient upstream
+        // 5xx (`api_error_status: 5xx`, after the SDK exhausts its
+        // internal retries), and on the upstream-stall envelope
+        // (`type: 'result'`, `output_tokens=0`, `stop_reason=null`); all
+        // three signals must survive the non-zero exit. Parse stdout once
+        // and dispatch to each detector.
         const parsed = tryParseJsonObject(stdout);
         const quotaExhausted = parsed ? extractClaudeCodeQuotaSignal(parsed, stdout) : undefined;
         if (quotaExhausted) {
           return { text: quotaExhausted.rawMessage, quotaExhausted };
         }
+        // Both transient-failure branches are resumable-aborts (NOT
+        // hardFailure): the orchestrator's hard-retry rotation cannot
+        // recover an upstream that's currently 5xx-ing or stalled — the
+        // SDK already exhausted its internal retries within the failed
+        // turn. Surface the synthetic `result` string as the agent's
+        // text so the message log records what happened.
+        const transientText = typeof parsed?.result === 'string' ? parsed.result : stdout.trim();
+        const asTransientFailure = (kind: TransientFailureKind, rawMessage: string): AgentResponse => ({
+          text: transientText,
+          transientFailure: { kind, rawMessage },
+        });
+        const upstream5xx = parsed ? detectUpstreamFiveXx(parsed, stdout) : undefined;
+        if (upstream5xx) {
+          return asTransientFailure('upstream_5xx', upstream5xx.rawMessage);
+        }
         const transient = parsed ? detectTransientFailure(parsed, stdout) : undefined;
         if (transient) {
-          // Treat as resumable-abort, NOT hardFailure: the orchestrator's
-          // hard-retry rotation cannot recover a stalled upstream.
-          const text = typeof parsed?.result === 'string' ? parsed.result : stdout.trim();
-          return {
-            text,
-            transientFailure: { kind: 'degenerate_response', rawMessage: transient.rawMessage },
-          };
+          return asTransientFailure('degenerate_response', transient.rawMessage);
         }
         // Zero output on non-zero exit indicates the claude process was
         // killed (SIGTERM) or crashed before producing any assistant text —
@@ -412,6 +424,28 @@ function detectTransientFailure(parsed: Record<string, unknown>, stdout: string)
 }
 
 /**
+ * Detects the synthetic "upstream 5xx" envelope: Claude Code's SDK
+ * retries transient provider 5xx responses three times internally; if
+ * all three fail (e.g. a sustained Anthropic outage with mid-SSE-stream
+ * aborts), the CLI emits a `type: 'result'` envelope with
+ * `api_error_status` in the 5xx range and exits non-zero.
+ *
+ * Mirrors the defensive intent of `detectTransientFailure`: false
+ * positives would silently swallow real errors, so the predicate is
+ * strict. Restricted to 5xx so that 4xx envelopes (400 poisoned-
+ * history, 401, 403) the SDK does NOT retry are NOT misclassified —
+ * those are real errors the agent should see unmodified.
+ */
+function detectUpstreamFiveXx(parsed: Record<string, unknown>, stdout: string): { rawMessage: string } | undefined {
+  if (parsed.type !== 'result') return undefined;
+  if (parsed.is_error !== true) return undefined;
+  const status = parsed.api_error_status;
+  if (typeof status !== 'number') return undefined;
+  if (status < 500 || status >= 600) return undefined;
+  return { rawMessage: stdout.trim() };
+}
+
+/**
  * Parses Claude Code's `--output-format json` response.
  * Falls back to raw stdout when the output is not valid JSON.
  */
@@ -419,9 +453,13 @@ function parseClaudeCodeJson(stdout: string): AgentResponse {
   const parsed = tryParseJsonObject(stdout);
   if (parsed && 'result' in parsed) {
     const text = typeof parsed.result === 'string' ? parsed.result : stdout.trim();
-    const transient = detectTransientFailure(parsed, stdout);
     const base: AgentResponse =
       typeof parsed.total_cost_usd === 'number' ? { text, costUsd: parsed.total_cost_usd } : { text };
+    // Quota and 5xx envelopes both arrive with exit ≠ 0 by design, so
+    // they're handled in the non-zero-exit branch of extractResponse.
+    // Only the degenerate-response shape (exit = 0 but empty completion)
+    // is reachable here.
+    const transient = detectTransientFailure(parsed, stdout);
     if (transient) {
       return { ...base, transientFailure: { kind: 'degenerate_response', rawMessage: transient.rawMessage } };
     }

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -69,12 +69,21 @@ export interface AgentResponse {
    * its JSON parses, but no assistant message was generated.
    *
    * Shaped as a discriminated union (`kind`) so future detected shapes
-   * (`'connection_reset'`, `'5xx_passthrough'`, etc.) can extend without
-   * a breaking change. Mirrors the contract of `quotaExhausted`: the
-   * orchestrator MUST treat this as terminal-but-resumable, MUST NOT
-   * retry the turn (the in-loop reprompt against a stalled upstream is
-   * hopeless), and MUST preserve the checkpoint so `workflow resume`
-   * can re-enter the failing state once the upstream is healthy.
+   * (`'connection_reset'`, etc.) can extend without a breaking change.
+   * Current kinds:
+   *   - `'degenerate_response'`: exit=0, output_tokens=0, stop_reason=null
+   *     (sustained LiteLLM/Z.AI stall surfaced as an empty completion).
+   *   - `'upstream_5xx'`: Claude Code's `api_error_status: 5xx` envelope,
+   *     emitted after the SDK exhausts its internal retries against a
+   *     transient provider 5xx (e.g. mid-SSE-stream abort during an
+   *     Anthropic outage). The CLI exits non-zero with a synthetic
+   *     `result` string ("API Error: 500 Internal server error. ...").
+   *
+   * Mirrors the contract of `quotaExhausted`: the orchestrator MUST
+   * treat this as terminal-but-resumable, MUST NOT retry the turn (the
+   * in-loop reprompt against a stalled upstream is hopeless), and MUST
+   * preserve the checkpoint so `workflow resume` can re-enter the
+   * failing state once the upstream is healthy.
    *
    * `rawMessage` is the original envelope/stdout, preserved for
    * diagnostics. Adapters that cannot produce this signal must leave
@@ -83,10 +92,16 @@ export interface AgentResponse {
    * signal.
    */
   readonly transientFailure?: {
-    readonly kind: 'degenerate_response';
+    readonly kind: TransientFailureKind;
     readonly rawMessage: string;
   };
 }
+
+/**
+ * Discriminant for the `transientFailure.kind` field. Exported as a single
+ * source of truth so adding a new kind only requires editing one file.
+ */
+export type TransientFailureKind = 'degenerate_response' | 'upstream_5xx';
 
 /**
  * Branded agent identifier to prevent mixing with other string types.

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -104,6 +104,21 @@ export interface AgentResponse {
 export type TransientFailureKind = 'degenerate_response' | 'upstream_5xx';
 
 /**
+ * Human-readable description of a transient-failure kind, used in
+ * user-facing terminal-status text and error messages. Centralized so
+ * adding a new kind forces an exhaustive switch update (TypeScript
+ * errors here if the kind is unhandled).
+ */
+export function describeTransientFailureKind(kind: TransientFailureKind): string {
+  switch (kind) {
+    case 'degenerate_response':
+      return 'agent returned no content (output_tokens=0, stop_reason=null)';
+    case 'upstream_5xx':
+      return 'upstream returned a 5xx error after SDK retries exhausted';
+  }
+}
+
+/**
  * Branded agent identifier to prevent mixing with other string types.
  */
 export type AgentId = string & { readonly __brand: 'AgentId' };

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -309,15 +309,17 @@ export class DockerAgentSession implements Session {
       this.turns.push(turn);
 
       // Mark the first turn complete whenever the agent CLI produced any
-      // stdout. Claude Code's `--session-id` is a create-only flag — the CLI
-      // rejects the next call with "Session ID is already in use" if the
-      // transcript JSONL on disk already exists. Any non-empty stdout proves
-      // the session got far enough for the CLI to materialize that JSONL,
-      // even if the run ultimately exited non-zero (e.g. Anthropic API
-      // 400 mid-stream). The next turn must therefore use `--resume` rather
-      // than re-pinning the same id. Hard failures with empty stdout still
-      // route through rotateAgentConversationId() at the orchestrator layer.
-      if (exitCode === 0 || stdout.length > 0) {
+      // non-whitespace stdout. Claude Code's `--session-id` is a create-only
+      // flag — the CLI rejects the next call with "Session ID is already in
+      // use" if the transcript JSONL on disk already exists. Any real stdout
+      // proves the session got far enough for the CLI to materialize that
+      // JSONL, even if the run ultimately exited non-zero (e.g. Anthropic
+      // API 400 mid-stream). The next turn must therefore use `--resume`
+      // rather than re-pinning the same id. The whitespace-trimmed check
+      // matches `extractResponse`'s hard-failure definition (stdout.trim()
+      // empty); hard failures still route through rotateAgentConversationId()
+      // at the orchestrator layer.
+      if (exitCode === 0 || stdout.trim().length > 0) {
         this.firstTurnComplete = true;
       }
 

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -308,10 +308,16 @@ export class DockerAgentSession implements Session {
       };
       this.turns.push(turn);
 
-      // Only mark the first turn as complete on success. On a failed turn
-      // (non-zero exit), the agent may not have created the session yet, so
-      // the next turn must still pin a fresh session id rather than resume.
-      if (exitCode === 0) {
+      // Mark the first turn complete whenever the agent CLI produced any
+      // stdout. Claude Code's `--session-id` is a create-only flag — the CLI
+      // rejects the next call with "Session ID is already in use" if the
+      // transcript JSONL on disk already exists. Any non-empty stdout proves
+      // the session got far enough for the CLI to materialize that JSONL,
+      // even if the run ultimately exited non-zero (e.g. Anthropic API
+      // 400 mid-stream). The next turn must therefore use `--resume` rather
+      // than re-pinning the same id. Hard failures with empty stdout still
+      // route through rotateAgentConversationId() at the orchestrator layer.
+      if (exitCode === 0 || stdout.length > 0) {
         this.firstTurnComplete = true;
       }
 

--- a/src/docker/provider-config.ts
+++ b/src/docker/provider-config.ts
@@ -6,6 +6,8 @@
  * sentinel keys for real ones.
  */
 
+import { isPlainObject } from '../utils/is-plain-object.js';
+
 /**
  * Discriminator for the agent invoking the proxy. Set at proxy construction
  * time via `MitmProxyOptions.agentKind`. Currently the only named kind is
@@ -244,31 +246,166 @@ export function stripScheduleSkillTools(body: Record<string, unknown>): RewriteR
   });
 }
 
+const FUNCTION_BLOCK_PATTERN = /<function>([\s\S]*?)<\/function>\s*/g;
+const FUNCTION_BLOCK_NAME_PATTERN = /"name"\s*:\s*"([^"]+)"/;
+
+/**
+ * Walks `body.messages[].content[].tool_result.content[]` and removes
+ * references to schedule-skill tools that `stripScheduleSkillTools` strips
+ * from the outgoing `tools` array. Two leakage paths are scrubbed:
+ * `{type:"tool_reference", tool_name:"<stripped>"}` entries from ToolSearch
+ * keyword/`select:` results, and `<function>{"name":"<stripped>",...}</function>`
+ * schema blocks from `select:` results that load a full tool schema.
+ *
+ * Necessary because removing a tool from `tools` does NOT remove dangling
+ * references already recorded in conversation history. Anthropic 400s the
+ * next request with "Tool reference 'X' not found in available tools" if
+ * any such reference survives, and Claude Code records that 400 as a
+ * synthetic assistant turn it cannot recover from — wedging the session.
+ */
+export function stripScheduleSkillToolReferences(body: Record<string, unknown>): RewriteResult | null {
+  const messages = body.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return null;
+
+  const stripped: string[] = [];
+  const newMessages: unknown[] = [];
+
+  for (const rawMsg of messages as unknown[]) {
+    const result = rewriteMessageContent(rawMsg);
+    if (result === null) {
+      newMessages.push(rawMsg);
+      continue;
+    }
+    newMessages.push(result.value);
+    stripped.push(...result.labels);
+  }
+
+  if (stripped.length === 0) return null;
+  return { modified: { ...body, messages: newMessages }, stripped };
+}
+
+interface Rewrite {
+  readonly value: Record<string, unknown>;
+  readonly labels: readonly string[];
+}
+
+function rewriteMessageContent(rawMsg: unknown): Rewrite | null {
+  if (!isPlainObject(rawMsg)) return null;
+  const content = rawMsg.content;
+  if (!Array.isArray(content)) return null;
+
+  const labels: string[] = [];
+  const newContent: unknown[] = [];
+  let changed = false;
+
+  for (const rawBlock of content as unknown[]) {
+    const result = rewriteToolResultBlock(rawBlock);
+    if (result === null) {
+      newContent.push(rawBlock);
+      continue;
+    }
+    newContent.push(result.value);
+    labels.push(...result.labels);
+    changed = true;
+  }
+
+  if (!changed) return null;
+  return { value: { ...rawMsg, content: newContent }, labels };
+}
+
+function rewriteToolResultBlock(rawBlock: unknown): Rewrite | null {
+  if (!isPlainObject(rawBlock)) return null;
+  if (rawBlock.type !== 'tool_result') return null;
+  const innerContent = rawBlock.content;
+  if (!Array.isArray(innerContent)) return null;
+
+  const labels: string[] = [];
+  const keptInner: unknown[] = [];
+  let changed = false;
+
+  for (const rawEntry of innerContent as unknown[]) {
+    const result = scrubToolResultEntry(rawEntry);
+    if (result === null) {
+      keptInner.push(rawEntry);
+      continue;
+    }
+    if (result.kind !== 'drop') {
+      keptInner.push(result.value);
+    }
+    labels.push(...result.labels);
+    changed = true;
+  }
+
+  if (!changed) return null;
+  // Empty tool_result.content arrays are accepted by the Anthropic API,
+  // but a deterministic placeholder makes the scrub visible to the agent
+  // and avoids depending on that acceptance.
+  const finalInner = keptInner.length > 0 ? keptInner : [{ type: 'text', text: '(filtered)' }];
+  return { value: { ...rawBlock, content: finalInner }, labels };
+}
+
+type EntryResult =
+  | { readonly kind: 'drop'; readonly labels: readonly string[] }
+  | { readonly kind: 'replace'; readonly value: Record<string, unknown>; readonly labels: readonly string[] };
+
+function scrubToolResultEntry(rawEntry: unknown): EntryResult | null {
+  if (!isPlainObject(rawEntry)) return null;
+
+  if (rawEntry.type === 'tool_reference' && typeof rawEntry.tool_name === 'string') {
+    if (!SCHEDULE_SKILL_TOOL_NAMES.has(rawEntry.tool_name)) return null;
+    return { kind: 'drop', labels: [`tool_reference:${rawEntry.tool_name}`] };
+  }
+
+  if (rawEntry.type === 'text' && typeof rawEntry.text === 'string') {
+    // Fast-path: most tool_result text is tool output, not ToolSearch results.
+    if (!rawEntry.text.includes('<function>')) return null;
+    const labels: string[] = [];
+    const scrubbed = rawEntry.text.replace(FUNCTION_BLOCK_PATTERN, (match, blockBody: string) => {
+      const nameMatch = FUNCTION_BLOCK_NAME_PATTERN.exec(blockBody);
+      if (nameMatch && SCHEDULE_SKILL_TOOL_NAMES.has(nameMatch[1])) {
+        labels.push(`function_block:${nameMatch[1]}`);
+        return '';
+      }
+      return match;
+    });
+    if (labels.length === 0) return null;
+    return { kind: 'replace', value: { ...rawEntry, text: scrubbed }, labels };
+  }
+
+  return null;
+}
+
 /**
  * Combined rewriter for Anthropic /v1/messages requests. Always strips
  * server-side tools; additionally strips the schedule built-in skill's tools
- * when the originating agent is a workflow agent. Agent kinds other than
- * 'workflow' (including `undefined`) do not strip the schedule tools, so
- * interactive and standalone sessions are unaffected.
+ * and any dangling history references to them when the originating agent is
+ * a workflow agent. Agent kinds other than 'workflow' (including `undefined`)
+ * do not strip the schedule tools, so interactive and standalone sessions
+ * are unaffected.
  */
 export function anthropicRequestRewriter(
   body: Record<string, unknown>,
   context: { method: string; path: string; agentKind?: AgentKind },
 ): RewriteResult | null {
   const serverSide = stripServerSideTools(body);
-  const afterServerSide = serverSide ? serverSide.modified : body;
+  let current = serverSide ? serverSide.modified : body;
+  const stripped: string[] = serverSide ? [...serverSide.stripped] : [];
 
   if (context.agentKind === 'workflow') {
-    const scheduleStrip = stripScheduleSkillTools(afterServerSide);
-    if (scheduleStrip) {
-      return {
-        modified: scheduleStrip.modified,
-        stripped: [...(serverSide?.stripped ?? []), ...scheduleStrip.stripped],
-      };
+    const toolsStrip = stripScheduleSkillTools(current);
+    if (toolsStrip) {
+      current = toolsStrip.modified;
+      stripped.push(...toolsStrip.stripped);
+    }
+    const historyStrip = stripScheduleSkillToolReferences(current);
+    if (historyStrip) {
+      current = historyStrip.modified;
+      stripped.push(...historyStrip.stripped);
     }
   }
 
-  return serverSide;
+  if (stripped.length === 0) return null;
+  return { modified: current, stripped };
 }
 
 /**

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -3,7 +3,7 @@ import type { DockerAuthKind, IronCurtainConfig } from '../config/types.js';
 import type { Sandbox } from '../sandbox/index.js';
 import type { ResolvedResourceBudgetConfig } from '../config/user-config.js';
 import type { CumulativeBudgetSnapshot } from './resource-budget-tracker.js';
-import type { AgentId } from '../docker/agent-adapter.js';
+import type { AgentId, TransientFailureKind } from '../docker/agent-adapter.js';
 import type { DockerInfrastructure } from '../docker/docker-infrastructure.js';
 import type { WhitelistCandidateIpc } from '../trusted-process/approval-whitelist.js';
 
@@ -566,7 +566,7 @@ export interface AgentTurnResult {
    * checkpoint preserved.
    */
   readonly transientFailure?: {
-    readonly kind: 'degenerate_response';
+    readonly kind: TransientFailureKind;
     readonly rawMessage: string;
   };
 }

--- a/src/workflow/errors.ts
+++ b/src/workflow/errors.ts
@@ -1,5 +1,5 @@
 import type { AgentConversationId } from '../session/types.js';
-import type { TransientFailureKind } from '../docker/agent-adapter.js';
+import { describeTransientFailureKind, type TransientFailureKind } from '../docker/agent-adapter.js';
 
 /**
  * Wraps an error thrown from within `executeAgentState()` so the XState
@@ -91,7 +91,7 @@ export class WorkflowTransientFailureError extends Error {
   readonly rawMessage: string;
 
   constructor(options: WorkflowTransientFailureOptions) {
-    super(`Agent turn aborted: upstream stall (kind=${options.kind})`);
+    super(`Agent turn aborted: transient upstream failure — ${describeTransientFailureKind(options.kind)}`);
     this.name = 'WorkflowTransientFailureError';
     this.stateId = options.stateId;
     this.kind = options.kind;

--- a/src/workflow/errors.ts
+++ b/src/workflow/errors.ts
@@ -1,4 +1,5 @@
 import type { AgentConversationId } from '../session/types.js';
+import type { TransientFailureKind } from '../docker/agent-adapter.js';
 
 /**
  * Wraps an error thrown from within `executeAgentState()` so the XState
@@ -80,13 +81,13 @@ export function isWorkflowQuotaExhaustedError(err: unknown): err is WorkflowQuot
  */
 export interface WorkflowTransientFailureOptions {
   readonly stateId: string;
-  readonly kind: 'degenerate_response';
+  readonly kind: TransientFailureKind;
   readonly rawMessage: string;
 }
 
 export class WorkflowTransientFailureError extends Error {
   readonly stateId: string;
-  readonly kind: 'degenerate_response';
+  readonly kind: TransientFailureKind;
   readonly rawMessage: string;
 
   constructor(options: WorkflowTransientFailureOptions) {

--- a/src/workflow/message-log.ts
+++ b/src/workflow/message-log.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import type { TransientFailureKind } from '../docker/agent-adapter.js';
 
 // ---------------------------------------------------------------------------
 // Log entry types
@@ -86,7 +87,7 @@ export interface QuotaExhaustedEntry extends BaseEntry {
 export interface TransientFailureEntry extends BaseEntry {
   readonly type: 'transient_failure';
   readonly role: string;
-  readonly kind: 'degenerate_response';
+  readonly kind: TransientFailureKind;
   readonly rawMessage: string;
 }
 

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -66,7 +66,7 @@ import type {
   SessionMode,
 } from '../session/types.js';
 import { createAgentConversationId, createBundleId } from '../session/types.js';
-import type { AgentId } from '../docker/agent-adapter.js';
+import type { AgentId, TransientFailureKind } from '../docker/agent-adapter.js';
 import { ensureSecureBundleDir, type DockerInfrastructure } from '../docker/docker-infrastructure.js';
 import {
   buildWorkflowMachine,
@@ -612,7 +612,7 @@ interface WorkflowInstance {
    * terminal rather than the failing state. Applies to `quotaExhausted`
    * too; closing requires a checkpoint-on-start change.
    */
-  transientFailure?: { readonly kind: 'degenerate_response'; readonly rawMessage: string };
+  transientFailure?: { readonly kind: TransientFailureKind; readonly rawMessage: string };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -66,7 +66,7 @@ import type {
   SessionMode,
 } from '../session/types.js';
 import { createAgentConversationId, createBundleId } from '../session/types.js';
-import type { AgentId, TransientFailureKind } from '../docker/agent-adapter.js';
+import { describeTransientFailureKind, type AgentId, type TransientFailureKind } from '../docker/agent-adapter.js';
 import { ensureSecureBundleDir, type DockerInfrastructure } from '../docker/docker-infrastructure.js';
 import {
   buildWorkflowMachine,
@@ -2326,8 +2326,8 @@ export class WorkflowOrchestrator implements WorkflowController {
       instance.finalStatus = {
         phase: 'aborted',
         reason:
-          `Upstream stall: agent returned no content (kind=${instance.transientFailure.kind}; ` +
-          `resumable — run "ironcurtain workflow resume <baseDir>" once upstream is healthy)\n${excerpt}`,
+          `Transient upstream failure: ${describeTransientFailureKind(instance.transientFailure.kind)} ` +
+          `(resumable — run "ironcurtain workflow resume <baseDir>" once upstream is healthy)\n${excerpt}`,
       };
     } else if (stateValue === 'aborted' || stateValue.includes('abort')) {
       instance.finalStatus = {

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -412,6 +412,85 @@ describe('Claude Code Adapter', () => {
     expect(nonStringResponse.transientFailure).toBeUndefined();
   });
 
+  /**
+   * Builds an api_error_status envelope matching Claude Code's
+   * post-SDK-retry shape. `extras` lets a test override any base field
+   * or omit one (set to `undefined`) for predicate-strictness checks.
+   */
+  function makeErrorStatusEnvelope(status: number, extras: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      type: 'result',
+      is_error: true,
+      api_error_status: status,
+      result: `API Error: ${status}`,
+      stop_reason: 'stop_sequence',
+      usage: { input_tokens: 0, output_tokens: 0 },
+      ...extras,
+    });
+  }
+
+  it('surfaces transientFailure as upstream_5xx on the captured 500-after-SDK-retries envelope (exit=1)', () => {
+    // Ground-truth shape from a real Anthropic outage: must classify as
+    // resumable-abort (NOT hardFailure, NOT quotaExhausted) so the
+    // orchestrator preserves the checkpoint instead of burning its
+    // retry budget against an upstream that is currently 5xx-ing.
+    const envelope = makeErrorStatusEnvelope(500, {
+      subtype: 'success',
+      result:
+        'API Error: 500 Internal server error. This is a server-side issue, usually temporary — try again in a moment.',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.transientFailure).toBeDefined();
+    expect(response.transientFailure!.kind).toBe('upstream_5xx');
+    expect(response.transientFailure!.rawMessage).toContain('api_error_status');
+    expect(response.text).toContain('API Error: 500');
+    expect(response.hardFailure).toBeUndefined();
+    expect(response.quotaExhausted).toBeUndefined();
+  });
+
+  it('classifies 502, 503, 504 as upstream_5xx (any 5xx status, not just 500)', () => {
+    for (const status of [502, 503, 504, 599]) {
+      const response = claudeCodeAdapter.extractResponse(1, makeErrorStatusEnvelope(status));
+      expect(response.transientFailure?.kind).toBe('upstream_5xx');
+    }
+  });
+
+  it('does NOT classify 4xx (400, 401, 403) as upstream_5xx — those must surface as errors, not resumable-aborts', () => {
+    // Misclassifying a 4xx as upstream_5xx would silently swallow real
+    // bugs (e.g. a poisoned tool-use history) into a checkpoint-
+    // preserving abort that would just re-hit the same 400 on resume.
+    for (const status of [400, 401, 403, 404, 499]) {
+      const response = claudeCodeAdapter.extractResponse(1, makeErrorStatusEnvelope(status));
+      expect(response.transientFailure).toBeUndefined();
+    }
+  });
+
+  it('does not flag upstream_5xx when api_error_status is missing or non-numeric (defensive)', () => {
+    const missing = makeErrorStatusEnvelope(500, { api_error_status: undefined });
+    expect(claudeCodeAdapter.extractResponse(1, missing).transientFailure).toBeUndefined();
+
+    const wrongType = makeErrorStatusEnvelope(500, { api_error_status: '500' });
+    expect(claudeCodeAdapter.extractResponse(1, wrongType).transientFailure).toBeUndefined();
+  });
+
+  it('does not flag upstream_5xx when is_error is missing or false (predicate strictness)', () => {
+    const noFlag = makeErrorStatusEnvelope(500, { is_error: undefined });
+    expect(claudeCodeAdapter.extractResponse(1, noFlag).transientFailure).toBeUndefined();
+  });
+
+  it('does not break the existing 429 (quota) path — 429 must still route to quotaExhausted', () => {
+    // Mutual-exclusion regression guard: the new 5xx detector must run
+    // AFTER the quota check so a 429 envelope (which would also pass
+    // `is_error: true` + numeric `api_error_status`) is still
+    // classified as quotaExhausted, not upstream_5xx.
+    const envelope = makeErrorStatusEnvelope(429, {
+      result: 'Usage limit reached for 5 hour. Your limit will reset at 2026-05-16 22:00:00',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.quotaExhausted).toBeDefined();
+    expect(response.transientFailure).toBeUndefined();
+  });
+
   it('returns conversation state config for session resume', () => {
     const config = claudeCodeAdapter.getConversationStateConfig!();
     expect(config.hostDirName).toBe('claude-state');

--- a/test/docker-agent-session-retry.test.ts
+++ b/test/docker-agent-session-retry.test.ts
@@ -243,6 +243,32 @@ describe('DockerAgentSession retry path', () => {
     expect(flagValue(calls[1], '--session-id')).toBeUndefined();
   });
 
+  it('whitespace-only stdout on a hard failure does NOT flip firstTurnComplete', async () => {
+    // The gate uses `stdout.trim().length > 0` so the adapter's hard-failure
+    // definition (also `.trim().length === 0`) agrees: a CLI that prints only
+    // newlines/spaces before dying is still a hard failure that needs
+    // rotateAgentConversationId() to mint a fresh UUID. If the gate flipped
+    // on whitespace, the orchestrator's rotation would happen but the next
+    // call would have used --resume against a never-materialized JSONL.
+    const { exec, calls } = scriptedExec([
+      { exitCode: 143, stdout: '   \n  \t\n', stderr: '' },
+      { exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' },
+    ]);
+    const deps = buildDeps(tempDir, exec);
+    session = new DockerAgentSession(deps);
+    await session.initialize();
+
+    const first = await session.sendMessageDetailed('attempt 1');
+    expect(first.hardFailure).toBe(true);
+
+    session.rotateAgentConversationId();
+    await session.sendMessageDetailed('attempt 2');
+
+    expect(flagValue(calls[1], '--session-id')).toBeDefined();
+    expect(flagValue(calls[1], '--session-id')).not.toBe(deps.agentConversationId);
+    expect(flagValue(calls[1], '--resume')).toBeUndefined();
+  });
+
   it('after a successful turn, subsequent calls use --resume with the same UUID', async () => {
     const { exec, calls } = scriptedExec([
       { exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' },

--- a/test/docker-agent-session-retry.test.ts
+++ b/test/docker-agent-session-retry.test.ts
@@ -219,6 +219,30 @@ describe('DockerAgentSession retry path', () => {
     expect(flagValue(calls[1], '--resume')).toBeUndefined();
   });
 
+  it('after a partial-failure turn (exit!=0 with non-empty stdout), the next call uses --resume', async () => {
+    // Regression: the Anthropic-API-400-mid-stream class produces exit=1 with
+    // partial assistant text already on stdout AND a session JSONL on disk.
+    // Previously the gate was `exit === 0` only, so the retry re-emitted
+    // `--session-id <same-uuid>` and Claude Code rejected it with
+    // "Session ID is already in use" (the flag is create-only). The current
+    // gate also flips on any non-empty stdout, so the retry uses `--resume`.
+    const { exec, calls } = scriptedExec([
+      { exitCode: 1, stdout: 'partial assistant output', stderr: '' },
+      { exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' },
+    ]);
+    const deps = buildDeps(tempDir, exec);
+    session = new DockerAgentSession(deps);
+    await session.initialize();
+
+    await session.sendMessageDetailed('attempt 1');
+    await session.sendMessageDetailed('attempt 2');
+
+    expect(flagValue(calls[0], '--session-id')).toBe(deps.agentConversationId);
+    expect(flagValue(calls[0], '--resume')).toBeUndefined();
+    expect(flagValue(calls[1], '--resume')).toBe(deps.agentConversationId);
+    expect(flagValue(calls[1], '--session-id')).toBeUndefined();
+  });
+
   it('after a successful turn, subsequent calls use --resume with the same UUID', async () => {
     const { exec, calls } = scriptedExec([
       { exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' },

--- a/test/docker-agent-session-retry.test.ts
+++ b/test/docker-agent-session-retry.test.ts
@@ -288,6 +288,39 @@ describe('DockerAgentSession retry path', () => {
     expect(result.text).toBe('preamble only');
   });
 
+  it('forwards transientFailure from an upstream 5xx envelope (exit=1, api_error_status=500)', async () => {
+    // Mirrors the degenerate_response plumbing test above for the new
+    // upstream_5xx detection: after the SDK exhausts its 3 internal
+    // retries against a transient Anthropic 5xx, the CLI emits a
+    // `type: 'result'` envelope with `api_error_status: 500` and exits
+    // non-zero. The session must surface the structured signal through
+    // sendMessageDetailed so the orchestrator short-circuits instead of
+    // burning its retry budget against a still-broken upstream.
+    const upstream5xxEnvelope = JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      api_error_status: 500,
+      result:
+        'API Error: 500 Internal server error. This is a server-side issue, usually temporary — try again in a moment.',
+      stop_reason: 'stop_sequence',
+      usage: { input_tokens: 0, output_tokens: 0 },
+    });
+    const { exec } = scriptedExec([{ exitCode: 1, stdout: upstream5xxEnvelope, stderr: '' }]);
+    const deps = buildDeps(tempDir, exec);
+    session = new DockerAgentSession(deps);
+    await session.initialize();
+
+    const result = await session.sendMessageDetailed('do the thing');
+
+    expect(result.transientFailure).toBeDefined();
+    expect(result.transientFailure!.kind).toBe('upstream_5xx');
+    expect(result.transientFailure!.rawMessage).toContain('api_error_status');
+    expect(result.hardFailure).toBe(false);
+    expect(result.quotaExhausted).toBeUndefined();
+    expect(result.text).toContain('API Error: 500');
+  });
+
   it('sendMessage delegates to sendMessageDetailed and returns just the text', async () => {
     const { exec } = scriptedExec([{ exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' }]);
     const deps = buildDeps(tempDir, exec);

--- a/test/mitm-proxy.test.ts
+++ b/test/mitm-proxy.test.ts
@@ -11,6 +11,7 @@ import {
   anthropicRequestRewriter,
   isEndpointAllowed,
   stripScheduleSkillTools,
+  stripScheduleSkillToolReferences,
   stripServerSideTools,
   shouldRewriteBody,
   type ProviderConfig,
@@ -322,6 +323,182 @@ describe('stripScheduleSkillTools', () => {
   });
 });
 
+describe('stripScheduleSkillToolReferences', () => {
+  /** Reach into a single-message, single-block fixture's tool_result.content. */
+  function innerOf(result: { modified: Record<string, unknown> }): Array<Record<string, unknown>> {
+    const msg = (result.modified.messages as Array<Record<string, unknown>>)[0];
+    const block = (msg.content as Array<Record<string, unknown>>)[0];
+    return block.content as Array<Record<string, unknown>>;
+  }
+
+  it('returns null when body has no messages field', () => {
+    expect(stripScheduleSkillToolReferences({ model: 'claude-3' })).toBeNull();
+  });
+
+  it('returns null when messages array is empty', () => {
+    expect(stripScheduleSkillToolReferences({ messages: [] })).toBeNull();
+  });
+
+  it('returns null when no tool_result references stripped tools', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_abc',
+              content: [
+                { type: 'tool_reference', tool_name: 'TodoWrite' },
+                { type: 'tool_reference', tool_name: 'TaskOutput' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(stripScheduleSkillToolReferences(body)).toBeNull();
+  });
+
+  it('drops tool_reference entries for schedule-skill tool names', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_abc',
+              content: [
+                { type: 'tool_reference', tool_name: 'TaskOutput' },
+                { type: 'tool_reference', tool_name: 'CronCreate' },
+                { type: 'tool_reference', tool_name: 'ScheduleWakeup' },
+                { type: 'tool_reference', tool_name: 'TodoWrite' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = stripScheduleSkillToolReferences(body);
+    expect(result).not.toBeNull();
+    expect(result!.stripped).toEqual(['tool_reference:CronCreate', 'tool_reference:ScheduleWakeup']);
+    expect(innerOf(result!)).toEqual([
+      { type: 'tool_reference', tool_name: 'TaskOutput' },
+      { type: 'tool_reference', tool_name: 'TodoWrite' },
+    ]);
+  });
+
+  it('substitutes a placeholder when every entry was stripped', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_abc',
+              content: [
+                { type: 'tool_reference', tool_name: 'CronCreate' },
+                { type: 'tool_reference', tool_name: 'CronDelete' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = stripScheduleSkillToolReferences(body);
+    expect(result).not.toBeNull();
+    expect(innerOf(result!)).toEqual([{ type: 'text', text: '(filtered)' }]);
+  });
+
+  it('removes <function> schema blocks naming stripped tools from text content', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_abc',
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    '<functions>\n' +
+                    '<function>{"description":"Sched","name":"CronCreate","parameters":{}}</function>\n' +
+                    '<function>{"description":"Todos","name":"TodoWrite","parameters":{}}</function>\n' +
+                    '</functions>',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = stripScheduleSkillToolReferences(body);
+    expect(result).not.toBeNull();
+    expect(result!.stripped).toEqual(['function_block:CronCreate']);
+    const innerContent = innerOf(result!);
+    expect(innerContent).toHaveLength(1);
+    expect((innerContent[0] as { text: string }).text).not.toContain('CronCreate');
+    expect((innerContent[0] as { text: string }).text).toContain('TodoWrite');
+  });
+
+  it('leaves non-tool_result content blocks untouched', () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'CronCreate is a tool I read about.' }],
+        },
+      ],
+    };
+    expect(stripScheduleSkillToolReferences(body)).toBeNull();
+  });
+
+  it('leaves messages with string content untouched', () => {
+    const body = { messages: [{ role: 'user', content: 'plain string content' }] };
+    expect(stripScheduleSkillToolReferences(body)).toBeNull();
+  });
+
+  // ToolSearch keyword-match result that wedged a workflow: the CronCreate
+  // tool_reference survives in history even though the tools array no
+  // longer contains it, so Anthropic 400s the next request.
+  it('strips CronCreate from a real-world ToolSearch tool_result fixture', () => {
+    const body = {
+      model: 'claude-opus-4-7',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_01SxC1QRJq1rNG6vRLtQ1gVM',
+              content: [
+                { type: 'tool_reference', tool_name: 'TaskOutput' },
+                { type: 'tool_reference', tool_name: 'TaskStop' },
+                { type: 'tool_reference', tool_name: 'Monitor' },
+                { type: 'tool_reference', tool_name: 'TodoWrite' },
+                { type: 'tool_reference', tool_name: 'CronCreate' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = stripScheduleSkillToolReferences(body);
+    expect(result).not.toBeNull();
+    expect(result!.stripped).toEqual(['tool_reference:CronCreate']);
+    const serialized = JSON.stringify(result!.modified);
+    expect(serialized).not.toContain('CronCreate');
+    expect(serialized).toContain('TaskOutput');
+    expect(serialized).toContain('TaskStop');
+    expect(serialized).toContain('Monitor');
+    expect(serialized).toContain('TodoWrite');
+  });
+});
+
 describe('anthropicRequestRewriter', () => {
   const ctx = (agentKind?: 'workflow') => ({
     method: 'POST',
@@ -382,6 +559,64 @@ describe('anthropicRequestRewriter', () => {
   it('returns null when nothing needs stripping in workflow mode', () => {
     const body = { tools: [{ name: 'Read', input_schema: {} }] };
     expect(anthropicRequestRewriter(body, ctx('workflow'))).toBeNull();
+  });
+
+  // Real-world regression: the actual broken request shape from the aborted
+  // run. The tools array no longer contains CronCreate (Claude Code never
+  // surfaced it as a custom tool), but the messages history carries a
+  // tool_reference to it from a prior ToolSearch result. Without history
+  // scrubbing, the rewriter would forward this unchanged and Anthropic
+  // would 400 with "Tool reference 'CronCreate' not found in available
+  // tools". Both the tools-array path and the history path must fire.
+  it('scrubs both tools array and history references in workflow mode', () => {
+    const body = {
+      model: 'claude-opus-4-7',
+      tools: [
+        { name: 'Read', input_schema: {} },
+        { name: 'ScheduleWakeup', input_schema: {} },
+      ],
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_01SxC1QRJq1rNG6vRLtQ1gVM',
+              content: [
+                { type: 'tool_reference', tool_name: 'TaskOutput' },
+                { type: 'tool_reference', tool_name: 'CronCreate' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = anthropicRequestRewriter(body, ctx('workflow'));
+    expect(result).not.toBeNull();
+    expect(result!.stripped).toEqual(['ScheduleWakeup', 'tool_reference:CronCreate']);
+    const serialized = JSON.stringify(result!.modified);
+    expect(serialized).not.toContain('CronCreate');
+    expect(serialized).not.toContain('ScheduleWakeup');
+    expect(serialized).toContain('Read');
+    expect(serialized).toContain('TaskOutput');
+  });
+
+  it('history scrub does NOT fire when agentKind is undefined', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_abc',
+              content: [{ type: 'tool_reference', tool_name: 'CronCreate' }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(anthropicRequestRewriter(body, ctx(undefined))).toBeNull();
   });
 });
 

--- a/test/workflow-dispatch.test.ts
+++ b/test/workflow-dispatch.test.ts
@@ -1532,7 +1532,7 @@ describe('workflows.listResumable', () => {
     const cp = makeCheckpoint({
       machineState: 'plan',
       timestamp: '2026-04-23T15:00:00.000Z',
-      finalStatus: { phase: 'aborted', reason: 'Upstream stall: agent returned no content' },
+      finalStatus: { phase: 'aborted', reason: 'Transient upstream failure: agent returned no content' },
     });
     seedRunDirectory(baseDir, id, { definition: def, checkpoint: cp });
 

--- a/test/workflow/orchestrator-transient.test.ts
+++ b/test/workflow/orchestrator-transient.test.ts
@@ -131,8 +131,8 @@ describe('WorkflowOrchestrator transient-failure short-circuit', () => {
     const status = orchestrator.getStatus(workflowId);
     expect(status?.phase).toBe('aborted');
     if (status?.phase === 'aborted') {
-      expect(status.reason).toContain('Upstream stall');
-      expect(status.reason).toContain('degenerate_response');
+      expect(status.reason).toContain('Transient upstream failure');
+      expect(status.reason).toContain('agent returned no content');
       expect(status.reason).toContain('resume');
     }
 


### PR DESCRIPTION
## Summary

Three independent fixes for an end-to-end workflow-abort cascade reproduced on a 2.6-hour Envoy vuln-discovery run. Each commit closes one layer; together they make Docker-mode workflows survive both Anthropic transient outages and the SDK behaviors that the cascade depended on.

- **`b74d5a9` — proxy history-scrub.** Commit `620cdcf` strips the `schedule` skill's tools from the outgoing `tools` array for workflow agents, but does not remove references to them already in conversation history. Claude Code's `ToolSearch` deferred-tool fetcher surfaces stripped names as `tool_reference` entries inside `tool_result.content[]` (for both keyword and `select:` queries) and as `<function>{...}</function>` schema blocks in text content. Anthropic 400s any subsequent request carrying such a reference with `"Tool reference 'X' not found in available tools"`, and Claude Code records that 400 as a synthetic assistant turn it cannot recover from — wedging the session permanently.
  
  Adds `stripScheduleSkillToolReferences()` to `src/docker/provider-config.ts`. Walks `body.messages[].content[].tool_result.content[]` and removes both leakage shapes. Composed into `anthropicRequestRewriter` after the existing tools-array strip, only when `agentKind === 'workflow'`. Empty `tool_result.content` arrays get a `(filtered)` text placeholder so the scrub is visible to the agent.

- **`34f5e29` — resume after partial-failure turn.** Claude Code's `--session-id` is create-only; the CLI rejects the next call with `"Session ID ... is already in use"` if the transcript JSONL on disk already exists, and `--resume <uuid>` is required to continue. The session decided between the two based on `firstTurnComplete`, which was only set when `exitCode === 0`. If a turn exits non-zero but produced any stdout (e.g. an Anthropic failure mid-stream after streaming partial text), the JSONL is already materialized on disk. The orchestrator's soft-failure path would then reprompt with `--session-id <same-uuid>`, Claude Code rejected the call, and the state aborted before the reprompt could run.
  
  Flips `firstTurnComplete = true` in `src/docker/docker-agent-session.ts` whenever stdout is non-empty (a reliable proxy for "the session JSONL was materialized"). The next turn uses `--resume`. Hard failures (exit ≠ 0 AND empty stdout) still route through `rotateAgentConversationId()` at the orchestrator layer unchanged.

- **`0477217` — classify upstream 5xx as transient failure.** On retries-exhausted against a transient Anthropic 5xx, Claude Code emits a `type: 'result'` envelope with `is_error: true`, `api_error_status` in the 5xx range, and a synthetic `"API Error: 5xx ..."` string in `result`, then exits non-zero. This looked like a "successful turn missing the `agent_status` block" (commit `a75220d`) — triggering the anchor-check reprompt, which fired another `claude --resume` immediately, hit the same broken upstream, and burned the retry budget. A single transient outage that resolved in seconds killed a 2.6-hour run.
  
  Adds `detectUpstreamFiveXx()` in `src/docker/adapters/claude-code.ts` alongside the existing 429 (`quotaExhausted`) and degenerate-response (`transientFailure`) detectors. Surfaces `transientFailure: { kind: 'upstream_5xx', rawMessage }` so the orchestrator preserves the checkpoint and the run can resume. Detection is restricted to numeric `api_error_status` in [500, 600) so the SDK's non-retried 4xx envelopes (poisoned-history 400, 401, 403) still surface as real errors. The `transientFailure.kind` discriminant is extracted to a single exported `TransientFailureKind` type.

## Test plan

- [x] `npm test -- test/mitm-proxy.test.ts` (83 tests pass, including 8 new for `stripScheduleSkillToolReferences` + 2 integration tests in `anthropicRequestRewriter` — one is a real-world fixture lifted from the aborted run's JSONL line 149)
- [x] `npm test -- test/docker-agent-session-retry.test.ts` (10 tests pass, including a new partial-failure-turn → `--resume` regression test and a new upstream-5xx envelope plumbing test)
- [x] `npm test -- test/docker-agent-adapter.test.ts` (43 tests pass, including 5 new for upstream-5xx: real-world envelope, 502/503/504/599 positive, 400/401/403/404/499 negative, defensive guards for missing/non-numeric `api_error_status`, regression guard that 429 still routes to `quotaExhausted`)
- [x] `npm test -- test/workflow/orchestrator-retry.test.ts` (5 tests pass — orchestrator handler is already kind-agnostic, no logic change needed for the new `kind`)
- [x] `npm run build` clean
- [x] `npx prettier --write` + `npx eslint` clean on touched files
- [x] Verified against ground-truth JSONL from the aborted run (`~/.ironcurtain/workflow-runs/5cc70e67-c89d-465c-a5f5-ba70ccc32adc/containers/d1b49437-.../bundle/claude-state/projects/-workspace/24bebc11-*.jsonl`)

## Notes

- The orchestrator currently treats `transientFailure` as immediate abort (throws `WorkflowTransientFailureError`) — the run aborts cleanly with checkpoint preserved, but there is no in-loop backoff for transient outages. `workflow resume` is the recovery path. Adding orchestrator-level backoff/retry for transient kinds is a follow-up — out of scope for this PR.
- `TODO.md` and various untracked `.md` notes in the working tree are unrelated and not included.