### PR TITLE
fix(preflight): make builtin mode honor configured model provider

### DIFF
--- a/src/config/first-start.ts
+++ b/src/config/first-start.ts
@@ -21,7 +21,7 @@ import {
   type UserConfig,
   type WebSearchProvider,
 } from './user-config.js';
-import { parseModelId, type ProviderId } from './model-provider.js';
+import { parseModelId, PROVIDER_ENV_VARS, type ProviderId } from './model-provider.js';
 import {
   clampDockerResources,
   isImagePresent,
@@ -34,13 +34,6 @@ import type { AgentId } from '../docker/agent-adapter.js';
 import { checkDockerAvailable } from '../session/preflight.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-/** Maps provider IDs to their expected environment variable names. */
-const PROVIDER_ENV_VARS: Record<ProviderId, string> = {
-  anthropic: 'ANTHROPIC_API_KEY',
-  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
-  openai: 'OPENAI_API_KEY',
-};
 
 /** Checks if a prompt result was cancelled and exits cleanly. */
 function handleCancel(value: unknown): void {

--- a/src/config/model-provider.ts
+++ b/src/config/model-provider.ts
@@ -53,6 +53,20 @@ const DEFAULT_PROVIDER: ProviderId = 'anthropic';
 const KNOWN_PROVIDERS = new Set<string>(['anthropic', 'google', 'openai']);
 
 /**
+ * Environment variable that supplies each provider's API key.
+ *
+ * Single source of truth for the provider→env-var mapping. Declared as an
+ * exhaustive `Record<ProviderId, string>` so adding a provider to
+ * {@link ProviderId} forces a matching entry here at compile time. Must stay
+ * in sync with the env-var overrides applied in `resolveUserConfig()`.
+ */
+export const PROVIDER_ENV_VARS: Record<ProviderId, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
+  openai: 'OPENAI_API_KEY',
+};
+
+/**
  * Parsed model specifier. A "qualified model ID" has the form
  * "provider:model-name". A bare model ID defaults to Anthropic.
  */

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -19,7 +19,12 @@ import {
   readOnlyCredentialSources,
   type CredentialSources,
 } from '../docker/oauth-credentials.js';
-import { resolveApiKeyForProvider, parseModelId, type ProviderId } from '../config/model-provider.js';
+import {
+  resolveApiKeyForProvider,
+  parseModelId,
+  PROVIDER_ENV_VARS,
+  type ProviderId,
+} from '../config/model-provider.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
 
 const execFile = promisify(execFileCb);
@@ -310,22 +315,26 @@ function dockerUnavailableMessage(detailedMessage: string): string {
   ].join('\n');
 }
 
