### PR TITLE
feat(workflow): structured deterministic result contract (verdict routing)

### DIFF
--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -241,7 +241,7 @@ Exit codes:
 | `WF006` | warning  | `settings.maxRounds` set but no transition uses `isRoundLimitReached` guard (limit silently ignored)    |
 | `WF007` | warning  | Agent state references a persona not installed locally (runtime failure)                                |
 | `WF008` | error    | `maxVisits` state has a cap-guarded transition positioned after a non-approval `when` (cap never fires) |
-| `WF011` | warning  | Container deterministic state can run before an agent has populated its container scope                  |
+| `WF011` | warning  | Container deterministic state can run before an agent has populated its container scope                 |
 | `WF012` | warning  | Deterministic state routes on `when:{verdict}` but declares no `resultFile`                             |
 
 Example:
@@ -578,7 +578,10 @@ classify:
 
 The result file is read only after all commands exit successfully. If a command
 fails, legacy `isPassed`/`isFailed` behavior is unchanged and the file is not
-read. If the file is missing, malformed, not a JSON object, or lacks a non-empty
+read. When the file sets `passed`, it overrides the exit-code-derived pass/fail
+(an evaluator can exit 0 yet report `passed: false` — e.g. a candidate that ran
+cleanly but failed its checks), and `isPassed`/`isFailed` then see that
+overridden value. If the file is missing, malformed, not a JSON object, or lacks a non-empty
 string `verdict`, the deterministic result becomes `passed: false` with the
 reserved verdict `result_file_error`, which can be routed with
 `when: { verdict: result_file_error }`. `resultFile` and deterministic

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -241,6 +241,8 @@ Exit codes:
 | `WF006` | warning  | `settings.maxRounds` set but no transition uses `isRoundLimitReached` guard (limit silently ignored)    |
 | `WF007` | warning  | Agent state references a persona not installed locally (runtime failure)                                |
 | `WF008` | error    | `maxVisits` state has a cap-guarded transition positioned after a non-approval `when` (cap never fires) |
+| `WF011` | warning  | Container deterministic state can run before an agent has populated its container scope                  |
+| `WF012` | warning  | Deterministic state routes on `when:{verdict}` but declares no `resultFile`                             |
 
 Example:
 
@@ -550,6 +552,39 @@ Container deterministic commands run with `/workspace` as their working
 directory, see the same workspace as the agent states in that scope, and can
 read workflow helper code from `/workflow-scripts`.
 
+Container deterministic states can also route on a helper-written verdict file.
+Set `resultFile` to a normalized workspace-relative path and have the helper
+write JSON with a required string `verdict`, optional object `payload`, and
+optional boolean `passed`:
+
+```yaml
+classify:
+  type: deterministic
+  description: Route on helper output
+  container: true
+  resultFile: .workflow/result.json
+  run:
+    - - python3
+      - /workflow-scripts/classify.py
+  transitions:
+    - to: passed
+      when: { verdict: pass }
+    - to: blocked
+      when: { verdict: block }
+    - to: error
+      when: { verdict: result_file_error }
+    - to: error
+```
+
+The result file is read only after all commands exit successfully. If a command
+fails, legacy `isPassed`/`isFailed` behavior is unchanged and the file is not
+read. If the file is missing, malformed, not a JSON object, or lacks a non-empty
+string `verdict`, the deterministic result becomes `passed: false` with the
+reserved verdict `result_file_error`, which can be routed with
+`when: { verdict: result_file_error }`. `resultFile` and deterministic
+`when:{verdict}` routing are container-only; host deterministic states remain
+guard-based.
+
 When a deterministic state fails (any command exited non-zero) and routes to an agent state, the failed commands' captured output (stderr per command, falling back to stdout when stderr is empty, joined across all failing commands) is forwarded as the agent's prior-state context, rendered under `## Output from <det-state> / Directive: ...` in the agent's prompt. Successful deterministic results update only `previousTestCount`; the agent's own prior-state context fields (`previousAgentOutput`, `previousAgentNotes`, `previousStateName`) are left untouched, so the next agent still sees the last agent state's output.
 
 ### Terminal states
