### PR TITLE
fix(cli): strict arg parsing for leaf subcommands

### DIFF
--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -5,6 +5,8 @@
  * so every subcommand produces consistent, aligned help output.
  */
 
+import { parseArgs } from 'node:util';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -140,4 +142,27 @@ export function checkHelp(values: { help?: boolean }, spec: CommandSpec): boolea
   if (!values.help) return false;
   printHelp(spec);
   return true;
+}
+
+/**
+ * Strict `parseArgs` for leaf subcommands. Forces `strict: true` so an unknown
+ * option (or a missing value for a string option) is rejected rather than
+ * silently swallowed. On a parse error, prints the message plus a usage hint
+ * referencing `commandName` (e.g. `ironcurtain daemon`) and exits 1.
+ *
+ * Routers that forward unrecognized flags to a deeper parser must keep using
+ * `parseArgs({ strict: false })` directly — this helper is for leaves that
+ * actually consume their flags.
+ */
+export function parseArgsStrict(
+  config: Omit<Parameters<typeof parseArgs>[0], 'strict'>,
+  commandName: string,
+): ReturnType<typeof parseArgs> {
+  try {
+    return parseArgs({ ...config, strict: true });
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.stderr.write(`Run \`${commandName} --help\` for usage.\n`);
+    process.exit(1);
+  }
 }

--- a/src/daemon/daemon-command.ts
+++ b/src/daemon/daemon-command.ts
@@ -11,12 +11,11 @@
  * Otherwise, the command operates directly on the filesystem.
  */
 
-import { parseArgs } from 'node:util';
 import { IronCurtainDaemon } from './ironcurtain-daemon.js';
 import { sendControlRequest, type ControlRequest, type ControlResponse } from './control-socket.js';
 import type { AgentId } from '../docker/agent-adapter.js';
 import { formatDuration } from '../cron/format-utils.js';