-function builtinNeedsApiKeyMessage(provider: ProviderId): string {
-  const envVarMap: Record<ProviderId, string> = {
-    anthropic: 'ANTHROPIC_API_KEY',
-    openai: 'OPENAI_API_KEY',
-    google: 'GOOGLE_GENERATIVE_AI_API_KEY',
-  };
-  const envVar = envVarMap[provider];
-  return [
+function builtinNeedsApiKeyMessage(provider: ProviderId, qualifiedModelId: string): string {
+  const envVar = PROVIDER_ENV_VARS[provider];
+  const lines = [
     'Cannot start IronCurtain.',
     `preferredMode is "builtin" but no ${envVar} is configured.`,
-    `Builtin mode requires an API key for provider "${provider}".`,
+    `Builtin mode talks to the "${provider}" provider directly using an API key` +
+      ` (selected by your configured model "${qualifiedModelId}").`,
+  ];
+  // Anthropic users commonly have Claude OAuth credentials from `claude login`;
+  // call out that those do not work in builtin mode to avoid confusion.
+  if (provider === 'anthropic') {
+    lines.push('Claude OAuth credentials are not usable in builtin mode — an API key is required.');
+  }
+  lines.push(
     '',
     ...formatModeRemediation('docker'),
     '',
     `Set ${envVar} in your environment, or run \`ironcurtain config\`.`,
-  ].join('\n');
+  );
+  return lines.join('\n');
 }
 
 /**
@@ -424,10 +433,11 @@ async function resolveDefaultMode(
 
   if (preferredMode === 'builtin') {
     // Fail before the Docker probe — fast feedback for missing keys.
-    const { provider } = parseModelId(config.userConfig.agentModelId);
+    const agentModelId = config.userConfig.agentModelId;
+    const { provider } = parseModelId(agentModelId);
     const apiKey = resolveApiKeyForProvider(provider, config.userConfig);
     if (apiKey.length === 0) {
-      throw new PreflightError(builtinNeedsApiKeyMessage(provider));
+      throw new PreflightError(builtinNeedsApiKeyMessage(provider, agentModelId));
     }
     return { mode: { kind: 'builtin' }, reason: 'preferredMode = builtin' };
   }

--- a/src/session/preflight.ts
+++ b/src/session/preflight.ts
@@ -19,7 +19,7 @@ import {
   readOnlyCredentialSources,
   type CredentialSources,
 } from '../docker/oauth-credentials.js';
-import { resolveApiKeyForProvider } from '../config/model-provider.js';
+import { resolveApiKeyForProvider, parseModelId, type ProviderId } from '../config/model-provider.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
 
 const execFile = promisify(execFileCb);
@@ -310,15 +310,21 @@ function dockerUnavailableMessage(detailedMessage: string): string {
   ].join('\n');
 }
 
-function builtinNeedsApiKeyMessage(): string {
+function builtinNeedsApiKeyMessage(provider: ProviderId): string {
+  const envVarMap: Record<ProviderId, string> = {
+    anthropic: 'ANTHROPIC_API_KEY',
+    openai: 'OPENAI_API_KEY',
+    google: 'GOOGLE_GENERATIVE_AI_API_KEY',
+  };
+  const envVar = envVarMap[provider];
   return [
     'Cannot start IronCurtain.',
-    'preferredMode is "builtin" but no ANTHROPIC_API_KEY is configured.',
-    'Builtin mode talks to Anthropic directly using an API key — Claude OAuth credentials are not usable in builtin mode.',
+    `preferredMode is "builtin" but no ${envVar} is configured.`,
+    `Builtin mode requires an API key for provider "${provider}".`,
     '',
     ...formatModeRemediation('docker'),
     '',
-    'Set ANTHROPIC_API_KEY in your environment, or run `ironcurtain config`.',
+    `Set ${envVar} in your environment, or run \`ironcurtain config\`.`,
   ].join('\n');
 }
 
@@ -418,9 +424,10 @@ async function resolveDefaultMode(
 
   if (preferredMode === 'builtin') {
     // Fail before the Docker probe — fast feedback for missing keys.
-    const apiKey = resolveApiKeyForProvider('anthropic', config.userConfig);
+    const { provider } = parseModelId(config.userConfig.agentModelId);
+    const apiKey = resolveApiKeyForProvider(provider, config.userConfig);
     if (apiKey.length === 0) {
-      throw new PreflightError(builtinNeedsApiKeyMessage());
+      throw new PreflightError(builtinNeedsApiKeyMessage(provider));
     }
     return { mode: { kind: 'builtin' }, reason: 'preferredMode = builtin' };
   }

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -29,8 +29,13 @@ const oauthOnlySources: CredentialSources = {
 };
 
 function createTestConfig(
-  overrides: { anthropicApiKey?: string; preferredMode?: 'docker' | 'builtin' } = {},
+  overrides: {
+    anthropicApiKey?: string;
+    preferredMode?: 'docker' | 'builtin';
+    agentModelId?: string;
+  } = {},
 ): IronCurtainConfig {
+  const agentModelId = overrides.agentModelId ?? 'anthropic:claude-sonnet-4-6';
   return {
     auditLogPath: './audit.jsonl',
     allowedDirectory: TEST_SANDBOX_DIR,
@@ -40,14 +45,18 @@ function createTestConfig(
     protectedPaths: [],
     generatedDir: `${REAL_TMP}/test-generated`,
     constitutionPath: `${REAL_TMP}/test-constitution.md`,
-    agentModelId: 'anthropic:claude-sonnet-4-6',
+    agentModelId,
     escalationTimeoutSeconds: 300,
     userConfig: {
-      agentModelId: 'anthropic:claude-sonnet-4-6',
+      agentModelId,
       policyModelId: 'anthropic:claude-sonnet-4-6',
+      prefilterModelId: 'anthropic:claude-haiku-4-5',
       anthropicApiKey: overrides.anthropicApiKey ?? 'test-api-key',
       googleApiKey: '',
       openaiApiKey: '',
+      anthropicBaseUrl: '',
+      openaiBaseUrl: '',
+      googleBaseUrl: '',
       escalationTimeoutSeconds: 300,
       resourceBudget: {
         maxTotalTokens: 1_000_000,
@@ -64,11 +73,16 @@ function createTestConfig(
       },
       autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
       auditRedaction: { enabled: true },
+      memory: { enabled: true, autoSave: true, llmBaseUrl: undefined, llmApiKey: undefined },
+      webSearch: { provider: null, brave: null, tavily: null, serpapi: null },
       serverCredentials: {},
+      signal: null,
       gooseProvider: 'anthropic',
       gooseModel: 'claude-sonnet-4-20250514',
       preferredDockerAgent: 'claude-code',
       preferredMode: overrides.preferredMode ?? 'docker',
+      packageInstall: { enabled: true, quarantineDays: 2, allowedPackages: [], deniedPackages: [] },
+      dockerResources: { memoryMb: 8192, cpus: 4 },
     },
   };
 }
@@ -288,6 +302,7 @@ describe('resolveSessionMode', () => {
         expect(loadFromFile).not.toHaveBeenCalled();
         expect(loadFromKeychain).not.toHaveBeenCalled();
       });
+
     });
 
     describe('--agent overrides preferredMode', () => {

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -320,9 +320,34 @@ describe('resolveSessionMode', () => {
 
         await expect(promise).rejects.toThrow(PreflightError);
         await expect(promise).rejects.toThrow(/no OPENAI_API_KEY/);
+        // The message names the provider and the configured model that drove it,
+        // and omits the Anthropic-only OAuth caveat for non-Anthropic providers.
+        await expect(promise).rejects.toThrow(/"openai" provider/);
+        await expect(promise).rejects.toThrow(/openai:gpt-4o/);
+        await expect(promise).rejects.not.toThrow(/OAuth/);
         expect(dockerSpy).not.toHaveBeenCalled();
         expect(loadFromFile).not.toHaveBeenCalled();
         expect(loadFromKeychain).not.toHaveBeenCalled();
+      });
+
+      it('includes the Anthropic OAuth caveat when the configured provider is anthropic', async () => {
+        const dockerSpy = vi.fn(dockerAvailable);
+        const loadFromFile = vi.fn(() => null);
+        const loadFromKeychain = vi.fn(() => null);
+
+        const promise = resolveSessionMode({
+          config: createTestConfig({
+            anthropicApiKey: '',
+            preferredMode: 'builtin',
+            agentModelId: 'anthropic:claude-sonnet-4-6',
+          }),
+          isDockerAvailable: dockerSpy,
+          credentialSources: { loadFromFile, loadFromKeychain },
+        });
+
+        await expect(promise).rejects.toThrow(/no ANTHROPIC_API_KEY/);
+        await expect(promise).rejects.toThrow(/Claude OAuth credentials are not usable/);
+        expect(dockerSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -303,6 +303,27 @@ describe('resolveSessionMode', () => {
         expect(loadFromKeychain).not.toHaveBeenCalled();
       });
 
+      it('uses the provider inferred from agentModelId for builtin API key validation', async () => {
+        const dockerSpy = vi.fn(dockerAvailable);
+        const loadFromFile = vi.fn(() => null);
+        const loadFromKeychain = vi.fn(() => null);
+
+        const promise = resolveSessionMode({
+          config: createTestConfig({
+            anthropicApiKey: '',
+            preferredMode: 'builtin',
+            agentModelId: 'openai:gpt-4o',
+          }),
+          isDockerAvailable: dockerSpy,
+          credentialSources: { loadFromFile, loadFromKeychain },
+        });
+
+        await expect(promise).rejects.toThrow(PreflightError);
+        await expect(promise).rejects.toThrow(/no OPENAI_API_KEY/);
+        expect(dockerSpy).not.toHaveBeenCalled();
+        expect(loadFromFile).not.toHaveBeenCalled();
+        expect(loadFromKeychain).not.toHaveBeenCalled();
+      });
     });
 
     describe('--agent overrides preferredMode', () => {


### PR DESCRIPTION
Configuring ironcurtain to use (Azure) OpenAI and builtin mode,

    # ~/.ironcurtain/config.json
    {
      "agentModelId": "openai:gpt-5.4",
      "preferredMode": "builtin"
    }

with the OpenAI provider configured in environment variable,

     OPENAI_API_KEY=<redacted>
     OPENAI_BASE_URL=https://<redacted>.openai.azure.com/openai/v1/

I found that `ironcurtain start` failed, due to a hardcoded assumption of using anthropic and `ANTHROPIC_API_KEY` not being set. Unexpectedly, `ironcurtain start --agent builtin` worked.

This commit removes the hardcoded assumption of always using Anthropic from `resolveDefaultMode()`, which handles the `preferredMode = "builtin"` config path. It also updates `builtinNeedsApiKeyMessage()` to report the correct env var for the configured provider using an exhaustive map, so adding a future provider causes a compile error rather than a silent wrong suggestion.

## Summary

<!-- What does this PR do and why? -->

## Security Impact

<!-- Required for changes to the trusted process, policy engine, sandbox, or MCP proxy. Delete this section for docs-only or test-only changes. -->

- [ ] Changes the policy evaluation logic or rule format
- [ ] Modifies the sandbox boundary or V8 isolate setup
- [ ] Adds or changes MCP server spawning, IPC, or credential handling
- [ ] Introduces new tool argument roles or path resolution logic
- [x] None of the above

## Test plan

<!-- How did you verify this works? -->

- [x] Existing tests pass (`npm test`)
- [ ] Added new tests for the change
- [x] Manual testing (describe below)

### Manual testing

#### Reproducing the error

With the above mentioned config for Azure OpenAI I get the following error, using 2ae1d1b2da270d1bf647252039cc52971acbbd89:

    USERNAME@nixos:~/git-reps/ironcurtain$ npm start
    
    > @provos/ironcurtain@0.11.0 start
    > tsx src/cli.ts start
    
    /home/USERNAME/git-reps/ironcurtain/src/session/preflight.ts:423
          throw new PreflightError(builtinNeedsApiKeyMessage());
                ^
    
    PreflightError: Cannot start IronCurtain.
    preferredMode is "builtin" but no ANTHROPIC_API_KEY is configured.
    Builtin mode talks to Anthropic directly using an API key — Claude OAuth credentials are not usable in builtin mode.
    
    To run this session in Docker mode, pass:
      --agent claude-code
    
    To make Docker the default permanently, run:
      ironcurtain config
    and set Session Mode > Preferred mode to "docker".
    
    Set ANTHROPIC_API_KEY in your environment, or run `ironcurtain config`.
    
    Run `ironcurtain doctor` for a full diagnostic.
        at resolveDefaultMode (/home/USERNAME/git-reps/ironcurtain/src/session/preflight.ts:423:13)
        at resolveSessionMode (/home/USERNAME/git-reps/ironcurtain/src/session/preflight.ts:387:10)
        at main (/home/USERNAME/git-reps/ironcurtain/src/index.ts:120:27)
        at <anonymous> (/home/USERNAME/git-reps/ironcurtain/src/cli.ts:116:11)
    
    Node.js v22.22.0
    
#### Confirming that fault is fixed

Switching to bec3b384862103395a3481037aa79b3b5b3a21f3 the error goes away, and the prompt appears as expected:

    USERNAME@nixos:~/git-reps/ironcurtain$ npm start
    
    > @provos/ironcurtain@0.11.0 start
    > tsx src/cli.ts start
    
    Mode: builtin
    Note: tool-annotations.json contains server(s) no longer in mcp-servers.json: "github".
    ⠼ Initializing session...MCP Proxy Server fatal error: Error: Failed to connect to MCP server "git" (/home/USERNAME/git-reps/ironcurtain/node_modules/.bin/srt -s /tmp/nix-shell.Xjo5Tj/ironcurtain-srt-fe1U2x/git.srt-settings.json -c node /home/USERNAME/git-reps/ironcurtain/node_modules/.bin/git-mcp-server): MCP error -32000: Connection closed
    Server stderr: bwrap: Can't mount tmpfs on /newroot/home/USERNAME/.gnupg: No such file or directory
    
    ✔ Session ready
    
    IronCurtain interactive mode. Type /quit to exit.
    
    Commands: /quit /logs /budget /approve /approve+ /deny
    
    >

Based this, I conclude that the change fixes the problem with a hardcoded assumption of using an anthropic provider. 