@@ -581,11 +616,11 @@ There are two ways to control transitions: declarative `when` conditions and cod
   when: { verdict: escalate }
 ```
 
-`when` matches against the agent's status block output. All specified fields must match (AND semantics). The primary matchable field is `verdict`. Other fields (`completed`, `confidence`, `escalation`, `testCount`, `notes`) are also available but are deprecated for routing -- use `verdict` and `notes` instead.
+`when` matches against the agent's status block output. On container deterministic states with `resultFile`, `when:{verdict}` matches the helper-written deterministic verdict. All specified fields must match (AND semantics). The supported matchable field is `verdict`; other fields (`completed`, `confidence`, `escalation`, `testCount`, `notes`) are deprecated and rejected by validation.
 
 The `verdict` field accepts any string value, enabling custom verdicts for direct routing (e.g., `"thesis_validate"`, `"escalate"`, `"reanalyze"`). Well-known values are `approved`, `rejected`, `blocked`, and `spec_flaw`. This is the recommended pattern for new workflows: instruct the agent to use specific verdict strings in its prompt, then match on them with `when`.
 
-`when` is only available on agent state transitions (not deterministic states). A transition cannot have both `when` and `guard`.
+Deterministic `when:{verdict}` requires `container: true`; without `resultFile`, WF012 warns that the verdict edges are dead. A transition cannot have both `when` and `guard`.
 
 **`guard` -- code-based conditions (for context-based checks):**
 
@@ -596,7 +631,7 @@ The `verdict` field accepts any string value, enabling custom verdicts for direc
 | `isStalled`                | Agent produced identical output artifacts as previous round                                                                              |
 | `isPassed`                 | Deterministic state commands all passed                                                                                                  |
 
-Use `guard` for conditions that depend on workflow context (round limits, stall detection) or for deterministic state transitions (`isPassed`). For verdict-based routing, use `when` clauses -- e.g., `when: { verdict: "approved" }` supports any verdict string for direct routing.
+Use `guard` for conditions that depend on workflow context (round limits, stall detection) and for legacy deterministic pass/fail routing (`isPassed`). For verdict-based routing, use `when` clauses -- e.g., `when: { verdict: "approved" }` supports any verdict string for direct routing.
 
 `isRoundLimitReached` applies a single workflow-wide cap across every state; `isStateVisitLimitReached` scopes the cap to one state via that state's `maxVisits`. Use the per-state guard for narrowly bounded loops (e.g., a review step that should escalate after N iterations without halting the whole workflow).
 

--- a/docs/designs/deterministic-result-contract.md
+++ b/docs/designs/deterministic-result-contract.md
@@ -1,0 +1,968 @@
+# Structured Deterministic Result Contract
+
+Status: Design (ready to implement)
+Audience: IronCurtain workflow-runtime engineers
+Predecessor: `docs/designs/deterministic-in-container-execution.md` (PR #292, merged). This
+document fills the explicit seam that doc left open in its §1 ("What did NOT ship → The
+structured deterministic result contract") and §4.6 ("the result-contract piece plugs into the
+**reduction** step (`reduceDeterministicCommands`), not the exec path").
+
+Consumer context: `docs/designs/asi-evolve-native-workflow.md` needs this so an `evaluate` /
+`record_node` deterministic state can distinguish `evaluated` from `evaluator_blocked` and route a
+hard failure straight to a gate/terminal without an agent turn. **That workflow is out of scope
+here** — this is general-purpose runtime work.
+
+---
+
+## 1. Summary & goals
+
+### What ships
+
+A **`container: true`** `deterministic` state can emit a **structured verdict + machine-readable
+payload** by having its packaged helper write a **result file** (`result.json` with
+`{ "verdict": "...", ... }`) into the run workspace. The machine then routes the deterministic state
+on `when: { verdict: ... }` edges —
+**the exact same `__matchesWhen` mechanism agent states already use**
+(`src/workflow/machine-builder.ts:233-236`, `:433-461`). This lets a deterministic state e.g.
+distinguish `evaluated` vs `evaluator_blocked` and route a hard failure straight to a terminal/gate
+with no agent turn.
+
+Concretely, the deltas are:
+
+1. **YAML**: an optional `resultFile: <path>` field on deterministic states (relative to
+   `/workspace`); `when: { verdict: ... }` transitions become legal on deterministic states.
+   **Both `resultFile` and `when:{verdict}` edges require `container: true`** (see §5.2 / §7.3 for
+   why and where this is enforced).
+2. **Result-file contract**: `result.json` shape `{ verdict: string, payload?: object, passed?:
+boolean }` with defined precedence vs exit code and defined missing/malformed behavior.
+3. **Execution**: the helper writes the result file under `/workspace` in the container; the
+   orchestrator reads the same bytes host-side under `instance.workspacePath` (the bind-mount
+   source) after `reduceDeterministicCommands` runs, and attaches `verdict`/`payload` to
+   `DeterministicInvokeResult`. This is **container-only** — see §5.2.
+4. **Machine-builder**: deterministic `onDone` transitions gain a `when` branch that reuses the
+   `__matchesWhen` guard; the deterministic-result→event mapping is extended so `__matchesWhen` can
+   read a `verdict`.
+5. **Validation**: the deterministic-`when` rejection (`src/workflow/validate.ts:336-338`) is
+   relaxed; a new semantic check requires `container: true` on any deterministic state that uses
+   `resultFile` or `when:{verdict}` edges (§7.3); a new lint (WF012) warns when `when:{verdict}`
+   edges exist without a declared `resultFile`.
+
+### What does NOT ship
+
+- No change to **agent-state** routing, the `__matchesWhen` guard body, or `AgentOutput`.
+- No change to **container execution, packaging, the per-workflow image build, or `docker exec`**
+  (all shipped in PR #292). The result file is a plain workspace artifact the helper writes; the
+  runtime never tells the helper how to compute its verdict.
+- No new `WorkflowEvent` variant is **required** (see §6 for the chosen approach: extend the
+  existing `VALIDATION_PASSED`/`VALIDATION_FAILED` events with an optional `verdict`/`payload`
+  carrier and route `__matchesWhen` through them — `isPassed` keeps reading `VALIDATION_PASSED`).
+
+### Back-compat invariant (the load-bearing one)
+
+**Every existing guard-only deterministic state keeps working byte-identically.** Today
+deterministic transitions support only `guard:` (`isPassed`, pass/fail via stdout-mined `passed`).
+A deterministic state with **no `resultFile`** never reads a result file, produces a
+`DeterministicInvokeResult` with `verdict` undefined, and routes exactly as it does today:
+`passed → VALIDATION_PASSED → isPassed`, else `VALIDATION_FAILED`. The result file is strictly
+opt-in; `resultFile` defaults to absent. No shipped workflow has a `type: deterministic` state
+today (verified in PR #292 §3.3), so the regression surface is the `deterministic-eval-smoke`
+fixture, which is guard-only and must stay green.
+
+---
+
+## 2. Current behavior (cited)
+
+**Deterministic execution → result.** `executeDeterministicState(workflowId, input)`
+(`src/workflow/orchestrator.ts:2343`) dispatches host (`runDeterministicHost`, `:2404`) vs container
+(`runDeterministicInContainer`, `:2417`) by `input.container`, both funneling through the shared
+reducer `reduceDeterministicCommands(commands, runCommand)` (`:2376`). The reducer skips empty
+command arrays, mines a test count from stdout (`/(\d+)\s+(?:tests?|specs?)\s+pass/i`), accumulates
+per-command failures, and returns:
+
+```ts
+// src/workflow/machine-builder.ts:69-74
+export interface DeterministicInvokeResult {
+  readonly passed: boolean; // allErrors.length === 0
+  readonly testCount?: number;
+  readonly errors?: string;
+}
+```
+
+`passed` is purely "no command errored" (exit code 0 for every command). There is no notion of a
+verdict; the only routing signal a deterministic state can produce today is this boolean.
+
+**Result → event mapping.** In the XState guard adapter
+(`src/workflow/machine-builder.ts:413-419`), when the done event is _not_ an agent result it is
+treated as a deterministic result and mapped:
+
+```ts
+const detResult = doneEvent.output as DeterministicInvokeResult | undefined;
+if (detResult?.passed) {
+  workflowEvent = { type: 'VALIDATION_PASSED', testCount: detResult.testCount ?? 0 };
+} else {
+  workflowEvent = { type: 'VALIDATION_FAILED', errors: detResult?.errors ?? 'unknown' };
+}
+```
+
+**The `isPassed` guard** (`src/workflow/guards.ts:34-36`) is just
+`event.type === 'VALIDATION_PASSED'`. That is the _only_ guard a deterministic transition can use
+for routing today.
+
+**`when` is rejected on deterministic states.** `buildDeterministicState`
+(`src/workflow/machine-builder.ts:271-301`) builds `onDone` transitions using **only** `t.guard`
+and silently drops `t.when` (`:276-280`). Validation makes that explicit:
+
+```ts
+// src/workflow/validate.ts:336-338  (validateWhenClauses)
+if (state.type === 'deterministic' && t.when) {
+  issues.push(`State "${stateId}" is deterministic and cannot use "when" (agent output not available)`);
+}
+```
+
+The rationale in the comment — "agent output not available" — is exactly the gap this contract
+closes: a deterministic state _can_ now produce structured output, via a result file.
+
+**The `__matchesWhen` guard** (`src/workflow/machine-builder.ts:433-461`) is the agent-state
+mechanism: built per-transition as `{ type: '__matchesWhen', params: { when: t.when } }`
+(`:237-238`). It calls `extractInvokeResult(doneEvent)` (`:97-103`) to pull an `AgentInvokeResult`
+(detected by the presence of `output` + `outputHash`), reads `result.output` (an `AgentOutput`),
+and matches each `when` key against `agentOutput[key]` with `!==` AND-semantics. `extractInvokeResult`
+returns `undefined` for a deterministic result (no `outputHash`), so today `__matchesWhen` would
+**fail closed** (`return false`, `:444`) on a deterministic state — which is why deterministic
+`when` was disallowed rather than silently no-op.
+
+**`collectTransitionTargets`** is exported from `src/workflow/validate.ts:199` and reused by lint
+(`src/workflow/lint.ts` WF011 at `:473`). The lint family lives in `src/workflow/lint.ts`; the
+`DiagnosticCode` union (`lint.ts:55`) is the **non-contiguous** set
+`WF001|WF002|WF003|WF004|WF006|WF007|WF008|WF010|WF011` (no WF005, no WF009). `WF012` is unused, so
+adding it does not collide.
+
+**Workspace ↔ container.** A `container: true` deterministic state runs with `--workdir /workspace`
+(`CONTAINER_WORKSPACE_DIR = '/workspace'`, `src/docker/agent-adapter.ts:19`). `/workspace` is the
+RW bind mount of the host run workspace `instance.workspacePath`: the field is declared at
+`src/workflow/orchestrator.ts:601`, passed to the infrastructure factory at `:838` →
+`createDockerInfrastructure(..., input.workspacePath, ...)` at `:1138` →
+`prepareDockerInfrastructure(workspaceDir, ...)` (`src/docker/docker-infrastructure.ts:345`) → the
+RW mount `{ source: core.workspaceDir, target: CONTAINER_WORKSPACE_DIR, readonly: false }`
+(`docker-infrastructure.ts:967`). So a file the helper writes at `/workspace/<path>` inside the
+container is readable host-side at `resolve(instance.workspacePath, <path>)`.
+
+A host-side (`container: false`) deterministic state, by contrast, runs the helper via
+`execFileAsync(binary, args)` with **no `cwd`** (`src/workflow/orchestrator.ts:2408`), so the
+helper writes relative to the orchestrator's `process.cwd()`, **not** the workspace. There is no
+mount aligning the two paths, so a host helper's result file and `applyResultFile`'s
+`resolve(instance.workspacePath, resultFile)` read would point at different files. **This is the
+reason the result contract is container-only** (enforced in §7.3; host-side verdict routing is
+deferred — §13). `WORKFLOW_ARTIFACT_DIR = '.workflow'` (`src/workflow/types.ts:12`) is the existing
+convention for runtime-written workspace artifacts.
+
+---
+
+## 3. YAML surface
+
+### 3.1 New field
+
+Add to **deterministic** states:
+
+| Field        | Type     | Default | Meaning                                                                                                                                                                                                                                                                                                 |
+| ------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resultFile` | `string` | absent  | Path **relative to the workspace root** where the helper writes its result JSON. **Requires `container: true`** (§7.3). When set, the orchestrator reads it after the commands run and exposes its `verdict`/`payload` for `when:{verdict}` routing. Absent ⇒ legacy guard-only behavior, no file read. |
+
+**Path rules** (enforced in §7): `resultFile` must be a relative, normalized POSIX path with no
+leading `/`, no `..` segment, and no NUL — it is resolved under `/workspace` inside the container
+(where the helper writes) and read host-side under the identical bind-mount source
+`instance.workspacePath`. It is **not** a `containerScope` and has no charset coupling to it.
+Recommended convention: put it under the existing `.workflow` artifact dir, e.g.
+`resultFile: .workflow/result.json`, so it lands next to other runtime artifacts and is swept by the
+same checkpoint/inspect tooling. The runtime does **not** mandate `.workflow/`; any in-workspace
+relative path is accepted.
+
+### 3.2 Authoring `when:{verdict}` transitions
+
+A deterministic state authors verdict edges exactly like an agent state does:
+
+```yaml
+transitions:
+  - to: <state>
+    when: { verdict: <string> }
+```
+
+- **`guard:`-only states stay valid** — unchanged. No `resultFile`, no `when`: pure legacy.
+- **Coexistence rule.** A single deterministic state's transition list **may mix** `when:{verdict}`
+  edges and `guard:` edges. A single _transition_ may **not** carry both `guard` and `when` (already
+  enforced — mutual exclusivity at `validate.ts:329-332`). This is identical to agent states.
+- **Ordering rule (XState first-match).** XState evaluates `onDone` transitions **top-to-bottom and
+  takes the first whose guard passes**. Authors therefore order specific `when:{verdict}` edges
+  _before_ any catch-all. The recommended pattern is verdict edges first, then a final **unguarded**
+  edge (or a `guard: isPassed` edge) as the default:
+
+  ```yaml
+  transitions:
+    - to: blocked_terminal
+      when: { verdict: evaluator_blocked } # specific, checked first
+    - to: record_node
+      when: { verdict: evaluated }
+    - to: failed # default fall-through (unguarded)
+  ```
+
+  `__matchesWhen` returns `false` (not throw) when the verdict doesn't match
+  (`machine-builder.ts:458`), so a non-matching verdict edge is skipped and evaluation continues to
+  the next transition — same semantics as agent states.
+
+### 3.3 Before / after YAML
+
+**Before** (guard-only, today's only option — unchanged, still valid):
+
+```yaml
+evaluate:
+  type: deterministic
+  container: true
+  run:
+    - ['/opt/workflow-venv/bin/python', '/workflow-scripts/run_eval.py']
+  transitions:
+    - to: report
+      guard: isPassed
+    - to: failed
+```
+
+**After** (verdict-routed):
+
+```yaml
+evaluate:
+  type: deterministic
+  container: true
+  resultFile: .workflow/result.json # helper writes {"verdict": "...", ...} here
+  run:
+    - ['/opt/workflow-venv/bin/python', '/workflow-scripts/run_eval.py']
+  transitions:
+    - to: blocked # hard failure: skip the agent loop entirely
+      when: { verdict: evaluator_blocked }
+    - to: record_node # normal path
+      when: { verdict: evaluated }
+    - to: failed # default: malformed/missing verdict, or unexpected value
+```
+
+---
+
+## 4. Result-file contract
+
+### 4.1 Schema
+
+The helper writes **valid JSON** matching:
+
+```jsonc
+{
+  "verdict": "evaluated", // REQUIRED when the file is present: non-empty string
+  "payload": { "score": 0.91 }, // OPTIONAL: arbitrary JSON object (not array/scalar)
+  "passed": true, // OPTIONAL: boolean; see precedence in §4.3
+}
+```
+
+| Field     | Required           | Type             | Meaning                                                                                              |
+| --------- | ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `verdict` | yes (when present) | non-empty string | Routing key for `when:{verdict}`. Free-form, like `AgentOutput.verdict`.                             |
+| `payload` | no                 | JSON object      | Opaque machine-readable data for downstream consumers. Surfaced on the result; not used for routing. |
+| `passed`  | no                 | boolean          | Lets the helper assert pass/fail independent of process exit code. See §4.3.                         |
+
+`payload` is intentionally a free-form object. The runtime stores it on the result and (per §6)
+makes it available to context, but does **not** schema-validate its interior — that is the
+consuming workflow's concern (e.g. asi-evolve's `record_node` reads it).
+
+### 4.2 Verdict-file required when `when:{verdict}` edges exist?
+
+**No — soft requirement, lint-only.** A deterministic state that has `when:{verdict}` edges but no
+`resultFile` cannot ever produce a verdict, so those edges are dead. This is an **author error**,
+surfaced as a lint warning **WF012** (§7), not a hard validation failure (lint is advisory; some
+authors gate verdict edges behind a default that always fires). At runtime, a `when:{verdict}` edge
+with no result file simply never matches (verdict is `undefined`) and the default edge is taken.
+
+### 4.3 Precedence: exit code vs verdict file
+
+The verdict file governs **routing**; the exit code still governs **`passed`** unless the file
+overrides it. Precedence, evaluated after `reduceDeterministicCommands` returns its
+`{ passed, testCount, errors }`:
+
+1. **`passed` field present in result file** → it **overrides** the exit-code-derived `passed`.
+   (A helper can `exit(0)` but declare `passed: false`, or vice-versa. This is the escape hatch for
+   "the evaluator ran fine but the candidate failed" — exit 0, `verdict: evaluated`, `passed:
+false`.)
+2. **`passed` field absent** → keep the exit-code-derived `passed` from the reducer (today's
+   semantics).
+3. **`verdict`** is always taken verbatim from the file (independent of `passed`). Routing checks
+   `when:{verdict}` first; the `passed`-derived `VALIDATION_PASSED`/`isPassed` fallback only matters
+   for guard edges.
+
+**Why exit code stays authoritative for `passed` by default:** it preserves the back-compat
+invariant — a legacy helper that doesn't write `passed` behaves exactly as today. The file is the
+_additive_ signal.
+
+### 4.4 Missing / malformed file behavior
+
+Define a **reserved verdict** so authors can route the "the contract itself broke" case
+explicitly. The reserved verdict is the constant `DETERMINISTIC_RESULT_ERROR_VERDICT =
+'result_file_error'` (new export in `src/workflow/types.ts`, see §11).
+
+| Condition                                                           | `verdict`             | `passed`                      | `errors` (appended)                        |
+| ------------------------------------------------------------------- | --------------------- | ----------------------------- | ------------------------------------------ |
+| `resultFile` absent (legacy)                                        | `undefined`           | exit-code-derived (unchanged) | unchanged                                  |
+| `resultFile` set, commands all passed, file present & well-formed   | from file             | file `passed` ?? exit-derived | unchanged                                  |
+| `resultFile` set, file **missing** after commands ran               | `'result_file_error'` | `false`                       | `+ "result file <path> not found"`         |
+| `resultFile` set, file present but **not valid JSON**               | `'result_file_error'` | `false`                       | `+ "result file <path> is not valid JSON"` |
+| `resultFile` set, JSON valid but **no/empty/non-string `verdict`**  | `'result_file_error'` | `false`                       | `+ "result file <path> missing verdict"`   |
+| `resultFile` set, but a **command already errored** (non-zero exit) | not read              | `false`                       | unchanged (command error)                  |
+
+Rules:
+
+- **File read is conditional on commands having passed.** If `reduceDeterministicCommands` already
+  set `passed: false` (a command exited non-zero), the orchestrator does **not** read the result
+  file — the command failure is authoritative and `verdict` stays `undefined`. (A helper that wants
+  to _report_ a verdict on failure should `exit(0)` and set `passed: false` in the file, per §4.3.)
+- A malformed/missing file when one was promised is a **failure** (`passed: false`) _and_ yields the
+  reserved verdict, so the author can write `when: { verdict: result_file_error }` to route it, or
+  just let it fall through to the default edge.
+- The reserved verdict string is documented and exported; authors **must not** emit it from their
+  own helpers (the lint WF012 does not police this, but `WORKFLOWS.md` documents the reservation).
+
+---
+
+## 5. Execution / reducer changes
+
+### 5.1 Extend `DeterministicInvokeResult` and `DeterministicInvokeInput`
+
+`src/workflow/machine-builder.ts:60-74`:
+
+```ts
+export interface DeterministicInvokeInput {
+  readonly stateId: string;
+  readonly commands: readonly (readonly string[])[];
+  readonly context: WorkflowContext;
+  readonly container?: boolean;
+  readonly containerScope?: string;
+  readonly timeoutMs?: number;
+  readonly resultFile?: string; // NEW: workspace-relative path
+}
+
+export interface DeterministicInvokeResult {
+  readonly passed: boolean;
+  readonly testCount?: number;
+  readonly errors?: string;
+  readonly verdict?: string; // NEW: from result file (or reserved error verdict)
+  readonly payload?: Record<string, unknown>; // NEW: opaque machine-readable data
+}
+```
+
+Both new input fields are populated in the **two** construction sites that already populate
+`container`/`containerScope`/`timeoutMs`:
+
+- Machine-builder mapper (`src/workflow/machine-builder.ts:286-293`): add `resultFile:
+config.resultFile`.
+- Resume replay (`src/workflow/orchestrator.ts:1457`, the `replayInvokeForRestoredState` det
+  branch): add `resultFile: stateDef.resultFile`.
+
+`DeterministicStateDefinition` (`src/workflow/types.ts:251-275`) gains `readonly resultFile?:
+string;`.
+
+### 5.2 Where the orchestrator reads the file (container branch)
+
+The reducer is **not** touched — per PR #292 §4.6, the result-contract piece plugs in _after_ the
+reduction step, at the `executeDeterministicState` level (`orchestrator.ts:2343`), where the
+orchestrator has `instance` (hence `workspacePath`) and the stateId. Add a new private method
+`applyResultFile(instance, input, result)` called at the end of the **container** branch of
+`executeDeterministicState`. The result contract is **container-only** (§7.3 rejects `resultFile`
+without `container: true`), so the host branch is left byte-identical to today — it does **not**
+call `applyResultFile`:
+
+```ts
+private async executeDeterministicState(
+  workflowId: WorkflowId,
+  input: DeterministicInvokeInput,
+): Promise<DeterministicInvokeResult> {
+  // --- HOST branch (unchanged; resultFile rejected for container:false in §7.3) ---
+  if (!input.container) {
+    return this.runDeterministicHost(input.commands);
+  }
+
+  // --- CONTAINER branch (existing dispatch, unchanged through bundle resolution) ---
+  const instance = this.workflows.get(workflowId);
+  if (!instance) return { passed: false, errors: `workflow ${workflowId} not found` };
+  if (!this.shouldUseSharedContainer(instance.definition)) {
+    return { passed: false, errors: `State "${input.stateId}" requires shared-container Docker execution.` };
+  }
+  const scope = input.containerScope ?? DEFAULT_CONTAINER_SCOPE;
+  const bundleWasLive = instance.bundlesByScope.has(scope);
+  const bundle = await this.ensureBundleForScope(instance, scope);
+  const warning = bundleWasLive ? undefined : /* ...existing soft warning... */;
+  const base = await this.runDeterministicInContainer(bundle, input, warning);
+  return this.applyResultFile(instance, input, base);   // container-only read site
+}
+```
+
+> The container branch keeps its existing `instance` fetch and the `{ passed: false, errors:
+'workflow ... not found' }` / `shouldUseSharedContainer` guards unchanged. Because the read is
+> reached only on the container path, `instance` is always defined when `applyResultFile` runs.
+>
+> The XState `deterministicService` actor that calls `executeDeterministicState`
+> (`orchestrator.ts:1685-1687`) forwards `input` and returns `output` **opaquely**, so it needs
+> **no edit**; the only changed sites are `executeDeterministicState` itself (`:2343`) and the
+> resume replay (`:1457`, which gains `resultFile: stateDef.resultFile` per §5.1).
+
+**`applyResultFile`** — the container-side reader:
+
+```ts
+private async applyResultFile(
+  instance: WorkflowInstance | undefined,
+  input: DeterministicInvokeInput,
+  base: DeterministicInvokeResult,
+): Promise<DeterministicInvokeResult> {
+  if (input.resultFile === undefined) return base;              // legacy: no file
+  if (!base.passed) return base;                                // command already failed (§4.4)
+
+  // The helper wrote the file at /workspace/<resultFile> inside the container;
+  // instance.workspacePath is the host source of that bind mount, so we read
+  // the same bytes back here. (Reached only on the container path — §7.3.)
+  const workspace = instance?.workspacePath;
+  const resolved = workspace
+    ? resolve(workspace, input.resultFile)                      // input.resultFile is validated relative (§7)
+    : undefined;
+
+  const fail = (msg: string): DeterministicInvokeResult => ({
+    ...base,
+    passed: false,
+    verdict: DETERMINISTIC_RESULT_ERROR_VERDICT,
+    errors: base.errors ? `${base.errors}\n${msg}` : msg,
+  });
+
+  // Defense-in-depth: §7.3 validation already guarantees a safe relative path,
+  // but re-check before touching the file (the path string is author-controlled).
+  if (!isSafeWorkspaceRelativePath(input.resultFile)) {
+    return fail(`result file ${input.resultFile} is not a safe workspace-relative path`);
+  }
+
+  if (!resolved || !existsSync(resolved)) return fail(`result file ${input.resultFile} not found`);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(resolved, 'utf-8'));
+  } catch {
+    return fail(`result file ${input.resultFile} is not valid JSON`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return fail(`result file ${input.resultFile} is not a JSON object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.verdict !== 'string' || obj.verdict.length === 0) {
+    return fail(`result file ${input.resultFile} missing verdict`);
+  }
+
+  const payload =
+    typeof obj.payload === 'object' && obj.payload !== null && !Array.isArray(obj.payload)
+      ? (obj.payload as Record<string, unknown>)
+      : undefined;
+  const passed = typeof obj.passed === 'boolean' ? obj.passed : base.passed;  // §4.3 precedence
+
+  return { ...base, passed, verdict: obj.verdict, payload };
+}
+```
+
+`resolve`, `existsSync`, `readFileSync` are already imported in `orchestrator.ts`;
+`isSafeWorkspaceRelativePath` is exported from `validate.ts` (see §7.3) and imported here.
+
+**The read resolves under `instance.workspacePath`, which is the host source of the `/workspace`
+bind mount** (mount chain in §2): the orchestrator reads back the exact bytes the container helper
+wrote. This holds **only for the container path** — a `container: false` helper writes relative to
+`process.cwd()`, not the workspace (`orchestrator.ts:2408`, see §2), which is precisely why §7.3
+forbids `resultFile` on host states; host-side verdict routing is deferred (§13). The validation in
+§7 guarantees `input.resultFile` cannot escape the workspace (no `..`, no leading `/`), so the
+`resolve(workspace, …)` containment is safe; as defense-in-depth, `applyResultFile` re-checks that
+the resolved path is still under `workspace` and treats an escape as `result_file_error` (mirrors
+the §7 static check at runtime).
+
+### 5.3 Why not in the reducer
+
+`reduceDeterministicCommands` is deliberately I/O-free over the workspace and shared by host and
+container exactly so the two paths can't drift (PR #292 §4.4). Reading a workspace artifact is a
+post-reduction concern that needs `instance` (which the reducer doesn't have). Keeping the read in
+`applyResultFile` preserves the reducer's single-fork invariant and makes the back-compat path
+(no `resultFile`) a literal early-return.
+
+---
+
+## 6. Machine-builder changes
+
+Two changes, both in `src/workflow/machine-builder.ts`.
+
+### 6.1 Build `when:{verdict}` transitions for deterministic states
+
+`buildDeterministicState` (`:271-301`) currently maps transitions with **only** `t.guard`. Mirror
+the agent path (`buildAgentOnDoneTransitions`, `:234-249`): prefer `when` (via `__matchesWhen`),
+else `guard`:
+
+```ts
+function buildDeterministicState(stateId, config, definition): object {
+  const onDoneTransitions = config.transitions.map((t) => {
+    let guard: string | { type: string; params: { when: Readonly<Record<string, WhenValue>> } } | undefined;
+    if (t.when) {
+      guard = { type: '__matchesWhen', params: { when: t.when } };
+    } else if (t.guard) {
+      guard = t.guard;
+    }
+    return {
+      target: t.to,
+      ...(guard ? { guard } : {}),
+      actions: collectTransitionActions(t, 'updateContextFromDeterministicResult'),
+    };
+  });
+  // ... invoke wiring unchanged (add resultFile to the input mapper, §5.1) ...
+}
+```
+
+The `__matchesWhen` guard is **already registered globally** (`:433`); deterministic states pick it
+up for free. The only thing that doesn't work yet is that `__matchesWhen` reads an `AgentOutput` via
+`extractInvokeResult`, which returns `undefined` for a deterministic result — §6.2 fixes that.
+
+### 6.2 Make a deterministic result matchable by `__matchesWhen`
+
+`__matchesWhen` (`:433-461`) needs an object with a `verdict` field to match against. The cleanest
+seam that **keeps `isPassed` working** and adds **no new `WorkflowEvent` variant**: teach
+`__matchesWhen` to also accept a deterministic result and synthesize a minimal `AgentOutput`-shaped
+match object from it.
+
+Add, right after the agent-result extraction in `__matchesWhen` (`:437-442`):
+
+```ts
+xstateGuards['__matchesWhen'] = ({ event }, params) => {
+  const doneEvent = event as { type: string; output?: unknown };
+  let matchSource: Pick<AgentOutput, 'verdict'> | AgentOutput | undefined;
+
+  if (doneEvent.type.startsWith('xstate.done.actor.')) {
+    const agentResult = extractInvokeResult(doneEvent);
+    if (agentResult) {
+      matchSource = agentResult.output; // agent path (unchanged)
+    } else {
+      // Deterministic path: synthesize a match object carrying the verdict.
+      const det = doneEvent.output as DeterministicInvokeResult | undefined;
+      if (det && typeof det.verdict === 'string') {
+        matchSource = { verdict: det.verdict };
+      }
+    }
+  }
+  if (!matchSource) return false;
+  // ... existing param/when guards (:446-453) unchanged ...
+  for (const [key, expected] of Object.entries(when)) {
+    const actual = (matchSource as Record<string, unknown>)[key];
+    if (actual !== expected) return false;
+  }
+  return true;
+};
+```
+
+Because validation already restricts deterministic `when` keys to `verdict` only (the existing
+`nonVerdictKeys` check at `validate.ts:352-359` applies to both state types), the synthesized object
+needs only `verdict`. If a future change allows more keys, the synthesized object is extended in
+lockstep.
+
+**The `VALIDATION_PASSED`/`VALIDATION_FAILED` mapping (`:413-419`) is left unchanged.** It still
+drives `isPassed` and the `updateContextFromDeterministicResult` action. So:
+
+- `when:{verdict}` edges route via `__matchesWhen` reading `result.verdict` directly off the done
+  event's `output` (a `DeterministicInvokeResult`) — **bypassing** the `VALIDATION_*` mapping
+  entirely, exactly as the agent path bypasses it.
+- `guard: isPassed` edges route via the `VALIDATION_PASSED` mapping (driven by `result.passed`,
+  which now respects the file's `passed` override per §4.3) — **byte-identical to today** for
+  legacy states.
+
+This is the minimal-surface choice: no new event type, no change to `isPassed`, no change to the
+guard-adapter loop. (Alternative considered and rejected: adding a
+`{ type: 'VERDICT'; verdict; payload }` event variant and a guard adapter for it — more surface, and
+`__matchesWhen` already operates directly on the done-event output, not on a `WorkflowEvent`.)
+
+### 6.3 Surface `payload` into context (optional, recommended)
+
+`updateContextFromDeterministicResult` (`:512-532`) currently copies `testCount` and, on failure,
+`errors` into `previousAgentOutput`. Extend it to also stash `result.payload` and `result.verdict`
+so a downstream **agent** state can read the deterministic verdict/payload. Add a
+`readonly lastDeterministicResult?: { readonly verdict?: string; readonly payload?: Record<string,
+unknown> }` field to `WorkflowContext` (`src/workflow/types.ts:423-470`, near `previousTestCount`;
+`WorkflowContext` is fully `readonly`, so the field matches that style) and set it in the action.
+This is **not required for routing** (routing reads the done event directly) but is the natural way
+asi-evolve's `record_node` agent consumes the payload. Gate this behind "do we have a consumer" —
+ship the field; the prompt-builder wiring that _renders_ it is asi-evolve's concern, out of scope
+here.
+
+---
+
+## 7. Validation changes (`src/workflow/validate.ts`)
+
+### 7.1 Schema
+
+`deterministicStateSchema` (`:78-86`) gains the field, reusing a new workspace-relative-path check:
+
+```ts
+const deterministicStateSchema = z.object({
+  // ... existing ...
+  resultFile: z.string().min(1).optional(),
+  transitions: z.array(agentTransitionSchema).min(1),
+});
+```
+
+The `agentTransitionSchema` (already used for deterministic transitions, `:85`) already permits
+`when`, so no transition-schema change is needed — only the semantic guard below is relaxed.
+
+### 7.2 Relax the deterministic-`when` rejection
+
+Remove the hard rejection at `validate.ts:336-338`:
+
+```ts
+// DELETE:
+if (state.type === 'deterministic' && t.when) {
+  issues.push(`State "${stateId}" is deterministic and cannot use "when" (agent output not available)`);
+}
+```
+
+Everything else in `validateWhenClauses` (`:324-387`) already handles both state types uniformly and
+**continues to apply to deterministic states**:
+
+- mutual exclusivity of `guard`+`when` per transition (`:329-332`),
+- empty-`when` rejection (`:343-347`),
+- **`verdict`-only key restriction** (`:352-359`) — deterministic `when` is thus limited to
+  `{ verdict: ... }`, which is exactly what §6.2 supports,
+- value-type check: `verdict` must be a string (`WHEN_KEY_TYPES.verdict`, `:270`), enforced at
+  `:372-378`. `verdict` accepts any string (no enum), so custom verdicts route.
+
+No new positive validation of the verdict-transition _set_ is required beyond these; the existing
+machinery is sufficient.
+
+### 7.3 New `resultFile` rules: container-only + path safety
+
+**(a) Container-only rule (the load-bearing one).** The result contract only works when the helper
+runs in the container, because that is the only path where the helper's write target (`/workspace`)
+and the orchestrator's read target (`instance.workspacePath`) are the same bytes (§2, §5.2). A
+host-side (`container: false`) helper writes relative to `process.cwd()` (`orchestrator.ts:2408`),
+so its result file would never be where `applyResultFile` reads — every such state would return
+`result_file_error`. Reject this at validation time rather than letting it fail at runtime.
+
+`validateContainerScopes` (`validate.ts:472-505`) is the natural home: it already iterates every
+deterministic state and gates `container: true` against `sharedContainer`/`mode`. Add a sibling
+check in that same deterministic branch (after the existing `container === true` checks):
+
+```ts
+// A deterministic state that uses resultFile, or routes on when:{verdict},
+// requires container:true — the result-file path only aligns host<->container
+// inside the workspace bind mount (host-side cwd is process.cwd(), not /workspace).
+const usesVerdictEdges = state.transitions.some((t) => t.when && 'verdict' in t.when);
+if ((state.resultFile !== undefined || usesVerdictEdges) && state.container !== true) {
+  issues.push(
+    `State "${stateId}" uses resultFile / when:{verdict} routing but is not container: true. ` +
+      `The deterministic result contract is container-only (the host helper's cwd is not the workspace).`,
+  );
+}
+```
+
+(This sits next to the existing `containerScope`/`container` checks in `validateContainerScopes` so
+all of a deterministic state's container preconditions are validated in one place.)
+
+**(b) Path safety.** Add a semantic check (in `validateSemantics`, alongside the existing per-state
+loop at `validate.ts:404`, or folded into the same `validateContainerScopes` pass): for each
+deterministic state with `resultFile` set, reject if the path is not a safe workspace-relative path:
+
+```ts
+// reject: absolute, parent-escape, or NUL
+if (state.type === 'deterministic' && state.resultFile !== undefined) {
+  const rf = state.resultFile;
+  if (rf.startsWith('/') || rf.split('/').includes('..') || rf.includes('\0')) {
+    issues.push(
+      `State "${stateId}" has resultFile "${rf}" — must be a workspace-relative path (no leading "/", no "..").`,
+    );
+  }
+}
+```
+
+Factor the path check into a small `isSafeWorkspaceRelativePath(p): boolean` helper so the runtime
+defense-in-depth check in §5.2 shares it.
+
+**(c) Reject `resultFile` on non-deterministic state types (author feedback).** `resultFile` lives
+only in `deterministicStateSchema`, so Zod's `.strip()` would **silently drop** a `resultFile`
+mistakenly placed on an agent/terminal/human_gate state — the author gets no diagnostic. Mirror the
+existing `containerScope` raw-input gate (`validate.ts:159-176`, which rejects `containerScope` on
+non-agent/non-deterministic types) by extending it to also reject `resultFile` on any non-deterministic
+state: `State "<id>" (type: <t>) has "resultFile" but that field is only valid on deterministic states.`
+Cheap; prevents a silent no-op. (Optional — not a correctness blocker, since a stripped `resultFile`
+just yields legacy guard-only behavior.)
+
+### 7.4 Lint WF012 — verdict edges without a result file
+
+New lint in `src/workflow/lint.ts` (mirrors WF011's shape; reuses `collectTransitionTargets` /
+iterates states):
+
+- **Code:** add `'WF012'` to `DiagnosticCode` (`lint.ts:55`).
+- **Check `checkVerdictEdgesHaveResultFile(def)`:** for each `deterministic` state, if any transition
+  has `t.when` with a `verdict` key **and** the state has no `resultFile`, emit a `warning`:
+
+  > Deterministic state `<id>` routes on `when:{verdict}` but declares no `resultFile`; the verdict
+  > will always be undefined and these edges are dead. Add `resultFile: <path>` and have the helper
+  > write `{ "verdict": ... }` there.
+
+- Wire into `lintWorkflow` (`lint.ts:95-107`) next to WF011.
+- **Symmetric note (not a separate code):** a `resultFile` with no `when:{verdict}` edges is _not_
+  an error (a helper may write a result for payload-only consumption by a later agent). Do not warn.
+
+---
+
+## 8. Back-compat
+
+The invariant from §1 restated as a checklist the implementation must hold:
+
+1. **No `resultFile`** ⇒ on the container branch `applyResultFile` early-returns the reducer result
+   untouched, and the host branch never calls it at all ⇒ `verdict` undefined,
+   `passed`/`testCount`/`errors` identical to today.
+2. **No `when` on transitions** ⇒ `buildDeterministicState` maps only `guard`, identical XState
+   config to today (the `else if (t.guard)` branch).
+3. **`VALIDATION_PASSED`/`VALIDATION_FAILED` mapping unchanged** ⇒ `isPassed` byte-identical.
+4. **stdout-mined `passed`/`testCount` unchanged** ⇒ the reducer is not touched.
+5. **`deterministic-eval-smoke` fixture** (guard-only, no `resultFile`) keeps routing
+   `evaluate → report → done` via `isPassed`. It is the regression oracle (no shipped real workflow
+   has a deterministic state).
+
+A `test/workflow/orchestrator-deterministic.test.ts` case asserts that with `resultFile` undefined,
+`applyResultFile` returns the exact reducer object (reference-stable shape) and reads no file.
+
+---
+
+## 9. Resume & checkpoint
+
+- **Result files are workspace artifacts**, written under `instance.workspacePath` (the persisted
+  run workspace, bind-mounted to `/workspace`). They are **not** part of `WorkflowCheckpoint` — they
+  live in the workspace dir, which already survives resume (the workspace is re-mounted from the
+  persisted run dir, PR #292 §7). No new checkpoint field is needed for the file itself.
+- **Deterministic states are replayed on resume** via `replayInvokeForRestoredState`
+  (`orchestrator.ts:1448-1457`); the replay path constructs `DeterministicInvokeInput` and must
+  include `resultFile: stateDef.resultFile` (§5.1) so a re-run reads the file the same way. The
+  re-run **re-executes the commands**, which **re-write** the result file (helpers are expected
+  idempotent, matching the existing replay assumption for the command array). The orchestrator reads
+  the freshly-written file, so a stale file from a prior partial run is overwritten — no special
+  handling.
+- **`lastDeterministicResult` context field** (§6.3), if added, is part of `WorkflowContext` and is
+  therefore checkpointed/restored with the rest of context automatically (no extra wiring); on
+  replay it is overwritten by the re-run's `updateContextFromDeterministicResult`.
+- **Edge case:** if a workflow is resumed _at_ a terminal/gate immediately after a verdict-routed
+  deterministic state (the deterministic state already completed pre-checkpoint), there is no replay
+  of the deterministic state and no file read — the routing decision was baked into the checkpointed
+  XState position. Correct and requires nothing.
+
+---
+
+## 10. Acceptance — end-to-end gating test (REQUIRED)
+
+This is the gap PR #292 left (its integration items #8–#10 were **manual, not committed CI**). Close
+it with an **automated, gated, real-Docker integration test** that proves the machine routes a
+deterministic state on a **helper-written verdict file**, not on stdout pass/fail.
+
+### 10.1 Fixture: `deterministic-verdict-smoke`
+
+Ship under `src/workflow/workflows/deterministic-verdict-smoke/`. Shape: **a minimal agent mints the
+container and records the task; a deterministic in-container state's packaged helper reads the task
+and writes a `verdict` into `result.json`; two `when:{verdict}` edges route to two distinct
+terminals.** The helper picks its verdict from the task input so **both branches are exercisable**.
+
+How the task reaches the helper: the agent writes the verbatim task string to a workspace file the
+helper reads. (The orchestrator already persists the task at `<metaDir>/task/description.md`
+host-side, but that is not mounted into the container; the simplest container-visible channel is the
+agent writing it into `/workspace`.)
+
+```yaml
+# src/workflow/workflows/deterministic-verdict-smoke/workflow.yaml
+name: deterministic-verdict-smoke
+description: 'TESTING ONLY - deterministic state routes on a helper-written verdict file.'
+initial: author
+
+settings:
+  mode: docker
+  dockerAgent: claude-code
+  sharedContainer: true
+  model: anthropic:claude-haiku-4-5
+
+states:
+  author:
+    type: agent
+    description: Record the task verbatim so the deterministic helper can read it.
+    persona: global
+    prompt: |
+      Write the EXACT task text you were given to the file /workspace/task.txt and nothing else.
+      Create no other files. Finish with the required agent_status block.
+    inputs: []
+    outputs: []
+    transitions:
+      - to: classify
+
+  classify:
+    type: deterministic
+    description: Read the task and emit a verdict file the machine routes on.
+    container: true # default scope "primary" — reuses author's bundle
+    resultFile: .workflow/result.json
+    run:
+      - ['python3', '/workflow-scripts/classify.py']
+    transitions:
+      - to: passed_terminal
+        when: { verdict: pass }
+      - to: blocked_terminal
+        when: { verdict: block }
+      - to: error_terminal # default: result_file_error or unexpected verdict
+        when: { verdict: result_file_error }
+      - to: error_terminal # belt-and-braces unguarded default
+
+  passed_terminal:
+    type: terminal
+    description: Helper emitted verdict=pass.
+  blocked_terminal:
+    type: terminal
+    description: Helper emitted verdict=block.
+  error_terminal:
+    type: terminal
+    description: Verdict file missing/malformed or unexpected verdict.
+```
+
+```python
+# src/workflow/workflows/deterministic-verdict-smoke/scripts/classify.py
+# No third-party deps -> no requirements.txt -> shared agent image (no per-workflow build).
+import json, pathlib
+
+ws = pathlib.Path("/workspace")
+out = ws / ".workflow"
+out.mkdir(exist_ok=True)
+task = (ws / "task.txt").read_text().strip().lower() if (ws / "task.txt").exists() else ""
+
+# Verdict is chosen from the task input so both branches are reachable.
+verdict = "block" if "block" in task else "pass"
+
+(out / "result.json").write_text(
+    json.dumps({"verdict": verdict, "payload": {"task": task}, "passed": True}) + "\n"
+)
+# Deliberately print a misleading "0 tests pass"-free line to prove routing is NOT
+# stdout-derived: stdout says nothing about pass/block; only result.json decides.
+print(f"classified: {verdict}")
+```
+
+No `requirements.txt`/`package.json` ⇒ no per-workflow image build (PR #292 §6.1 fast path); the
+fixture exercises the verdict contract in isolation from the dep-bake machinery.
+
+### 10.2 Completion gate (stated precisely)
+
+The test runs the workflow twice against a **real Docker daemon**:
+
+- `workflow start deterministic-verdict-smoke "pass"` ⇒ final state **`passed_terminal`**.
+- `workflow start deterministic-verdict-smoke "block"` ⇒ final state **`blocked_terminal`**.
+
+**Gate:** both runs land on their **verdict-specific terminal**, and neither lands on
+`error_terminal`. Because `classify.py`'s **stdout carries no pass/fail signal** (`isPassed` would
+see `VALIDATION_PASSED` for _both_ runs — the commands always exit 0), the only thing that can
+distinguish `passed_terminal` from `blocked_terminal` is the **verdict read from `result.json`**.
+Two distinct terminals from two task inputs therefore **prove the machine routed on the
+helper-written verdict file, not on stdout pass/fail.** A guard-only implementation could not reach
+both terminals.
+
+### 10.3 Automated gated integration test
+
+`test/workflow/deterministic-verdict-smoke.integration.test.ts`:
+
+- Gate with `describe.skipIf(!process.env.INTEGRATION_TEST || !dockerReady)` using the existing
+  `isDockerAvailable()` / `isDockerImageAvailable(IMAGE)` helpers
+  (`test/helpers/docker-available.ts`) and the `dockerReady` composition from
+  `test/skills-end-to-end.integration.test.ts:397`.
+- Drive the orchestrator the way `skills-end-to-end.integration.test.ts` does (construct the
+  orchestrator with real infra, `start()` the fixture, poll the run to terminal, assert the final
+  state name from the checkpoint / lifecycle events).
+- Two cases (`"pass"` → `passed_terminal`, `"block"` → `blocked_terminal`), plus a **negative
+  case**: a third fixture variant (or a mutated helper that writes no file) lands on
+  `error_terminal` with verdict `result_file_error` — proving the §4.4 reserved-verdict path is
+  reachable and routable.
+- This test **doubles as the asi-evolve `evaluate`/`record_node` smoke test**: same pattern (agent
+  mints container → deterministic helper emits verdict → verdict routes to distinct successors), so
+  asi-evolve can build its `evaluate` state against a proven contract.
+
+### 10.4 Manual run (developer loop)
+
+```
+INTEGRATION_TEST=1 npm test -- test/workflow/deterministic-verdict-smoke.integration.test.ts
+# or by hand:
+tsx src/cli.ts workflow start deterministic-verdict-smoke "pass"   # → passed_terminal
+tsx src/cli.ts workflow start deterministic-verdict-smoke "block"  # → blocked_terminal
+tsx src/cli.ts workflow inspect <baseDir>                          # confirm final state
+```
+
+---
+
+## 11. File-by-file change list
+
+| File                                                            | Change                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/workflow/types.ts`                                         | Add `readonly resultFile?: string` to `DeterministicStateDefinition` (`:251`). Add `export const DETERMINISTIC_RESULT_ERROR_VERDICT = 'result_file_error'`. Add `readonly lastDeterministicResult?: { readonly verdict?: string; readonly payload?: Record<string, unknown> }` to `WorkflowContext` (`:423-470`, fully readonly) (§6.3).                                                                                               |
+| `src/workflow/machine-builder.ts`                               | Extend `DeterministicInvokeInput` (`resultFile?`) and `DeterministicInvokeResult` (`verdict?`, `payload?`) (`:60-74`). Build `when:{verdict}` deterministic transitions via `__matchesWhen` in `buildDeterministicState` (`:271`). Teach `__matchesWhen` to read a deterministic `verdict` (`:433`). Populate `resultFile` in the input mapper (`:286`). Stash `verdict`/`payload` in `updateContextFromDeterministicResult` (`:512`). |
+| `src/workflow/orchestrator.ts`                                  | In `executeDeterministicState` (`:2343`) add `applyResultFile(instance, input, base)` on the **container** branch only (host branch unchanged — contract is container-only). Thread `resultFile` into the replay-path `DeterministicInvokeInput` (`:1457`). The `deterministicService` actor (`:1685-1687`) forwards opaquely → **no edit**. Import `DETERMINISTIC_RESULT_ERROR_VERDICT` + `isSafeWorkspaceRelativePath`.              |
+| `src/workflow/validate.ts`                                      | Add `resultFile` to `deterministicStateSchema` (`:78`). **Remove** the deterministic-`when` rejection (`:336-338`). In `validateContainerScopes` (`:472-505`) add the **container-only** check: a deterministic state with `resultFile` or `when:{verdict}` edges must be `container: true`. Add `resultFile` path-safety semantic check + export `isSafeWorkspaceRelativePath`.                                                       |
+| `src/workflow/lint.ts`                                          | Add `'WF012'` to `DiagnosticCode` (`:55`); add `checkVerdictEdgesHaveResultFile` and wire into `lintWorkflow` (`:95-107`).                                                                                                                                                                                                                                                                                                             |
+| `src/workflow/workflows/deterministic-verdict-smoke/`           | NEW acceptance fixture: `workflow.yaml` + `scripts/classify.py` (no deps).                                                                                                                                                                                                                                                                                                                                                             |
+| `test/workflow/orchestrator-deterministic.test.ts`              | Add `applyResultFile` unit cases (§12): well-formed verdict, `passed` override, missing/malformed → reserved verdict, no-`resultFile` no-op, command-failed-skips-read.                                                                                                                                                                                                                                                                |
+| `test/workflow/machine-builder.test.ts`                         | Add: deterministic `when:{verdict}` builds `__matchesWhen` guard; `__matchesWhen` matches a `DeterministicInvokeResult.verdict`; guard-only path unchanged; input mapper emits `resultFile`.                                                                                                                                                                                                                                           |
+| `test/workflow/validate.test.ts`                                | Add: deterministic `when:{verdict}` now valid; `guard`+`when` on one transition still rejected; non-`verdict` key rejected; bad `resultFile` path rejected; no-regression snapshot over shipped fixtures + `deterministic-eval-smoke`.                                                                                                                                                                                                 |
+| `test/workflow/lint.test.ts`                                    | Add WF012: verdict edges without `resultFile` warn; with `resultFile` clean; `deterministic-verdict-smoke` lints clean.                                                                                                                                                                                                                                                                                                                |
+| `test/workflow/deterministic-verdict-smoke.integration.test.ts` | NEW gated real-Docker integration test (§10.3): `"pass"`→`passed_terminal`, `"block"`→`blocked_terminal`, malformed→`error_terminal`.                                                                                                                                                                                                                                                                                                  |
+| `WORKFLOWS.md`                                                  | Document `resultFile`, the `result.json` contract (§4), `when:{verdict}` on deterministic states, the reserved `result_file_error` verdict, and WF012.                                                                                                                                                                                                                                                                                 |
+
+---
+
+## 12. Unit / integration test plan (beyond the gating fixture)
+
+**Unit (vitest, no Docker):**
+
+1. `applyResultFile` (orchestrator-deterministic): (a) no `resultFile` ⇒ returns base unchanged, no
+   `fs` read (spy `readFileSync` not called); (b) well-formed `{verdict,payload,passed}` ⇒ fields
+   merged, `passed` from file overrides base; (c) `passed` absent ⇒ keeps base `passed`; (d) file
+   missing ⇒ `verdict='result_file_error'`, `passed=false`, error appended; (e) invalid JSON / array
+   / non-object ⇒ reserved verdict; (f) empty/non-string `verdict` ⇒ reserved verdict; (g) base
+   already failed (command non-zero) ⇒ file **not** read, `verdict` undefined; (h) `..`/absolute
+   `resultFile` reaching runtime ⇒ reserved verdict (defense-in-depth).
+2. `machine-builder`: deterministic transition with `when:{verdict:'x'}` produces guard
+   `{type:'__matchesWhen', params:{when:{verdict:'x'}}}`; with `guard:'isPassed'` produces
+   `guard:'isPassed'`; `__matchesWhen` returns true when done-event output is a
+   `DeterministicInvokeResult` with matching `verdict`, false on mismatch/undefined; agent path
+   unchanged.
+3. `validate`: deterministic `when:{verdict}` accepted; `when:{completed:true}` on deterministic
+   rejected (non-`verdict` key); `guard`+`when` same transition rejected; absolute/`..` `resultFile`
+   rejected; valid `resultFile` accepted.
+4. `lint`: WF012 fires/clears as specified; the existing codes
+   (`WF001|WF002|WF003|WF004|WF006|WF007|WF008|WF010|WF011`) are unaffected (snapshot).
+5. `isPassed` back-compat: a guard-only deterministic result still maps to
+   `VALIDATION_PASSED`/`FAILED` and `isPassed` routes identically (existing tests stay green).
+
+**Integration (real Docker, `INTEGRATION_TEST=1`):** the §10.3 `deterministic-verdict-smoke` test —
+two-terminal verdict routing + reserved-verdict negative case. This is the only _required_ Docker
+test; the rest are unit-level and run in normal CI.
+
+---
+
+## 13. Open questions / human decisions
+
+1. **`passed`-in-file overriding exit code (§4.3).** Decided: the file's `passed` wins when present.
+   The alternative — exit code is always authoritative and `passed` in the file is ignored — is
+   simpler but blocks the "evaluator exited 0 but the candidate failed" pattern asi-evolve wants.
+   _Maintainer call:_ keep the override, or restrict it (e.g. only allow `passed:false` to _demote_,
+   never `passed:true` to _promote_ a non-zero exit). Recommended: keep the full override; the helper
+   is trusted workflow-author code.
+2. **Should a missing/malformed result file be a hard `onError` (storeError → error target) instead
+   of a routable `result_file_error` verdict (§4.4)?** Decided: routable verdict + `passed:false`, so
+   authors can branch on it. The alternative routes it through the existing `onError`
+   (`findErrorTarget`) wiring, which is blunter (no verdict) but reuses an existing path. Recommended:
+   routable verdict — it's strictly more expressive and the error is still in `errors`.
+3. **Whether to ship the `lastDeterministicResult` context field / payload-into-context now (§6.3)**
+   or defer it until asi-evolve actually consumes the payload. Decided: ship the context field (it's
+   cheap and checkpoint-free) but **not** the prompt-builder rendering (asi-evolve's concern).
+   _Maintainer call:_ if YAGNI is preferred, drop the field entirely and let asi-evolve add it — the
+   routing contract (verdict) stands alone without it.
+4. **Host-side (`container: false`) verdict routing is deferred — out of scope here.** This design
+   scopes the result contract to `container: true` (§1, §5.2, §7.3) because the host helper's cwd is
+   `process.cwd()`, not the workspace (`orchestrator.ts:2408`), so its result file never aligns with
+   `applyResultFile`'s `resolve(instance.workspacePath, …)` read. Lifting this would mean giving the
+   host helper a `cwd` set to `instance.workspacePath` (the reviewer's option b) — a change to
+   `runDeterministicHost`'s `execFileAsync` call plus its own back-compat note (today's host states
+   run with the orchestrator's cwd) and a dedicated host-side routing test. Tracked as future work;
+   asi-evolve's `evaluate`/`record_node` states are container-only, so nothing depends on it now.

--- a/src/workflow/lint.ts
+++ b/src/workflow/lint.ts
@@ -52,7 +52,17 @@ import type { ResolvedSkill, SkillDiscoveryError } from '../skills/types.js';
  * supply a `workflowFilePath` (the package dir is the only place skill
  * manifests can live).
  */
-export type DiagnosticCode = 'WF001' | 'WF002' | 'WF003' | 'WF004' | 'WF006' | 'WF007' | 'WF008' | 'WF010' | 'WF011';
+export type DiagnosticCode =
+  | 'WF001'
+  | 'WF002'
+  | 'WF003'
+  | 'WF004'
+  | 'WF006'
+  | 'WF007'
+  | 'WF008'
+  | 'WF010'
+  | 'WF011'
+  | 'WF012';
 export type DiagnosticSeverity = 'error' | 'warning';
 
 export interface Diagnostic {
@@ -105,6 +115,7 @@ export function lintWorkflow(def: WorkflowDefinition, ctx: LintContext): LintRes
     ...checkPersonaExists(def, ctx),
     ...checkVisitCapTransitionOrder(def),
     ...checkContainerScopePopulatedByAgent(def),
+    ...checkVerdictEdgesHaveResultFile(def),
     ...checkSkillReferencesAndManifests(def, ctx),
   ];
 }
@@ -475,6 +486,34 @@ function isReachableWithoutScopeAgent(def: WorkflowDefinition, target: string, s
     }
   }
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// WF012 — deterministic verdict edges need a resultFile source
+// ---------------------------------------------------------------------------
+
+function checkVerdictEdgesHaveResultFile(def: WorkflowDefinition): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+
+  for (const [stateId, state] of Object.entries(def.states)) {
+    if (state.type !== 'deterministic') continue;
+    if (state.resultFile !== undefined) continue;
+
+    const hasVerdictWhen = state.transitions.some((t) => t.when !== undefined && 'verdict' in t.when);
+    if (!hasVerdictWhen) continue;
+
+    diagnostics.push({
+      code: 'WF012',
+      severity: 'warning',
+      stateId,
+      message:
+        `Deterministic state "${stateId}" routes on when:{verdict} but declares no resultFile; ` +
+        `the verdict will always be undefined and these edges are dead.`,
+      hint: `Add resultFile: <path> and have the helper write { "verdict": ... } there.`,
+    });
+  }
+
+  return diagnostics;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/workflow/lint.ts
+++ b/src/workflow/lint.ts
@@ -15,7 +15,13 @@ import type {
   AgentTransitionDefinition,
 } from './types.js';
 import { GLOBAL_PERSONA, DEFAULT_CONTAINER_SCOPE } from './types.js';
