### PR TITLE
feat(mux): add --capture-traces; wire capture into the PTY session path

### DIFF
--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -228,10 +228,11 @@ export class DockerAgentSession implements Session {
     // call begin/end here, or the orchestrator's richer call would be
     // silently dropped by the dispatcher's first-wins idempotency, losing
     // persona/fsmState on the `session-start` manifest entry.
-    // No-op when capture is disabled (writer absent). Method-existence guard
-    // tolerates test infrastructures that don't implement the capture
-    // surface. See docs/designs/mitm-token-trajectory-capture.md §11.
-    if (this.ownsInfra && this.infra.beginCaptureSession) {
+    // No-op when capture is disabled (writer absent). The `ownsInfra` gate
+    // is a real lifecycle decision (borrow mode lets the orchestrator drive
+    // begin/end); the method is always present.
+    // See docs/designs/mitm-token-trajectory-capture.md §11.
+    if (this.ownsInfra) {
       this.infra.beginCaptureSession({ sessionId: this.sessionId });
     }
 
@@ -457,7 +458,7 @@ export class DockerAgentSession implements Session {
     // symmetric with the begin call above: in borrow mode the orchestrator
     // owns begin/end, so the session calling end alone would terminate a
     // capture session the orchestrator is still using.
-    if (this.ownsInfra && this.infra.endCaptureSession) {
+    if (this.ownsInfra) {
       await this.infra.endCaptureSession(this.sessionId).catch((err: unknown) => {
         logger.warn(`endCaptureSession failed: ${err instanceof Error ? err.message : String(err)}`);
       });

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -219,10 +219,12 @@ export interface PreContainerInfrastructure {
    * agent emits is already tagged with the right session. See
    * docs/designs/mitm-token-trajectory-capture.md §11.
    *
-   * Marked optional (undefined when omitted on test mocks); production
-   * bundles always implement it.
+   * Always present (never optional): the method is inert when the writer
+   * is undefined, so "always present, sometimes a no-op" is correct.
+   * Making it required turns "forgot to wire capture" into a compile
+   * error instead of a silent no-op.
    */
-  beginCaptureSession?: (opts: {
+  beginCaptureSession: (opts: {
     sessionId: import('../session/types.js').SessionId;
     persona?: string;
     fsmState?: string;
@@ -235,10 +237,12 @@ export interface PreContainerInfrastructure {
    * `session.close()` so the manifest entry is durable even if `session.close()`
    * throws.
    *
-   * No-op when capture is disabled. Marked optional (undefined when
-   * omitted on test mocks); production bundles always implement it.
+   * No-op when capture is disabled. Always present (never optional): the
+   * method is inert when the writer is undefined, so "always present,
+   * sometimes a no-op" is correct, and a consumer that forgets to wire
+   * capture now fails to compile rather than silently dropping it.
    */
-  endCaptureSession?: (sessionId: import('../session/types.js').SessionId) => Promise<void>;
+  endCaptureSession: (sessionId: import('../session/types.js').SessionId) => Promise<void>;
 
   /**
    * Internal: trajectory-capture writer reference, exposed so
@@ -299,23 +303,30 @@ const BUNDLE_SKILLS_SUBDIR = 'skills';
  */
 /**
  * Optional trajectory-capture inputs threaded through to the MITM
- * proxy. When `enabled` is false (or this object is absent), no writer
- * is constructed and no taps are installed — zero cost on the
+ * proxy. Carries the RAW CLI/RPC override — this function is the single
+ * place that resolves enablement against config (`override ?? config >
+ * false`), so consumers never duplicate the `?? userConfig.capture?.enabled`
+ * precedence. When this object is absent, or resolution yields false, no
+ * writer is constructed and no taps are installed — zero cost on the
  * forwarding path. See docs/designs/mitm-token-trajectory-capture.md.
  */
-export interface CaptureSetupOptions {
+export interface CaptureSetupInput {
   /**
-   * When true, construct a TrajectoryCaptureWriter and pass it through
-   * to the MITM proxy. The writer's captures directory is
-   * `capturesDir` below.
+   * Raw CLI/RPC override (boolean | undefined); undefined falls through
+   * to `config.userConfig.capture?.enabled`, then to false. The single
+   * resolution point lives in `prepareDockerInfrastructure`.
    */
-  readonly enabled: boolean;
-  /** Absolute path where `{sessionId}.jsonl` and `manifest.jsonl` are written. */
+  readonly override?: boolean;
+  /**
+   * Absolute path where `{sessionId}.jsonl` and `manifest.jsonl` are
+   * written. A real per-path difference (session dir vs bundle dir), so
+   * the caller supplies it rather than the infra layer deriving it.
+   */
   readonly capturesDir: string;
   /** Human-readable agent name (e.g. `'claude-code'`). */
   readonly recordedAgentName?: string;
   /** Workflow run ID, when this bundle belongs to a workflow run. */
-  readonly workflowRunId?: string;
+  readonly workflowRunId?: WorkflowId;
 }
 
 export async function prepareDockerInfrastructure(
@@ -328,7 +339,7 @@ export async function prepareDockerInfrastructure(
   workflowId?: WorkflowId,
   scope?: string,
   resolvedSkills?: readonly ResolvedSkill[],
-  captureOptions?: CaptureSetupOptions,
+  captureInput?: CaptureSetupInput,
 ): Promise<PreContainerInfrastructure> {
   // The audit log path is read from config so the bundle is
   // self-describing: downstream consumers (AuditLogTailer, sandbox
@@ -478,21 +489,27 @@ export async function prepareDockerInfrastructure(
   // so agentKind is fixed at construction time.
   const agentKind: AgentKind | undefined = workflowId !== undefined ? 'workflow' : undefined;
 
+  // Single resolution point for trajectory-capture enablement. The raw
+  // CLI/RPC override wins; otherwise fall through to config; otherwise
+  // off. Consumers pass the raw override only — they never re-resolve
+  // against `userConfig.capture?.enabled`.
+  const captureEnabled = captureInput ? (captureInput.override ?? config.userConfig.capture?.enabled ?? false) : false;
+
   // Construct the trajectory-capture writer when capture is enabled.
   // When disabled, no writer is created, no taps are installed, and the
   // forwarding path is byte-identical to today (per §10 "zero cost when
   // disabled").
   let captureWriter: TrajectoryCaptureWriter | undefined;
-  if (captureOptions?.enabled) {
+  if (captureEnabled && captureInput) {
     const { createTrajectoryCaptureWriter } = await import('./trajectory-capture.js');
-    captureWriter = createTrajectoryCaptureWriter({ capturesDir: captureOptions.capturesDir });
+    captureWriter = createTrajectoryCaptureWriter({ capturesDir: captureInput.capturesDir });
   }
 
   const captureProxyOptions = captureWriter
     ? {
         capture: captureWriter,
-        recordedAgentName: captureOptions?.recordedAgentName,
-        workflowRunId: captureOptions?.workflowRunId,
+        recordedAgentName: captureInput?.recordedAgentName,
+        workflowRunId: captureInput?.workflowRunId,
         bundleId: String(bundleId),
       }
     : {};
@@ -693,7 +710,7 @@ export async function createDockerInfrastructure(
   workflowId?: WorkflowId,
   scope?: string,
   resolvedSkills?: readonly ResolvedSkill[],
-  captureOptions?: CaptureSetupOptions,
+  captureInput?: CaptureSetupInput,
 ): Promise<DockerInfrastructure> {
   const core = await prepareDockerInfrastructure(
     config,
@@ -705,7 +722,7 @@ export async function createDockerInfrastructure(
     workflowId,
     scope,
     resolvedSkills,
-    captureOptions,
+    captureInput,
   );
 
   try {

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -47,6 +47,12 @@ export interface PtySessionOptions {
   /** Persona name. Used to build CLAUDE.md and system prompt augmentation. */
   readonly persona?: string;
   /**
+   * Trajectory-capture override: CLI flag wins over `userConfig.capture.enabled`.
+   * `true` forces capture on for this run, `undefined` falls through to config.
+   * See docs/designs/mitm-token-trajectory-capture.md §10.
+   */
+  readonly captureTracesOverride?: boolean;
+  /**
    * Override for the PTY attach step. Defaults to the production `attachPty`
    * which proxies the user's terminal into the container PTY socket.
    * Tests inject a stub that performs assertions against the live container
@@ -257,6 +263,13 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
   let docker: Awaited<ReturnType<typeof prepareDockerInfrastructure>>['docker'] | null = null;
   let useTcp: boolean;
   let networkName: string | null = null;
+  // Flushes the trajectory-capture session (clean, non-poisoned session-end)
+  // before infra teardown. Assigned inside the try once the bundle exists;
+  // invoked in finally. Undefined when capture is disabled. PTY mode tears
+  // down proxies manually (it does not call destroyDockerInfrastructure), so
+  // this explicit flush is required for a clean capture — the destroy-time
+  // safety net does not run here.
+  let flushCapture: (() => Promise<void>) | undefined;
   let ptyExitCode: number | null = null;
   let adapterIdForSnapshot: string | null = null;
   let adapterDisplayNameForSnapshot: string | null = null;
@@ -275,6 +288,17 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     // this keeps the deterministic `ironcurtain-pty-<id[0:12]>` container
     // name that prior-crash recovery depends on.
     const bundleId = effectiveSessionId as BundleId;
+    // Trajectory-capture resolution: CLI override > userConfig > false. The
+    // writer is constructed only when enabled — zero cost when disabled.
+    const captureEnabled = options.captureTracesOverride ?? options.config.userConfig.capture?.enabled ?? false;
+    const { getSessionCapturesDir } = await import('../config/paths.js');
+    const captureOptions = captureEnabled
+      ? {
+          enabled: true as const,
+          capturesDir: getSessionCapturesDir(effectiveSessionId),
+          recordedAgentName: options.mode.agent,
+        }
+      : undefined;
     const infra = await prepareDockerInfrastructure(
       sessionConfig,
       options.mode,
@@ -285,10 +309,34 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       undefined,
       undefined,
       dirConfig.resolvedSkills,
+      captureOptions,
     );
     // PTY sessions are standalone: pin the MITM proxy's token-stream
     // routing ID to this session's ID for the session's lifetime.
-    infra.setTokenSessionId(effectiveSessionId as import('../session/types.js').SessionId);
+    const captureSessionId = effectiveSessionId as import('../session/types.js').SessionId;
+    infra.setTokenSessionId(captureSessionId);
+
+    // Begin trajectory capture (no-op when disabled). Standalone PTY runs
+    // exactly one session through the bundle. The matching flush is in the
+    // finally block, awaited BEFORE proxy teardown (§11 ordering) so the
+    // session-end manifest entry is durable. PTY mode does not call
+    // destroyDockerInfrastructure, so we both end the session (clean,
+    // non-poisoned end) and close the writer here.
+    infra.beginCaptureSession?.({ sessionId: captureSessionId });
+    if (infra.captureWriter) {
+      flushCapture = async () => {
+        await infra
+          .endCaptureSession?.(captureSessionId)
+          .catch((err: unknown) =>
+            logger.warn(`PTY capture endSession failed: ${err instanceof Error ? err.message : String(err)}`),
+          );
+        await infra.captureWriter
+          ?.close()
+          .catch((err: unknown) =>
+            logger.warn(`PTY capture writer close failed: ${err instanceof Error ? err.message : String(err)}`),
+          );
+      };
+    }
 
     ({ docker, proxy, mitmProxy, useTcp } = infra);
     const {
@@ -628,6 +676,12 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       } catch {
         /* best effort */
       }
+    }
+
+    // Flush trajectory capture before proxy teardown so the session-end
+    // manifest entry is durable (§11). No-op when capture is disabled.
+    if (flushCapture) {
+      await flushCapture();
     }
 
     if (docker) {

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -29,7 +29,7 @@ import { PTY_SOCK_NAME, DEFAULT_PTY_PORT } from './pty-types.js';
 import type { PtySessionRegistration, SessionSnapshot } from './pty-types.js';
 import { createEscalationWatcher, atomicWriteJsonSync } from '../escalation/escalation-watcher.js';
 import type { EscalationWatcher } from '../escalation/escalation-watcher.js';
-import { getSessionDir, getPtyRegistryDir, SESSION_STATE_FILENAME } from '../config/paths.js';
+import { getSessionDir, getSessionCapturesDir, getPtyRegistryDir, SESSION_STATE_FILENAME } from '../config/paths.js';
 import * as logger from '../logger.js';
 import { buildDockerClaudeMd } from './claude-md-seed.js';
 import { getInternalNetworkName } from './platform.js';
@@ -291,7 +291,6 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     // Trajectory-capture: pass the RAW override; the infra layer is the
     // single place that resolves it against userConfig. The writer is
     // constructed only when enabled — zero cost when disabled.
-    const { getSessionCapturesDir } = await import('../config/paths.js');
     const infra = await prepareDockerInfrastructure(
       sessionConfig,
       options.mode,

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -288,17 +288,10 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     // this keeps the deterministic `ironcurtain-pty-<id[0:12]>` container
     // name that prior-crash recovery depends on.
     const bundleId = effectiveSessionId as BundleId;
-    // Trajectory-capture resolution: CLI override > userConfig > false. The
-    // writer is constructed only when enabled — zero cost when disabled.
-    const captureEnabled = options.captureTracesOverride ?? options.config.userConfig.capture?.enabled ?? false;
+    // Trajectory-capture: pass the RAW override; the infra layer is the
+    // single place that resolves it against userConfig. The writer is
+    // constructed only when enabled — zero cost when disabled.
     const { getSessionCapturesDir } = await import('../config/paths.js');
-    const captureOptions = captureEnabled
-      ? {
-          enabled: true as const,
-          capturesDir: getSessionCapturesDir(effectiveSessionId),
-          recordedAgentName: options.mode.agent,
-        }
-      : undefined;
     const infra = await prepareDockerInfrastructure(
       sessionConfig,
       options.mode,
@@ -309,7 +302,11 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       undefined,
       undefined,
       dirConfig.resolvedSkills,
-      captureOptions,
+      {
+        override: options.captureTracesOverride,
+        capturesDir: getSessionCapturesDir(effectiveSessionId),
+        recordedAgentName: options.mode.agent,
+      },
     );
     // PTY sessions are standalone: pin the MITM proxy's token-stream
     // routing ID to this session's ID for the session's lifetime.
@@ -322,11 +319,11 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     // session-end manifest entry is durable. PTY mode does not call
     // destroyDockerInfrastructure, so we both end the session (clean,
     // non-poisoned end) and close the writer here.
-    infra.beginCaptureSession?.({ sessionId: captureSessionId });
+    infra.beginCaptureSession({ sessionId: captureSessionId });
     if (infra.captureWriter) {
       flushCapture = async () => {
         await infra
-          .endCaptureSession?.(captureSessionId)
+          .endCaptureSession(captureSessionId)
           .catch((err: unknown) =>
             logger.warn(`PTY capture endSession failed: ${err instanceof Error ? err.message : String(err)}`),
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ export async function main(args?: string[]): Promise<void> {
       workspacePath,
       resumeSessionId,
       persona: resumeSessionId ? undefined : personaName,
+      captureTracesOverride,
     });
     process.exit(0);
   }

--- a/src/mux/mux-app.ts
+++ b/src/mux/mux-app.ts
@@ -33,6 +33,8 @@ export interface MuxAppOptions {
   readonly agent?: string;
   /** Optional model ID override (passed as --model to child sessions). */
   readonly model?: string;
+  /** When true, spawned child sessions capture LLM API traces (`--capture-traces`). */
+  readonly captureTraces?: boolean;
   /** Whether to auto-spawn an initial session. Default: true. */
   readonly autoSpawn?: boolean;
   /** Protected paths for workspace validation. */
@@ -118,6 +120,7 @@ export function createMuxApp(options: MuxAppOptions): MuxApp {
       resumeSessionId: opts?.resumeSessionId,
       persona: opts?.persona,
       model: options.model,
+      captureTraces: options.captureTraces,
       muxId: options.muxId,
       muxPid: options.muxPid,
     });

--- a/src/mux/mux-command.ts
+++ b/src/mux/mux-command.ts
@@ -32,6 +32,10 @@ const muxSpec: CommandSpec = {
   options: [
     { flag: 'agent', short: 'a', description: 'Agent mode (default: from config)', placeholder: '<name>' },
     { flag: 'model', short: 'm', description: 'Override the agent model ID', placeholder: '<model>' },
+    {
+      flag: 'capture-traces',
+      description: 'Capture LLM API traces for sessions spawned by this mux (overrides config)',
+    },
   ],
 };
 
@@ -124,6 +128,7 @@ export async function main(args?: string[], deps: MuxMainDeps = {}): Promise<voi
       help: { type: 'boolean', short: 'h' },
       agent: { type: 'string', short: 'a' },
       model: { type: 'string', short: 'm' },
+      'capture-traces': { type: 'boolean' },
     },
     allowPositionals: true,
     strict: false,
@@ -133,6 +138,9 @@ export async function main(args?: string[], deps: MuxMainDeps = {}): Promise<voi
 
   const requestedAgentRaw = values.agent as string | undefined;
   const model = values.model as string | undefined;
+  // CLI flag forces capture on for spawned sessions; absence falls through to
+  // each child's config resolution (so we pass the flag, never an explicit off).
+  const captureTraces = (values['capture-traces'] as boolean | undefined) ? true : undefined;
 
   const config = loadConfig();
 
@@ -183,6 +191,7 @@ export async function main(args?: string[], deps: MuxMainDeps = {}): Promise<voi
   const app = createApp({
     agent: resolvedAgent,
     model,
+    captureTraces,
     autoSpawn: false,
     protectedPaths: config.protectedPaths,
     muxId,

--- a/src/mux/pty-bridge.ts
+++ b/src/mux/pty-bridge.ts
@@ -96,6 +96,8 @@ export interface PtyBridgeOptions {
   readonly persona?: string;
   /** Optional model ID override (passed as --model to the child). */
   readonly model?: string;
+  /** When true, pass `--capture-traces` to the child `ironcurtain start --pty`. */
+  readonly captureTraces?: boolean;
   /** Mux instance ID to propagate to child sessions via env var. */
   readonly muxId?: string;
   /** Mux process PID to propagate to child sessions via env var. */
@@ -132,6 +134,9 @@ export async function createPtyBridge(options: PtyBridgeOptions): Promise<PtyBri
   }
   if (options.model) {
     spawnArgs.push('--model', options.model);
+  }
+  if (options.captureTraces) {
+    spawnArgs.push('--capture-traces');
   }
   // Create a copy of process.env so we don't mutate the shared object
   const childEnv: Record<string, string> = { ...(process.env as Record<string, string>) };

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -27,6 +27,7 @@ import {
   SESSION_METADATA_FILENAME,
 } from '../config/paths.js';
 import { validatePolicyDir as sharedValidatePolicyDir } from '../config/validate-policy-dir.js';
+import { getSessionCapturesDir } from '../config/paths.js';
 import type { IronCurtainConfig } from '../config/types.js';
 import * as logger from '../logger.js';
 import { resolvePersona, applyServerAllowlist, filterMcpServersByPolicy } from '../persona/resolve.js';
@@ -287,7 +288,6 @@ async function createDockerSession(
       // single place that resolves it against userConfig. Writer is only
       // constructed when enabled — zero cost when disabled. See
       // docs/designs/mitm-token-trajectory-capture.md §10.
-      const { getSessionCapturesDir } = await import('../config/paths.js');
       infra = await createDockerInfrastructure(
         sessionConfig.config,
         { kind: 'docker', agent: agentId },

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -283,18 +283,11 @@ async function createDockerSession(
       // name for prior-crash recovery.
       const bundleId = bundleIdFromSessionId(sessionId);
       const { createDockerInfrastructure } = await import('../docker/docker-infrastructure.js');
-      // Trajectory-capture resolution: CLI / RPC override > userConfig > false.
-      // See docs/designs/mitm-token-trajectory-capture.md §10. Writer is
-      // only constructed when enabled — zero cost when disabled.
-      const captureEnabled = options.captureTracesOverride ?? sessionConfig.config.userConfig.capture?.enabled ?? false;
+      // Trajectory-capture: pass the RAW override; the infra layer is the
+      // single place that resolves it against userConfig. Writer is only
+      // constructed when enabled — zero cost when disabled. See
+      // docs/designs/mitm-token-trajectory-capture.md §10.
       const { getSessionCapturesDir } = await import('../config/paths.js');
-      const captureOptions = captureEnabled
-        ? {
-            enabled: true,
-            capturesDir: getSessionCapturesDir(sessionId),
-            recordedAgentName: agentId,
-          }
-        : undefined;
       infra = await createDockerInfrastructure(
         sessionConfig.config,
         { kind: 'docker', agent: agentId },
@@ -305,7 +298,11 @@ async function createDockerSession(
         undefined,
         undefined,
         sessionConfig.resolvedSkills,
-        captureOptions,
+        {
+          override: options.captureTracesOverride,
+          capturesDir: getSessionCapturesDir(sessionId),
+          recordedAgentName: agentId,
+        },
       );
       // Standalone sessions use their bundle for the session's entire
       // lifetime; pin the token-stream routing ID to this session's ID.

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -50,6 +50,7 @@ import {
 } from '../config/paths.js';
 import { POLICY_LOAD_PATH } from '../trusted-process/control-server.js';
 import { loadConfig, loadPersonaPolicyArtifacts } from '../config/index.js';
+import { getBundleCapturesDir } from '../config/paths.js';
 import { validatePolicyDir } from '../config/validate-policy-dir.js';
 import type { ResolvedUserConfig } from '../config/user-config.js';
 import { getTokenStreamBus } from '../docker/token-stream-bus.js';
@@ -1022,7 +1023,6 @@ export class WorkflowOrchestrator implements WorkflowController {
     const { createDockerInfrastructure } = await import('../docker/docker-infrastructure.js');
     const { loadConfig, applyAllowedDirectoryToMcpArgs } = await import('../config/index.js');
     const { filterMcpServersByPolicy } = await import('../persona/resolve.js');
-    const { getBundleCapturesDir } = await import('../config/paths.js');
 
     // The raw `--capture-traces` override is threaded through unresolved;
     // the infrastructure factory is the single place that resolves it

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -404,13 +404,16 @@ export interface WorkflowOrchestratorDeps {
   readonly loadPolicyRpc?: (input: LoadPolicyRpcInput) => Promise<void>;
 
   /**
-   * Resolved trajectory-capture enablement for this workflow run. When
-   * true, the default infrastructure factory constructs a writer for
-   * each bundle, and `executeAgentState` brackets each agent's session
-   * with `bundle.beginCaptureSession` / `bundle.endCaptureSession`.
-   * Defaults to false. See docs/designs/mitm-token-trajectory-capture.md §10.
+   * Raw trajectory-capture override for this workflow run (CLI
+   * `--capture-traces` flag). Passed UNRESOLVED to the infrastructure
+   * factory, which is the single place that resolves it against
+   * `userConfig.capture?.enabled`. When resolution yields true, the
+   * factory constructs a writer for each bundle and `executeAgentState`
+   * brackets each agent's session with `bundle.beginCaptureSession` /
+   * `bundle.endCaptureSession`. Undefined falls through to config.
+   * See docs/designs/mitm-token-trajectory-capture.md §10.
    */
-  readonly captureEnabled?: boolean;
+  readonly captureTracesOverride?: boolean;
 }
 
 /** Lifecycle events emitted by the orchestrator. */
@@ -1021,11 +1024,11 @@ export class WorkflowOrchestrator implements WorkflowController {
     const { filterMcpServersByPolicy } = await import('../persona/resolve.js');
     const { getBundleCapturesDir } = await import('../config/paths.js');
 
-    // Resolve capture enablement once for the entire workflow run.
-    // Precedence: orchestrator dep flag (set by CLI) > userConfig > false.
-    // The same value is applied to every scope's bundle.
-    const baseUserConfig = loadConfig().userConfig;
-    const captureEnabled = this.deps.captureEnabled ?? baseUserConfig.capture?.enabled ?? false;
+    // The raw `--capture-traces` override is threaded through unresolved;
+    // the infrastructure factory is the single place that resolves it
+    // against `userConfig.capture?.enabled`. The same raw override is
+    // applied to every scope's bundle.
+    const captureTracesOverride = this.deps.captureTracesOverride;
 
     return async (input) => {
       const config = loadConfig();
@@ -1056,14 +1059,6 @@ export class WorkflowOrchestrator implements WorkflowController {
       config.auditLogPath = getBundleAuditLogPath(input.workflowId, input.bundleId);
       config.mcpServers = filterMcpServersByPolicy(config.mcpServers, input.requiredServers);
       applyAllowedDirectoryToMcpArgs(config.mcpServers, input.workspacePath);
-      const captureOptions = captureEnabled
-        ? {
-            enabled: true,
-            capturesDir: getBundleCapturesDir(input.workflowId, input.bundleId),
-            recordedAgentName: input.agentId,
-            workflowRunId: input.workflowId,
-          }
-        : undefined;
       return createDockerInfrastructure(
         config,
         { kind: 'docker', agent: input.agentId },
@@ -1077,7 +1072,12 @@ export class WorkflowOrchestrator implements WorkflowController {
         input.workflowId,
         input.scope,
         input.resolvedSkills,
-        captureOptions,
+        {
+          override: captureTracesOverride,
+          capturesDir: getBundleCapturesDir(input.workflowId, input.bundleId),
+          recordedAgentName: input.agentId,
+          workflowRunId: input.workflowId,
+        },
       );
     };
   }
@@ -2029,10 +2029,9 @@ export class WorkflowOrchestrator implements WorkflowController {
       // begin/end pair on the bundle. The matching `endCaptureSession`
       // is in the finally block, awaited BEFORE session.close() per §11
       // so the manifest entry is durable even if close() throws.
-      // Method-existence check (not just `bundle?.`) tolerates test
-      // bundles that satisfy `DockerInfrastructure` structurally without
-      // implementing the new capture surface.
-      if (bundle?.beginCaptureSession) {
+      // `bundle` is genuinely optional (builtin / per-state-container
+      // workflows have no shared bundle); the method is always present.
+      if (bundle) {
         bundle.beginCaptureSession({
           sessionId: agentSessionId,
           persona: stateConfig.persona,
@@ -2220,9 +2219,9 @@ export class WorkflowOrchestrator implements WorkflowController {
       // session.close() throws. The two-phase drain inside
       // endCaptureSession waits for in-flight reassembly to settle
       // before enqueuing the manifest end-marker (§9 / §11).
-      // Method-existence check tolerates test bundles that satisfy
-      // `DockerInfrastructure` structurally without implementing capture.
-      if (bundle?.endCaptureSession) {
+      // `bundle` is genuinely optional (builtin / per-state-container
+      // workflows); the method is always present when the bundle is.
+      if (bundle) {
         await bundle.endCaptureSession(endedSessionId).catch((err: unknown) => {
           writeStderr(`[workflow] endCaptureSession failed for "${stateId}": ${toErrorMessage(err)}`);
         });

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -260,9 +260,6 @@ async function runStart(args: string[]): Promise<void> {
   const gateHandler = createGateHandler();
   const sessionFactory = createWorkflowSessionFactory(modelOverride);
   const config = loadConfig();
-  // Capture precedence: CLI flag > userConfig > false. Resolved once
-  // for the workflow run and applied uniformly to every bundle.
-  const captureEnabled = captureTracesFlag ?? config.userConfig.capture?.enabled ?? false;
 
   const deps: WorkflowOrchestratorDeps = {
     createSession: sessionFactory,
@@ -272,7 +269,9 @@ async function runStart(args: string[]): Promise<void> {
     baseDir,
     checkpointStore,
     userConfig: config.userConfig,
-    captureEnabled,
+    // Pass the RAW --capture-traces flag; the infrastructure factory
+    // resolves it against userConfig (single resolution point).
+    captureTracesOverride: captureTracesFlag,
   };
 
   const orchestrator = new WorkflowOrchestrator(deps);

--- a/test/docker-agent-session-retry.test.ts
+++ b/test/docker-agent-session-retry.test.ts
@@ -86,6 +86,8 @@ function buildDeps(
     authKind: 'apikey',
     containerId: 'container-abc123',
     containerName: 'ironcurtain-test',
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   };
 
   return {

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -406,6 +406,8 @@ function makeMockCore(opts: MockCoreOptions): PreContainerInfrastructure {
     authKind: 'apikey',
     setTokenSessionId: () => {},
     restageSkills: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   };
 }
 

--- a/test/docker-session-factory.test.ts
+++ b/test/docker-session-factory.test.ts
@@ -181,6 +181,8 @@ function createMockInfra(rootDir: string, idSuffix = 'borrow'): DockerInfrastruc
     internalNetwork: undefined,
     setTokenSessionId: () => {},
     restageSkills: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   };
 }
 

--- a/test/docker-session.test.ts
+++ b/test/docker-session.test.ts
@@ -222,6 +222,8 @@ function createMockInfra(opts: MockInfraOptions): DockerInfrastructure {
     sidecarContainerId: opts.sidecarContainerId,
     internalNetwork: opts.internalNetwork,
     setTokenSessionId: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   };
 }
 

--- a/test/mux-command.test.ts
+++ b/test/mux-command.test.ts
@@ -178,6 +178,36 @@ describe('ironcurtain mux preflight integration', () => {
     expect(stderrText).toMatch(/Mode: docker \/ claude-code \(API key\)/);
   });
 
+  it('--capture-traces forwards captureTraces: true to the MuxApp', async () => {
+    const resolveSessionMode = vi.fn().mockResolvedValue(makePreflightSuccess('claude-code'));
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await muxMain(['--capture-traces'], {
+      resolveSessionMode,
+      createMuxApp,
+      skipNativeProbes: true,
+    });
+
+    expect(createMuxApp).toHaveBeenCalledOnce();
+    const appOptions = createMuxApp.mock.calls[0][0] as MuxAppOptions;
+    expect(appOptions.captureTraces).toBe(true);
+  });
+
+  it('without --capture-traces, captureTraces is undefined (child falls through to config)', async () => {
+    const resolveSessionMode = vi.fn().mockResolvedValue(makePreflightSuccess('claude-code'));
+    const createMuxApp = vi.fn(() => makeFakeMuxApp());
+
+    await muxMain([], {
+      resolveSessionMode,
+      createMuxApp,
+      skipNativeProbes: true,
+    });
+
+    expect(createMuxApp).toHaveBeenCalledOnce();
+    const appOptions = createMuxApp.mock.calls[0][0] as MuxAppOptions;
+    expect(appOptions.captureTraces).toBeUndefined();
+  });
+
   it('PreflightError is printed in red and exits with code 1; MuxApp is NOT constructed', async () => {
     const resolveSessionMode = vi.fn().mockRejectedValue(new PreflightError('Docker is not available'));
     const createMuxApp = vi.fn(() => makeFakeMuxApp());

--- a/test/skills-end-to-end.integration.test.ts
+++ b/test/skills-end-to-end.integration.test.ts
@@ -121,6 +121,8 @@ function makeBundleStub(workflowId: string, bundleId: BundleId, bundleDir: strin
     restageSkills: (skills: readonly ResolvedSkill[]) => {
       stageSkillsToBundle(skills, skillsDir);
     },
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   } as unknown as DockerInfrastructure;
 }
 

--- a/test/workflow/orchestrator-bifurcated.test.ts
+++ b/test/workflow/orchestrator-bifurcated.test.ts
@@ -55,6 +55,8 @@ function makeStubInfrastructure(
     bundleId,
     scope,
     setTokenSessionId: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   } as unknown as DockerInfrastructure & { readonly __scope: string };
 }
 
@@ -404,6 +406,9 @@ describe('WorkflowOrchestrator bifurcated workflow (containerScope)', () => {
       workflowId,
       bundleId: factoryInput?.bundleId ?? ('fake' as BundleId),
       scope: factoryInput?.scope,
+      setTokenSessionId: () => {},
+      beginCaptureSession: () => {},
+      endCaptureSession: async () => {},
     } as unknown as DockerInfrastructure;
     releaseFactory(mintedBundle);
 

--- a/test/workflow/orchestrator-policy-cycling.test.ts
+++ b/test/workflow/orchestrator-policy-cycling.test.ts
@@ -47,6 +47,8 @@ function makeStubInfrastructure(workflowId: string, bundleId: BundleId): DockerI
     workflowId,
     bundleId,
     setTokenSessionId: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   } as unknown as DockerInfrastructure;
 }
 

--- a/test/workflow/orchestrator-session-paths.test.ts
+++ b/test/workflow/orchestrator-session-paths.test.ts
@@ -47,6 +47,8 @@ function makeStubInfrastructure(workflowId: string, bundleId: BundleId): DockerI
     workflowId,
     bundleId,
     setTokenSessionId: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   } as unknown as DockerInfrastructure;
 }
 

--- a/test/workflow/orchestrator-shared-container.test.ts
+++ b/test/workflow/orchestrator-shared-container.test.ts
@@ -42,6 +42,8 @@ function makeStubInfrastructure(workflowId: string, bundleId: BundleId): DockerI
     workflowId,
     bundleId,
     setTokenSessionId: () => {},
+    beginCaptureSession: () => {},
+    endCaptureSession: async () => {},
   } as unknown as DockerInfrastructure;
   return bundle;
 }
@@ -574,6 +576,8 @@ describe('WorkflowOrchestrator shared-container mode', () => {
           setTokenSessionId: (id: string | undefined) => {
             tokenSessionIdCalls.push(id);
           },
+          beginCaptureSession: () => {},
+          endCaptureSession: async () => {},
         } as unknown as DockerInfrastructure;
         return bundle;
       });
@@ -654,6 +658,8 @@ describe('WorkflowOrchestrator shared-container mode', () => {
           setTokenSessionId: (id: string | undefined) => {
             tokenSessionIdCalls.push(id);
           },
+          beginCaptureSession: () => {},
+          endCaptureSession: async () => {},
         } as unknown as DockerInfrastructure;
       });
       const destroyInfra = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Adds `--capture-traces` to `ironcurtain mux`, propagated to every PTY session the multiplexer spawns. The flag threads:

`mux --capture-traces` → `MuxAppOptions.captureTraces` → `createPtyBridge` → child argv `ironcurtain start --pty --capture-traces`.

## Also fixes a latent gap

Capture was wired into the **batch** `docker-agent-session.ts` path (and the workflow orchestrator), but **not** into `runPtySession` / `pty-session.ts`. So `ironcurtain start --pty --capture-traces` was silently a no-op — the flag parsed but was never passed to the PTY session. This is exactly the "keep dual session modes in sync" rule from `src/docker/CLAUDE.md`.

`runPtySession` now:
- resolves capture (CLI override > `userConfig.capture.enabled` > false),
- passes `CaptureSetupOptions` to `prepareDockerInfrastructure` (the infra layer already supported it),
- brackets the session with `beginCaptureSession`,
- and — because PTY tears down proxies **manually** rather than via `destroyDockerInfrastructure` (whose safety-net flush never runs here) — explicitly calls `endCaptureSession` + `captureWriter.close()` in `finally` **before** proxy teardown, so the `session-end` manifest entry is durable and the session ends **clean (non-poisoned)** per the §11 ordering.

## Zero cost when disabled

No writer constructed, no taps installed — identical to the existing `start`/`workflow`/`daemon` behavior when capture is off. There is no `--no-capture-traces` (consistent with the rest of the feature); the mux flag forces-on and otherwise falls through to each child's config resolution.

## Tests

- Two new `mux-command` tests: `--capture-traces` → `captureTraces: true` reaches `MuxAppOptions`; absence → `undefined`.
- Existing suites green: `mux-command` (9), `pty-session` (16), `docker`/trajectory (391). tsc / eslint / prettier clean.

Capturing the actual trajectory from a live `mux` tab needs Docker + an interactive PTY (not runnable in CI); the wiring is verified by unit tests and by `mux --help` showing the flag. Per-session JSONL lands under `~/.ironcurtain/sessions/<sessionId>/captures/` (standalone PTY layout), per `TRAJECTORIES.md`.