### PR TITLE
feat(web-ui): copy-to-clipboard button for workflow instructions

### DIFF
--- a/packages/web-ui/src/routes/Workflows.svelte
+++ b/packages/web-ui/src/routes/Workflows.svelte
@@ -33,6 +33,8 @@
   import { Alert } from '$lib/components/ui/alert/index.js';
   import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '$lib/components/ui/table/index.js';
   import WorkflowDetail from './WorkflowDetail.svelte';
+  import Copy from 'phosphor-svelte/lib/Copy';
+  import Check from 'phosphor-svelte/lib/Check';
 
   const CUSTOM_PATH_SENTINEL = '__custom__';
 
@@ -69,6 +71,51 @@
     }
     expandedTasks = next;
   }
+
+  // Per-row "just copied" feedback for the instructions copy button. Keyed by
+  // workflowId; the entry briefly flips to true after a successful copy and
+  // reverts after COPY_FEEDBACK_MS. Timeouts are tracked so they can be cleared
+  // on unmount to avoid leaks / state updates after teardown.
+  const COPY_FEEDBACK_MS = 2000;
+  let copiedTasks = $state<Set<string>>(new Set());
+  const copyTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function setCopied(id: string, value: boolean): void {
+    const next = new Set(copiedTasks);
+    if (value) {
+      next.add(id);
+    } else {
+      next.delete(id);
+    }
+    copiedTasks = next;
+  }
+
+  async function copyInstructions(id: string, text: string): Promise<void> {
+    try {
+      if (!navigator.clipboard?.writeText) return;
+      await navigator.clipboard.writeText(text);
+      setCopied(id, true);
+      const existing = copyTimeouts.get(id);
+      if (existing) clearTimeout(existing);
+      copyTimeouts.set(
+        id,
+        setTimeout(() => {
+          setCopied(id, false);
+          copyTimeouts.delete(id);
+        }, COPY_FEEDBACK_MS),
+      );
+    } catch {
+      // Clipboard write can reject (e.g. permission denied). Fail silently;
+      // the user simply sees no "Copied" confirmation.
+    }
+  }
+
+  $effect(() => {
+    return () => {
+      for (const t of copyTimeouts.values()) clearTimeout(t);
+      copyTimeouts.clear();
+    };
+  });
 
   const isCustomPath = $derived(selectedDefinition === CUSTOM_PATH_SENTINEL);
   const effectivePath = $derived(isCustomPath ? customPath.trim() : selectedDefinition);
@@ -363,6 +410,7 @@
 
     {#snippet taskCell(workflowId: string, taskDescription: string | undefined, maxLen: number)}
       {@const isOpen = expandedTasks.has(workflowId)}
+      {@const isCopied = copiedTasks.has(workflowId)}
       {#if taskDescription}
         <button
           type="button"
@@ -379,6 +427,29 @@
         >
           {isOpen ? taskDescription : truncate(taskDescription, maxLen)}
         </button>
+        {#if isOpen}
+          <Button
+            variant="ghost"
+            size="sm"
+            class="mt-1 h-6 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+            aria-label="Copy instructions to clipboard"
+            title="Copy instructions to clipboard"
+            data-testid={`task-copy-${workflowId}`}
+            onclick={(e: MouseEvent) => {
+              e.stopPropagation();
+              e.preventDefault();
+              copyInstructions(workflowId, taskDescription);
+            }}
+          >
+            {#if isCopied}
+              <Check size={13} weight="bold" class="text-success" />
+              Copied
+            {:else}
+              <Copy size={13} />
+              Copy
+            {/if}
+          </Button>
+        {/if}
       {:else}
         <span class="text-muted-foreground">--</span>
       {/if}

--- a/packages/web-ui/src/routes/Workflows.test.ts
+++ b/packages/web-ui/src/routes/Workflows.test.ts
@@ -315,4 +315,98 @@ describe('Workflows route', () => {
       expect(toggle.textContent).toContain('something to reveal');
     });
   });
+
+  // ── Copy instructions to clipboard ────────────────────────────────
+  describe('Copy instructions button', () => {
+    const longTask =
+      'Investigate the flaky integration test and produce a minimal reproduction so the root cause can be triaged.';
+
+    function mockClipboard(): { writeText: ReturnType<typeof vi.fn> } {
+      const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+      vi.stubGlobal('navigator', { clipboard: { writeText } });
+      return { writeText };
+    }
+
+    it('appears only when the task is expanded and copies the full instructions text', async () => {
+      const { writeText } = mockClipboard();
+      mockListResumable.mockResolvedValue([
+        makePastRun({ workflowId: 'p-copy', phase: 'completed', taskDescription: longTask }),
+      ]);
+      render(Workflows);
+
+      // Copy button is hidden while collapsed.
+      const toggle = (await screen.findByTestId('task-toggle-p-copy')) as HTMLButtonElement;
+      expect(screen.queryByTestId('task-copy-p-copy')).toBeNull();
+
+      // Expand, then the copy button appears.
+      await fireEvent.click(toggle);
+      const copyBtn = (await screen.findByTestId('task-copy-p-copy')) as HTMLButtonElement;
+      expect(copyBtn).toBeTruthy();
+
+      await fireEvent.click(copyBtn);
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText).toHaveBeenCalledWith(longTask);
+    });
+
+    it('shows "Copied" feedback after a successful copy', async () => {
+      mockClipboard();
+      mockListResumable.mockResolvedValue([
+        makePastRun({ workflowId: 'p-fb', phase: 'completed', taskDescription: longTask }),
+      ]);
+      render(Workflows);
+
+      await fireEvent.click((await screen.findByTestId('task-toggle-p-fb')) as HTMLButtonElement);
+      const copyBtn = (await screen.findByTestId('task-copy-p-fb')) as HTMLButtonElement;
+      expect(copyBtn.textContent).toContain('Copy');
+      expect(copyBtn.textContent).not.toContain('Copied');
+
+      await fireEvent.click(copyBtn);
+      expect((await screen.findByTestId('task-copy-p-fb')).textContent).toContain('Copied');
+    });
+
+    it('clicking copy does NOT collapse the expanded task (propagation stopped)', async () => {
+      mockClipboard();
+      mockListResumable.mockResolvedValue([
+        makePastRun({ workflowId: 'p-prop', phase: 'completed', taskDescription: longTask }),
+      ]);
+      render(Workflows);
+
+      const toggle = (await screen.findByTestId('task-toggle-p-prop')) as HTMLButtonElement;
+      await fireEvent.click(toggle);
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+
+      // Clicking copy must not re-trigger the toggle handler.
+      await fireEvent.click((await screen.findByTestId('task-copy-p-prop')) as HTMLButtonElement);
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      expect(toggle.textContent).toContain('triaged');
+    });
+
+    it('clicking copy in the active table does NOT select the workflow (row click suppressed)', async () => {
+      mockClipboard();
+      mockAppState.workflows = new Map([
+        ['wf-row', makeSummary({ workflowId: 'wf-row', phase: 'running', taskDescription: longTask })],
+      ]);
+      render(Workflows);
+
+      await fireEvent.click((await screen.findByTestId('task-toggle-wf-row')) as HTMLButtonElement);
+      await fireEvent.click((await screen.findByTestId('task-copy-wf-row')) as HTMLButtonElement);
+
+      // The row's onclick (selectWorkflow) must not have fired.
+      expect(mockAppState.selectedWorkflowId).toBeNull();
+    });
+
+    it('guards gracefully when navigator.clipboard is unavailable', async () => {
+      vi.stubGlobal('navigator', {});
+      mockListResumable.mockResolvedValue([
+        makePastRun({ workflowId: 'p-noclip', phase: 'completed', taskDescription: longTask }),
+      ]);
+      render(Workflows);
+
+      await fireEvent.click((await screen.findByTestId('task-toggle-p-noclip')) as HTMLButtonElement);
+      const copyBtn = (await screen.findByTestId('task-copy-p-noclip')) as HTMLButtonElement;
+      // No throw, and no "Copied" feedback since the write was a no-op.
+      await fireEvent.click(copyBtn);
+      expect(copyBtn.textContent).not.toContain('Copied');
+    });
+  });
 });