-import { collectTransitionTargets, findReachableStates, iterateSkillRefIssues, parseArtifactRef } from './validate.js';
+import {
+  collectTransitionTargets,
+  findReachableStates,
+  iterateSkillRefIssues,
+  parseArtifactRef,
+  usesVerdictEdges,
+} from './validate.js';
 import { getWorkflowPackageDir } from './discovery.js';
 import { ACTIONABLE_DISCOVERY_REASONS, discoverSkillsWithErrors } from '../skills/discovery.js';
 import type { ResolvedSkill, SkillDiscoveryError } from '../skills/types.js';
@@ -499,8 +505,7 @@ function checkVerdictEdgesHaveResultFile(def: WorkflowDefinition): Diagnostic[] 
     if (state.type !== 'deterministic') continue;
     if (state.resultFile !== undefined) continue;
 
-    const hasVerdictWhen = state.transitions.some((t) => t.when !== undefined && 'verdict' in t.when);
-    if (!hasVerdictWhen) continue;
+    if (!usesVerdictEdges(state.transitions)) continue;
 
     diagnostics.push({
       code: 'WF012',

--- a/src/workflow/machine-builder.ts
+++ b/src/workflow/machine-builder.ts
@@ -532,12 +532,21 @@ export function buildWorkflowMachine(definition: WorkflowDefinition, taskDescrip
         const result = doneEvent.output;
         if (!result) return {};
 
+        // Only attach lastDeterministicResult when the state actually produced a
+        // verdict/payload (a result-file state). Guard-only deterministic states
+        // leave context byte-identical to the legacy path (the field stays absent).
+        const verdictUpdate =
+          result.verdict !== undefined || result.payload !== undefined
+            ? {
+                lastDeterministicResult: {
+                  ...(result.verdict !== undefined ? { verdict: result.verdict } : {}),
+                  ...(result.payload !== undefined ? { payload: result.payload } : {}),
+                },
+              }
+            : {};
         const baseUpdate = {
           previousTestCount: result.testCount ?? context.previousTestCount,
-          lastDeterministicResult: {
-            ...(result.verdict !== undefined ? { verdict: result.verdict } : {}),
-            ...(result.payload !== undefined ? { payload: result.payload } : {}),
-          },
+          ...verdictUpdate,
         };
         if (result.passed) return baseUpdate;
 

--- a/src/workflow/machine-builder.ts
+++ b/src/workflow/machine-builder.ts
@@ -64,6 +64,7 @@ export interface DeterministicInvokeInput {
   readonly container?: boolean;
   readonly containerScope?: string;
   readonly timeoutMs?: number;
+  readonly resultFile?: string;
 }
 
 /** Result from a deterministic (test/lint) state. */
@@ -71,6 +72,8 @@ export interface DeterministicInvokeResult {
   readonly passed: boolean;
   readonly testCount?: number;
   readonly errors?: string;
+  readonly verdict?: string;
+  readonly payload?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -273,11 +276,20 @@ function buildDeterministicState(
   config: DeterministicStateDefinition,
   definition: WorkflowDefinition,
 ): object {
-  const onDoneTransitions = config.transitions.map((t) => ({
-    target: t.to,
-    ...(t.guard ? { guard: t.guard } : {}),
-    actions: collectTransitionActions(t, 'updateContextFromDeterministicResult'),
-  }));
+  const onDoneTransitions = config.transitions.map((t) => {
+    let guard: string | { type: string; params: { when: Readonly<Record<string, WhenValue>> } } | undefined;
+    if (t.when) {
+      guard = { type: '__matchesWhen', params: { when: t.when } };
+    } else if (t.guard) {
+      guard = t.guard;
+    }
+
+    return {
+      target: t.to,
+      ...(guard ? { guard } : {}),
+      actions: collectTransitionActions(t, 'updateContextFromDeterministicResult'),
+    };
+  });
 
   return {
     invoke: {
@@ -290,6 +302,7 @@ function buildDeterministicState(
         container: config.container ?? false,
         containerScope: config.containerScope,
         timeoutMs: config.timeoutMs,
+        resultFile: config.resultFile,
       }),
       onDone: onDoneTransitions,
       onError: {
@@ -432,16 +445,21 @@ export function buildWorkflowMachine(definition: WorkflowDefinition, taskDescrip
   // directly (via extractInvokeResult inline) rather than on WorkflowEvent.
   xstateGuards['__matchesWhen'] = ({ event }, params) => {
     const doneEvent = event as { type: string; output?: unknown };
-    let agentOutput: AgentOutput | undefined;
+    let matchSource: Readonly<Record<string, unknown>> | undefined;
 
     if (doneEvent.type.startsWith('xstate.done.actor.')) {
       const result = extractInvokeResult(doneEvent as { output?: unknown });
       if (result) {
-        agentOutput = result.output;
+        matchSource = result.output as unknown as Readonly<Record<string, unknown>>;
+      } else {
+        const detResult = doneEvent.output as DeterministicInvokeResult | undefined;
+        if (typeof detResult?.verdict === 'string') {
+          matchSource = { verdict: detResult.verdict };
+        }
       }
     }
 
-    if (!agentOutput) return false;
+    if (!matchSource) return false;
 
     // Defensive: fail closed if params are missing or when is empty/missing.
     // Validation prevents these cases, but we don't want a silent unconditional
@@ -454,7 +472,7 @@ export function buildWorkflowMachine(definition: WorkflowDefinition, taskDescrip
     const when = whenMap as Readonly<Record<string, WhenValue>>;
 
     for (const [key, expected] of Object.entries(when)) {
-      const actual = agentOutput[key as keyof AgentOutput];
+      const actual = matchSource[key];
       if (actual !== expected) return false;
     }
     return true;
@@ -516,6 +534,10 @@ export function buildWorkflowMachine(definition: WorkflowDefinition, taskDescrip
 
         const baseUpdate = {
           previousTestCount: result.testCount ?? context.previousTestCount,
+          lastDeterministicResult: {
+            ...(result.verdict !== undefined ? { verdict: result.verdict } : {}),
+            ...(result.payload !== undefined ? { payload: result.payload } : {}),
+          },
         };
         if (result.passed) return baseUpdate;
 

--- a/src/workflow/machine-builder.ts
+++ b/src/workflow/machine-builder.ts
@@ -234,7 +234,13 @@ function compileAction(action: WorkflowTransitionAction): XStateActionEntry {
   return { type: 'resetVisitCounts', params: { stateIds: action.stateIds } };
 }
 
-function buildAgentOnDoneTransitions(transitions: readonly AgentTransitionDefinition[]): readonly object[] {
+// Shared onDone-transition builder for agent and deterministic states: both map a
+// `when:` clause to the __matchesWhen guard, else a bare `guard:`, and run a
+// per-state-type context-update action. Only the update action differs.
+function buildOnDoneTransitions(
+  transitions: readonly AgentTransitionDefinition[],
+  updateAction: string,
+): readonly object[] {
   return transitions.map((t) => {
     let guard: string | { type: string; params: { when: Readonly<Record<string, WhenValue>> } } | undefined;
     if (t.when) {
@@ -246,7 +252,7 @@ function buildAgentOnDoneTransitions(transitions: readonly AgentTransitionDefini
     return {
       target: t.to,
       ...(guard ? { guard } : {}),
-      actions: collectTransitionActions(t, 'updateContextFromAgentResult'),
+      actions: collectTransitionActions(t, updateAction),
     };
   });
 }
@@ -262,7 +268,7 @@ function buildAgentState(stateId: string, config: AgentStateDefinition, definiti
         stateConfig: config,
         context,
       }),
-      onDone: buildAgentOnDoneTransitions(config.transitions),
+      onDone: buildOnDoneTransitions(config.transitions, 'updateContextFromAgentResult'),
       onError: {
         target: findErrorTarget(config, definition),
         actions: ['storeError', 'updateContextFromAgentInvocationError'],
@@ -276,20 +282,7 @@ function buildDeterministicState(
   config: DeterministicStateDefinition,
   definition: WorkflowDefinition,
 ): object {
-  const onDoneTransitions = config.transitions.map((t) => {
-    let guard: string | { type: string; params: { when: Readonly<Record<string, WhenValue>> } } | undefined;
-    if (t.when) {
-      guard = { type: '__matchesWhen', params: { when: t.when } };
-    } else if (t.guard) {
-      guard = t.guard;
-    }
-
-    return {
-      target: t.to,
-      ...(guard ? { guard } : {}),
-      actions: collectTransitionActions(t, 'updateContextFromDeterministicResult'),
-    };
-  });
+  const onDoneTransitions = buildOnDoneTransitions(config.transitions, 'updateContextFromDeterministicResult');
 
   return {
     invoke: {

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -9,7 +9,7 @@ import {
   unlinkSync,
   cpSync,
 } from 'node:fs';
-import { resolve } from 'node:path';
+import { relative, resolve } from 'node:path';
 import { MessageLog, type AgentRetryReason } from './message-log.js';
 import { createHash, type Hash } from 'node:crypto';
 import { execFile as execFileCb } from 'node:child_process';
@@ -37,6 +37,7 @@ import {
   WORKFLOW_ARTIFACT_DIR,
   GLOBAL_PERSONA,
   DEFAULT_CONTAINER_SCOPE,
+  DETERMINISTIC_RESULT_ERROR_VERDICT,
   resolveWorkflowSkillsOptions,
 } from './types.js';
 import {
@@ -93,7 +94,12 @@ import {
 } from './status-parser.js';
 import { buildAgentCommand, buildArtifactReprompt, buildStatusInstructions } from './prompt-builder.js';
 import { collectFilesRecursive, hasAnyFiles, snapshotArtifacts } from './artifacts.js';
-import { parseArtifactRef, validateDefinition, validateWorkflowSkillReferences } from './validate.js';
+import {
+  isSafeWorkspaceRelativePath,
+  parseArtifactRef,
+  validateDefinition,
+  validateWorkflowSkillReferences,
+} from './validate.js';
 import { parseDefinitionFile, getWorkflowPackageDir } from './discovery.js';
 import { resolveSkillsForSession } from '../skills/discovery.js';
 import type { ResolvedSkill } from '../skills/types.js';
@@ -1461,6 +1467,7 @@ export class WorkflowOrchestrator implements WorkflowController {
             container: stateDef.container ?? false,
             containerScope: stateDef.containerScope,
             timeoutMs: stateDef.timeoutMs,
+            resultFile: stateDef.resultFile,
           });
 
     // Feed the result back to the actor as an XState internal invoke event.
@@ -2363,7 +2370,67 @@ export class WorkflowOrchestrator implements WorkflowController {
       ? undefined
       : `container: true state "${input.stateId}": scope "${scope}" had no live container before this state. ` +
         `On a fresh run this likely means no prior state populated it; on resume this can be expected.`;
-    return this.runDeterministicInContainer(bundle, input, warning);
+    const base = await this.runDeterministicInContainer(bundle, input, warning);
+    return this.applyResultFile(instance, input, base);
+  }
+
+  private applyResultFile(
+    instance: WorkflowInstance,
+    input: DeterministicInvokeInput,
+    base: DeterministicInvokeResult,
+  ): DeterministicInvokeResult {
+    if (input.resultFile === undefined) return base;
+    if (!base.passed) return base;
+
+    const appendError = (message: string): DeterministicInvokeResult => ({
+      ...base,
+      passed: false,
+      verdict: DETERMINISTIC_RESULT_ERROR_VERDICT,
+      errors: base.errors ? `${base.errors}\n${message}` : message,
+    });
+
+    if (!isSafeWorkspaceRelativePath(input.resultFile)) {
+      return appendError(`result file ${input.resultFile} is not a safe workspace-relative path`);
+    }
+
+    const workspace = resolve(instance.workspacePath);
+    const resultPath = resolve(workspace, input.resultFile);
+    const pathFromWorkspace = relative(workspace, resultPath);
+    if (pathFromWorkspace === '' || pathFromWorkspace.startsWith('..')) {
+      return appendError(`result file ${input.resultFile} escapes the workspace`);
+    }
+
+    if (!existsSync(resultPath)) {
+      return appendError(`result file ${input.resultFile} not found`);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(resultPath, 'utf8'));
+    } catch {
+      return appendError(`result file ${input.resultFile} is not valid JSON`);
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return appendError(`result file ${input.resultFile} is not a JSON object`);
+    }
+
+    const resultObject = parsed as Record<string, unknown>;
+    if (typeof resultObject.verdict !== 'string' || resultObject.verdict.length === 0) {
+      return appendError(`result file ${input.resultFile} missing verdict`);
+    }
+
+    const payload =
+      typeof resultObject.payload === 'object' && resultObject.payload !== null && !Array.isArray(resultObject.payload)
+        ? (resultObject.payload as Record<string, unknown>)
+        : undefined;
+
+    return {
+      ...base,
+      verdict: resultObject.verdict,
+      passed: typeof resultObject.passed === 'boolean' ? resultObject.passed : base.passed,
+      ...(payload !== undefined ? { payload } : {}),
+    };
   }
 
   /**

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -9,7 +9,9 @@ import {
   unlinkSync,
   cpSync,
 } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { resolve } from 'node:path';
+import { isWithinDirectory } from '../types/argument-roles.js';
+import { errorMessage } from '../utils/error-message.js';
 import { MessageLog, type AgentRetryReason } from './message-log.js';
 import { createHash, type Hash } from 'node:crypto';
 import { execFile as execFileCb } from 'node:child_process';
@@ -2393,10 +2395,13 @@ export class WorkflowOrchestrator implements WorkflowController {
       return appendError(`result file ${input.resultFile} is not a safe workspace-relative path`);
     }
 
-    const workspace = resolve(instance.workspacePath);
-    const resultPath = resolve(workspace, input.resultFile);
-    const pathFromWorkspace = relative(workspace, resultPath);
-    if (pathFromWorkspace === '' || pathFromWorkspace.startsWith('..')) {
+    const resultPath = resolve(instance.workspacePath, input.resultFile);
+    // Symlink-safe containment: a container can plant a symlink inside the shared
+    // workspace, and this read happens host-side — so resolve both sides to their
+    // canonical real paths before comparing (same posture as the policy engine,
+    // see resolveRealPath / CLAUDE.md). A lexical resolve()/relative() check would
+    // follow such a symlink and read off-workspace on the host.
+    if (!isWithinDirectory(resultPath, instance.workspacePath)) {
       return appendError(`result file ${input.resultFile} escapes the workspace`);
     }
 
@@ -2404,9 +2409,18 @@ export class WorkflowOrchestrator implements WorkflowController {
       return appendError(`result file ${input.resultFile} not found`);
     }
 
+    // Split read vs parse so a read failure (EISDIR/EPERM/...) is not mislabeled
+    // as a JSON syntax error.
+    let raw: string;
+    try {
+      raw = readFileSync(resultPath, 'utf8');
+    } catch (err) {
+      return appendError(`result file ${input.resultFile} could not be read: ${errorMessage(err)}`);
+    }
+
     let parsed: unknown;
     try {
-      parsed = JSON.parse(readFileSync(resultPath, 'utf8'));
+      parsed = JSON.parse(raw);
     } catch {
       return appendError(`result file ${input.resultFile} is not valid JSON`);
     }

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -65,6 +65,9 @@ export function resolveWorkflowSkillsOptions(
  */
 export const DEFAULT_CONTAINER_SCOPE = 'primary';
 
+/** Reserved deterministic result verdict emitted when a declared result file cannot be read or parsed. */
+export const DETERMINISTIC_RESULT_ERROR_VERDICT = 'result_file_error';
+
 // ---------------------------------------------------------------------------
 // Branded identifiers
 // ---------------------------------------------------------------------------
@@ -271,6 +274,11 @@ export interface DeterministicStateDefinition {
    * Undefined uses the runner default.
    */
   readonly timeoutMs?: number;
+  /**
+   * Workspace-relative JSON result file written by a containerized helper.
+   * Container-only; see validate.ts for path and routing constraints.
+   */
+  readonly resultFile?: string;
   readonly transitions: readonly AgentTransitionDefinition[];
 }
 
@@ -428,6 +436,10 @@ export interface WorkflowContext {
   /** Per-role output hash for stall detection. */
   readonly previousOutputHashes: Record<string, string>;
   readonly previousTestCount: number | null;
+  readonly lastDeterministicResult?: {
+    readonly verdict?: string;
+    readonly payload?: Record<string, unknown>;
+  };
   readonly humanPrompt: string | null;
   readonly reviewHistory: readonly string[];
   readonly parallelResults: Record<string, ParallelSlotResult>;

--- a/src/workflow/validate.ts
+++ b/src/workflow/validate.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { posix as pathPosix, resolve } from 'node:path';
 import { z } from 'zod';
 import { validateSkillName } from '../skills/staging.js';
 import { discoverSkills } from '../skills/discovery.js';
@@ -82,6 +82,7 @@ const deterministicStateSchema = z.object({
   container: z.boolean().optional(),
   containerScope: z.string().regex(CONTAINER_SCOPE_PATTERN).optional(),
   timeoutMs: z.number().int().positive().optional(),
+  resultFile: z.string().min(1).optional(),
   transitions: z.array(agentTransitionSchema).min(1),
 });
 
@@ -158,7 +159,15 @@ function validateRawInput(raw: unknown): string[] {
 
     if (!isPlainObject(stateValue)) continue;
     const stateType = stateValue.type;
-    if (typeof stateType !== 'string' || stateType === 'agent') continue;
+    if (typeof stateType !== 'string') continue;
+
+    if ('resultFile' in stateValue && stateType !== 'deterministic') {
+      issues.push(
+        `State "${stateId}" (type: ${stateType}) has "resultFile" but that field is only valid on deterministic states.`,
+      );
+    }
+
+    if (stateType === 'agent') continue;
 
     for (const field of AGENT_ONLY_STATE_FIELDS) {
       if (field in stateValue) {
@@ -259,6 +268,15 @@ export function findReachableStates(initial: string, states: Record<string, Work
 const AGENT_OUTPUT_FIELD_SET: ReadonlySet<string> = new Set(AGENT_OUTPUT_FIELDS);
 const CONFIDENCE_VALUE_SET: ReadonlySet<string> = new Set(CONFIDENCE_VALUES);
 
+export function isSafeWorkspaceRelativePath(path: string): boolean {
+  if (path.length === 0) return false;
+  if (path.includes('\0')) return false;
+  if (path.startsWith('/')) return false;
+  if (path === '.') return false;
+  if (path.split('/').some((part) => part === '..')) return false;
+  return pathPosix.normalize(path) === path;
+}
+
 /**
  * Expected runtime type for each AgentOutput field used in `when` clauses.
  * `expected` is the human-readable error label; `check` is the runtime test.
@@ -330,11 +348,6 @@ function validateWhenClauses(stateId: string, state: WorkflowStateDefinition, is
       issues.push(
         `State "${stateId}" has transition to "${t.to}" with both "guard" and "when" — they are mutually exclusive`,
       );
-    }
-
-    // Agent-only scope: when on deterministic state
-    if (state.type === 'deterministic' && t.when) {
-      issues.push(`State "${stateId}" is deterministic and cannot use "when" (agent output not available)`);
     }
 
     if (!t.when) continue;
@@ -492,8 +505,21 @@ function validateContainerScopes(definition: WorkflowDefinition, issues: string[
 
     if (state.type !== 'deterministic') continue;
 
+    const usesVerdictEdges = state.transitions.some((t) => t.when !== undefined && 'verdict' in t.when);
+
     if (state.containerScope !== undefined && state.container !== true) {
       issues.push(`State "${stateId}" declares containerScope but is not container: true`);
+    }
+    if ((state.resultFile !== undefined || usesVerdictEdges) && state.container !== true) {
+      issues.push(
+        `State "${stateId}" uses resultFile / when:{verdict} routing but is not container: true. ` +
+          `Structured deterministic result routing is container-only.`,
+      );
+    }
+    if (state.resultFile !== undefined && !isSafeWorkspaceRelativePath(state.resultFile)) {
+      issues.push(
+        `State "${stateId}" has resultFile "${state.resultFile}" — must be a workspace-relative path (no leading "/", no "..").`,
+      );
     }
     if (state.container === true && !sharedContainer) {
       issues.push(`State "${stateId}" has container: true but the workflow does not have sharedContainer: true.`);

--- a/src/workflow/validate.ts
+++ b/src/workflow/validate.ts
@@ -218,6 +218,15 @@ export function collectTransitionTargets(state: WorkflowStateDefinition): string
 }
 
 /**
+ * True if any transition routes on a `when: { verdict: ... }` clause. Shared by
+ * the container-only validation rule (`validateContainerScopes`) and the WF012
+ * lint (which requires such states to declare a `resultFile`).
+ */
+export function usesVerdictEdges(transitions: readonly AgentTransitionDefinition[]): boolean {
+  return transitions.some((t) => t.when !== undefined && 'verdict' in t.when);
+}
+
+/**
  * Parses a workflow input artifact reference. A trailing `?` marks the
  * input as optional — the consumer may skip it if the artifact isn't
  * produced.
@@ -505,12 +514,10 @@ function validateContainerScopes(definition: WorkflowDefinition, issues: string[
 
     if (state.type !== 'deterministic') continue;
 
-    const usesVerdictEdges = state.transitions.some((t) => t.when !== undefined && 'verdict' in t.when);
-
     if (state.containerScope !== undefined && state.container !== true) {
       issues.push(`State "${stateId}" declares containerScope but is not container: true`);
     }
-    if ((state.resultFile !== undefined || usesVerdictEdges) && state.container !== true) {
+    if ((state.resultFile !== undefined || usesVerdictEdges(state.transitions)) && state.container !== true) {
       issues.push(
         `State "${stateId}" uses resultFile / when:{verdict} routing but is not container: true. ` +
           `Structured deterministic result routing is container-only.`,

--- a/src/workflow/workflows/deterministic-verdict-smoke/scripts/classify.py
+++ b/src/workflow/workflows/deterministic-verdict-smoke/scripts/classify.py
@@ -1,0 +1,15 @@
+import json
+import pathlib
+
+ws = pathlib.Path("/workspace")
+out = ws / ".workflow"
+out.mkdir(exist_ok=True)
+task = (ws / "task.txt").read_text().strip().lower() if (ws / "task.txt").exists() else ""
+
+verdict = "block" if "block" in task else "pass"
+
+(out / "result.json").write_text(
+    json.dumps({"verdict": verdict, "payload": {"task": task}, "passed": True}) + "\n"
+)
+
+print("classified")

--- a/src/workflow/workflows/deterministic-verdict-smoke/scripts/classify.py
+++ b/src/workflow/workflows/deterministic-verdict-smoke/scripts/classify.py
@@ -6,10 +6,13 @@ out = ws / ".workflow"
 out.mkdir(exist_ok=True)
 task = (ws / "task.txt").read_text().strip().lower() if (ws / "task.txt").exists() else ""
 
-verdict = "block" if "block" in task else "pass"
+# An "error" task exercises the missing-file -> result_file_error path: the helper
+# exits 0 but writes no result file, so the orchestrator must route to error_terminal.
+if "error" not in task:
+    verdict = "block" if "block" in task else "pass"
+    (out / "result.json").write_text(
+        json.dumps({"verdict": verdict, "payload": {"task": task}, "passed": True}) + "\n"
+    )
 
-(out / "result.json").write_text(
-    json.dumps({"verdict": verdict, "payload": {"task": task}, "passed": True}) + "\n"
-)
-
+# stdout is verdict-blind regardless of branch — routing can only come from the file.
 print("classified")

--- a/src/workflow/workflows/deterministic-verdict-smoke/workflow.yaml
+++ b/src/workflow/workflows/deterministic-verdict-smoke/workflow.yaml
@@ -1,0 +1,50 @@
+name: deterministic-verdict-smoke
+description: 'TESTING ONLY - deterministic state routes on a helper-written verdict file.'
+initial: author
+
+settings:
+  mode: docker
+  dockerAgent: claude-code
+  sharedContainer: true
+  model: anthropic:claude-haiku-4-5
+
+states:
+  author:
+    type: agent
+    description: Record the task verbatim so the deterministic helper can read it.
+    persona: global
+    prompt: |
+      Write the EXACT task text you were given to the file /workspace/task.txt and nothing else.
+      Create no other files. Finish with the required agent_status block.
+    inputs: []
+    outputs: []
+    transitions:
+      - to: classify
+
+  classify:
+    type: deterministic
+    description: Read the task and emit a verdict file the machine routes on.
+    container: true
+    resultFile: .workflow/result.json
+    run:
+      - ['python3', '/workflow-scripts/classify.py']
+    transitions:
+      - to: passed_terminal
+        when: { verdict: pass }
+      - to: blocked_terminal
+        when: { verdict: block }
+      - to: error_terminal
+        when: { verdict: result_file_error }
+      - to: error_terminal
+
+  passed_terminal:
+    type: terminal
+    description: Helper emitted verdict=pass.
+
+  blocked_terminal:
+    type: terminal
+    description: Helper emitted verdict=block.
+
+  error_terminal:
+    type: terminal
+    description: Verdict file missing/malformed or unexpected verdict.

--- a/test/workflow/deterministic-verdict-smoke.integration.test.ts
+++ b/test/workflow/deterministic-verdict-smoke.integration.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { REAL_TMP, testCompiledPolicy, testToolAnnotations } from '../fixtures/test-policy.js';
+import { isDockerAvailable, isDockerImageAvailable } from '../helpers/docker-available.js';
+import type { IronCurtainConfig } from '../../src/config/types.js';
+import {
+  createDockerInfrastructure,
+  destroyDockerInfrastructure,
+  type DockerInfrastructure,
+} from '../../src/docker/docker-infrastructure.js';
+import {
+  WorkflowOrchestrator,
+  type CreateWorkflowInfrastructureInput,
+  type WorkflowLifecycleEvent,
+} from '../../src/workflow/orchestrator.js';
+import type { SessionOptions } from '../../src/session/types.js';
+import { approvedResponse, createDeps, MockSession, waitForCompletion } from './test-helpers.js';
+
+const IMAGE = 'ironcurtain-claude-code:latest';
+const TEST_HOME = `${REAL_TMP}/ironcurtain-deterministic-verdict-${process.pid}`;
+
+function findHostCaDir(): string | null {
+  const home = process.env.IRONCURTAIN_HOME ?? join(homedir(), '.ironcurtain');
+  const ca = join(home, 'ca');
+  return existsSync(ca) ? ca : null;
+}
+
+const hostCaDir = findHostCaDir();
+const dockerReady =
+  process.env.INTEGRATION_TEST === '1' && isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+
+function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): IronCurtainConfig {
+  return {
+    auditLogPath: join(workspaceDir, 'audit.jsonl'),
+    allowedDirectory: workspaceDir,
+    mcpServers: {},
+    protectedPaths: [],
+    generatedDir,
+    constitutionPath: join(generatedDir, 'constitution.md'),
+    agentModelId: 'anthropic:claude-sonnet-4-6',
+    escalationTimeoutSeconds: 300,
+    userConfig: {
+      agentModelId: 'anthropic:claude-sonnet-4-6',
+      policyModelId: 'anthropic:claude-sonnet-4-6',
+      anthropicApiKey: 'test-fake-key-no-network',
+      googleApiKey: '',
+      openaiApiKey: '',
+      escalationTimeoutSeconds: 300,
+      resourceBudget: {
+        maxTotalTokens: 1_000_000,
+        maxSteps: 200,
+        maxSessionSeconds: 1800,
+        maxEstimatedCostUsd: 5.0,
+        warnThresholdPercent: 80,
+      },
+      autoCompact: {
+        enabled: false,
+        thresholdTokens: 80_000,
+        keepRecentMessages: 10,
+        summaryModelId: 'anthropic:claude-haiku-4-5',
+      },
+      autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
+      auditRedaction: { enabled: false },
+      memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
+      packageInstall: {
+        enabled: false,
+        quarantineDays: 2,
+        allowedPackages: [],
+        deniedPackages: [],
+      },
+      serverCredentials: {},
+      dockerResources: { memoryMb: null, cpus: null },
+    },
+  } as unknown as IronCurtainConfig;
+}
+
+describe.skipIf(!dockerReady)('deterministic-verdict-smoke with real Docker container', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalAuth: string | undefined;
+  let originalApiKey: string | undefined;
+  const liveBundles = new Set<DockerInfrastructure>();
+
+  beforeAll(() => {
+    originalHome = process.env.IRONCURTAIN_HOME;
+    originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
+    originalApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.IRONCURTAIN_HOME = TEST_HOME;
+    process.env.IRONCURTAIN_DOCKER_AUTH = 'apikey';
+    process.env.ANTHROPIC_API_KEY = 'test-fake-key-no-network';
+    mkdirSync(TEST_HOME, { recursive: true });
+    cpSync(hostCaDir as string, join(TEST_HOME, 'ca'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    for (const bundle of liveBundles) {
+      await destroyDockerInfrastructure(bundle).catch(() => {});
+    }
+    liveBundles.clear();
+
+    if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = originalHome;
+    if (originalAuth === undefined) delete process.env.IRONCURTAIN_DOCKER_AUTH;
+    else process.env.IRONCURTAIN_DOCKER_AUTH = originalAuth;
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'deterministic-verdict-smoke-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runSmoke(task: 'pass' | 'block'): Promise<readonly string[]> {
+    const runDir = resolve(tmpDir, `run-${task}`);
+    const workspaceDir = resolve(tmpDir, `workspace-${task}`);
+    const generatedDir = resolve(TEST_HOME, `generated-${task}`);
+    mkdirSync(runDir, { recursive: true });
+    mkdirSync(workspaceDir, { recursive: true });
+    mkdirSync(generatedDir, { recursive: true });
+    writeFileSync(resolve(generatedDir, 'compiled-policy.json'), JSON.stringify(testCompiledPolicy));
+    writeFileSync(resolve(generatedDir, 'tool-annotations.json'), JSON.stringify(testToolAnnotations));
+
+    const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) => {
+      const config = buildDockerSessionConfig(input.workspacePath, generatedDir);
+      const bundleDir = resolve(TEST_HOME, 'bundles', input.bundleId);
+      const escalationDir = resolve(bundleDir, 'escalations');
+      mkdirSync(bundleDir, { recursive: true });
+      mkdirSync(escalationDir, { recursive: true });
+      const bundle = await createDockerInfrastructure(
+        config,
+        { kind: 'docker', agent: 'claude-code' },
+        bundleDir,
+        input.workspacePath,
+        escalationDir,
+        input.bundleId,
+        input.workflowId,
+        input.scope,
+        input.resolvedSkills,
+        undefined,
+        input.workflowScriptsDir,
+      );
+      liveBundles.add(bundle);
+      return bundle;
+    });
+
+    const destroyInfra = vi.fn(async (bundle: DockerInfrastructure) => {
+      liveBundles.delete(bundle);
+      await destroyDockerInfrastructure(bundle);
+    });
+
+    const createSession = vi.fn(async (options: SessionOptions) => {
+      const workspacePath = options.workspacePath;
+      if (!workspacePath) throw new Error('workflow agent session missing workspacePath');
+      writeFileSync(resolve(workspacePath, 'task.txt'), task);
+      return new MockSession({ responses: () => approvedResponse('task recorded') });
+    });
+
+    const orchestrator = new WorkflowOrchestrator(
+      createDeps(runDir, {
+        createSession,
+        createWorkflowInfrastructure: createInfra,
+        destroyWorkflowInfrastructure: destroyInfra,
+      }),
+    );
+    const states: string[] = [];
+    orchestrator.onEvent((event: WorkflowLifecycleEvent) => {
+      if (event.kind === 'state_entered') states.push(event.state);
+    });
+
+    const manifestPath = resolve(
+      process.cwd(),
+      'src',
+      'workflow',
+      'workflows',
+      'deterministic-verdict-smoke',
+      'workflow.yaml',
+    );
+    const workflowId = await orchestrator.start(manifestPath, task, workspaceDir);
+    await waitForCompletion(orchestrator, workflowId, 90_000);
+    await orchestrator.shutdownAll();
+    return states;
+  }
+
+  it('routes pass and block task inputs to distinct verdict terminals', async () => {
+    const passStates = await runSmoke('pass');
+    const blockStates = await runSmoke('block');
+
+    expect(passStates.at(-1)).toBe('passed_terminal');
+    expect(blockStates.at(-1)).toBe('blocked_terminal');
+    expect(passStates).not.toContain('error_terminal');
+    expect(blockStates).not.toContain('error_terminal');
+  }, 240_000);
+});

--- a/test/workflow/deterministic-verdict-smoke.integration.test.ts
+++ b/test/workflow/deterministic-verdict-smoke.integration.test.ts
@@ -118,7 +118,7 @@ describe.skipIf(!dockerReady)('deterministic-verdict-smoke with real Docker cont
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  async function runSmoke(task: 'pass' | 'block'): Promise<readonly string[]> {
+  async function runSmoke(task: 'pass' | 'block' | 'error'): Promise<readonly string[]> {
     const runDir = resolve(tmpDir, `run-${task}`);
     const workspaceDir = resolve(tmpDir, `workspace-${task}`);
     const generatedDir = resolve(TEST_HOME, `generated-${task}`);
@@ -197,5 +197,15 @@ describe.skipIf(!dockerReady)('deterministic-verdict-smoke with real Docker cont
     expect(blockStates.at(-1)).toBe('blocked_terminal');
     expect(passStates).not.toContain('error_terminal');
     expect(blockStates).not.toContain('error_terminal');
+  }, 240_000);
+
+  it('routes a missing result file to the error terminal (result_file_error)', async () => {
+    // The helper exits 0 but writes no result.json, so applyResultFile must yield
+    // the reserved result_file_error verdict and the machine must route to error_terminal.
+    const errorStates = await runSmoke('error');
+
+    expect(errorStates.at(-1)).toBe('error_terminal');
+    expect(errorStates).not.toContain('passed_terminal');
+    expect(errorStates).not.toContain('blocked_terminal');
   }, 240_000);
 });

--- a/test/workflow/lint.test.ts
+++ b/test/workflow/lint.test.ts
@@ -819,11 +819,17 @@ describe('WF010 — skill references', () => {
 describe('bundled workflows lint clean', () => {
   const workflowsDir = resolve(__dirname, '..', '..', 'src', 'workflow', 'workflows');
 
-  // personaExists returns false unconditionally — both bundled workflows use
+  // personaExists returns false unconditionally — bundled workflows use
   // GLOBAL_PERSONA throughout, so WF007 must skip via the alias, not the stub.
   const bundledCtx: LintContext = { personaExists: () => false };
 
-  for (const name of ['vuln-discovery', 'design-and-code']) {
+  for (const name of [
+    'vuln-discovery',
+    'design-and-code',
+    'test-email-summary',
+    'deterministic-eval-smoke',
+    'deterministic-verdict-smoke',
+  ]) {
     it(`${name}: zero errors`, () => {
       const manifestPath = resolve(workflowsDir, name, 'workflow.yaml');
       const raw = parseYaml(readFileSync(manifestPath, 'utf-8'), { maxAliasCount: 0 });
@@ -917,5 +923,69 @@ describe('WF011 — container scope not populated by a prior agent', () => {
     const result = lintWorkflow(def, { ...stubCtx, workflowFilePath: manifestPath });
     expect(codes(result)).not.toContain('WF011');
     expect(result.filter((d) => d.severity === 'error').length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WF012 — deterministic verdict edges need a resultFile source
+// ---------------------------------------------------------------------------
+
+describe('WF012 — deterministic verdict edges without resultFile', () => {
+  function verdictWorkflow(withResultFile: boolean): WorkflowDefinition {
+    return validateDefinition({
+      name: 'wf012',
+      description: 'd',
+      initial: 'prep',
+      settings: { mode: 'docker', dockerAgent: 'claude-code', sharedContainer: true },
+      states: {
+        prep: {
+          type: 'agent',
+          description: 'prep',
+          persona: 'global',
+          prompt: 'p',
+          inputs: [],
+          outputs: [],
+          transitions: [{ to: 'classify' }],
+        },
+        classify: {
+          type: 'deterministic',
+          description: 'classify',
+          container: true,
+          ...(withResultFile ? { resultFile: '.workflow/result.json' } : {}),
+          run: [['python3', '/workflow-scripts/classify.py']],
+          transitions: [{ to: 'passed', when: { verdict: 'pass' } }, { to: 'failed' }],
+        },
+        passed: { type: 'terminal', description: 'passed' },
+        failed: { type: 'terminal', description: 'failed' },
+      },
+    });
+  }
+
+  it('warns when a deterministic state routes on verdict but declares no resultFile', () => {
+    const result = lintWorkflow(verdictWorkflow(false), stubCtx);
+    expect(codes(result)).toContain('WF012');
+    const d = result.find((x) => x.code === 'WF012');
+    expect(d?.severity).toBe('warning');
+    expect(d?.stateId).toBe('classify');
+    expect(d?.message).toContain('when:{verdict}');
+  });
+
+  it('does not warn when the deterministic verdict source is declared', () => {
+    expect(codes(lintWorkflow(verdictWorkflow(true), stubCtx))).not.toContain('WF012');
+  });
+
+  it('the bundled deterministic-verdict-smoke fixture lints clean for WF012', () => {
+    const manifestPath = resolve(
+      __dirname,
+      '..',
+      '..',
+      'src',
+      'workflow',
+      'workflows',
+      'deterministic-verdict-smoke',
+      'workflow.yaml',
+    );
+    const def = validateDefinition(parseYaml(readFileSync(manifestPath, 'utf-8'), { maxAliasCount: 0 }));
+    expect(codes(lintWorkflow(def, { ...stubCtx, workflowFilePath: manifestPath }))).not.toContain('WF012');
   });
 });

--- a/test/workflow/machine-builder.test.ts
+++ b/test/workflow/machine-builder.test.ts
@@ -628,6 +628,7 @@ describe('buildWorkflowMachine', () => {
       expect(capturedInput!.container).toBe(false);
       expect(capturedInput!.containerScope).toBeUndefined();
       expect(capturedInput!.timeoutMs).toBeUndefined();
+      expect(capturedInput!.resultFile).toBeUndefined();
     });
 
     it('passes container execution options to deterministic service', async () => {
@@ -639,6 +640,7 @@ describe('buildWorkflowMachine', () => {
         container: true,
         containerScope: 'eval',
         timeoutMs: 1234,
+        resultFile: '.workflow/result.json',
       };
       const result = buildWorkflowMachine(definition, 'my task');
       let capturedInput: DeterministicInvokeInput | undefined;
@@ -663,7 +665,86 @@ describe('buildWorkflowMachine', () => {
         container: true,
         containerScope: 'eval',
         timeoutMs: 1234,
+        resultFile: '.workflow/result.json',
       });
+    });
+
+    it('routes deterministic when:{verdict} transitions via __matchesWhen', async () => {
+      const definition: WorkflowDefinition = {
+        name: 'deterministic-verdict-routing-test',
+        description: 'Routes deterministic verdicts',
+        initial: 'classify',
+        states: {
+          classify: {
+            type: 'deterministic',
+            description: 'Classifies',
+            run: [['classify']],
+            container: true,
+            resultFile: '.workflow/result.json',
+            transitions: [
+              { to: 'passed_terminal', when: { verdict: 'pass' } },
+              { to: 'blocked_terminal', when: { verdict: 'block' } },
+              { to: 'error_terminal' },
+            ],
+          },
+          passed_terminal: { type: 'terminal', description: 'pass' },
+          blocked_terminal: { type: 'terminal', description: 'block' },
+          error_terminal: { type: 'terminal', description: 'error' },
+        },
+      };
+      const result = buildWorkflowMachine(definition, 'task');
+
+      const testMachine = result.machine.provide({
+        actors: {
+          deterministicService: fromPromise(async () => makeDeterministicResult({ verdict: 'block' })),
+        },
+      });
+
+      const actor = createActor(testMachine);
+      const visited = trackStates(actor);
+      actor.start();
+
+      await settle();
+
+      expect(visited).toContain('blocked_terminal');
+      expect(visited).not.toContain('passed_terminal');
+      expect(actor.getSnapshot().status).toBe('done');
+    });
+
+    it('falls through when deterministic verdict is undefined or mismatched', async () => {
+      const definition: WorkflowDefinition = {
+        name: 'deterministic-verdict-fallthrough-test',
+        description: 'Routes unmatched deterministic verdicts',
+        initial: 'classify',
+        states: {
+          classify: {
+            type: 'deterministic',
+            description: 'Classifies',
+            run: [['classify']],
+            container: true,
+            resultFile: '.workflow/result.json',
+            transitions: [{ to: 'passed_terminal', when: { verdict: 'pass' } }, { to: 'error_terminal' }],
+          },
+          passed_terminal: { type: 'terminal', description: 'pass' },
+          error_terminal: { type: 'terminal', description: 'error' },
+        },
+      };
+      const result = buildWorkflowMachine(definition, 'task');
+
+      const testMachine = result.machine.provide({
+        actors: {
+          deterministicService: fromPromise(async () => makeDeterministicResult({ verdict: 'other' })),
+        },
+      });
+
+      const actor = createActor(testMachine);
+      const visited = trackStates(actor);
+      actor.start();
+
+      await settle();
+
+      expect(visited).toContain('error_terminal');
+      expect(visited).not.toContain('passed_terminal');
     });
   });
 

--- a/test/workflow/orchestrator-deterministic.test.ts
+++ b/test/workflow/orchestrator-deterministic.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { WorkflowDefinition, WorkflowId } from '../../src/workflow/types.js';
+import {
+  DETERMINISTIC_RESULT_ERROR_VERDICT,
+  type WorkflowDefinition,
+  type WorkflowId,
+} from '../../src/workflow/types.js';
 import type { DockerInfrastructure } from '../../src/docker/docker-infrastructure.js';
 import type { DockerExecResult } from '../../src/docker/types.js';
 import type { DeterministicInvokeInput, DeterministicInvokeResult } from '../../src/workflow/machine-builder.js';
@@ -75,15 +79,34 @@ function registerInstance(
   orchestrator: WorkflowOrchestrator,
   definition: WorkflowDefinition,
   bundlesByScope: Map<string, DockerInfrastructure>,
+  workspacePath: string,
 ): void {
   const instance = {
     id: WF_ID,
     definition,
     bundlesByScope,
+    workspacePath,
     aborted: false,
   };
   // Private map; bracket access is the focused-unit-test seam.
   (orchestrator as unknown as { workflows: Map<WorkflowId, unknown> }).workflows.set(WF_ID, instance);
+}
+
+function callApplyResultFile(
+  orchestrator: WorkflowOrchestrator,
+  workspacePath: string,
+  input: DeterministicInvokeInput,
+  base: DeterministicInvokeResult,
+): DeterministicInvokeResult {
+  return (
+    orchestrator as unknown as {
+      applyResultFile: (
+        instance: { workspacePath: string },
+        input: DeterministicInvokeInput,
+        base: DeterministicInvokeResult,
+      ) => DeterministicInvokeResult;
+    }
+  ).applyResultFile({ workspacePath }, input, base);
 }
 
 /** Invokes the private executeDeterministicState through bracket access. */
@@ -122,7 +145,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
       const exec = vi.fn(async (): Promise<DockerExecResult> => ({ exitCode: 0, stdout: '', stderr: '' }));
       const bundles = new Map<string, DockerInfrastructure>([['primary', makeStubBundle('cid', exec).bundle]]);
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, bundles);
+      registerInstance(orchestrator, sharedContainerDef, bundles, tmpDir);
 
       // A real host command that prints a stdout test-count line. `node -e`
       // exercises the actual execFileAsync path (no execFile mocking).
@@ -139,7 +162,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
 
     it('host success path: passed true, no testCount when stdout lacks the regex', async () => {
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map());
+      registerInstance(orchestrator, sharedContainerDef, new Map(), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -153,7 +176,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
 
     it('host failure path: non-zero exit captures stderr into errors and flips passed', async () => {
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map());
+      registerInstance(orchestrator, sharedContainerDef, new Map(), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -169,7 +192,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
 
     it('host test-count regex sums across commands', async () => {
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map());
+      registerInstance(orchestrator, sharedContainerDef, new Map(), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -198,7 +221,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
       }));
       const bundles = new Map<string, DockerInfrastructure>([['primary', bundle]]);
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, bundles);
+      registerInstance(orchestrator, sharedContainerDef, bundles, tmpDir);
 
       await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -227,7 +250,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
     it('exit code 0 => passed true', async () => {
       const { bundle } = makeStubBundle('cid', async () => ({ exitCode: 0, stdout: 'ok', stderr: '' }));
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]));
+      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -246,7 +269,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
         stderr: 'something failed',
       }));
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]));
+      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -267,7 +290,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
         stderr: '',
       }));
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]));
+      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -287,7 +310,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
         stderr: '',
       }));
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]));
+      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -302,7 +325,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
     it('skips empty [] commands without calling docker.exec', async () => {
       const { bundle, exec } = makeStubBundle('cid', async () => ({ exitCode: 0, stdout: '', stderr: '' }));
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]));
+      registerInstance(orchestrator, sharedContainerDef, new Map([['primary', bundle]]), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -325,7 +348,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
         ['coder', coder.bundle],
       ]);
       const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
-      registerInstance(orchestrator, sharedContainerDef, bundles);
+      registerInstance(orchestrator, sharedContainerDef, bundles, tmpDir);
 
       await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -345,7 +368,7 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
         ...sharedContainerDef,
         settings: { mode: 'docker', dockerAgent: 'claude-code' },
       };
