### PR TITLE
fix(daemon): thread --capture-traces into daemon-launched workflows

### DIFF
--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -750,7 +750,12 @@ export class IronCurtainDaemon {
       devMode: this.webUiOptions?.devMode,
       captureTracesDefault: this.captureTracesDefault,
     });
-    server.setWorkflowManager(new WorkflowManager({ eventBus: server.getEventBus() }));
+    server.setWorkflowManager(
+      new WorkflowManager({
+        eventBus: server.getEventBus(),
+        captureTraces: this.captureTracesDefault,
+      }),
+    );
 
     const bridge = new TokenStreamBridge(server);
     server.setTokenStreamBridge(bridge);

--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -753,7 +753,11 @@ export class IronCurtainDaemon {
     server.setWorkflowManager(
       new WorkflowManager({
         eventBus: server.getEventBus(),
-        captureTraces: this.captureTracesDefault,
+        // Opt-in only, matching the cron-session path above: set the override
+        // solely when the daemon flag is present. Passing `false` here would
+        // override (and disable) a user's `capture.enabled` config, since the
+        // infrastructure factory resolves `override ?? userConfig.capture`.
+        ...(this.captureTracesDefault ? { captureTraces: true } : {}),
       }),
     );
 

--- a/src/workflow/workflow-manager.ts
+++ b/src/workflow/workflow-manager.ts
@@ -102,6 +102,14 @@ export interface WorkflowManagerOptions {
    * directories without mutating `IRONCURTAIN_HOME`.
    */
   readonly baseDirOverride?: string;
+  /**
+   * Raw `--capture-traces` opt-in forwarded from the daemon. Threaded into the
+   * orchestrator's deps as `captureTracesOverride` so daemon/web-UI-launched
+   * workflows honour the flag the same way the CLI `workflow start` path does.
+   * The infrastructure factory resolves it against `userConfig` (single
+   * resolution point); leaving it `undefined` falls back to config.
+   */
+  readonly captureTraces?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,10 +120,12 @@ export class WorkflowManager {
   private orchestrator: WorkflowOrchestrator | null = null;
   private readonly eventBus: TypedEventBus<WebEventMap>;
   private readonly baseDirOverride: string | undefined;
+  private readonly captureTraces: boolean | undefined;
 
   constructor(options: WorkflowManagerOptions) {
     this.eventBus = options.eventBus;
     this.baseDirOverride = options.baseDirOverride;
+    this.captureTraces = options.captureTraces;
   }
 
   /** Lazily creates the orchestrator on first use. */
@@ -332,6 +342,9 @@ export class WorkflowManager {
       baseDir,
       checkpointStore,
       userConfig: config.userConfig,
+      // Forward the raw `--capture-traces` daemon flag; the infrastructure
+      // factory resolves it against userConfig (single resolution point).
+      captureTracesOverride: this.captureTraces,
     };
 
     const orchestrator = new WorkflowOrchestrator(deps);

--- a/test/workflow-manager-capture-traces.test.ts
+++ b/test/workflow-manager-capture-traces.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Seam test: WorkflowManager must forward the daemon's `--capture-traces`
+ * opt-in (the `captureTraces` constructor option) into the orchestrator deps
+ * as `captureTracesOverride`.
+ *
+ * Regression guard for the bug where `daemon --capture-traces` had no effect
+ * on web-UI/daemon-launched workflows: the daemon constructed WorkflowManager
+ * without the flag and createOrchestrator() never set captureTracesOverride,
+ * so the trajectory writer was never built and no captures/ dir appeared.
+ *
+ * We mock the WorkflowOrchestrator constructor to capture the deps object the
+ * manager builds — the seam under test is "manager option -> orchestrator
+ * deps," upstream of the infrastructure factory that resolves the override
+ * against userConfig. createWorkflowSessionFactory is mocked (as in
+ * workflow-manager.test.ts) to avoid touching the user's real config.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import type { WorkflowOrchestratorDeps } from '../src/workflow/orchestrator.js';
+
+// Captures the deps passed to the (mocked) WorkflowOrchestrator constructor.
+let capturedDeps: WorkflowOrchestratorDeps | undefined;
+
+vi.mock('../src/workflow/cli-support.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/workflow/cli-support.js')>();
+  return {
+    ...actual,
+    createWorkflowSessionFactory: () => () => Promise.reject(new Error('session factory not used in tests')),
+  };
+});
+
+vi.mock('../src/workflow/orchestrator.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/workflow/orchestrator.js')>();
+  return {
+    ...actual,
+    WorkflowOrchestrator: class {
+      constructor(deps: WorkflowOrchestratorDeps) {
+        capturedDeps = deps;
+      }
+      onEvent(): void {}
+      listActive(): string[] {
+        return [];
+      }
+      async shutdownAll(): Promise<void> {}
+    },
+  };
+});
+
+import { WorkflowManager } from '../src/workflow/workflow-manager.js';
+import { WebEventBus } from '../src/web-ui/web-event-bus.js';
+
+describe('WorkflowManager capture-traces seam', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let manager: WorkflowManager | undefined;
+
+  beforeEach(() => {
+    capturedDeps = undefined;
+    tmpHome = resolve(tmpdir(), `ic-test-wfm-capture-${randomUUID()}`);
+    mkdirSync(tmpHome, { recursive: true });
+    originalHome = process.env.IRONCURTAIN_HOME;
+    process.env.IRONCURTAIN_HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    await manager?.shutdown();
+    manager = undefined;
+    if (originalHome === undefined) {
+      delete process.env.IRONCURTAIN_HOME;
+    } else {
+      process.env.IRONCURTAIN_HOME = originalHome;
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('forwards captureTraces:true to deps.captureTracesOverride', () => {
+    manager = new WorkflowManager({ eventBus: new WebEventBus(), captureTraces: true });
+    manager.getOrchestrator();
+    expect(capturedDeps).toBeDefined();
+    expect(capturedDeps?.captureTracesOverride).toBe(true);
+  });
+
+  it('forwards captureTraces:false to deps.captureTracesOverride', () => {
+    // false is meaningfully distinct from undefined: it must NOT be coerced
+    // away, so an explicit opt-out reaches the resolution point as false.
+    manager = new WorkflowManager({ eventBus: new WebEventBus(), captureTraces: false });
+    manager.getOrchestrator();
+    expect(capturedDeps?.captureTracesOverride).toBe(false);
+  });
+
+  it('leaves deps.captureTracesOverride undefined when the option is omitted', () => {
+    // Omitted -> the infrastructure factory falls back to userConfig, which is
+    // the documented single resolution point.
+    manager = new WorkflowManager({ eventBus: new WebEventBus() });
+    manager.getOrchestrator();
+    expect(capturedDeps?.captureTracesOverride).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`daemon --capture-traces` had no effect on workflows started from the web UI / daemon. No `captures/` directory ever appeared under the workflow-run dir, even though token-trajectory capture was requested.

## Root cause

The flag parsed and propagated correctly into the daemon (`captureTracesDefault`), and reached **standalone** sessions (`ironcurtain-daemon.ts:533`) and **ad-hoc `sessions.create`** (`:751`). But the daemon constructed `WorkflowManager` with only an `eventBus` (`ironcurtain-daemon.ts:753`), and `WorkflowManager.createOrchestrator()` never set `captureTracesOverride` on the orchestrator deps. So for daemon/web-UI-launched workflows:

- `deps.captureTracesOverride` was `undefined`
- the infrastructure factory (`docker-infrastructure.ts:496`) fell through to `config.userConfig.capture?.enabled` (also unset when relying on the flag)
- `captureEnabled = false` → the `TrajectoryCaptureWriter` was never constructed → no `captures/` dir

The CLI `workflow start` path set `captureTracesOverride` correctly (`workflow-command.ts:195`); only the daemon→`WorkflowManager` seam dropped it.

## Fix

- Add `captureTraces?: boolean` to `WorkflowManagerOptions`; store it; set `captureTracesOverride` in the deps inside `createOrchestrator()`.
- Pass `this.captureTracesDefault` when the daemon constructs `WorkflowManager`.

The infrastructure factory remains the single resolution point (`override ?? userConfig.capture.enabled`); omitting the option preserves the existing config fallback.

## Test

New `test/workflow-manager-capture-traces.test.ts` mocks the `WorkflowOrchestrator` constructor and asserts the seam: `captureTraces` `true` / `false` / omitted map to `deps.captureTracesOverride` `true` / `false` / `undefined`. (The `false` case guards against an explicit opt-out being coerced to `undefined`.) Verified it fails when the fix is reverted.

## Validation

- New test 3/3 pass; existing `workflow-manager.test.ts` 19/19 pass.
- `tsc --noEmit` exits 0; eslint + prettier clean (pre-commit hook passed).

## Note

Fixes capture for future runs. Existing runs are not retroactively captured — restart the daemon with `--capture-traces` (now effective) for the next workflow.