### PR TITLE
fix(preflight): resolve @utcp/code-mode at parent so cwd doesn't matter

### DIFF
--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -203,5 +203,9 @@ export async function runDoctorCommand(argv: string[], deps: DoctorDeps = {}): P
  * SIGKILL the child).
  */
 function exitWithStatus(collected: CheckResult[]): never {
-  process.exit(collected.some((c) => c.status === 'fail') ? 1 : 0);
+  const code = collected.some((c) => c.status === 'fail') ? 1 : 0;
+  // Set exitCode first so any handler that swallows process.exit (test
+  // harnesses, signal handlers) still sees a non-zero status for CI to gate on.
+  process.exitCode = code;
+  process.exit(code);
 }

--- a/src/utils/preflight-checks.ts
+++ b/src/utils/preflight-checks.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { getIronCurtainHome } from '../config/paths.js';
 
 export interface PreflightCheckResult {
@@ -97,10 +98,13 @@ function runSandboxViabilityCheck(): Promise<PreflightCheckResult> {
     // Resolve the absolute path here so the child's cwd doesn't affect lookup —
     // a bare `@utcp/code-mode` specifier in `node -e` is resolved against
     // `<process.cwd()>/[eval]`, which breaks when the user invokes ironcurtain
-    // from outside the installed package tree (e.g. global installs).
-    let utcpEntry: string;
+    // from outside the installed package tree (e.g. global installs). Convert
+    // to a file:// URL because ESM import() treats strings as URL-like, so a
+    // raw path containing `#` or `?` would be misparsed as fragment/query.
+    let utcpEntryUrl: string;
     try {
-      utcpEntry = createRequire(import.meta.url).resolve('@utcp/code-mode');
+      const utcpEntry = createRequire(import.meta.url).resolve('@utcp/code-mode');
+      utcpEntryUrl = pathToFileURL(utcpEntry).href;
     } catch (err) {
       resolvePromise({
         ok: false,
@@ -111,7 +115,7 @@ function runSandboxViabilityCheck(): Promise<PreflightCheckResult> {
     }
 
     const script = `
-      import(${JSON.stringify(utcpEntry)})
+      import(${JSON.stringify(utcpEntryUrl)})
         .then((m) => m.CodeModeUtcpClient.create())
         .then(() => process.exit(0))
         .catch((e) => {

--- a/src/utils/preflight-checks.ts
+++ b/src/utils/preflight-checks.ts
@@ -94,9 +94,24 @@ export async function checkSandboxViability(): Promise<PreflightCheckResult> {
 
 function runSandboxViabilityCheck(): Promise<PreflightCheckResult> {
   return new Promise((resolvePromise) => {
-    // The script simply attempts to import and instantiate the UTCP client.
+    // Resolve the absolute path here so the child's cwd doesn't affect lookup —
+    // a bare `@utcp/code-mode` specifier in `node -e` is resolved against
+    // `<process.cwd()>/[eval]`, which breaks when the user invokes ironcurtain
+    // from outside the installed package tree (e.g. global installs).
+    let utcpEntry: string;
+    try {
+      utcpEntry = createRequire(import.meta.url).resolve('@utcp/code-mode');
+    } catch (err) {
+      resolvePromise({
+        ok: false,
+        message: 'Missing required dependency: @utcp/code-mode',
+        details: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
     const script = `
-      import('@utcp/code-mode')
+      import(${JSON.stringify(utcpEntry)})
         .then((m) => m.CodeModeUtcpClient.create())
         .then(() => process.exit(0))
         .catch((e) => {
@@ -146,31 +161,29 @@ function runSandboxViabilityCheck(): Promise<PreflightCheckResult> {
         return;
       }
 
-      let details = stderrOutput.trim();
+      const stderr = stderrOutput.trim();
       let message = 'Failed to initialize the V8 sandbox (isolated-vm).';
+      let hint: string | undefined;
 
       if (signal) {
         message = `V8 sandbox crashed with signal ${signal}.`;
         if (signal === 'SIGSEGV' || signal === 'SIGILL') {
-          details =
+          hint =
             'This is often caused by an incompatible Node.js version (e.g., Node 25). ' +
             'Please use Node.js 22, 23, or 24.';
         }
-      } else if (details.includes('NODE_MODULE_VERSION')) {
+      } else if (stderr.includes('NODE_MODULE_VERSION')) {
         message = 'Native module ABI mismatch detected.';
-        details =
+        hint =
           'You likely changed Node.js versions without rebuilding dependencies. ' +
           'Run `npm rebuild` or `rm -rf node_modules && npm install` to fix this.';
-      } else if (details.includes('Cannot find package')) {
+      } else if (stderr.includes('Cannot find package')) {
         message = 'Missing required dependency: @utcp/code-mode';
-        details = 'Run `npm install` to ensure all dependencies are present.';
+        hint = 'Run `npm install` to ensure all dependencies are present.';
       }
 
-      settle({
-        ok: false,
-        message,
-        details: details || `Process exited with code ${code}`,
-      });
+      const details = [hint, stderr].filter(Boolean).join('\n') || `Process exited with code ${code}`;
+      settle({ ok: false, message, details });
     });
 
     child.on('error', (err) => {


### PR DESCRIPTION
## Summary

- Fix a cwd-dependent failure in the sandbox-viability preflight: `node -e "import('@utcp/code-mode')..."` resolves the bare specifier from `<process.cwd()>/[eval]`, so running `ironcurtain` from outside the installed package tree (e.g. after `npm install -g`, from `~` or `/`) falsely reported "Missing required dependency: @utcp/code-mode" even when the package was correctly installed. Resolve the absolute path at the parent via `createRequire().resolve()` and pass it into the child via `JSON.stringify`. If the parent itself can't resolve the package, short-circuit with the underlying error instead of spawning.
- Preserve the child's stderr alongside any advisory hint in the failure path (previously the canned "Run \`npm install\`" text clobbered the actual error in `details`).
- Harden `ironcurtain doctor` to set `process.exitCode` in addition to `process.exit(code)` so CI / test harnesses that intercept `process.exit` still see the non-zero status when checks fail.

Both bugs were caught by a pre-release packaging audit (`npm pack` + install into a throwaway prefix + run from `/`). The preflight bug is the load-bearing one — it would have hit every user installing globally and invoking `ironcurtain` from anywhere other than the install tree.

## Test plan

- [x] `npm run build` + `npm pack` + `npm install --prefix /tmp/ic-pkg-test --omit=dev <tarball>`
- [x] `cd / && /tmp/ic-pkg-test/node_modules/.bin/ironcurtain doctor` → V8 sandbox now reports `OK` (was `✗ Missing required dependency: @utcp/code-mode` before the patch)
- [x] Existing preflight / doctor / run-preflight unit tests pass
- [x] `npm run lint` + `npm run format` clean (enforced by pre-commit)