-      registerInstance(orchestrator, nonShared, new Map());
+      registerInstance(orchestrator, nonShared, new Map(), tmpDir);
 
       const result = await callExecuteDeterministicState(orchestrator, WF_ID, {
         stateId: 'check',
@@ -371,6 +394,144 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
 
       expect(result.passed).toBe(false);
       expect(result.errors).toContain('not found');
+    });
+  });
+
+  describe('resultFile contract', () => {
+    it('returns the reducer result unchanged when resultFile is absent', () => {
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+      const base: DeterministicInvokeResult = { passed: true, testCount: 3, errors: undefined };
+
+      const result = callApplyResultFile(
+        orchestrator,
+        tmpDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+        },
+        base,
+      );
+
+      expect(result).toBe(base);
+    });
+
+    it('reads verdict and payload from a well-formed result file after successful commands', () => {
+      mkdirSync(join(tmpDir, '.workflow'), { recursive: true });
+      writeFileSync(
+        join(tmpDir, '.workflow', 'result.json'),
+        JSON.stringify({ verdict: 'block', payload: { reason: 'policy' } }),
+      );
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+
+      const result = callApplyResultFile(
+        orchestrator,
+        tmpDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+          resultFile: '.workflow/result.json',
+        },
+        { passed: true, testCount: 2 },
+      );
+
+      expect(result).toEqual({
+        passed: true,
+        testCount: 2,
+        verdict: 'block',
+        payload: { reason: 'policy' },
+      });
+    });
+
+    it('lets a boolean result-file passed field override command success', () => {
+      mkdirSync(join(tmpDir, '.workflow'), { recursive: true });
+      writeFileSync(join(tmpDir, '.workflow', 'result.json'), JSON.stringify({ verdict: 'failed', passed: false }));
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+
+      const result = callApplyResultFile(
+        orchestrator,
+        tmpDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+          resultFile: '.workflow/result.json',
+        },
+        { passed: true },
+      );
+
+      expect(result.passed).toBe(false);
+      expect(result.verdict).toBe('failed');
+    });
+
+    it('maps a missing result file to the reserved routable verdict', () => {
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+
+      const result = callApplyResultFile(
+        orchestrator,
+        tmpDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+          resultFile: '.workflow/result.json',
+        },
+        { passed: true, errors: 'prior warning' },
+      );
+
+      expect(result.passed).toBe(false);
+      expect(result.verdict).toBe(DETERMINISTIC_RESULT_ERROR_VERDICT);
+      expect(result.errors).toContain('prior warning');
+      expect(result.errors).toContain('not found');
+    });
+
+    it('maps malformed JSON and missing verdict to the reserved routable verdict', () => {
+      mkdirSync(join(tmpDir, '.workflow'), { recursive: true });
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+      const input: DeterministicInvokeInput = {
+        stateId: 'check',
+        commands: [['node', 'check.js']],
+        context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+        container: true,
+        resultFile: '.workflow/result.json',
+      };
+
+      writeFileSync(join(tmpDir, '.workflow', 'result.json'), '{');
+      const malformed = callApplyResultFile(orchestrator, tmpDir, input, { passed: true });
+      expect(malformed.passed).toBe(false);
+      expect(malformed.verdict).toBe(DETERMINISTIC_RESULT_ERROR_VERDICT);
+      expect(malformed.errors).toContain('not valid JSON');
+
+      writeFileSync(join(tmpDir, '.workflow', 'result.json'), JSON.stringify({ payload: { ok: true } }));
+      const missingVerdict = callApplyResultFile(orchestrator, tmpDir, input, { passed: true });
+      expect(missingVerdict.passed).toBe(false);
+      expect(missingVerdict.verdict).toBe(DETERMINISTIC_RESULT_ERROR_VERDICT);
+      expect(missingVerdict.errors).toContain('missing verdict');
+    });
+
+    it('does not read resultFile when command reduction already failed', () => {
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+      const base: DeterministicInvokeResult = { passed: false, errors: 'command failed' };
+
+      const result = callApplyResultFile(
+        orchestrator,
+        tmpDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+          resultFile: '.workflow/result.json',
+        },
+        base,
+      );
+
+      expect(result).toBe(base);
     });
   });
 });

