### PR TITLE
fix(trajectory): classify missing-terminal streams as mid-stream-abort

### DIFF
--- a/src/docker/trajectory-reassembler.ts
+++ b/src/docker/trajectory-reassembler.ts
@@ -26,6 +26,20 @@ export class ReassemblyError extends Error {
   }
 }
 
+/**
+ * Thrown by `finalize()` when the stream ended before the provider's
+ * terminal event was parsed. This is a transport truncation / upstream
+ * abort, NOT a reassembly bug — the caller should classify it as
+ * `mid-stream-abort` rather than `reassembly-failure` so disconnects don't
+ * pollute reassembly-failure metrics.
+ */
+export class TruncatedStreamError extends ReassemblyError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TruncatedStreamError';
+  }
+}
+
 export interface RawEvent {
   readonly eventType: string;
   readonly dataUtf8: string;
@@ -369,7 +383,7 @@ export abstract class AbstractSseReassembler implements Reassembler {
       throw new ReassemblyError(this.failureReason ?? 'reassembly failed');
     }
     if (!this.terminalSeen()) {
-      throw new ReassemblyError('stream ended without terminal event');
+      throw new TruncatedStreamError('stream ended without terminal event');
     }
     return this.assembleResult();
   }

--- a/src/docker/trajectory-tap.ts
+++ b/src/docker/trajectory-tap.ts
@@ -23,7 +23,7 @@ import { randomUUID } from 'node:crypto';
 import type { TrajectoryCaptureWriter } from './trajectory-capture.js';
 import { type Reassembler, redactHeaders } from './trajectory-types.js';
 import type { ExchangeRecord, PoisonReason } from './trajectory-types.js';
-import { createReassembler, providerForHost, ReassemblyError } from './trajectory-reassembler.js';
+import { createReassembler, providerForHost, ReassemblyError, TruncatedStreamError } from './trajectory-reassembler.js';
 import type { SessionId } from '../session/types.js';
 import * as logger from '../logger.js';
 
@@ -333,12 +333,20 @@ export function beginCaptureExchange(inputs: BeginCaptureExchangeInputs): Captur
             });
             finishCompletion(true);
           } catch (err) {
-            // Reassembly failure: do NOT emit a partial record. Per §5
-            // and §9, the session is poisoned with `reassembly-failure`
-            // so the eventual `session-end` carries the reason.
+            // Do NOT emit a partial record. Distinguish a transport
+            // truncation (stream ended before the terminal event) from a
+            // genuine reassembly bug (a parse/dispatch/assembly failure):
+            // the former is an upstream abort that must NOT pollute
+            // reassembly-failure metrics. A clean `end()` with no terminal
+            // event reaches here e.g. when an upstream reset is flushed
+            // gracefully via `inlet.end()` (the gzip-tail recovery path).
             const msg = err instanceof ReassemblyError ? err.message : String(err);
-            logger.warn(`[trajectory-tap] reassembly failed (${inputs.host}): ${msg}`);
-            poisonAndAbort('reassembly-failure', err instanceof Error ? err : new Error(msg));
+            if (err instanceof TruncatedStreamError) {
+              poisonAndAbort('mid-stream-abort', err);
+            } else {
+              logger.warn(`[trajectory-tap] reassembly failed (${inputs.host}): ${msg}`);
+              poisonAndAbort('reassembly-failure', err instanceof Error ? err : new Error(msg));
+            }
           }
         } else {
           // No reassembler: capture the raw bytes verbatim. `streaming`

--- a/test/docker/trajectory-poison.test.ts
+++ b/test/docker/trajectory-poison.test.ts
@@ -241,14 +241,16 @@ describe('Trajectory poison: failure modes', () => {
       headers: { 'content-type': 'text/event-stream' },
     });
 
-    // Feed a malformed SSE event: message_start ok, but stream ends
-    // before message_stop arrives. Then signal upstream end via the
-    // PassThrough's end() — the reassembler.finalize() will throw,
-    // the tap should call markSessionPoisoned('reassembly-failure'),
-    // and no record should be enqueued.
+    // Feed a genuinely malformed event sequence: message_start (ok) followed
+    // by a content_block_delta for an index with NO preceding
+    // content_block_start. The dispatcher throws ("content_block_delta for
+    // unknown index 0"), latching the reassembler as failed — a real parse
+    // failure, distinct from a transport truncation. finalize() rethrows it
+    // (NOT a TruncatedStreamError), so the tap poisons 'reassembly-failure'
+    // and no record is enqueued.
     const malformedSse =
       'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_x","type":"message","role":"assistant","model":"c","content":[]}}\n\n' +
-      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n';
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}\n\n';
 
     const src = new PassThrough();
     src.pipe(tap);