-import { checkHelp, type CommandSpec } from '../cli-help.js';
+import { checkHelp, parseArgsStrict, type CommandSpec } from '../cli-help.js';
 
 const daemonSpec: CommandSpec = {
   name: 'ironcurtain daemon',
@@ -87,22 +86,24 @@ function handleForwardedResponse(response: ControlResponse | null, successMessag
 }
 
 export async function runDaemonCommand(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    options: {
-      agent: { type: 'string', short: 'a' },
-      'no-signal': { type: 'boolean' },
-      'web-ui': { type: 'boolean' },
-      'web-port': { type: 'string' },
-      'web-ui-dev': { type: 'boolean' },
-      'capture-traces': { type: 'boolean' },
-      force: { type: 'boolean', short: 'f' },
-      runs: { type: 'string' },
-      help: { type: 'boolean', short: 'h' },
+  const { values, positionals } = parseArgsStrict(
+    {
+      args: argv,
+      options: {
+        agent: { type: 'string', short: 'a' },
+        'no-signal': { type: 'boolean' },
+        'web-ui': { type: 'boolean' },
+        'web-port': { type: 'string' },
+        'web-ui-dev': { type: 'boolean' },
+        'capture-traces': { type: 'boolean' },
+        force: { type: 'boolean', short: 'f' },
+        runs: { type: 'string' },
+        help: { type: 'boolean', short: 'h' },
+      },
+      allowPositionals: true,
     },
-    allowPositionals: true,
-    strict: false,
-  });
+    daemonSpec.name,
+  );
 
   if (checkHelp(values as { help?: boolean }, daemonSpec)) {
     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseArgs } from 'node:util';
 import chalk from 'chalk';
 import ora from 'ora';
 import {
@@ -12,7 +11,7 @@ import {
   getPackageGeneratedDir,
 } from './config/index.js';
 import { getUserConfigPath } from './config/paths.js';
-import { checkHelp, type CommandSpec } from './cli-help.js';
+import { checkHelp, parseArgsStrict, type CommandSpec } from './cli-help.js';
 import * as logger from './logger.js';
 import { CliTransport } from './session/cli-transport.js';
 import { createStandaloneSession } from './session/index.js';
@@ -48,22 +47,24 @@ const startSpec: CommandSpec = {
 };
 
 export async function main(args?: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: args ?? process.argv.slice(2),
-    options: {
-      help: { type: 'boolean', short: 'h' },
-      resume: { type: 'string', short: 'r' },
-      agent: { type: 'string', short: 'a' },
-      workspace: { type: 'string', short: 'w' },
-      persona: { type: 'string', short: 'p' },
-      pty: { type: 'boolean' },
-      model: { type: 'string', short: 'm' },
-      'capture-traces': { type: 'boolean' },
-      'list-agents': { type: 'boolean' },
+  const { values, positionals } = parseArgsStrict(
+    {
+      args: args ?? process.argv.slice(2),
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        resume: { type: 'string', short: 'r' },
+        agent: { type: 'string', short: 'a' },
+        workspace: { type: 'string', short: 'w' },
+        persona: { type: 'string', short: 'p' },
+        pty: { type: 'boolean' },
+        model: { type: 'string', short: 'm' },
+        'capture-traces': { type: 'boolean' },
+        'list-agents': { type: 'boolean' },
+      },
+      allowPositionals: true,
     },
-    allowPositionals: true,
-    strict: false,
-  });
+    startSpec.name,
+  );
 
   if (checkHelp(values as { help?: boolean }, startSpec)) return;
 

--- a/src/mux/mux-command.ts
+++ b/src/mux/mux-command.ts
@@ -10,12 +10,11 @@ import { randomBytes } from 'node:crypto';
 import { chmodSync, constants, mkdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseArgs } from 'node:util';
 import { getPtyRegistryDir } from '../config/paths.js';
 import type { ResolvedUserConfig } from '../config/user-config.js';
 import { parseModelId, resolveApiKeyForProvider } from '../config/model-provider.js';
 import { loadConfig } from '../config/index.js';
-import { checkHelp, type CommandSpec } from '../cli-help.js';
+import { checkHelp, parseArgsStrict, type CommandSpec } from '../cli-help.js';
 import {
   resolveSessionMode as defaultResolveSessionMode,
   formatModeLine,
@@ -122,17 +121,19 @@ export async function main(args?: string[], deps: MuxMainDeps = {}): Promise<voi
   }
 
   // Parse args
-  const { values } = parseArgs({
-    args: args ?? [],
-    options: {
-      help: { type: 'boolean', short: 'h' },
-      agent: { type: 'string', short: 'a' },
-      model: { type: 'string', short: 'm' },
-      'capture-traces': { type: 'boolean' },
+  const { values } = parseArgsStrict(
+    {
+      args: args ?? [],
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        agent: { type: 'string', short: 'a' },
+        model: { type: 'string', short: 'm' },
+        'capture-traces': { type: 'boolean' },
+      },
+      allowPositionals: true,
     },
-    allowPositionals: true,
-    strict: false,
-  });
+    muxSpec.name,
+  );
 
   if (checkHelp(values as { help?: boolean }, muxSpec)) return;
 

--- a/src/observe/observe-command.ts
+++ b/src/observe/observe-command.ts
@@ -10,12 +10,11 @@
  * line-oriented renderer.
  */
 
-import { parseArgs } from 'node:util';
 import { readFileSync } from 'node:fs';
 import chalk from 'chalk';
 import { WebSocket } from 'ws';
 
-import { checkHelp, type CommandSpec } from '../cli-help.js';
+import { checkHelp, parseArgsStrict, type CommandSpec } from '../cli-help.js';
 import { getWebUiStatePath } from '../config/paths.js';
 import { renderEventBatch, renderConnected, renderSessionEnded, type RenderOptions } from './observe-renderer.js';
 import { wsDataToString } from '../web-ui/ws-utils.js';
@@ -151,19 +150,21 @@ function handlePushEvent(
 // ---------------------------------------------------------------------------
 
 export async function runObserveCommand(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    options: {
-      all: { type: 'boolean' },
-      raw: { type: 'boolean' },
-      debug: { type: 'boolean' },
-      json: { type: 'boolean' },
-      'no-tui': { type: 'boolean' },
-      help: { type: 'boolean', short: 'h' },
+  const { values, positionals } = parseArgsStrict(
+    {
+      args: argv,
+      options: {
+        all: { type: 'boolean' },
+        raw: { type: 'boolean' },
+        debug: { type: 'boolean' },
+        json: { type: 'boolean' },
+        'no-tui': { type: 'boolean' },
+        help: { type: 'boolean', short: 'h' },
+      },
+      allowPositionals: true,
     },
-    allowPositionals: true,
-    strict: false,
-  });
+    observeSpec.name,
+  );
 
   if (checkHelp(values as { help?: boolean }, observeSpec)) return;
 

--- a/src/persona/persona-command.ts
+++ b/src/persona/persona-command.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync
 import { join } from 'node:path';
 import { parseArgs } from 'node:util';
 import chalk from 'chalk';
-import { checkHelp, printHelp, type CommandSpec } from '../cli-help.js';
+import { checkHelp, parseArgsStrict, printHelp, type CommandSpec } from '../cli-help.js';
 import { loadConfig } from '../config/index.js';
 import { openEditor, openEditorForMultiline } from '../utils/editor.js';
 import { createPersonaName, type PersonaDefinition, type PersonaName } from './types.js';
@@ -157,15 +157,18 @@ async function compileWithSpinner(name: PersonaName, p: typeof import('@clack/pr
 // ---------------------------------------------------------------------------
 
 async function runCreate(nameStr: string, args: string[]): Promise<void> {
-  const { values: createValues } = parseArgs({
-    args,
-    options: {
-      description: { type: 'string' },
-      servers: { type: 'string' },
-      'no-generate': { type: 'boolean' },
+  const { values: createValues } = parseArgsStrict(
+    {
+      args,
+      options: {
+        description: { type: 'string' },
+        servers: { type: 'string' },
+        'no-generate': { type: 'boolean' },
+      },
+      allowPositionals: true,
     },
-    strict: false,
-  });
+    'ironcurtain persona create',
+  );
 
   const name = createPersonaName(nameStr);
   const personaDir = getPersonaDir(name);

--- a/src/pipeline/compile.ts
+++ b/src/pipeline/compile.ts
@@ -47,12 +47,16 @@ export function parseCompilePolicyArgs(argv: string[] = process.argv.slice(2)): 
       server: { type: 'string' },
       'no-mcp': { type: 'boolean' },
     },
-    strict: false,
+    // Strict so unknown flags are rejected; allowPositionals keeps the
+    // `compile-policy` subcommand token (present in process.argv.slice(2))
+    // from being treated as an unexpected argument.
+    allowPositionals: true,
+    strict: true,
   });
   const constitution = typeof values.constitution === 'string' ? values.constitution : undefined;
   const outputDir = typeof values['output-dir'] === 'string' ? values['output-dir'] : undefined;
   const server = typeof values.server === 'string' ? values.server : undefined;
-  const noMcp = (values['no-mcp'] as boolean | undefined) ?? false;
+  const noMcp = values['no-mcp'] ?? false;
   return {
     constitution: constitution ? resolve(constitution) : undefined,
     outputDir: outputDir ? resolve(outputDir) : undefined,
@@ -66,7 +70,14 @@ export function parseCompilePolicyArgs(argv: string[] = process.argv.slice(2)): 
 // ---------------------------------------------------------------------------
 
 export async function main(): Promise<void> {
-  const cliArgs = parseCompilePolicyArgs();
+  let cliArgs;
+  try {
+    cliArgs = parseCompilePolicyArgs();
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.stderr.write('Run `ironcurtain compile-policy --help` for usage.\n');
+    process.exit(1);
+  }
   const config = loadPipelineConfig(cliArgs);
 
   // Load tool annotations early to validate they exist before printing the banner

--- a/src/pipeline/refresh-lists.ts
+++ b/src/pipeline/refresh-lists.ts
@@ -11,9 +11,8 @@
 
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseArgs } from 'node:util';
 import chalk from 'chalk';
-import { checkHelp, type CommandSpec } from '../cli-help.js';
+import { checkHelp, parseArgsStrict, type CommandSpec } from '../cli-help.js';
 import { resolveAllLists } from './list-resolver.js';
 import { connectViaProxy, type ProxyConnection } from './proxy-mcp-connections.js';
 import {
@@ -56,17 +55,19 @@ interface RefreshListsOptions {
 }
 
 function parseRefreshArgs(args: string[]): RefreshListsOptions | null {
-  const { values } = parseArgs({
-    args,
-    options: {
-      help: { type: 'boolean', short: 'h' },
-      list: { type: 'string' },
-      'with-mcp': { type: 'boolean' },
-      'no-mcp': { type: 'boolean' },
+  const { values } = parseArgsStrict(
+    {
+      args,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        list: { type: 'string' },
+        'with-mcp': { type: 'boolean' },
+        'no-mcp': { type: 'boolean' },
+      },
+      allowPositionals: true,
     },
-    allowPositionals: true,
-    strict: false,
-  });
+    refreshListsSpec.name,
+  );
 
   if (checkHelp(values as { help?: boolean }, refreshListsSpec)) return null;
 

--- a/test/compile-policy-cli.test.ts
+++ b/test/compile-policy-cli.test.ts
@@ -36,17 +36,17 @@ describe('parseCompilePolicyArgs', () => {
     expect(result.outputDir).toBe('/tmp/output');
   });
 
-  it('ignores flags without values', () => {
-    const result = parseCompilePolicyArgs(['--constitution']);
-    expect(result.constitution).toBeUndefined();
+  it('rejects a known flag given without its value', () => {
+    expect(() => parseCompilePolicyArgs(['--constitution'])).toThrow();
   });
 
-  it('ignores unknown flags', () => {
-    const result = parseCompilePolicyArgs(['--unknown', 'value']);
-    expect(result.constitution).toBeUndefined();
-    expect(result.outputDir).toBeUndefined();
-    expect(result.server).toBeUndefined();
-    expect(result.noMcp).toBe(false);
+  it('rejects unknown flags', () => {
+    expect(() => parseCompilePolicyArgs(['--unknown', 'value'])).toThrow(/unknown/i);
+  });
+
+  it('tolerates the subcommand-name positional (process.argv.slice(2) form)', () => {
+    const result = parseCompilePolicyArgs(['compile-policy', '--no-mcp']);
+    expect(result.noMcp).toBe(true);
   });
 
   it('resolves relative constitution paths to absolute', () => {


### PR DESCRIPTION
## Problem

Leaf subcommand parsers used `parseArgs({ strict: false })`, so an unknown option was silently swallowed instead of rejected. The motivating case:

```
ironcurtain daemon --web-ui --no-signal --capture-blah
```

ran fine — `--capture-blah` (a typo for `--capture-traces`) was dropped on the floor, so the daemon started **with trace capture off** while the operator believed it was on. Silent failure in exactly the wrong direction.

## Change

Add a shared `parseArgsStrict(config, commandName)` helper in `cli-help.ts` that forces `strict: true` and, on a parse error, prints the message plus a `Run \`<command> --help\` for usage.` hint and exits 1. Route every **leaf** parser through it:

- `start`, `daemon`, `mux`, `observe`, `refresh-lists`, `persona create`

`compile-policy` keeps its pure, unit-tested parser, so it uses bare `strict: true` (throws) with a friendly try/catch in `main()`. It also gains `allowPositionals: true` because it parses `process.argv.slice(2)`, which contains the `compile-policy` token — strict mode defaults `allowPositionals` to `false`, which would otherwise reject it.

**Routers stay lenient by design** (top-level `cli.ts`, the `persona` dispatcher, and `auth`'s scope extractor) since they forward unrecognized flags to deeper parsers. `doctor`, `annotate-tools`, and the `workflow` leaves were already strict.

## Behavior note

A known **string** option given without a value (e.g. a dangling `--web-port`) now also errors under strict mode. That's correct, but it's a slightly stricter contract than before.

## Tests

Rewrote the two `compile-policy-cli` cases that asserted lenient behavior to assert rejection, and added a positional-tolerance test for the `process.argv.slice(2)` invocation form.

- `tsc --noEmit`, `eslint`, `prettier`: clean
- 200 tests pass (compile-policy / mux / doctor / persona / dynamic-lists)
- `madge --circular`: no cycles
- Manual smoke: unknown flags on `daemon` / `mux` / `compile-policy` exit 1 with a clear message; `--help` still exits 0