--- a/test/workflow/orchestrator-deterministic.test.ts
+++ b/test/workflow/orchestrator-deterministic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -512,6 +512,61 @@ describe('WorkflowOrchestrator deterministic execution dispatch', () => {
       expect(missingVerdict.passed).toBe(false);
       expect(missingVerdict.verdict).toBe(DETERMINISTIC_RESULT_ERROR_VERDICT);
       expect(missingVerdict.errors).toContain('missing verdict');
+    });
+
+    it('rejects a result file that escapes the workspace via a symlink (security)', () => {
+      // A container can plant a symlink in the shared workspace; the host-side read
+      // must not follow it off-workspace. The symlink points to a sibling of the
+      // workspace, so canonical-path containment must reject it.
+      const wsDir = join(tmpDir, 'ws');
+      const secret = join(tmpDir, 'outside-secret.json');
+      writeFileSync(secret, JSON.stringify({ verdict: 'leak' }));
+      mkdirSync(join(wsDir, '.workflow'), { recursive: true });
+      symlinkSync(secret, join(wsDir, '.workflow', 'result.json'));
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+
+      const result = callApplyResultFile(
+        orchestrator,
+        wsDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+          resultFile: '.workflow/result.json',
+        },
+        { passed: true },
+      );
+
+      expect(result.passed).toBe(false);
+      expect(result.verdict).toBe(DETERMINISTIC_RESULT_ERROR_VERDICT);
+      expect(result.errors).toContain('escapes the workspace');
+      expect(result.verdict).not.toBe('leak'); // never surfaced the symlinked-out verdict
+    });
+
+    it('reports a read error (not "not valid JSON") when resultFile is a directory', () => {
+      // resultFile points at a directory -> readFileSync throws EISDIR, which must be
+      // reported as a read failure rather than conflated with a JSON parse error.
+      mkdirSync(join(tmpDir, '.workflow', 'result.json'), { recursive: true });
+      const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+
+      const result = callApplyResultFile(
+        orchestrator,
+        tmpDir,
+        {
+          stateId: 'check',
+          commands: [['node', 'check.js']],
+          context: { taskDescription: 'task' } as DeterministicInvokeInput['context'],
+          container: true,
+          resultFile: '.workflow/result.json',
+        },
+        { passed: true },
+      );
+
+      expect(result.passed).toBe(false);
+      expect(result.verdict).toBe(DETERMINISTIC_RESULT_ERROR_VERDICT);
+      expect(result.errors).toContain('could not be read');
+      expect(result.errors).not.toContain('not valid JSON');
     });
 
     it('does not read resultFile when command reduction already failed', () => {

--- a/test/workflow/validate.test.ts
+++ b/test/workflow/validate.test.ts
@@ -343,10 +343,44 @@ describe('validateDefinition', () => {
       }
     });
 
-    it('rejects when on deterministic state', () => {
+    it('accepts deterministic when:{verdict} when the state is containerized and declares resultFile', () => {
+      const def = {
+        name: 'deterministic-verdict',
+        description: 'Deterministic verdict routing',
+        initial: 'author',
+        settings: { mode: 'docker', sharedContainer: true },
+        states: {
+          author: {
+            type: 'agent',
+            description: 'Mints container',
+            persona: 'global',
+            prompt: 'author',
+            inputs: [],
+            outputs: [],
+            transitions: [{ to: 'classify' }],
+          },
+          classify: {
+            type: 'deterministic',
+            description: 'Classifies',
+            run: [['python3', '/workflow-scripts/classify.py']],
+            container: true,
+            resultFile: '.workflow/result.json',
+            transitions: [
+              { to: 'passed', when: { verdict: 'pass' } },
+              { to: 'blocked', when: { verdict: 'block' } },
+            ],
+          },
+          passed: { type: 'terminal', description: 'pass' },
+          blocked: { type: 'terminal', description: 'block' },
+        },
+      };
+
+      expect(() => validateDefinition(def)).not.toThrow();
+    });
+
+    it('rejects deterministic when:{verdict} when the state is not container:true', () => {
       const def = deepClone(validDefinition());
       const states = def.states as Record<string, Record<string, unknown>>;
-      // Replace review with a deterministic state that uses when
       states.review.transitions = [{ to: 'test' }];
       states.test = {
         type: 'deterministic',
@@ -354,12 +388,13 @@ describe('validateDefinition', () => {
         run: [['npm', 'test']],
         transitions: [{ to: 'gate', when: { verdict: 'approved' } }, { to: 'plan' }],
       };
+
+      expect(() => validateDefinition(def)).toThrow(WorkflowValidationError);
       try {
         validateDefinition(def);
-        expect.fail('should have thrown');
       } catch (e) {
         const err = e as WorkflowValidationError;
-        expect(err.issues).toEqual(expect.arrayContaining([expect.stringContaining('deterministic')]));
+        expect(err.issues).toEqual(expect.arrayContaining([expect.stringContaining('container: true')]));
       }
     });
 
@@ -878,21 +913,84 @@ describe('validateDefinition', () => {
         expect(err.issues.some((i) => i.includes('settings.mode is not "docker"'))).toBe(true);
       }
     });
+
+    it('rejects resultFile on a non-container deterministic state', () => {
+      const def = sharedContainerDef({});
+      const states = def.states as Record<string, unknown>;
+      states.review = {
+        type: 'deterministic',
+        description: 'Bad result file',
+        resultFile: '.workflow/result.json',
+        run: [['true']],
+        transitions: [{ to: 'done', guard: 'isPassed' }, { to: 'done' }],
+      };
+
+      expect(() => validateDefinition(def)).toThrow(WorkflowValidationError);
+      try {
+        validateDefinition(def);
+      } catch (err) {
+        if (!(err instanceof WorkflowValidationError)) throw err;
+        expect(err.issues.some((i) => i.includes('container: true'))).toBe(true);
+      }
+    });
+
+    it('rejects unsafe resultFile paths', () => {
+      for (const resultFile of ['/tmp/result.json', '../result.json', './result.json', 'a//result.json']) {
+        const def = sharedContainerDef({});
+        const states = def.states as Record<string, unknown>;
+        states.review = {
+          type: 'deterministic',
+          description: 'Bad result file path',
+          container: true,
+          resultFile,
+          run: [['true']],
+          transitions: [{ to: 'done', guard: 'isPassed' }, { to: 'done' }],
+        };
+
+        expect(() => validateDefinition(def)).toThrow(WorkflowValidationError);
+        try {
+          validateDefinition(def);
+        } catch (err) {
+          if (!(err instanceof WorkflowValidationError)) throw err;
+          expect(err.issues.some((i) => i.includes('workspace-relative path'))).toBe(true);
+        }
+      }
+    });
+
+    it('rejects resultFile on non-deterministic states via the raw-input check', () => {
+      const def = deepClone(validDefinition());
+      const states = def.states as Record<string, Record<string, unknown>>;
+      states.plan.resultFile = '.workflow/result.json';
+
+      expect(() => validateDefinition(def)).toThrow(WorkflowValidationError);
+      try {
+        validateDefinition(def);
+      } catch (err) {
+        if (!(err instanceof WorkflowValidationError)) throw err;
+        expect(err.issues).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining('"resultFile" but that field is only valid on deterministic states'),
+          ]),
+        );
+      }
+    });
   });
 });
 
 // ---------------------------------------------------------------------------