--- a/packages/web-ui/src/routes/Workflows.test.ts
+++ b/packages/web-ui/src/routes/Workflows.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import type { PastRunDto, WorkflowDefinitionDto, WorkflowSummaryDto, HumanGateRequestDto } from '$lib/types.js';
 
@@ -320,6 +320,16 @@ describe('Workflows route', () => {
   describe('Copy instructions button', () => {
     const longTask =
       'Investigate the flaky integration test and produce a minimal reproduction so the root cause can be triaged.';
+
+    // These tests vi.stubGlobal('navigator', ...); restore the real jsdom
+    // navigator after each one so the stub never leaks into later tests or
+    // other files in the same worker. Restore navigator specifically rather
+    // than vi.unstubAllGlobals(), which would also drop the module-level
+    // ResizeObserver stub that render() depends on.
+    const realNavigator = globalThis.navigator;
+    afterEach(() => {
+      vi.stubGlobal('navigator', realNavigator);
+    });
 
     function mockClipboard(): { writeText: ReturnType<typeof vi.fn> } {
       const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);


### PR DESCRIPTION
Adds a **Copy** button next to a workflow run's instructions (`taskDescription`) in the expanded task cell of the Workflows view, so a user can grab the instructions and reuse them.

## Behavior
- The button appears when a task row is expanded (next to the full instructions text).
- Clicking it copies `taskDescription` to the clipboard and shows a green check + "Copied" for ~2s, then reverts.
- Lives in the shared `taskCell` snippet, so it works on both the active workflows table and the past-runs list.

## Implementation notes
- **Propagation:** the click handler calls `stopPropagation()` + `preventDefault()`. The button sits inside both the task-toggle (collapse) and the `TableRow` select handlers, so without this, copying would collapse the row and/or select the workflow. Both are suppressed.
- **Robustness:** `navigator.clipboard?.writeText` is guarded for availability and its rejection is swallowed gracefully; the "copied" feedback uses local per-row state with a tracked timeout that's cleared on unmount (no leaks).
- **A11y / conventions:** a real `<button>` with `aria-label`, matching the existing ghost-button + `phosphor-svelte` icon patterns in the file.

## Tests
5 new vitest cases in `Workflows.test.ts`: `writeText` called with the instructions; "Copied" feedback appears; copy does not collapse the expanded task; copy does not select the row; graceful no-op when `navigator.clipboard` is unavailable.

- `npm test -w packages/web-ui` → 343 passed
- lint / prettier / svelte-check clean; `npm run build:web-ui` builds.

Scope: `packages/web-ui/src/routes/Workflows.svelte` (+71), `Workflows.test.ts` (+94). No other files touched.