@@ -498,6 +500,55 @@ describe('Trajectory poison: failure modes', () => {
     );
     await new Promise<void>((r) => setImmediate(r));
     tap.destroy(new Error('socket reset before message_stop'));
+
+    await new Promise<void>((r) => setImmediate(r));
+    await writer.endSession(sid);
+
+    const traceFile = resolve(dir, `${sid}.jsonl`);
+    if (existsSync(traceFile)) {
+      expect(readJsonl(traceFile).length).toBe(0);
+    }
+    const manifest = readManifest(dir);
+    const end = manifest.find((m) => m.event === 'session-end' && m.sessionId === sid);
+    if (end?.event === 'session-end') {
+      expect(end.poisoned).toBe(true);
+      expect(end.poisonReason).toBe('mid-stream-abort');
+    }
+  });
+
+  it('lifecycle: clean end() with no terminal event poisons mid-stream-abort, NOT reassembly-failure', async () => {
+    // The gzip-tail recovery path turns an upstream reset into a graceful
+    // inlet.end() → a clean tap 'end' with no terminal event parsed. That is a
+    // transport truncation, not a reassembly bug, so it must poison
+    // mid-stream-abort. (Before the TruncatedStreamError fix this clean-end
+    // path mislabeled truncations as reassembly-failure.)
+    writer = createTrajectoryCaptureWriter({ capturesDir: dir });
+    const sid = makeSessionId('sess-clean-end-no-terminal');
+    writer.beginSession({ sessionId: sid });
+
+    const handle = beginCaptureExchange({
+      writer,
+      sessionId: sid,
+      host: 'api.anthropic.com',
+      path: '/v1/messages',
+      method: 'POST',
+      requestHeaders: { 'content-type': 'application/json' },
+      requestStartedAt: Date.now(),
+    });
+    handle.setRequestBody(Buffer.from('{}', 'utf-8'));
+    const tap = handle.attachResponse({
+      statusCode: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+
+    // Well-formed partial stream (message_start, no message_stop), ended
+    // CLEANLY — mirrors an upstream reset flushed gracefully via inlet.end().
+    tap.end(
+      Buffer.from(
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"c","content":[]}}\n\n',
+        'utf-8',
+      ),
+    );
 
     await new Promise<void>((r) => setImmediate(r));
     await writer.endSession(sid);

--- a/test/docker/trajectory-poison.test.ts
+++ b/test/docker/trajectory-poison.test.ts
@@ -245,9 +245,10 @@ describe('Trajectory poison: failure modes', () => {
     // by a content_block_delta for an index with NO preceding
     // content_block_start. The dispatcher throws ("content_block_delta for
     // unknown index 0"), latching the reassembler as failed — a real parse
-    // failure, distinct from a transport truncation. finalize() rethrows it
-    // (NOT a TruncatedStreamError), so the tap poisons 'reassembly-failure'
-    // and no record is enqueued.
+    // failure, distinct from a transport truncation. finalize() then throws a
+    // plain ReassemblyError carrying the latched failure message (NOT a
+    // TruncatedStreamError), so the tap poisons 'reassembly-failure' and no
+    // record is enqueued.
     const malformedSse =
       'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_x","type":"message","role":"assistant","model":"c","content":[]}}\n\n' +
       'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}\n\n';


### PR DESCRIPTION
Post-merge review feedback on #288 (Copilot).

## Problem
When a captured SSE stream ends **before its terminal event**, that's a transport truncation / upstream abort — not a reassembly bug. But the tap's clean-`end()` finalize path poisoned it as `reassembly-failure`, which pollutes reassembly-failure metrics and misleads diagnosis. The gzip-tail recovery fix in #288 made this more likely: it routes an upstream reset through a graceful `inlet.end()`, producing a clean tap `end` with no terminal parsed → the misclassification.

(The `tap.on('close')`/`'error')` teardown paths already classified this correctly via `canFinalize()`; only the direct `end → finalize()` path was wrong.)

## Fix
- **reassembler**: `finalize()` throws a dedicated `TruncatedStreamError` (a `ReassemblyError` subclass) for the no-terminal case.
- **tap**: map `TruncatedStreamError` → `mid-stream-abort`; genuine parse/dispatch/assembly errors still → `reassembly-failure` (the `failed`-flag check in `finalize()` runs first, so dispatch failures are unaffected).
- **mitm**: no change to the `inlet.end()`-on-error behavior — upstream error details are already logged at the response-error handler (`mitm-proxy.ts:900-902`), and switching to `destroy(err)` (Copilot's alternative) would re-break the gzip-tail recovery (zlib doesn't flush on destroy). So `end()` + correct classification is the complete fix.

## Tests
- New guard: a well-formed *partial* stream ended cleanly (`tap.end()`, no terminal) → poisons `mid-stream-abort` (would have been `reassembly-failure` before).
- Repurposed the mislabeled `(b)` test (it fed a partial stream but claimed "malformed/dispatcher failure") to feed a **real** dispatcher failure (`content_block_delta` for an unknown index) so it genuinely exercises `reassembly-failure`.

**Verified:** lint 0, build 0, full docker suite green (181 tests). No live run needed — the change only affects poison *classification* of truncated streams, covered precisely by the unit tests.