-// No-regression — shipped workflows still validate after the schema additions
-// (deterministic `container` / `containerScope` / `timeoutMs`). None of these
-// ship a deterministic state, so this is a pure backward-compat gate on the
-// schema changes: every bundled workflow.yaml must still parse + validate with
-// zero errors. (Test plan §11 #1, backward-compat clause.)
+// No-regression — shipped workflows still validate after the schema additions.
 // ---------------------------------------------------------------------------
 
 describe('shipped workflows validate unchanged', () => {
   const workflowsDir = resolve(__dirname, '..', '..', 'src', 'workflow', 'workflows');
 
-  for (const name of ['vuln-discovery', 'design-and-code', 'test-email-summary']) {
+  for (const name of [
+    'vuln-discovery',
+    'design-and-code',
+    'test-email-summary',
+    'deterministic-eval-smoke',
+    'deterministic-verdict-smoke',
+  ]) {
     it(`${name}: workflow.yaml validates without errors`, () => {
       const manifestPath = resolve(workflowsDir, name, 'workflow.yaml');
       const raw = parseYaml(readFileSync(manifestPath, 'utf-8'), { maxAliasCount: 0 });


### PR DESCRIPTION
## What

The follow-up runtime piece after containerized deterministic execution: a `deterministic` workflow state can emit a **structured verdict + payload** via a helper-written result file, and the machine routes deterministic states on `when:{verdict}` edges through the **existing** `__matchesWhen` guard. This lets a deterministic state distinguish e.g. `evaluated` vs `evaluator_blocked` and route hard failures straight to a terminal/gate without an agent turn. Design doc: `docs/designs/deterministic-result-contract.md`.

## How

- **YAML:** opt in with `resultFile: <workspace-relative path>` on a `container: true` deterministic state; the helper writes `{ "verdict": string, "payload"?: object, "passed"?: boolean }`. Route with `when: { verdict: ... }`.
- **Container-only:** `resultFile` / `when:{verdict}` require `container: true` — the helper's `/workspace` write and the orchestrator's read are the same bytes only via the bind mount (a host helper writes to `process.cwd()`). Host deterministic states stay guard-based.
- **`applyResultFile`** reads the file host-side from `instance.workspacePath` *after* the commands run (only when they passed); a present file `passed` overrides the exit-code-derived result. Missing/malformed/verdict-less → reserved verdict `result_file_error` (`passed:false`), itself routable.
- **Back-compat (load-bearing):** the `VALIDATION_PASSED/FAILED` mapping and `isPassed` guard are untouched; guard-only deterministic states route byte-identically. The result file is strictly opt-in.
- **Validation:** the blanket deterministic-`when` rejection is removed (the verdict-only-key/type checks still apply); adds container-only + path-safety + misplaced-`resultFile` checks.
- **Lint WF012:** warns when a deterministic state routes on `when:{verdict}` but declares no `resultFile`.

Out of scope (separate follow-up): the ASI-Evolve workflow that consumes this.

## Acceptance — verified end-to-end against real Docker

`src/workflow/workflows/deterministic-verdict-smoke/` + `test/workflow/deterministic-verdict-smoke.integration.test.ts` (gated on `INTEGRATION_TEST=1` + a real Docker daemon). `classify.py`'s stdout is verdict-blind and all commands exit 0, so reaching distinct terminals can only come from the verdict file. Ran against real Docker:

- `"pass"` → `passed_terminal`, `"block"` → `blocked_terminal`, neither hits `error_terminal`.
- `"error"` (helper writes no file) → `error_terminal` via `result_file_error`.

A guard-only/`isPassed` implementation could not reach distinct terminals — so this gate proves verdict-file routing, not stdout pass/fail.

## Quality

- Opus code review: **ready-to-merge**; the two low-severity findings it raised were applied (gate `lastDeterministicResult` so guard-only context stays byte-identical; add the missing-file negative integration case).
- `/simplify` pass applied: extracted a shared `buildOnDoneTransitions` (agent + deterministic) and exported `usesVerdictEdges` (validate + WF012 lint), removing duplicated logic.
- `npm run build` and `npm run lint` clean; full `test/workflow/` suite green; integration test passes against real Docker.
- WORKFLOWS.md updated (lint table, `resultFile` schema/example, `when`/`guard` sections, the `passed`-override semantics).