### PR TITLE
feat(workflow): evolve single-round workflow slice

### DIFF
--- a/docs/designs/evolve-single-round-slice.md
+++ b/docs/designs/evolve-single-round-slice.md
@@ -1,0 +1,604 @@
+# Evolve Native Workflow — First Vertical Slice (single round, end to end)
+
+Status: Design — settled, ready to implement (author→critical-review→revise→verify loop; both §15 maintainer decisions signed off 2026-06-16: engine-native `.evolve_runs/` layout, and deferring `preflight_review` for this slice).
+Audience: IronCurtain workflow engineer implementing the first `evolve` workflow package
+Implementation contract: this document is meant to be implemented with **no further design input**. It names exact files, the full `workflow.yaml`, the `evolve_core` CLI argv each state runs, the engine-output→result-contract bridge, the package layout, and the binary end-to-end gate.
+
+Predecessors (merged, build ON — do not redesign):
+
+- **Containerized deterministic execution + script packaging** — `docs/designs/deterministic-in-container-execution.md` (PR #292). Gives us: `container: true` / `containerScope` on deterministic states (`src/workflow/validate.ts:79`, `src/workflow/types.ts:256`), `scripts/` staged read-only at `/workflow-scripts` (`src/docker/agent-adapter.ts:22`, `CONTAINER_SCRIPTS_DIR`), per-workflow image baked from `requirements.txt` at build time (`ensureWorkflowImage`, `src/docker/docker-infrastructure.ts:1352`), `--network=none` runtime, `/workspace` RW bind mount (`CONTAINER_WORKSPACE_DIR`, `src/docker/agent-adapter.ts:19`), and `--workdir /workspace` exec (`DockerManager.exec`, `src/docker/docker-manager.ts:264`).
+- **Structured deterministic result contract** — `docs/designs/deterministic-result-contract.md`. Gives us: `resultFile: <ws-relative path>` on deterministic states, `when: { verdict: ... }` routing on deterministic states, the `{ verdict, payload?, passed? }` `result.json` schema, the reserved `result_file_error` verdict (`DETERMINISTIC_RESULT_ERROR_VERDICT`, `src/workflow/types.ts`), container-only enforcement, and `applyResultFile` reading the file back from `instance.workspacePath`.
+
+Parent design: `docs/designs/asi-evolve-native-workflow.md` — the full FSM, state responsibilities, `.workflow/` domain layout, and `evolve_core` reuse. **This slice implements the smallest non-trivial subset of that design.**
+
+Engine packaged: `donotcommit/ASI-Evolve/skills/evolve/scripts/` — the `evolve_core/` engine (`cli.py:740` `main_for(entrypoint, argv)`) plus the `evolve-eval` / `evolve-db` / `evolve-brief` / `evolve-summary` / `evolve-files` / `evolve-cognition` wrapper scripts. Verified numpy-fallback (no FAISS) and `yaml` dependency below.
+
+---
+
+## 1. Summary & goals
+
+### What ships this slice
+
+A native IronCurtain workflow package at `src/workflow/workflows/evolve/` that runs **exactly one evolution round, end to end**, recording **one scored candidate** using the packaged `evolve_core` engine, through real container deterministic states with verdict routing:
+
+```
+preflight (agent) ─ready→ researcher (agent) ─→ evaluate (deterministic, container)
+   ├─ evaluated ─→ record_node (deterministic, container) ─ recorded ─→ done (terminal)
+   │                                                       └ needs_repair ─→ failed (terminal)
+   └─ evaluator_blocked ─→ failed (terminal)
+preflight ─blocked→ failed
+```
+
+- `preflight` (agent): writes `run_spec.yaml` (objective, evaluator command, score field) and initializes the run via `evolve_core` (`evolve-brief normalize`), with `approval.confirmed=true`.
+- `researcher` (agent): writes the candidate file under the step dir. In the gate it is **mocked** to write a known candidate.
+- `evaluate` (deterministic, `container: true`): runs `evolve-eval run` in the shared container, then a thin bridge writes `result.json` with `{ verdict: evaluated | evaluator_blocked, payload: { score, ... }, passed }`.
+- `record_node` (deterministic, `container: true`): runs `evolve-db record`, then the same bridge writes `result.json` with `{ verdict: recorded | needs_repair }`. Commits the node to the engine database and updates `best/`.
+- An automated, gated, real-Docker integration test (`evolve-single-round.integration.test.ts`) is the front-and-center completion gate.
+
+The engine ships **Tier 0** (numpy + PyYAML, brute-force numpy index, no FAISS), packaged in `scripts/` with a `requirements.txt` that triggers the per-workflow image build.
+
+### What's deferred (see §14)
+
+The multi-round loop, the `orchestrator` hub, sampling beyond the trivial first pick, the analyzer + cognition retrieval, FAISS/embeddings (Tier 1), and richer UI summary artifacts.
+
+### Goals (binary, restated as the gate)
+
+After the run reaches `done`: the engine database holds **exactly one node** carrying the evaluator score, the `best/` snapshot reflects that node, and the FSM terminated in `done` (not `failed`). A second case where the candidate fails the evaluator routes to the failure path. This proves the engine + container exec + verdict routing work **together**.
+
+---
+
+## 2. Where it fits
+
+The two runtime capabilities this slice consumes are **already merged** (PR #292 for container exec/packaging; the result contract is the immediately-preceding design). This slice is the **first real workflow consumer** of both — it is not a smoke fixture. It is the asi-evolve `evaluate`/`record_node` pattern made concrete with the real engine instead of a toy classifier.
+
+The two shipped smoke fixtures are the templates:
+
+- `src/workflow/workflows/deterministic-eval-smoke/` — agent mints container, deterministic `container: true` states `exec` packaged helpers, `requirements.txt` triggers the per-workflow image (numpy), `guard: isPassed` routing.
+- `src/workflow/workflows/deterministic-verdict-smoke/` — deterministic state's helper writes `result.json`, machine routes on `when: { verdict: ... }` to distinct terminals.
+
+This slice = `eval-smoke`'s packaging + `verdict-smoke`'s verdict routing, with `evolve_core` as the packaged engine and a real evaluator. The integration test (`test/workflow/deterministic-verdict-smoke.integration.test.ts`) is the literal model for §11.
+
+---
+
+## 3. Workflow package layout
+
+```text
+src/workflow/workflows/evolve/
+  workflow.yaml                       # the FSM (§4)
+  requirements.txt                    # numpy + pyyaml (§10) — triggers the per-workflow image
+  scripts/                            # staged read-only at /workflow-scripts (whole run)
+    evolve_core/                      # the packaged engine, copied verbatim from the skill
+      __init__.py
+      cli.py
+      run_state.py  file_lock.py
+      database.py  cognition.py  best_snapshot.py  diff.py
+      embedding.py  vector_index.py  structures.py
+      sampling_config.py
+      algorithms/                     # __init__.py base.py factory.py greedy.py island.py random.py ucb1.py
+    evolve-brief                      # wrapper: main_for("brief")  — preflight init
+    evolve-eval                       # wrapper: main_for("eval")   — evaluator run
+    evolve-db                         # wrapper: main_for("db")     — record/best/stats/sample
+    evolve-summary                    # wrapper: main_for("summary")
+    evolve-files                      # wrapper: main_for("files")  (unused this slice; ship for parity)
+    evolve-cognition                  # wrapper: main_for("cognition") (unused this slice; ship for parity)
+    evolve_result.py                  # NEW thin bridge: engine JSON -> result.json (§8.3)
+  skills/                             # OPTIONAL this slice — see §4.7. Prompts may live inline in workflow.yaml.
+```
+
+The wrappers already exist verbatim under `donotcommit/ASI-Evolve/skills/evolve/scripts/`; each does `sys.path.insert(0, SCRIPT_DIR)` then `from evolve_core.cli import main_for`. Copy them and `evolve_core/` unchanged. `evolve_result.py` is the **only net-new Python** (the bridge, §8.3).
+
+> **Why `requirements.txt` (a per-workflow image) and not the base image.** `evolve_core` imports **numpy** (`embedding.py`, `vector_index.py`) and **PyYAML** (`run_state.py:11 import yaml`). The base image (`docker/Dockerfile.base`) ships Python 3.12, `uv`, pip, and `ruff` but does **not** guarantee numpy or PyYAML. Rather than depend on a transitive base-image package, declare them explicitly. This triggers `ensureWorkflowImage` to bake `ironcurtain-wf-<hash>` `FROM ironcurtain-claude-code:latest` (`docker-infrastructure.ts:1352`) — content-addressed, offline-safe at `--network=none`. The parent design's "numpy-only (Tier 0)" is corrected here to **numpy + pyyaml**; it is still Tier 0 (no FAISS, no sentence-transformers).
+
+The deterministic states invoke helpers with the venv interpreter so the baked deps resolve:
+`['/opt/workflow-venv/bin/python', '/workflow-scripts/evolve-eval', 'run', ...]` (matches `eval-smoke`'s `/opt/workflow-venv/bin/python`).
+
+> **Agent states reach the venv + scripts too (real-run preflight).** `ensureWorkflowImage` returns the per-workflow image, which becomes `core.image` (`docker-infrastructure.ts:634`) — the _single_ image the whole bundle uses, **agent sessions included** (`:1105`). `/workflow-scripts` is staged once for the whole run (PR #292 §5.2), not filtered per agent-state `skills:`. So in a _real_ (non-mocked) run, the `preflight` agent session can execute `/opt/workflow-venv/bin/python /workflow-scripts/evolve-brief normalize ...` with numpy + pyyaml resolved. In the gate (§11) `preflight` is mocked and does not need this.
+
+---
+
+## 4. The FSM (full `workflow.yaml`)
+
+```yaml
+name: evolve
+description: 'Evolve — single-round evaluator-driven candidate search (first vertical slice).'
+initial: preflight
+
+settings:
+  mode: docker
+  dockerAgent: claude-code
+  sharedContainer: true # REQUIRED for container: true deterministic states
+  model: anthropic:claude-sonnet-4-6
+
+states:
+  preflight:
+    type: agent
+    description: Define the run spec (objective, evaluator command, score field) and initialize the evolve run.
+    persona: global
+    prompt: |
+      You are configuring a single-round Evolve experiment. The task you were given describes a
+      program-search objective with an evaluator that prints a score.
+
+      Do BOTH of these, in order, then finish with the required agent_status block:
+
+      1. Initialize the run by executing the evolve-brief helper. The run lives under
+         /workspace/.evolve_runs/main/. Use these flags (fill OBJECTIVE / EVAL_CMD from the task):
+
+         /opt/workflow-venv/bin/python /workflow-scripts/evolve-brief normalize \
+           --workspace-root /workspace \
+           --run-name main \
+           --objective "OBJECTIVE" \
+           --core-score eval_score \
+           --evaluation-command "EVAL_CMD" \
+           --evaluation-timeout-secs 30 \
+           --success-criterion "eval_score >= 1.0" \
+           --max-rounds 1 \
+           --patience 1 \
+           --stop-condition "max_rounds" \
+           --writable-path .evolve_runs \
+           --primary-target candidate.py \
+           --sampling-algorithm greedy \
+           --sample-n 1 \
+           --cognition-source-mode none \
+           --confirmed true
+
+         EVAL_CMD must be a shell command that reads the candidate at {quoted_code_path}, runs it,
+         and writes a JSON file at {quoted_results_path} containing an "eval_score" number.
+         (The helper substitutes {quoted_code_path} / {quoted_results_path} at eval time.)
+
+      2. Confirm the command exited 0 and that /workspace/.evolve_runs/main/run_spec.yaml exists.
+
+      If the task is missing an objective or an evaluator you cannot construct, set verdict: blocked.
+      Otherwise set verdict: ready.
+    inputs: []
+    outputs: []
+    transitions:
+      - to: researcher
+        when: { verdict: ready }
+      - to: failed
+        when: { verdict: blocked }
+
+  researcher:
+    type: agent
+    description: Materialize one candidate program at the step code path.
+    persona: global
+    prompt: |
+      Write exactly one candidate program for this round.
+
+      Write the COMPLETE candidate file to:
+        /workspace/.evolve_runs/main/steps/step_0001/code
+
+      Create the directory if needed. Write only that one file — no extra files, no commentary in
+      the file. The candidate must satisfy the objective in /workspace/.evolve_runs/main/run_spec.yaml.
+
+      Finish with the required agent_status block (informational; verdict is not routed here).
+    inputs: []
+    outputs: []
+    maxVisits: 3
+    transitions:
+      - to: evaluate
+
+  evaluate:
+    type: deterministic
+    description: Run the configured evaluator on the candidate inside the shared container.
+    container: true # default scope "primary" — reuses the bundle preflight/researcher minted
+    resultFile: .evolve_runs/main/steps/step_0001/result.json
+    run:
+      - [
+          '/opt/workflow-venv/bin/python',
+          '/workflow-scripts/evolve_result.py',
+          'evaluate',
+          '--run-dir',
+          '/workspace/.evolve_runs/main',
+          '--step-name',
+          'step_0001',
+          '--code-path',
+          '.evolve_runs/main/steps/step_0001/code',
+          '--result-file',
+          '/workspace/.evolve_runs/main/steps/step_0001/result.json',
+        ]
+    transitions:
+      - to: record_node
+        when: { verdict: evaluated }
+      - to: failed
+        when: { verdict: evaluator_blocked }
+      - to: failed
+        when: { verdict: result_file_error }
+      - to: failed # belt-and-braces unguarded default
+
+  record_node:
+    type: deterministic
+    description: Commit the scored candidate as a node and update the best snapshot.
+    container: true
+    resultFile: .evolve_runs/main/steps/step_0001/record_result.json
+    run:
+      - [
+          '/opt/workflow-venv/bin/python',
+          '/workflow-scripts/evolve_result.py',
+          'record',
+          '--run-dir',
+          '/workspace/.evolve_runs/main',
+          '--step-name',
+          'step_0001',
+          '--name',
+          'round-1',
+          '--code-path',
+          '.evolve_runs/main/steps/step_0001/code',
+          '--results-file',
+          '.evolve_runs/main/steps/step_0001/results.json',
+          '--result-file',
+          '/workspace/.evolve_runs/main/steps/step_0001/record_result.json',
+        ]
+    transitions:
+      - to: done
+        when: { verdict: recorded }
+      - to: failed
+        when: { verdict: needs_repair }
+      - to: failed
+        when: { verdict: result_file_error }
+      - to: failed
+
+  done:
+    type: terminal
+    description: One candidate scored and recorded; best snapshot updated.
+
+  failed:
+    type: terminal
+    description: Preflight blocked, evaluator failed, or record failed.
+```
+
+### 4.1 Why linear single-round (no `orchestrator` hub yet)
+
+The parent design centers on an `orchestrator` agent hub whose entire job is to **choose which specialist to dispatch next across rounds** (`design` / `evaluate` / `analyze` / `record` / `complete`). With exactly one round and a fixed `preflight → researcher → evaluate → record_node → done` sequence, there is **nothing for the hub to decide** — every transition is unconditional or a mechanical verdict. Adding the hub now would mean an agent turn that always emits the same verdict, plus the prompt/verdict machinery to validate it, for zero routing value. The hub earns its keep only once there is a loop and a sampling decision (deferred, §14). The linear graph here is a strict subgraph of the parent FSM: the same `preflight`/`researcher`/`evaluate`/`record_node` states and the same deterministic verdicts (`evaluated`/`evaluator_blocked`, `recorded`/`needs_repair`), just with the hub edges collapsed into direct transitions and `human_escalation` replaced by the `failed` terminal (§4.2).
+
+### 4.2 Failure routing: `failed` terminal, not `human_escalation`
+
+The parent design routes hard mechanical failures (`evaluator_blocked`, `needs_repair`) to a `human_escalation` human gate. This slice routes them to a `failed` **terminal** instead, because:
+
+- The slice's purpose is to prove the engine + container + verdict routing pipeline. A human gate on the failure path would make the negative test case (candidate fails the evaluator) **block on a human** instead of terminating cleanly — defeating CI-runnability.
+- `human_escalation` belongs to the multi-round design where a human can patch the run spec and resume. With one round and no loop, there is nothing to resume into; terminating is the correct single-round behavior.
+
+`human_escalation` returns in the multi-round slice (§14). The verdict **names** are kept identical to the parent (`evaluator_blocked`, `needs_repair`) so the routing targets are the only thing that changes when the hub is added.
+
+### 4.3 `preflight_review` human gate — DEFERRED this slice (justified)
+
+**Decision: the `preflight_review` human gate is NOT in this slice.** Instead, `preflight` itself sets `approval.confirmed=true` via `evolve-brief normalize --confirmed true`.
+
+Rationale — this keeps the end-to-end gate cleanly CI-runnable:
+
+- The completion gate (§11) must run unattended under `INTEGRATION_TEST=1`. A `human_gate` state pauses the FSM at `phase: waiting_human` and waits for `raiseGate`/an external `APPROVE` event (`test-helpers.ts:392 waitForGate`, `:425 waitForGateOrCompletion`). Auto-approving it requires the test to poll for the gate, then inject an `APPROVE` event and resume — extra orchestration that adds a failure surface (gate-timing flakiness) without testing anything this slice is about (engine + container exec + verdict routing).
+- The engine **already enforces approval at the right layer**, independent of graph topology: every mutating/evaluator helper calls `require_evolve_ready(run_dir)` (`run_state.py:288`), which raises `PermissionError` if `approval.confirmed` is false. So approval is enforced by the helper at the point of use, exactly as the parent design's security model demands ("Enforce approval with a machine-readable `approval.confirmed` field checked by every mutating/evaluator helper, not only by graph topology"). Setting `confirmed=true` in `preflight` is the machine-readable approval; the human gate is the _human_ surface, which this slice omits.
+- A real run would interpose the gate between `preflight` and `researcher`; the slice's FSM is a strict subgraph that drops it. Re-adding `preflight_review` (and `human_escalation`) is the first thing the next slice does (§14), and the integration-test pattern for auto-approving a gate already exists in the codebase (drive `raiseGate` mock, inject `APPROVE`) — it is deferred to keep _this_ gate binary and fast, not because it is hard.
+
+This is the genuine maintainer call flagged in §15.
+
+### 4.4 `evaluate` transitions
+
+`when: { verdict: evaluated }` → `record_node` (happy path). `when: { verdict: evaluator_blocked }` → `failed` (missing score / evaluator non-zero / malformed results). `when: { verdict: result_file_error }` → `failed` (the reserved verdict from §8.4 if the bridge itself fails to write the file). A final unguarded `to: failed` is the catch-all per the result-contract ordering rule (verdict edges first, then default).
+
+### 4.5 `researcher` is informational (unconditional return)
+
+`researcher` has a single unconditional `to: evaluate` transition, so per the runtime's steering model it gets **no injected verdict list and no verdict validation** — its `agent_status` block is informational. This matches the parent design (`researcher`: "informational verdict; unconditional return"). In the gate it is mocked.
+
+### 4.6 `maxVisits` on `researcher`
+
+`maxVisits: 3` guards repeated invalid candidate revisions (parent design `researcher.maxVisits`). It is inert in the single happy round but documents the cap. `evaluate`/`record_node` are deterministic and take no `maxVisits` (agent-only field, `validate.ts:133`).
+
+### 4.7 Skills
+
+A `skills/` directory is **optional** this slice. The two-state prompt content (preflight scoring contract, researcher candidate-generation modes) is small enough to live inline in `workflow.yaml` for the first slice. If lifted to a skill later, it must be de-sequenced per the CLAUDE.md skill-authoring rules (no stage labels / phase numbers). Not shipping `skills/` keeps the slice minimal; the parent design's full `evolve` skill is deferred.
+
+---
+
+## 5. `.workflow/` domain layout this slice writes
+
+> **Reconciliation (load-bearing).** The parent design specifies a _flattened_ `.workflow/database/nodes.json` layout. The packaged `evolve_core` engine, however, has a **fixed, non-negotiable** run layout baked into `run_state.py`: `build_run_dir(workspace_root, run_name)` returns `<workspace_root>/.evolve_runs/<run_name>/` (`run_state.py:115`), and `workspace_root_for_run(run_dir)` derives the workspace by going **two levels up** from the run dir (`run_dir.parent.parent`, `run_state.py:137`). The path-allowlisting (`ensure_path_allowed`) and the `database_data/nodes.json` storage path (`database.py:162`) all depend on this exact `<ws>/.evolve_runs/<run>/...` shape. Changing it means forking the engine — which contradicts "package, don't re-implement."
+>
+> **Decision: this slice uses the engine's native `.evolve_runs/main/` layout under `/workspace`, NOT `.workflow/`.** The parent design's `.workflow/` flattening is a _later_ migration (it requires either an engine fork or a path-mapping shim). The completion gate (§11) therefore asserts against `.evolve_runs/main/database_data/nodes.json` and `.evolve_runs/main/best/`, not `.workflow/database/nodes.json`. (The result-contract `resultFile` paths still live under the run dir, e.g. `.evolve_runs/main/steps/step_0001/result.json`.) This deviation from the task's `.workflow/...` wording is deliberate and is the only way to reuse the engine verbatim; it is flagged as a maintainer call in §15.
+
+What the slice writes under `/workspace` (host: `instance.workspacePath`):
+
+```text
+/workspace/
+  .evolve_runs/
+    main/                                  # run_dir  (build_run_dir(workspace, "main"))
+      run_spec.yaml                        # preflight: objective, evaluation.command, core_score, approval.confirmed=true
+      preflight_summary.md                 # preflight: write_preflight_summary()
+      cognition_seed.md                    # preflight: initialize_cognition_seed_file() (unused this slice)
+      round_log.jsonl                      # append-only event log (eval_run, db_record, ...)
+      steps/
+        step_0001/
+          code                             # researcher: the candidate program (engine copies here on eval/record)
+          results.json                     # evaluate: evaluator output, must carry eval_score
+          eval.command.txt eval.stdout eval.stderr   # evaluate: captured by evolve-eval run
+          result.json                      # evaluate bridge: { verdict, payload:{score}, passed }  (resultFile)
+          node.json                        # record_node: the committed Node record
+          record_result.json               # record_node bridge: { verdict, payload:{node_id,best_updated} }
+      database_data/
+        nodes.json                         # THE commit index: { next_id, nodes: {"0": {...}}, sampler_state }
+        faiss/
+          vector_store.pkl                 # brute-force numpy index (Tier 0 fallback)  (database.py:191 -> storage_dir/"faiss", vector_index.py:131)
+        .database.lock
+      cognition_data/                      # initialized empty (cognition_source_mode=none)
+      best/
+        step_0001/                         # run-level best (cmd_db_record: run_dir/best/<step_name>, cli.py:478) — NOT best/round-1/ (round-1 is only the Node name, cli.py:463)
+          code                             # record_node: best snapshot when this node improves best
+          results.json
+      steps/
+        best/
+          step_0001/                       # SECOND, separate snapshot from BestSnapshotManager (best_snapshot.py:19 best_dir=steps_dir/"best", :47 /step_name) — gate need not assert this
+            code
+            results.json
+```
+
+The single node lives in `database_data/nodes.json` as `{ "next_id": 1, "nodes": { "0": { ...Node... } }, "sampler_state": {...} }` — **a keyed object, not a bare array** (`database.py:139-143`). The Node's `score` field carries the evaluator score. This is the structure the completion gate inspects.
+
+`steps/` is append-only; `best/step_0001/` is written only when the node improves the best (always true for the first node). The best-dir name is the **step name** (`step_0001`), not the `--name` value (`round-1`) — `cmd_db_record` writes `run_dir/best/<step_name>` (`cli.py:478`) and `--name round-1` only becomes `Node.name` (`cli.py:463`). `.evolve_runs/` is an undeclared workspace subtree (not a declared output, so never `.vN`-snapshotted) — exactly the parent design's "leave large mutable stores undeclared" guidance.
+
+---
+
+## 6. `preflight` (agent)
+
+**Type:** agent (`persona: global`). **Routes on** `verdict: ready | blocked`.
+
+**Responsibility.** Produce `run_spec.yaml` with objective, evaluator command, score field, timeout, and approval, then initialize the engine run layout.
+
+**The exact engine call** (run by the agent inside the container; the agent is instructed to execute this argv):
+
+```
+/opt/workflow-venv/bin/python /workflow-scripts/evolve-brief normalize \
+  --workspace-root /workspace \
+  --run-name main \
+  --objective "<from task>" \
+  --core-score eval_score \
+  --evaluation-command "<shell cmd reading {quoted_code_path}, writing {quoted_results_path} with eval_score>" \
+  --evaluation-timeout-secs 30 \
+  --success-criterion "eval_score >= 1.0" \
+  --max-rounds 1 --patience 1 --stop-condition "max_rounds" \
+  --writable-path .evolve_runs --primary-target candidate.py \
+  --sampling-algorithm greedy --sample-n 1 \
+  --cognition-source-mode none \
+  --confirmed true
+```
+
+This calls `cmd_brief_normalize` (`cli.py:123`), which: builds `run_dir = /workspace/.evolve_runs/main`, `ensure_run_layout` (creates `steps/`, `database_data/`, `cognition_data/`, `best/`, `round_log.jsonl`), merges the flags into the run spec, validates required fields, and — because `--confirmed true` with no missing fields — writes `run_spec.yaml` (`save_run_spec`), `preflight_summary.md` (`write_preflight_summary`), and `cognition_seed.md` (`initialize_cognition_seed_file`). It prints JSON `{ confirmed, missing_fields, preflight_summary, run_dir, run_spec, seed_file }`.
+
+> **Required-field note (must match `REQUIRED_FIELD_CHECKS`, `run_state.py:58`).** `--confirmed true` is **rejected with a non-zero exit** if any required field is missing (`cli.py:192`: "Cannot confirm preflight while required fields are missing"). The argv above supplies every required field: `objective`, `evaluation.core_score`, `evaluation.command`, `evaluation.timeout_secs > 0`, `evaluation.success_criteria`, `budget.max_rounds > 0`, `budget.patience >= 0`, `stop_conditions`, `mutation_scope.writable_paths`, `mutation_scope.primary_targets`, `sampling.algorithm`, `sampling.sample_n > 0`, `cognition.source_mode`. The integration test's `preflight` mock (§11) must produce these or the run cannot confirm. `sampling.algorithm: greedy` is chosen (not the default `ucb1`) because with one node the sampler is irrelevant and `greedy` avoids any island/feature-dimension setup.
+
+**Verdict.** The agent emits `ready` after confirming the command exited 0 and `run_spec.yaml` exists; `blocked` if it cannot construct an evaluator. `preflight` is an agent state with only verdict-conditional edges, so the runtime injects the valid verdicts (`ready`, `blocked`) into its prompt and validates the emitted `agent_status` verdict.
+
+**No declared `preflight_summary` artifact.** `preflight` must declare `outputs: []` (and `researcher` `inputs: []`). This is **not cosmetic — it is a functional requirement.** After an agent state completes, the orchestrator runs `findMissingArtifacts(stateConfig, instance.artifactDir)` (`orchestrator.ts:2249,2691`), which resolves each declared output to `<ws>/.workflow/<output>/` (artifactDir = `<ws>/.workflow`, `orchestrator.ts:1249`; `WORKFLOW_ARTIFACT_DIR = '.workflow'`, `types.ts:12`) and checks `hasAnyFiles`. The engine, however, writes the summary to `.evolve_runs/main/preflight_summary.md`, **not** under `.workflow/preflight_summary/`. So a declared `outputs: ['preflight_summary']` would find that directory empty, fire the missing-artifact reprompt, and then **throw `Missing artifacts after retry: preflight_summary`** (`orchestrator.ts:2263-2264`) — the run never reaches `researcher`/`evaluate` and the §11 gate fails here. The summary file still exists under `.evolve_runs/main/preflight_summary.md` and is agent-visible; it is simply not surfaced as a declared `.workflow/` artifact this slice. (Surfacing it as a UI artifact requires either writing it under `.workflow/` or a copy step — deferred, §14 #9.)
+
+---
+
+## 7. `researcher` (agent)
+
+**Type:** agent (`persona: global`). **Unconditional** return to `evaluate` (informational verdict).
+
+**Responsibility.** Write the complete candidate program to `/workspace/.evolve_runs/main/steps/step_0001/code` (creating the dir). One file only, no commentary. Diff vs full-rewrite modes are deferred (parent design keeps both; this slice does full-rewrite only).
+
+**In the gate (§11), `researcher` is mocked** via the `createSession` stub to write a known candidate (`def solve(xs): return sum(xs)`) to that path. The mock writes the file directly to `options.workspacePath` (exactly as `deterministic-verdict-smoke.integration.test.ts:159-164` writes `task.txt`), so no real LLM runs.
+
+The candidate path (`steps/step_0001/code`) is the path the `evaluate` state passes to `evolve-eval run --code-path` (relative to workspace root). `evolve-eval` copies it into the step dir if not already there (`cli.py:258`), so writing it directly at the step path is the simplest contract.
+
+---
+
+## 8. `evaluate` (deterministic, container)
+
+**Type:** deterministic, `container: true`, default scope `primary` (reuses the bundle `preflight`/`researcher` minted). `resultFile: .evolve_runs/main/steps/step_0001/result.json`.
+
+### 8.1 What it runs
+
+A single command: the **bridge** `evolve_result.py evaluate`, which (a) invokes `evolve-eval run` and (b) translates the engine's JSON + `results.json` into the result-contract `result.json`. The bridge is necessary because **`evolve_core` does not emit `{ verdict, payload, passed }`** — `cmd_eval_run` (`cli.py:243`) emits `{ results_path, return_code, step_dir, success }` and the score lives in `results.json` (`eval_score`). The result contract needs a `verdict`; the bridge supplies it.
+
+### 8.2 The underlying engine call (issued by the bridge)
+
+```
+/opt/workflow-venv/bin/python /workflow-scripts/evolve-eval run \
+  --run-dir /workspace/.evolve_runs/main \
+  --code-path .evolve_runs/main/steps/step_0001/code \
+  --step-name step_0001 \
+  --timeout 30
+```
+
+`cmd_eval_run` (`cli.py:243`): calls `require_evolve_ready` (enforces `approval.confirmed`), copies the candidate to `steps/step_0001/code`, formats `evaluation.command` from `run_spec.yaml` with `{quoted_code_path}`/`{quoted_results_path}` placeholders, runs it via `subprocess.run(shell=True, cwd=/workspace, timeout=30)`, captures `eval.stdout`/`eval.stderr`/`eval.command.txt`, reads `steps/step_0001/results.json`, and on non-zero exit backfills `{success:false, eval_score:0.0, error}`. Returns `{ results_path, return_code, step_dir, success }`. Because the whole thing runs inside the `--network=none` shared container via `docker exec`, the evaluator is network-isolated and the container `--init` reaps its process tree (parent design's containment model).
+
+### 8.3 The bridge: `scripts/evolve_result.py` (NEW — the only net-new Python)
+
+A thin argparse CLI with two subcommands (`evaluate`, `record`). For `evaluate`:
+
+1. `subprocess.run([sys.executable, "<dir>/evolve-eval", "run", "--run-dir", run_dir, "--code-path", code_path, "--step-name", step, "--timeout", "30"], capture_output=True)`, then `json.loads(stdout)` to get the engine result `{ results_path, return_code, step_dir, success }`.
+2. Read `<run_dir>/steps/<step>/results.json` if present; pull `eval_score` (fall back to `score`).
+3. Decide the verdict — **key on the engine JSON's `return_code`/`success`, NOT the wrapper's own exit code.** `evolve-eval run` (`cmd_eval_run`, `cli.py:243`) catches the _evaluator subprocess_ failure, backfills `results.json` with `{success:false, eval_score:0.0, error}` (`cli.py:315`), and itself exits **0** via `emit_json` with `return_code != 0` in its JSON. So:
+   - `evaluated` — engine JSON `return_code == 0` (or `success: true`) AND `results.json` exists AND carries a numeric `eval_score`.
+   - `evaluator_blocked` — engine JSON `return_code != 0` (evaluator subprocess failed/timed out — `124`), OR `results.json` is missing, OR it has no numeric scalar score (the parent design's "treat missing scalar score as evaluator failure"). Also `evaluator_blocked` if the wrapper itself crashed (non-zero wrapper exit, e.g. `require_evolve_ready` raised → unconfirmed preflight).
+4. Compute `passed = (verdict == "evaluated")`. Note: a _low_ score (e.g. 0.0) with `return_code == 0` is `evaluated`, not `evaluator_blocked` — a bad candidate is a low score, not an evaluator failure (§11.4).
+5. Write the result file (`--result-file`, an absolute `/workspace/...` path matching the state's `resultFile`):
+   ```json
+   { "verdict": "evaluated", "payload": { "score": 6.0, "return_code": 0, "success": true }, "passed": true }
+   ```
+   On `evaluator_blocked`: `{ "verdict": "evaluator_blocked", "payload": { "return_code": 1, "error": "..." }, "passed": false }`.
+6. The bridge process itself **always exits 0** when it successfully writes the result file. This is deliberate: per the result contract (§4.3 of the contract doc), the file's `passed` field — not the bridge's exit code — drives `passed`, and routing is driven by `verdict`. A bridge that exited non-zero on `evaluator_blocked` would make `reduceDeterministicCommands` set `passed:false` and `applyResultFile` would then **skip the file read** (it only reads when `base.passed`), losing the verdict. So the bridge exits 0 and lets the file carry `passed:false`. If the bridge cannot _write_ the file at all (e.g. an internal crash), it exits non-zero and the runtime synthesizes the reserved `result_file_error` verdict (§8.4).
+
+### 8.4 How `result.json` drives routing
+
+After the command runs, `applyResultFile(instance, input, base)` (result-contract §5.2) reads `instance.workspacePath + "/.evolve_runs/main/steps/step_0001/result.json"` (the host source of the `/workspace` bind mount), validates it is a JSON object with a non-empty string `verdict`, applies the `passed` override, and attaches `verdict`/`payload` to the `DeterministicInvokeResult`. The machine routes the `when: { verdict: ... }` edges via `__matchesWhen`. If the file is missing/malformed, the runtime returns `verdict: result_file_error`, `passed: false` — routed to `failed` by the explicit `when: { verdict: result_file_error }` edge.
+
+**Engine output → result contract mapping (the bridge contract):**
+
+| Engine signal                                                                            | Bridge verdict      | `passed` | Routed to     |
+| ---------------------------------------------------------------------------------------- | ------------------- | -------- | ------------- |
+| engine JSON `return_code == 0`, `results.json.eval_score` numeric (any value, incl. 0.0) | `evaluated`         | `true`   | `record_node` |
+| engine JSON `return_code != 0` (evaluator subprocess failed/timed out)                   | `evaluator_blocked` | `false`  | `failed`      |
+| `results.json` missing or no numeric score                                               | `evaluator_blocked` | `false`  | `failed`      |
+| wrapper exits non-zero (e.g. `require_evolve_ready` raised — unconfirmed preflight)      | `evaluator_blocked` | `false`  | `failed`      |
+| bridge crashes before writing the file                                                   | `result_file_error` | `false`  | `failed`      |
+
+---
+
+## 9. `record_node` (deterministic, container)
+
+**Type:** deterministic, `container: true`, scope `primary`. `resultFile: .evolve_runs/main/steps/step_0001/record_result.json`.
+
+### 9.1 The underlying engine call (issued by the bridge)
+
+```
+/opt/workflow-venv/bin/python /workflow-scripts/evolve-db record \
+  --run-dir /workspace/.evolve_runs/main \
+  --step-name step_0001 \
+  --name round-1 \
+  --code-path .evolve_runs/main/steps/step_0001/code \
+  --results-file .evolve_runs/main/steps/step_0001/results.json
+```
+
+`cmd_db_record` (`cli.py:417`): `require_evolve_ready`; builds the `Database` (storage `database_data/`); copies code into the step dir; reads `results.json`; derives `score` from `results["score"] || results["eval_score"]` (or `--score`); constructs a `Node(name, code, results, score, meta_info={step_name})`; `db.add_with_previous_nodes(node)` — which assigns `node.id`, persists `database_data/nodes.json` atomically (temp + `os.fsync` + `os.replace`, `database.py:139-167`), and updates the numpy vector store; writes `steps/step_0001/node.json`; calls `snapshot.update_if_better(...)` (which writes the `BestSnapshotManager` snapshot at `steps/best/step_0001/`, `best_snapshot.py:47`); and, when `best_updated` is true, copies the run-level best to `best/step_0001/code` + `results.json` (the best-dir is keyed by **step name** `step_0001`, `cli.py:478` — NOT `best/round-1/`; `--name round-1` only becomes `Node.name`, `cli.py:463`). Returns `{ best_updated, node_id, step_dir }`.
+
+This is the parent design's transactional, idempotent durable write — the atomic `nodes.json` rename is the commit point, and `best/` is derived from committed nodes. For a single node, `best_updated` is always true.
+
+### 9.2 The bridge: `evolve_result.py record`
+
+1. `subprocess.run([sys.executable, "<dir>/evolve-db", "record", ...])`, capture stdout (the engine JSON).
+2. Parse `{ best_updated, node_id, step_dir }`.
+3. Verdict:
+   - `recorded` — `evolve-db record` exited 0 and returned a `node_id`.
+   - `needs_repair` — `evolve-db record` exited non-zero (the engine raised, e.g. a transaction/consistency error, or `require_evolve_ready` failed), or returned no `node_id`.
+4. `passed = (verdict == "recorded")`.
+5. Write `record_result.json`: `{ "verdict": "recorded", "payload": { "node_id": 0, "best_updated": true }, "passed": true }` (or the `needs_repair` form). Bridge exits 0 when the file is written (same rationale as §8.3).
+
+### 9.3 Routing
+
+`when: { verdict: recorded }` → `done`. `when: { verdict: needs_repair }` → `failed`. `when: { verdict: result_file_error }` → `failed`. Final unguarded `to: failed`.
+
+---
+
+## 10. Dependencies / image (Tier 0)
+
+`src/workflow/workflows/evolve/requirements.txt`:
+
+```
+numpy
+pyyaml
+```
+
+- **numpy** — `embedding.py` (hash-token embedding fallback) and `vector_index.py` (brute-force pickle index fallback), both numpy-only when FAISS/sentence-transformers are absent (`vector_index.py:12-18` `try: import faiss except: FAISS_AVAILABLE=False`).
+- **pyyaml** — `run_state.py:11 import yaml` (run spec load/save). Required; without it `evolve-brief`/`evolve-eval`/`evolve-db` crash on import.
+
+No `faiss-cpu`, no `sentence-transformers` (Tier 1, deferred §14). No `package.json` (no Node helpers).
+
+**Per-workflow image build is triggered.** Because `requirements.txt` is present, `ensureWorkflowImage(agentImage, scriptsDir, docker, ca)` (`docker-infrastructure.ts:1352`) builds `ironcurtain-wf-<hash>:latest` `FROM ironcurtain-claude-code:latest`, running `uv venv /opt/workflow-venv && uv pip install -r requirements.txt` at build time (network available at build, `--network=none` only at runtime). The build hash (`computeWorkflowImageHash`, `:1405`) keys on `requirements.txt` bytes, so the image rebuilds only when deps change. Helpers run via `/opt/workflow-venv/bin/python` so the baked venv resolves numpy + pyyaml. This is the same path `deterministic-eval-smoke` exercises with `requirements.txt: numpy` — verified to build end to end in PR #292 §11.
+
+---
+
+## 11. End-to-end validation gate (REQUIRED — front and center)
+
+`test/workflow/evolve-single-round.integration.test.ts`, gated `describe.skipIf(!dockerReady)` with `dockerReady = INTEGRATION_TEST === '1' && isDockerAvailable() && isDockerImageAvailable('ironcurtain-claude-code:latest') && hostCaDir !== null`. **Modeled line-for-line on `test/workflow/deterministic-verdict-smoke.integration.test.ts`** (same `TEST_HOME`/CA staging, same `buildDockerSessionConfig`, same `createInfra`/`destroyInfra` real bundles, same `createDeps`, same `onEvent` state collection, same `waitForCompletion`).
+
+### 11.1 Task
+
+A trivial program-search task: **"write `solve(xs)` returning the sum of `xs`; the evaluator scores it by checking `solve([1,2,3]) == 6`."** The evaluator command (set by the `preflight` mock) is a one-line Python that imports the candidate, computes the score, and writes `eval_score` to `results.json`.
+
+### 11.2 Agent sessions are mocked (`createSession`)
+
+The `createSession` stub returns a `MockSession` whose behavior depends on which state is running. **The stub MUST key off invocation order, not `options`.** Both `preflight` and `researcher` are `persona: global` agent states sharing one workspace, and `SessionOptions` carries **no state id** (`src/session/types.ts:361` — `persona`, `workspacePath`, etc., but nothing identifying the FSM state). So the stub cannot tell `preflight` from `researcher` by inspecting `options`; it must use a shared, factory-level call counter (the orchestrator calls `createSession` once per agent state, in FSM order). Concretely:
+
+- **1st invocation = `preflight`** — the mock **does not run the engine** (running `evolve-brief normalize` on the host is wrong — the host has no venv). It writes a hand-authored `run_spec.yaml` directly into the workspace at `.evolve_runs/main/run_spec.yaml` (with `approval.confirmed: true` and every required field) plus the directory skeleton (`steps/`, `database_data/`, `cognition_data/`, `best/`, empty `round_log.jsonl`). **It MUST return a status block with `verdict: ready`** — e.g. `statusBlock('ready', 'preflight confirmed')` (`test-helpers.ts:161`), **NOT `approvedResponse()`.** `preflight`'s transitions are all `when:{verdict}` (ready/blocked), so `getValidVerdicts` returns `{ready, blocked}` (`status-parser.ts:289-296`) and the orchestrator validates the emitted verdict against it (`orchestrator.ts:2215-2242`). The shared `approvedResponse()` helper emits `verdict: approved` (`test-helpers.ts:123-135`), which is **not** in `{ready, blocked}` → rejected → reprompt. **Why not run the real `evolve-brief` here:** the agent session is mocked precisely so no container/LLM round-trip happens for the agent states; the engine still runs for real in the **deterministic** states (`evaluate`/`record_node`) inside the container, which is what the gate proves. Writing `run_spec.yaml` by hand is the mock's job (it stands in for what the real preflight agent would have produced). The hand-authored spec's `evaluation.command` is the real evaluator the container will execute.
+- **2nd invocation = `researcher`** — write `/workspace/.evolve_runs/main/steps/step_0001/code` containing `def solve(xs):\n    return sum(xs)\n`. `researcher` has a single **unconditional** `to: evaluate` edge, so `getValidVerdicts` returns `undefined` (no verdict validation) — `approvedResponse()` is fine here.
+
+The order is deterministic (`preflight` then `researcher`), so the stub uses an incrementing call counter, exactly like `MockSession`'s array-response mode (`test-helpers.ts:49`). The stub **must assert it is called at most twice** (a 3rd `createSession` call signals the counter desynced — e.g. an unexpected reprompt minting a new session). With the `verdict: ready` fix above, `preflight` passes verdict validation on the first turn and **does not reprompt**, so exactly two `createSession` calls occur (preflight, researcher) and the counter stays aligned with the FSM state. (Were `preflight` to emit an invalid verdict, the reprompt happens on the _same_ session via `sendAgentTurn` — it would not mint a 3rd session — but it would corrupt the run; the `verdict: ready` requirement avoids it entirely.)
+
+> **Self-check the implementer must do:** the hand-authored `run_spec.yaml` must satisfy `REQUIRED_FIELD_CHECKS` (§6) AND `evaluation.command` must be a shell command valid inside the container that reads `{quoted_code_path}` and writes `eval_score` to `{quoted_results_path}`. Recommended command (single file, no extra deps):
+> `python3 -c "import json,sys; ns={}; exec(open({quoted_code_path}).read(),ns); s=ns['solve']([1,2,3]); json.dump({'eval_score': float(s), 'success': s==6}, open({quoted_results_path},'w'))"`
+> The negative case (§11.4) swaps the candidate so `solve([1,2,3]) != 6`.
+
+### 11.3 Completion gate (binary)
+
+The positive case runs `orchestrator.start(<evolve manifest>, <task>, workspaceDir)`, `waitForCompletion`, then asserts ALL of:
+
+1. **Terminal state is `done`** — `states.at(-1) === 'done'` and `states` does **not** contain `'failed'`. (`states` collected from `state_entered` lifecycle events, verdict-smoke test pattern.)
+2. **Exactly one node, carrying the evaluator score** — read `<workspaceDir>/.evolve_runs/main/database_data/nodes.json`; parse; assert `Object.keys(parsed.nodes).length === 1` and `parsed.nodes["0"].score === 6` (the evaluator's `eval_score` for `solve([1,2,3])`). (`next_id === 1`.)
+3. **`best/` reflects that node** — `<workspaceDir>/.evolve_runs/main/best/step_0001/code` exists and equals the known candidate; `<workspaceDir>/.evolve_runs/main/best/step_0001/results.json` carries `eval_score: 6`. (The best-dir is keyed by **step name** `step_0001`, written by `cmd_db_record` at `run_dir/best/<step_name>` — `cli.py:478`. Asserting `best/round-1/` would always fail: `round-1` is only the Node name, `cli.py:463`. The gate need not also assert the separate `steps/best/step_0001/` snapshot written by `BestSnapshotManager`.)
+4. **Result-contract files prove verdict routing** — `steps/step_0001/result.json` has `verdict: "evaluated"`; `steps/step_0001/record_result.json` has `verdict: "recorded"`.
+
+### 11.4 Negative case (candidate fails the evaluator)
+
+A second test where the `researcher` mock writes a **wrong** candidate (e.g. `def solve(xs): return 0`). The evaluator computes `solve([1,2,3]) == 0 != 6`, so `results.json` has `eval_score: 0.0`, `success: false`. **Decision on routing and recording for the negative case:**
+
+- The evaluator still **runs successfully and produces a numeric score** (0.0). A non-matching candidate is a _low score_, not an _evaluator failure_. So `evaluate` emits `verdict: evaluated` (score 0.0), NOT `evaluator_blocked`. The candidate IS recorded (`record_node` → `recorded`), and the run reaches **`done`** with one node of score 0.0. This is the correct evolutionary semantics: failed candidates are still recorded (parent design: "Store every candidate, including failed or low-scoring candidates").
+- To exercise the **`evaluator_blocked` → `failed`** path explicitly, a **third** case makes the evaluator itself fail: the `researcher` mock writes a candidate with no `solve` symbol (e.g. `x = 1`), so the evaluator command raises (`KeyError: 'solve'`) and the _evaluator subprocess_ exits non-zero. `evolve-eval run` catches it, **backfills `results.json` with `{success:false, eval_score:0.0, error}`** (`cli.py:315-320`), and returns engine JSON `return_code != 0` (the wrapper itself still exits 0), so the bridge keys on that `return_code` and emits `evaluator_blocked`. The run terminates in **`failed`** with **zero** nodes recorded (`record_node` never runs). **Precise absence-key:** because `cmd_eval_run` backfills it, `results.json` **exists** even on a crash — so the gate must NOT key on `results.json`. The reliable absence is **`nodes.json`**: it is written only by `cmd_db_record` → `db.add_with_previous_nodes` → `_persist_locked` (`cli.py:472`, `database.py:162`), and `record_node` never runs on the blocked route, so `nodes.json` is **absent** (the file is never created — it is not the empty-object `{ next_id: 0, nodes: {} }` form, since no `Database` write occurs). Gate for this case: `states.at(-1) === 'failed'`, `states` contains `'evaluate'` but not `'record_node'`, `result.json` has `verdict: "evaluator_blocked"`, and `nodes.json` does not exist.
+
+So: **low-score candidate → recorded, reaches `done`** (semantically correct); **evaluator crash → not recorded, reaches `failed`** (the `evaluator_blocked` path). Both are asserted.
+
+### 11.5 Why this gate proves the three things work together
+
+The candidate score reaching `nodes.json` proves the **engine** ran (eval + record) inside the container. The score being present at all proves **container exec** delivered the evaluator output back to the workspace bind mount. The run reaching `done` rather than `failed` — and the `evaluator_blocked` case reaching `failed` — proves **verdict routing** read the bridge-written `result.json` and took the right `when: { verdict }` edge (a guard-only `isPassed` implementation could not distinguish `evaluated` from `evaluator_blocked`, nor route a low-score `done` from a crash `failed`). The three are inseparable in the assertion: no single one passing alone produces the observed terminal + `nodes.json` + `best/`.
+
+### 11.6 Manual run
+
+```
+INTEGRATION_TEST=1 npm test -- test/workflow/evolve-single-round.integration.test.ts
+# or by hand (real preflight/researcher agents):
+tsx src/cli.ts workflow start evolve "write solve(xs) returning sum(xs); evaluator scores solve([1,2,3])==6"
+tsx src/cli.ts workflow inspect <baseDir>   # confirm final state = done
+```
+
+---
+
+## 12. File-by-file new files
+
+| File                                                     | Purpose                                                                                                                                                                                                                               |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/workflow/workflows/evolve/workflow.yaml`            | The FSM (§4). New workflow definition.                                                                                                                                                                                                |
+| `src/workflow/workflows/evolve/requirements.txt`         | `numpy` + `pyyaml` (§10). Triggers the per-workflow image.                                                                                                                                                                            |
+| `src/workflow/workflows/evolve/scripts/evolve_core/**`   | The packaged engine, copied verbatim from `donotcommit/ASI-Evolve/skills/evolve/scripts/evolve_core/` (all modules + `algorithms/`).                                                                                                  |
+| `src/workflow/workflows/evolve/scripts/evolve-brief`     | Wrapper `main_for("brief")`, copied verbatim.                                                                                                                                                                                         |
+| `src/workflow/workflows/evolve/scripts/evolve-eval`      | Wrapper `main_for("eval")`, copied verbatim.                                                                                                                                                                                          |
+| `src/workflow/workflows/evolve/scripts/evolve-db`        | Wrapper `main_for("db")`, copied verbatim.                                                                                                                                                                                            |
+| `src/workflow/workflows/evolve/scripts/evolve-summary`   | Wrapper `main_for("summary")`, copied verbatim (unused this slice; ship for parity).                                                                                                                                                  |
+| `src/workflow/workflows/evolve/scripts/evolve-files`     | Wrapper `main_for("files")`, copied verbatim (unused this slice).                                                                                                                                                                     |
+| `src/workflow/workflows/evolve/scripts/evolve-cognition` | Wrapper `main_for("cognition")`, copied verbatim (unused this slice).                                                                                                                                                                 |
+| `src/workflow/workflows/evolve/scripts/evolve_result.py` | **NEW** bridge: `evaluate`/`record` subcommands that run the engine and write `result.json` / `record_result.json` per §8.3 / §9.2. The only net-new Python.                                                                          |
+| `test/workflow/evolve-single-round.integration.test.ts`  | **NEW** gated real-Docker integration test (§11): positive (`done`, 1 node, best), low-score (`done`, recorded), evaluator-crash (`failed`, 0 nodes).                                                                                 |
+| `test/workflow/evolve-result-bridge.test.ts`             | **NEW** unit tests for `evolve_result.py` logic (§13) — run as a Python test or via a thin TS harness invoking the script with stubbed `evolve-eval`/`evolve-db`. (Decide language; Python `pytest`-style or a Node `spawn` harness.) |
+
+**Glue / existing-code touches (verify, likely zero):**
+
+- `eslint.config.js` already ignores `src/workflow/workflows/*/scripts/` (PR #292 §10), so the packaged Python/JS won't break lint. Confirm `evolve/scripts/` is covered by that glob.
+- No orchestrator/validate/machine-builder changes — both runtime capabilities are merged. The slice is **pure workflow-package + test**.
+- Discovery picks up `evolve` automatically by directory name (`resolveWorkflowPath('evolve')`, `discovery.ts:205`); no registry edit.
+
+---
+
+## 13. Unit test plan
+
+Unit-level (no Docker), targeting the three things this slice adds on top of the merged runtime:
+
+1. **Run-spec / preflight argv** — assert the `evolve-brief normalize` argv in `workflow.yaml`'s `preflight` prompt supplies every `REQUIRED_FIELD_CHECKS` field (§6), so `--confirmed true` cannot be rejected. (Static check on the YAML prompt, or a small Python test that runs `cmd_brief_normalize` with these args against a temp workspace and asserts `confirmed: true, missing_fields: []`.)
+2. **Eval-result bridge → `result.json` shape** (`evolve_result.py evaluate`): with a stub `evolve-eval` that (a) exits 0 + writes `results.json{eval_score: 6}` → bridge writes `{verdict: evaluated, passed: true, payload.score: 6}`; (b) exits 0 + `results.json{eval_score: 0}` → `{verdict: evaluated, passed: true, payload.score: 0}` (low score still `evaluated`); (c) exits non-zero → `{verdict: evaluator_blocked, passed: false}`; (d) `results.json` missing → `evaluator_blocked`; (e) `results.json` present but no numeric score → `evaluator_blocked`. Assert the bridge process exits 0 in (a)–(e) (file carries `passed`).
+3. **Record bridge → `record_result.json`** (`evolve_result.py record`): stub `evolve-db record` exits 0 returning `{node_id: 0, best_updated: true}` → `{verdict: recorded, passed: true, payload:{node_id:0,best_updated:true}}`; stub exits non-zero → `{verdict: needs_repair, passed: false}`.
+4. **Record idempotency at unit level** (engine-level, exercises `cmd_db_record`): record the same `step_name` twice against a temp run dir → the second call appends a _second_ node (the engine keys on `next_id`, not step name) — **document that `evolve-db record` is NOT idempotent by step name** (it always allocates a new id). This matters because the parent design wants step-id idempotency; this slice runs `record_node` exactly once, so it is unaffected, but the unit test pins the current behavior so the multi-round slice knows it must add an idempotency guard. (Genuine finding, flagged in §15.)
+5. **YAML structural validation + lint** — `evolve/workflow.yaml` passes `validate` (`container: true` + `sharedContainer: true` + `mode: docker`; `resultFile` requires `container: true`; verdict edges legal on deterministic) and lints clean (WF011: each `container: true` state is preceded by a `primary`-scope agent state — `preflight`/`researcher` are `persona: global` → default `primary` scope; WF012: both `container` states declare `resultFile`). Add `evolve` to the no-regression validation snapshot.
+
+---
+
+## 14. Deferred to later slices
+
+1. **Multi-round loop** — repeat `researcher → evaluate → record_node` for N rounds; allocate `step_NNNN` per round; enforce `budget.max_rounds`/`patience`.
+2. **`orchestrator` hub** — the agent router that chooses the next specialist (`design`/`evaluate`/`analyze`/`record`/`complete`) and writes the directive; restores the hub-and-spoke graph.
+3. **`preflight_review` + `human_escalation` human gates** — re-add the human surfaces; integration test auto-approves the gate via the `raiseGate`/`APPROVE` pattern.
+4. **Sampling beyond trivial first pick** — `db sample` with real UCB1/island selection of parent context; visit-count transactions.
+5. **Analyzer + cognition retrieval** — `analyzer` agent state writing `analysis.md`; `cognition init/add/search`; seed files.
+6. **FAISS / sentence-transformers (Tier 1)** — add `faiss-cpu` + `sentence-transformers` to `requirements.txt` for the real embedding stack; the build-hash already rebuilds on manifest change.
+7. **`.workflow/` flattened layout** — migrate the engine's `.evolve_runs/<run>/` layout to the parent design's `.workflow/database/nodes.json` shape (needs an engine fork or a path-mapping shim — §5/§15).
+8. **Record idempotency by step id** — make `evolve-db record` resume-safe (currently allocates a new node id every call — §13.4).
+9. **UI summary artifacts** — declared `.workflow/` outputs for preflight summary, current best, round log, evaluator-failure bundle; round table in the web UI.
+10. **`final_summary` / `final_review`** — `evolve-summary final` + a final human gate.
+11. **Evaluator write-scoping** to `steps/<step_id>/` (parent design open gap; `--network=none` denies egress but `/workspace` is RW).
+
+---
+
+## 15. Open questions / human decisions
+
+1. **`.evolve_runs/` vs `.workflow/` layout (§5) — DECIDED: engine-native `.evolve_runs/main/` (maintainer sign-off 2026-06-16).** Accept the engine's native layout (with `database_data/nodes.json`), deviating from the parent design's `.workflow/database/nodes.json`, because `run_state.py` hard-codes `<ws>/.evolve_runs/<run>/...` and `workspace_root_for_run = run_dir.parent.parent` with no override flag — matching `.workflow/` would require forking the engine, contradicting "package, don't re-implement." The completion gate asserts against the engine-native paths.
+2. **`preflight_review` deferral (§4.3) — DECIDED: defer for this slice (maintainer sign-off 2026-06-16).** `preflight` sets `approval.confirmed=true` (via `evolve-brief normalize --confirmed true`); the human gate is omitted. Approval is **still enforced at the helper layer** — every mutating/evaluator helper calls `require_evolve_ready(run_dir)` (`run_state.py:288`), invoked from `cmd_eval_run` (`cli.py:245`) and `cmd_db_record` (`cli.py:419`), which raises if `approval.confirmed` is false. The parent design requires "explicit human approval before running the first evaluator" (`asi-evolve-native-workflow.md:945`); auto-confirming removes that _human_ surface (the machine-readable check remains), accepted here for a trusted-demo evaluator under `--network=none`. **The `preflight_review` human gate returns in the next slice (§14 #3) and is required before any non-demo use.**
+3. **The engine-output→result bridge (`evolve_result.py`, §8.3/§9.2).** `evolve_core` emits its own JSON (`{success, return_code}` / `{node_id, best_updated}`), not `{verdict, payload, passed}`, so a thin bridge is required to produce the result-contract file. _Maintainer call:_ keep the bridge as a separate packaged script (recommended — leaves the engine untouched and reusable), or add a `--result-file {verdict,...}` emit mode directly to `cli.py`'s `cmd_eval_run`/`cmd_db_record` (couples the engine to the IronCurtain result contract; rejected here to keep "package, don't fork").
+
+Lower-confidence sub-decisions also flagged inline: the negative-case routing (low score → `done`/recorded vs evaluator crash → `failed`, §11.4), and that `evolve-db record` is not idempotent by step name (§13.4, harmless this slice, must be fixed for multi-round).

--- a/docs/designs/evolve-single-round-slice.md
+++ b/docs/designs/evolve-single-round-slice.md
@@ -65,7 +65,6 @@ This slice = `eval-smoke`'s packaging + `verdict-smoke`'s verdict routing, with 
 ```text
 src/workflow/workflows/evolve/
   workflow.yaml                       # the FSM (§4)
-  requirements.txt                    # numpy + pyyaml (§10) — triggers the per-workflow image
   scripts/                            # staged read-only at /workflow-scripts (whole run)
     evolve_core/                      # the packaged engine, copied verbatim from the skill
       __init__.py
@@ -82,6 +81,9 @@ src/workflow/workflows/evolve/
     evolve-files                      # wrapper: main_for("files")  (unused this slice; ship for parity)
     evolve-cognition                  # wrapper: main_for("cognition") (unused this slice; ship for parity)
     evolve_result.py                  # NEW thin bridge: engine JSON -> result.json (§8.3)
+    requirements.txt                  # numpy + pyyaml (§10) — triggers the per-workflow image
+    LICENSE                           # upstream ASI-Evolve license (Apache 2.0)
+    README.md                         # upstream ASI-Evolve README (attribution)
   skills/                             # OPTIONAL this slice — see §4.7. Prompts may live inline in workflow.yaml.
 ```
 
@@ -472,7 +474,7 @@ This is the parent design's transactional, idempotent durable write — the atom
 
 ## 10. Dependencies / image (Tier 0)
 
-`src/workflow/workflows/evolve/requirements.txt`:
+`src/workflow/workflows/evolve/scripts/requirements.txt`:
 
 ```
 numpy
@@ -547,8 +549,10 @@ tsx src/cli.ts workflow inspect <baseDir>   # confirm final state = done
 | File                                                     | Purpose                                                                                                                                                                                                                               |
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/workflow/workflows/evolve/workflow.yaml`            | The FSM (§4). New workflow definition.                                                                                                                                                                                                |
-| `src/workflow/workflows/evolve/requirements.txt`         | `numpy` + `pyyaml` (§10). Triggers the per-workflow image.                                                                                                                                                                            |
+| `src/workflow/workflows/evolve/scripts/requirements.txt` | `numpy` + `pyyaml` (§10). Triggers the per-workflow image. Resolved from `scriptsDir` by `ensureWorkflowImage`.                                                                                                                       |
 | `src/workflow/workflows/evolve/scripts/evolve_core/**`   | The packaged engine, copied verbatim from `donotcommit/ASI-Evolve/skills/evolve/scripts/evolve_core/` (all modules + `algorithms/`).                                                                                                  |
+| `src/workflow/workflows/evolve/scripts/LICENSE`          | Upstream ASI-Evolve license (Apache 2.0), copied verbatim for attribution.                                                                                                                                                            |
+| `src/workflow/workflows/evolve/scripts/README.md`        | Upstream ASI-Evolve `README.md`, copied verbatim next to the LICENSE for attribution.                                                                                                                                                 |
 | `src/workflow/workflows/evolve/scripts/evolve-brief`     | Wrapper `main_for("brief")`, copied verbatim.                                                                                                                                                                                         |
 | `src/workflow/workflows/evolve/scripts/evolve-eval`      | Wrapper `main_for("eval")`, copied verbatim.                                                                                                                                                                                          |
 | `src/workflow/workflows/evolve/scripts/evolve-db`        | Wrapper `main_for("db")`, copied verbatim.                                                                                                                                                                                            |

--- a/src/workflow/workflows/evolve/scripts/LICENSE
+++ b/src/workflow/workflows/evolve/scripts/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/workflow/workflows/evolve/scripts/README.md
+++ b/src/workflow/workflows/evolve/scripts/README.md
@@ -1,0 +1,314 @@
+# ASI-Evolve — Let AI Do the Research, You Keep the Insight
+![ASI-Evolve overview](assets/Overview.png)
+
+> **"What if you could run a tireless AI researcher on your hardest problem — one that reads the literature, designs experiments, runs them, and learns from every failure?"**
+
+That's ASI-Evolve. It is a general agentic framework that closes the loop between **knowledge → hypothesis → experiment → analysis** — and repeats it autonomously, round after round, until it finds something that works.
+
+We built it for AI research. But the loop doesn't care about domain.  
+A financial analyst, a biomedical engineer, a climate scientist, or a game developer can all plug their own problem into ASI-Evolve and let it search for better solutions than any human has time to manually explore.
+
+**Quick try:** Install the Evolve Agent Skill under `skills/evolve` to have a lightweight first pass.
+
+<div align="center">
+
+[![Paper](https://img.shields.io/badge/Paper-ASI--Evolve-blue?style=flat&logo=googledocs&logoColor=white)](https://github.com/GAIR-NLP/ASI-Evolve/blob/main/assets/paper.pdf)
+[![arXiv](https://img.shields.io/badge/arXiv-2603.29640-b31b1b?style=flat&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2603.29640)
+
+</div>
+
+---
+
+## What ASI-Evolve Proved
+
+The paper validated ASI-Evolve on three hard AI problems — each requiring expensive compute, open-ended search, and multi-dimensional feedback:
+
+| Domain | What It Discovered | Gain |
+|---|---|---|
+| **Neural Architecture Design** | 105 SOTA linear attention architectures | **+0.97 pts** over DeltaNet (≈3× recent human gains) |
+| **Pretraining Data Curation** | Evolved pipeline that selects cleaner training data | **+3.96 pts** avg, **+18 pts** on MMLU |
+| **RL Algorithm Design** | Novel optimization mechanisms with mathematical innovations | **+12.5 pts** on AMC32 vs GRPO |
+| **Biomedical (Drug-Target Interaction)** | Stronger architecture for cold-start generalization | **+6.94 AUROC** |
+
+These are not toy benchmarks. These are real, frontier-level results — produced autonomously.
+
+---
+
+## The Core Loop (Works in Any Domain)
+
+| Step | Action |
+|---|---|
+| 1 | **LEARN** — retrieve relevant prior knowledge |
+| 2 | **DESIGN** — propose the next candidate program/idea |
+| 3 | **EXPERIMENT** — run it and collect metrics |
+| 4 | **ANALYZE** — turn results into reusable lessons |
+
+> Repeat the loop and improve each round.
+
+Three agents drive this loop:
+
+- **Researcher** — reads the database and cognition store, proposes the next candidate
+- **Engineer** — executes the candidate and collects structured metrics
+- **Analyzer** — distills outcomes into transferable lessons for future rounds
+
+Two memory systems keep the loop from going in circles:
+
+- **Cognition Store** — inject your domain knowledge, papers, or heuristics upfront so the AI doesn't start from zero
+- **Experiment Database** — every trial is stored with its motivation, code, result, and analysis; parent selection uses UCB1, greedy, random, or MAP-Elites island sampling
+
+---
+
+## Who Should Use This
+
+You don't need to be an AI researcher. You need:
+
+1. **A problem where better code = better outcome** — optimization, algorithm design, pipeline tuning, simulation strategy
+2. **An evaluation script** — something that takes a program and returns a score
+3. **Some domain knowledge** — papers, rules of thumb, known good approaches
+
+If you have those three things, ASI-Evolve can search the space for you.
+
+**Examples across domains:**
+
+| Industry | Problem You Can Throw At It |
+|---|---|
+| 🧬 Biomedicine | Drug-target interaction models, protein folding strategies, clinical trial algorithms |
+| ⚡ ML Infra | Inference schedulers, KV-cache eviction policies, batching strategies, kernel tiling |
+| 🌍 Climate / Energy | Grid load-balancing heuristics, carbon footprint optimization pipelines |
+| 🎮 Game AI | Bot strategies, procedural level generation algorithms, reward shaping functions |
+| 🏭 Manufacturing | Quality control classifiers, scheduling heuristics, defect detection pipelines |
+| 🔬 Materials Science | Crystal structure search algorithms, synthesis route optimization |
+| 📦 Logistics | Routing algorithms, warehouse assignment policies, demand forecasting models |
+
+---
+
+## Walkthrough: Inference Throughput Optimization
+
+> **Scenario:** You're an ML infra engineer. Your LLM serving system uses a fixed continuous-batching scheduler. You want to automatically discover a better request-scheduling policy that maximizes throughput while keeping P99 latency under budget — without spending weeks hand-tuning heuristics.
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/GAIR-NLP/ASI-Evolve.git
+cd ASI-Evolve
+pip install -r requirements.txt
+```
+
+### 2. Create your experiment
+
+```bash
+mkdir -p experiments/infer_scheduler/prompts
+```
+
+```
+experiments/infer_scheduler/
+├── input.md          ← problem description
+├── config.yaml       ← API key + overrides
+├── initial_program   ← baseline scheduler to evolve from
+├── init_cognition.py ← inject your domain knowledge
+├── evaluator.py      ← benchmark the candidate scheduler
+└── eval.sh           ← shell wrapper called each round
+```
+
+### 3. Describe the problem (`input.md`)
+
+```markdown
+# LLM Serving Scheduler
+
+Write a Python function `schedule(queue, gpu_mem_free_gb)` that selects
+a batch of requests from `queue` (list of dicts with keys: seq_len, priority,
+wait_ms) given available GPU memory, and returns a list of selected request ids.
+
+Optimize for: tokens/sec throughput (primary), P99 latency ms (must stay < 500ms).
+```
+
+### 4. Baseline program (`initial_program`)
+
+```python
+def schedule(queue, gpu_mem_free_gb):
+    """FCFS baseline — just take requests in arrival order."""
+    budget = int(gpu_mem_free_gb * 1024)  # rough token budget
+    selected, used = [], 0
+    for req in sorted(queue, key=lambda r: r["wait_ms"], reverse=True):
+        if used + req["seq_len"] <= budget:
+            selected.append(req["id"])
+            used += req["seq_len"]
+    return selected
+```
+
+### 5. Seed the cognition store (`init_cognition.py`)
+
+```python
+from cognition.store import CognitionStore
+
+store = CognitionStore(storage_dir="experiments/infer_scheduler/cognition_data")
+store.add([
+    {
+        "title": "Continuous Batching",
+        "content": "Orca-style iteration-level scheduling avoids head-of-line blocking "
+                   "by preempting long requests and inserting shorter ones mid-flight.",
+    },
+    {
+        "title": "Sequence Length Bucketing",
+        "content": "Grouping requests by similar sequence length reduces padding waste "
+                   "and improves GPU utilization significantly.",
+    },
+    {
+        "title": "Priority + Starvation",
+        "content": "Pure priority scheduling causes starvation. Age-weighted priority "
+                   "(priority * log(1 + wait_ms)) balances latency and throughput.",
+    },
+])
+```
+
+```bash
+python experiments/infer_scheduler/init_cognition.py
+```
+
+### 6. Evaluator (`evaluator.py` + `eval.sh`)
+
+```python
+import importlib.util, sys, json
+from benchmark import run_serving_simulation  # your internal benchmark harness
+
+def load(path):
+    spec = importlib.util.spec_from_file_location("candidate", path)
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+    return mod.schedule
+
+if __name__ == "__main__":
+    fn = load(sys.argv[1])
+    result = run_serving_simulation(scheduler_fn=fn, trace="traces/sharegpt_1k.jsonl")
+    # score = throughput; constraint violation penalizes automatically
+    score = result["tokens_per_sec"] if result["p99_latency_ms"] < 500 else 0
+    print(json.dumps({"score": score, "metrics": result}))
+```
+
+```bash
+# eval.sh
+#!/bin/bash
+python /path/to/experiments/infer_scheduler/evaluator.py "$1"
+```
+
+### 7. Run
+
+```bash
+python main.py \
+  --experiment infer_scheduler \
+  --steps 40 \
+  --sample-n 3 \
+  --eval-script /path/to/experiments/infer_scheduler/eval.sh
+```
+
+ASI-Evolve will iterate through scheduling policies — from simple heuristics to multi-factor priority functions with dynamic chunking — and write a structured lesson after every trial. After 40 rounds you have a ranked database of every policy tried, why each worked or failed, and the best-performing code ready to deploy.
+
+---
+
+## What ASI-Evolve Does That You Can't Do Manually
+
+| Manual Research | ASI-Evolve |
+|---|---|
+| Try 5–10 ideas per week | 50–200 candidates per run |
+| Knowledge stays in one person's head | Every insight written to the database |
+| Cold start on each new hypothesis | Cognition store primes every round |
+| Hard to know why something worked | Analyzer explains every outcome |
+| Results hard to reproduce | Full experiment tree stored on disk |
+
+---
+
+## Repository Layout
+
+```
+ASI-Evolve/
+├── main.py                         ← entry point
+├── config.yaml                     ← global defaults
+├── pipeline/                       ← Researcher, Engineer, Analyzer agents
+├── cognition/                      ← cognition store (embedding + FAISS)
+├── database/                       ← experiment database (nodes + sampling)
+├── utils/
+└── experiments/
+    ├── circle_packing_demo/        ← included runnable demo
+    └── best/circle_packing/        ← top programs from our ablation runs
+```
+
+> **Skill vs. repository:** When using the Skill, prior experiment traces and instructions accumulate in the model context, and the assistant is not constrained to the same fixed control flow as the official pipeline. End-to-end search quality and throughput are usually lower than when you run this repository directly. Use the Skill for a quick try-out; for very complex or tightly controlled work, prefer cloning and running from here.
+
+---
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+Requirements:
+- Python 3.10+
+- `bash` and `python3` on your system path
+- Any OpenAI-compatible API endpoint (GPT-4o, Claude, Gemini, local models via LiteLLM, etc.)
+- Optional: Weights & Biases for experiment tracking
+
+---
+
+## Quick Start (Circle-Packing Demo)
+
+The included demo evolves a program to pack 26 circles in a unit square — a clean benchmark used in our ablation studies.
+
+```bash
+# Initialize the cognition store
+python experiments/circle_packing_demo/init_cognition.py
+
+# Run 10 evolution steps
+python main.py \
+  --experiment circle_packing_demo \
+  --steps 10 \
+  --sample-n 3 \
+  --eval-script /path/to/experiments/circle_packing_demo/eval.sh
+```
+
+ASI-Evolve reaches SOTA-level circle-packing results in as few as **17 rounds**.
+
+---
+
+## Configuration Reference
+
+Configuration merges in this order (later overrides earlier):
+
+1. `config.yaml` at repository root
+2. `experiments/<name>/config.yaml`
+3. An explicit file passed with `--config`
+
+Key settings:
+
+| Key | What It Controls |
+|---|---|
+| `api.model` | The LLM driving all agents |
+| `pipeline.sample_n` | How many historical nodes to show the Researcher each round |
+| `pipeline.parallel.num_workers` | Parallel evolution workers (2–4 for production) |
+| `database.sampling.algorithm` | `ucb1` / `greedy` / `random` / `island` |
+| `cognition.retrieval.top_k` | How many cognition items to retrieve per round |
+
+---
+
+## Citation
+
+If you use ASI-Evolve in your work, please cite:
+
+```bibtex
+@misc{asi_evolve_2026,
+  title   = {ASI-Evolve: AI Accelerates AI},
+  author  = {Xu, Weixian and Mi, Tiantian and Liu, Yixiu and Nan, Yang and Zhou, Zhimeng and Ye, Lyumanshan and Zhang, Lin and Qiao, Yu and Liu, Pengfei},
+  year    = {2026},
+  note    = {SJTU / SII / GAIR. https://github.com/GAIR-NLP/ASI-Evolve}
+}
+```
+
+---
+
+<div align="center">
+
+**ASI-Evolve is open-source and ready for your domain.**  
+Fork it. Point it at your problem. Let it run.
+
+[📄 Paper](https://github.com/GAIR-NLP/ASI-Evolve/blob/main/assets/paper.pdf) · [🐛 Issues](https://github.com/GAIR-NLP/ASI-Evolve/issues) · [💬 Discussions](https://github.com/GAIR-NLP/ASI-Evolve/discussions)
+
+</div>

--- a/src/workflow/workflows/evolve/scripts/evolve-brief
+++ b/src/workflow/workflows/evolve/scripts/evolve-brief
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the Evolve preflight brief commands."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evolve_core.cli import main_for
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_for("brief"))

--- a/src/workflow/workflows/evolve/scripts/evolve-cognition
+++ b/src/workflow/workflows/evolve/scripts/evolve-cognition
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""CLI wrapper for cognition helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evolve_core.cli import main_for
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_for("cognition"))

--- a/src/workflow/workflows/evolve/scripts/evolve-db
+++ b/src/workflow/workflows/evolve/scripts/evolve-db
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""CLI wrapper for database helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evolve_core.cli import main_for
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_for("db"))

--- a/src/workflow/workflows/evolve/scripts/evolve-eval
+++ b/src/workflow/workflows/evolve/scripts/evolve-eval
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""CLI wrapper for evaluation helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evolve_core.cli import main_for
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_for("eval"))

--- a/src/workflow/workflows/evolve/scripts/evolve-files
+++ b/src/workflow/workflows/evolve/scripts/evolve-files
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""CLI wrapper for file-scope helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evolve_core.cli import main_for
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_for("files"))

--- a/src/workflow/workflows/evolve/scripts/evolve-summary
+++ b/src/workflow/workflows/evolve/scripts/evolve-summary
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""CLI wrapper for summary helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evolve_core.cli import main_for
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_for("summary"))

--- a/src/workflow/workflows/evolve/scripts/evolve_core/__init__.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/__init__.py
@@ -1,0 +1,14 @@
+"""Vendored runtime helpers for the Evolve skill."""
+
+from .structures import CognitionItem, Node
+from .cognition import Cognition
+from .database import Database
+from .best_snapshot import BestSnapshotManager
+
+__all__ = [
+    "BestSnapshotManager",
+    "Cognition",
+    "CognitionItem",
+    "Database",
+    "Node",
+]

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/__init__.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/__init__.py
@@ -1,0 +1,17 @@
+"""Sampling algorithms used by the skill database."""
+
+from .base import BaseSampler
+from .factory import get_sampler
+from .greedy import GreedySampler
+from .island import IslandSampler
+from .random import RandomSampler
+from .ucb1 import UCB1Sampler
+
+__all__ = [
+    "BaseSampler",
+    "GreedySampler",
+    "IslandSampler",
+    "RandomSampler",
+    "UCB1Sampler",
+    "get_sampler",
+]

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/base.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/base.py
@@ -1,0 +1,21 @@
+"""Base interface for node samplers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..structures import Node
+
+
+class BaseSampler(ABC):
+    @abstractmethod
+    def sample(self, nodes: List["Node"], n: int) -> List["Node"]:
+        raise NotImplementedError
+
+    def on_node_added(self, node: "Node") -> None:
+        return None
+
+    def on_node_removed(self, node: "Node") -> None:
+        return None

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/factory.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/factory.py
@@ -1,0 +1,90 @@
+"""Factory for sampler implementations."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+import sys
+
+from .base import BaseSampler
+from .greedy import GreedySampler
+from .island import IslandSampler
+from .random import RandomSampler
+from .ucb1 import UCB1Sampler
+
+
+def get_sampler(algorithm: str, **kwargs) -> BaseSampler:
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    if algorithm == "custom":
+        custom_path = str(kwargs.pop("custom_sampler_path", "") or "").strip()
+        custom_class = str(kwargs.pop("custom_sampler_class", "") or "").strip()
+        custom_search_paths = kwargs.pop("custom_sampler_search_paths", None)
+        sampler_class = load_custom_sampler_class(
+            custom_path,
+            custom_class,
+            search_paths=custom_search_paths,
+        )
+        sampler = sampler_class(**kwargs)
+        if not callable(getattr(sampler, "sample", None)):
+            raise ValueError(
+                f"Custom sampler '{custom_class}' must define a callable sample(nodes, n) method."
+            )
+        return sampler
+
+    samplers = {
+        "greedy": GreedySampler,
+        "island": IslandSampler,
+        "random": RandomSampler,
+        "ucb1": UCB1Sampler,
+    }
+    if algorithm not in samplers:
+        raise ValueError(
+            f"Unknown sampling algorithm: {algorithm}. Available: {sorted(samplers)}"
+        )
+    return samplers[algorithm](**kwargs)
+
+
+def load_custom_sampler_class(
+    custom_path: str,
+    custom_class: str,
+    search_paths: list[str] | None = None,
+):
+    if not custom_path or not custom_class:
+        raise ValueError(
+            "Custom sampling requires both custom_sampler_path and custom_sampler_class."
+        )
+
+    path = Path(custom_path)
+    if not path.exists():
+        raise ValueError(f"Custom sampler path does not exist: {path}")
+
+    module_name = "evolve_custom_sampler_" + hashlib.sha1(str(path).encode("utf-8")).hexdigest()
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Unable to load custom sampler module from: {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    effective_search_paths: list[str] = []
+    for candidate in [str(path.parent), *(search_paths or [])]:
+        if candidate and candidate not in effective_search_paths:
+            effective_search_paths.append(candidate)
+
+    inserted_paths: list[str] = []
+    try:
+        for candidate in reversed(effective_search_paths):
+            if candidate not in sys.path:
+                sys.path.insert(0, candidate)
+                inserted_paths.append(candidate)
+        spec.loader.exec_module(module)
+    finally:
+        for candidate in inserted_paths:
+            if candidate in sys.path:
+                sys.path.remove(candidate)
+
+    sampler_class = getattr(module, custom_class, None)
+    if sampler_class is None:
+        raise ValueError(
+            f"Custom sampler class '{custom_class}' was not found in: {path}"
+        )
+    return sampler_class

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/greedy.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/greedy.py
@@ -1,0 +1,17 @@
+"""Greedy sampling strategy."""
+
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
+from .base import BaseSampler
+
+if TYPE_CHECKING:
+    from ..structures import Node
+
+
+class GreedySampler(BaseSampler):
+    def sample(self, nodes: List["Node"], n: int) -> List["Node"]:
+        if not nodes:
+            return []
+        return sorted(nodes, key=lambda node: node.score, reverse=True)[:n]

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/island.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/island.py
@@ -1,0 +1,316 @@
+"""Island-based sampler with optional diversity features."""
+
+from __future__ import annotations
+
+import ast
+import random
+import time
+from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
+
+from .base import BaseSampler
+
+if TYPE_CHECKING:
+    from ..structures import Node
+
+
+class IslandSampler(BaseSampler):
+    def __init__(
+        self,
+        num_islands: int = 5,
+        migration_interval: int = 10,
+        migration_rate: float = 0.1,
+        exploration_ratio: float = 0.2,
+        exploitation_ratio: float = 0.3,
+        c: float = 1.414,
+        feature_dimensions: Optional[List[str]] = None,
+        feature_bins: int = 10,
+    ):
+        self.num_islands = num_islands
+        self.migration_interval = migration_interval
+        self.migration_rate = migration_rate
+        self.exploration_ratio = exploration_ratio
+        self.exploitation_ratio = exploitation_ratio
+        self.c = c
+        self.feature_dimensions = feature_dimensions or []
+        self.feature_bins = feature_bins
+
+        self.islands: List[Set[int]] = [set() for _ in range(num_islands)]
+        self.island_generations: List[int] = [0] * num_islands
+        self.island_best_nodes: List[Optional[int]] = [None] * num_islands
+        self.island_feature_maps: List[Dict[Tuple[int, ...], int]] = [
+            {} for _ in range(num_islands)
+        ]
+        self.feature_stats: Dict[str, Dict[str, Any]] = {}
+        self.current_island = 0
+        self.last_migration_generation = 0
+        self.archive: Set[int] = set()
+        self.archive_size = 100
+        self.diversity_cache: Dict[int, Dict[str, float]] = {}
+        self.diversity_cache_size = 1000
+        self.diversity_reference_set: List[str] = []
+        self.diversity_reference_size = 20
+        self.all_nodes: Dict[int, "Node"] = {}
+
+    def sample(self, nodes: List["Node"], n: int) -> List["Node"]:
+        if not nodes:
+            return []
+
+        for node in nodes:
+            if node.id is not None:
+                self.all_nodes[node.id] = node
+
+        if self._should_migrate():
+            self._migrate(nodes)
+
+        island_id = self.current_island % self.num_islands
+        island_nodes = self._get_island_nodes(island_id, nodes) or nodes
+        self.island_generations[island_id] += 1
+        self.current_island = (self.current_island + 1) % self.num_islands
+
+        selected: List["Node"] = []
+        while len(selected) < min(n, len(island_nodes)):
+            roll = random.random()
+            if roll < self.exploration_ratio:
+                candidate = self._sample_random(island_nodes)
+            elif roll < self.exploration_ratio + self.exploitation_ratio:
+                candidate = self._sample_from_archive(nodes) or self._sample_weighted(
+                    island_nodes
+                )
+            else:
+                candidate = self._sample_weighted(island_nodes)
+
+            if candidate is None or candidate in selected:
+                continue
+            candidate.visit_count += 1
+            selected.append(candidate)
+
+        return selected
+
+    def on_node_added(self, node: "Node") -> None:
+        if node.id is None:
+            return
+        self.all_nodes[node.id] = node
+        island_id = node.meta_info.get("island", self.current_island) % self.num_islands
+        node.meta_info["island"] = island_id
+        self.islands[island_id].add(node.id)
+        self._update_archive(node)
+        if self.feature_dimensions:
+            feature_coords = self._calculate_feature_coords(node)
+            if feature_coords is not None:
+                self.island_feature_maps[island_id][tuple(feature_coords)] = node.id
+
+    def on_node_removed(self, node: "Node") -> None:
+        if node.id is None:
+            return
+        self.all_nodes.pop(node.id, None)
+        island_id = node.meta_info.get("island")
+        if island_id is not None and island_id < len(self.islands):
+            self.islands[island_id].discard(node.id)
+        self.archive.discard(node.id)
+
+    def get_state(self) -> Dict[str, Any]:
+        return {
+            "archive": list(self.archive),
+            "current_island": self.current_island,
+            "diversity_cache": {str(key): value for key, value in self.diversity_cache.items()},
+            "diversity_reference_set": self.diversity_reference_set,
+            "feature_stats": self.feature_stats,
+            "island_best_nodes": self.island_best_nodes,
+            "island_feature_maps": [
+                {str(key): value for key, value in feature_map.items()}
+                for feature_map in self.island_feature_maps
+            ],
+            "island_generations": self.island_generations,
+            "last_migration_generation": self.last_migration_generation,
+        }
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        self.archive = set(state.get("archive", []))
+        self.current_island = state.get("current_island", 0) % self.num_islands
+        self.diversity_cache = {
+            int(key): value for key, value in state.get("diversity_cache", {}).items()
+        }
+        self.diversity_reference_set = state.get("diversity_reference_set", [])
+        self.feature_stats = state.get("feature_stats", {})
+        self.island_best_nodes = state.get("island_best_nodes", [None] * self.num_islands)
+        self.island_generations = state.get("island_generations", [0] * self.num_islands)
+        self.last_migration_generation = state.get("last_migration_generation", 0)
+
+        feature_maps = []
+        for raw_feature_map in state.get("island_feature_maps", []):
+            feature_maps.append(
+                {ast.literal_eval(key): value for key, value in raw_feature_map.items()}
+            )
+        if feature_maps:
+            self.island_feature_maps = feature_maps
+
+    def rebuild_from_nodes(self, nodes: List["Node"]) -> None:
+        self.islands = [set() for _ in range(self.num_islands)]
+        self.all_nodes = {node.id: node for node in nodes if node.id is not None}
+        self.island_feature_maps = [{} for _ in range(self.num_islands)]
+
+        for node in nodes:
+            if node.id is None:
+                continue
+            island_id = node.meta_info.get("island", 0) % self.num_islands
+            self.islands[island_id].add(node.id)
+            if self.feature_dimensions:
+                coords = self._calculate_feature_coords(node)
+                if coords is not None:
+                    self.island_feature_maps[island_id][tuple(coords)] = node.id
+
+    def get_island_stats(self, nodes: List["Node"]) -> Dict[str, Any]:
+        populations = []
+        for island_id in range(self.num_islands):
+            island_nodes = self._get_island_nodes(island_id, nodes)
+            populations.append(
+                {
+                    "island_id": island_id,
+                    "size": len(island_nodes),
+                    "best_score": max((node.score for node in island_nodes), default=0.0),
+                }
+            )
+        return {
+            "archive_size": len(self.archive),
+            "current_island": self.current_island,
+            "island_populations": populations,
+            "num_islands": self.num_islands,
+        }
+
+    def reset(self) -> None:
+        self.islands = [set() for _ in range(self.num_islands)]
+        self.island_generations = [0] * self.num_islands
+        self.island_best_nodes = [None] * self.num_islands
+        self.island_feature_maps = [{} for _ in range(self.num_islands)]
+        self.feature_stats.clear()
+        self.current_island = 0
+        self.last_migration_generation = 0
+        self.archive.clear()
+        self.diversity_cache.clear()
+        self.diversity_reference_set = []
+
+    def _get_island_nodes(self, island_id: int, nodes: List["Node"]) -> List["Node"]:
+        return [node for node in nodes if node.id in self.islands[island_id]]
+
+    @staticmethod
+    def _sample_random(nodes: List["Node"]) -> Optional["Node"]:
+        if not nodes:
+            return None
+        return random.choice(nodes)
+
+    @staticmethod
+    def _sample_weighted(nodes: List["Node"]) -> Optional["Node"]:
+        if not nodes:
+            return None
+        weights = [max(node.score, 0.001) for node in nodes]
+        return random.choices(nodes, weights=weights, k=1)[0]
+
+    def _sample_from_archive(self, nodes: List["Node"]) -> Optional["Node"]:
+        archive_nodes = [node for node in nodes if node.id in self.archive]
+        if not archive_nodes:
+            return None
+        return random.choice(archive_nodes)
+
+    def _update_archive(self, node: "Node") -> None:
+        if node.id is None:
+            return
+        self.archive.add(node.id)
+        if len(self.archive) > self.archive_size:
+            self.archive = set(sorted(self.archive)[-self.archive_size :])
+
+    def _calculate_feature_coords(self, node: "Node") -> Optional[List[int]]:
+        if not self.feature_dimensions:
+            return None
+
+        coords: List[int] = []
+        for feature in self.feature_dimensions:
+            if feature == "complexity":
+                value = float(len(node.code))
+            elif feature == "diversity":
+                value = self._get_cached_diversity(node)
+            else:
+                raw_value = node.results.get(feature)
+                if not isinstance(raw_value, (int, float)):
+                    return None
+                value = float(raw_value)
+
+            self._update_feature_stats(feature, value)
+            scaled = self._scale_feature_value(feature, value)
+            coords.append(max(0, min(self.feature_bins - 1, int(scaled * self.feature_bins))))
+
+        return coords
+
+    def _update_feature_stats(self, feature: str, value: float) -> None:
+        stats = self.feature_stats.setdefault(feature, {"min": value, "max": value})
+        stats["min"] = min(stats["min"], value)
+        stats["max"] = max(stats["max"], value)
+
+    def _scale_feature_value(self, feature: str, value: float) -> float:
+        stats = self.feature_stats.get(feature)
+        if not stats:
+            return 0.5
+        if stats["max"] - stats["min"] < 1e-10:
+            return 0.5
+        return max(0.0, min(1.0, (value - stats["min"]) / (stats["max"] - stats["min"])))
+
+    def _get_cached_diversity(self, node: "Node") -> float:
+        if not node.code:
+            return 0.0
+
+        code_hash = hash(node.code)
+        cached = self.diversity_cache.get(code_hash)
+        if cached:
+            return cached["value"]
+
+        if (
+            not self.diversity_reference_set
+            or len(self.diversity_reference_set) < self.diversity_reference_size
+        ):
+            self._update_diversity_reference_set()
+
+        scores = [
+            self._fast_code_diversity(node.code, reference)
+            for reference in self.diversity_reference_set
+            if reference != node.code
+        ]
+        diversity = sum(scores) / max(1, len(scores)) if scores else 0.0
+
+        if len(self.diversity_cache) >= self.diversity_cache_size:
+            oldest = min(self.diversity_cache.items(), key=lambda item: item[1]["timestamp"])[0]
+            del self.diversity_cache[oldest]
+        self.diversity_cache[code_hash] = {"timestamp": time.time(), "value": diversity}
+        return diversity
+
+    def _update_diversity_reference_set(self) -> None:
+        all_programs = [node.code for node in self.all_nodes.values() if node.code]
+        self.diversity_reference_set = all_programs[: self.diversity_reference_size]
+
+    @staticmethod
+    def _fast_code_diversity(code1: str, code2: str) -> float:
+        if code1 == code2:
+            return 0.0
+        chars = len(set(code1).symmetric_difference(set(code2)))
+        return abs(len(code1) - len(code2)) * 0.1 + chars * 0.5
+
+    def _should_migrate(self) -> bool:
+        return (
+            max(self.island_generations, default=0) - self.last_migration_generation
+        ) >= self.migration_interval
+
+    def _migrate(self, nodes: List["Node"]) -> None:
+        if self.num_islands < 2:
+            return
+        self.last_migration_generation = max(self.island_generations, default=0)
+        for island_id in range(self.num_islands):
+            island_nodes = sorted(
+                self._get_island_nodes(island_id, nodes),
+                key=lambda node: node.score,
+                reverse=True,
+            )
+            if not island_nodes:
+                continue
+            count = max(1, int(len(island_nodes) * self.migration_rate))
+            for node in island_nodes[:count]:
+                if node.id is None:
+                    continue
+                self.islands[(island_id + 1) % self.num_islands].add(node.id)

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/random.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/random.py
@@ -1,0 +1,18 @@
+"""Random sampling strategy."""
+
+from __future__ import annotations
+
+import random
+from typing import List, TYPE_CHECKING
+
+from .base import BaseSampler
+
+if TYPE_CHECKING:
+    from ..structures import Node
+
+
+class RandomSampler(BaseSampler):
+    def sample(self, nodes: List["Node"], n: int) -> List["Node"]:
+        if not nodes:
+            return []
+        return random.sample(nodes, min(n, len(nodes)))

--- a/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/ucb1.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/algorithms/ucb1.py
@@ -1,0 +1,55 @@
+"""UCB1-based sampling strategy."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import List, TYPE_CHECKING
+
+from .base import BaseSampler
+
+if TYPE_CHECKING:
+    from ..structures import Node
+
+
+class UCB1Sampler(BaseSampler):
+    def __init__(self, c: float = 1.414):
+        self.c = c
+
+    def sample(self, nodes: List["Node"], n: int) -> List["Node"]:
+        if not nodes:
+            return []
+
+        total_visits = sum(node.visit_count for node in nodes)
+        if total_visits == 0:
+            selected = random.sample(nodes, min(n, len(nodes)))
+            for node in selected:
+                node.visit_count += 1
+            return selected
+
+        scored_nodes = [node.score for node in nodes if node.visit_count > 0]
+        if not scored_nodes:
+            selected = random.sample(nodes, min(n, len(nodes)))
+            for node in selected:
+                node.visit_count += 1
+            return selected
+
+        min_score = min(scored_nodes)
+        max_score = max(scored_nodes)
+        score_range = max(max_score - min_score, 1.0)
+
+        ucb_scores = []
+        for node in nodes:
+            if node.visit_count == 0:
+                value = float("inf")
+            else:
+                normalized = (node.score - min_score) / score_range
+                exploration = self.c * math.sqrt(math.log(total_visits) / node.visit_count)
+                value = normalized + exploration
+            ucb_scores.append((node, value))
+
+        ucb_scores.sort(key=lambda item: item[1], reverse=True)
+        selected = [node for node, _ in ucb_scores[: min(n, len(nodes))]]
+        for node in selected:
+            node.visit_count += 1
+        return selected

--- a/src/workflow/workflows/evolve/scripts/evolve_core/best_snapshot.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/best_snapshot.py
@@ -1,0 +1,62 @@
+"""Utilities for persisting the best-scoring step outputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Lock
+from typing import List, Optional
+
+from .structures import Node
+
+
+class BestSnapshotManager:
+    """Maintain a `steps/best` directory with the strongest snapshots."""
+
+    def __init__(self, steps_dir: Path):
+        self.steps_dir = Path(steps_dir)
+        self.steps_dir.mkdir(parents=True, exist_ok=True)
+        self.best_dir = self.steps_dir / "best"
+        self.best_dir.mkdir(parents=True, exist_ok=True)
+        self.best_score = float("-inf")
+        self._lock = Lock()
+
+    def init_from_nodes(self, nodes: List[Node]) -> None:
+        if nodes:
+            self.best_score = max(node.score for node in nodes)
+
+    def update_if_better(
+        self,
+        node: Node,
+        step_name: str,
+        source_step_dir: Optional[Path] = None,
+    ) -> bool:
+        with self._lock:
+            if node.score <= self.best_score:
+                return False
+            self.best_score = node.score
+            self._write_snapshot(node, step_name, source_step_dir)
+            return True
+
+    def _write_snapshot(
+        self,
+        node: Node,
+        step_name: str,
+        source_step_dir: Optional[Path],
+    ) -> None:
+        best_step_dir = self.best_dir / step_name
+        best_step_dir.mkdir(parents=True, exist_ok=True)
+        (best_step_dir / "code").write_text(node.code or "", encoding="utf-8")
+
+        results_file = best_step_dir / "results.json"
+        source_results_file = source_step_dir / "results.json" if source_step_dir else None
+        if source_results_file and source_results_file.exists():
+            results_file.write_text(
+                source_results_file.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+        else:
+            results_file.write_text(
+                json.dumps(node.results or {}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )

--- a/src/workflow/workflows/evolve/scripts/evolve_core/cli.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/cli.py
@@ -1,0 +1,752 @@
+"""CLI entrypoints for the Evolve skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from difflib import unified_diff
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .best_snapshot import BestSnapshotManager
+from .cognition import Cognition
+from .database import Database
+from .run_state import (
+    append_round_log,
+    build_run_dir,
+    compute_missing_fields_for_workspace,
+    deep_merge,
+    ensure_path_allowed,
+    ensure_run_layout,
+    flatten_list,
+    initialize_cognition_seed_file,
+    load_run_spec,
+    load_structured_file,
+    normalize_spec_path,
+    require_evolve_ready,
+    save_run_spec,
+    workspace_root_for_run,
+    write_preflight_summary,
+)
+from .sampling_config import (
+    SAMPLING_CONFIG_IMMUTABLE_ERROR,
+    build_database_sampling_config,
+    configured_sampling_algorithm,
+    configured_sample_n,
+    run_has_recorded_nodes,
+    sampling_config_fingerprint,
+    validate_custom_sampler_for_workspace,
+)
+from .structures import CognitionItem, Node
+
+
+def emit_json(payload: Dict[str, Any]) -> int:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def parse_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "y"}:
+        return True
+    if lowered in {"0", "false", "no", "n"}:
+        return False
+    raise argparse.ArgumentTypeError(f"Invalid boolean value: {value}")
+
+
+def build_database(run_dir: Path, spec: Dict[str, Any]) -> Database:
+    algorithm, sampling_kwargs = build_database_sampling_config(
+        spec,
+        workspace_root_for_run(run_dir),
+    )
+    return Database(
+        storage_dir=Path(run_dir) / "database_data",
+        sampling_algorithm=algorithm,
+        sampling_kwargs=sampling_kwargs,
+    )
+
+
+def build_cognition(run_dir: Path) -> Cognition:
+    return Cognition(storage_dir=Path(run_dir) / "cognition_data", score_threshold=0.0)
+
+
+def extract_seed_items(markdown_path: Path) -> List[CognitionItem]:
+    text = Path(markdown_path).read_text(encoding="utf-8")
+    items: List[CognitionItem] = []
+    for raw_block in re.findall(r"```json\s*(.*?)```", text, re.DOTALL):
+        payload = json.loads(raw_block)
+        if isinstance(payload, dict):
+            payload = [payload]
+        for raw_item in payload:
+            items.append(
+                CognitionItem(
+                    content=raw_item.get("content", ""),
+                    source=raw_item.get("source", ""),
+                    metadata=raw_item.get("metadata", {}),
+                    id=raw_item.get("id"),
+                )
+            )
+    return items
+
+
+def command_context(
+    workspace_root: Path,
+    run_dir: Path,
+    step_dir: Path,
+    code_path: Path,
+    results_path: Path,
+    script_path: Optional[str],
+    timeout_secs: int,
+) -> Dict[str, str]:
+    raw = {
+        "workspace_root": str(workspace_root),
+        "run_dir": str(run_dir),
+        "step_dir": str(step_dir),
+        "code_path": str(code_path),
+        "results_path": str(results_path),
+        "script_path": script_path or "",
+        "timeout_secs": str(timeout_secs),
+    }
+    quoted = {
+        f"quoted_{key}": f'"{value}"' if value else '""'
+        for key, value in raw.items()
+    }
+    return {**raw, **quoted}
+
+
+def cmd_brief_normalize(args: argparse.Namespace) -> int:
+    workspace_root = Path(args.workspace_root or Path.cwd()).resolve()
+    run_dir = build_run_dir(workspace_root, args.run_name)
+    ensure_run_layout(run_dir)
+    spec = load_run_spec(run_dir)
+    original_sampling = sampling_config_fingerprint(spec)
+
+    if args.spec_file:
+        spec = deep_merge(spec, load_structured_file(Path(args.spec_file)))
+
+    if args.objective is not None:
+        spec["objective"] = args.objective
+    if args.core_score is not None:
+        spec["evaluation"]["core_score"] = args.core_score
+    if args.secondary_metric is not None:
+        spec["evaluation"]["secondary_metrics"] = flatten_list(args.secondary_metric)
+    if args.evaluation_command is not None:
+        spec["evaluation"]["command"] = args.evaluation_command
+    if args.evaluation_script_path is not None:
+        spec["evaluation"]["script_path"] = normalize_spec_path(
+            workspace_root, args.evaluation_script_path
+        )
+    if args.evaluation_timeout_secs is not None:
+        spec["evaluation"]["timeout_secs"] = args.evaluation_timeout_secs
+    if args.success_criterion is not None:
+        spec["evaluation"]["success_criteria"] = flatten_list(args.success_criterion)
+    if args.max_rounds is not None:
+        spec["budget"]["max_rounds"] = args.max_rounds
+    if args.patience is not None:
+        spec["budget"]["patience"] = args.patience
+    if args.stop_condition is not None:
+        spec["stop_conditions"] = flatten_list(args.stop_condition)
+    if args.writable_path is not None:
+        spec["mutation_scope"]["writable_paths"] = [
+            normalize_spec_path(workspace_root, value)
+            for value in flatten_list(args.writable_path)
+        ]
+    if args.primary_target is not None:
+        spec["mutation_scope"]["primary_targets"] = [
+            normalize_spec_path(workspace_root, value)
+            for value in flatten_list(args.primary_target)
+        ]
+    if args.sampling_algorithm is not None:
+        spec["sampling"]["algorithm"] = args.sampling_algorithm
+    if args.sample_n is not None:
+        spec["sampling"]["sample_n"] = args.sample_n
+    if args.sampling_feature is not None:
+        spec["sampling"]["feature_dimensions"] = flatten_list(args.sampling_feature)
+    if args.sampling_feature_bins is not None:
+        spec["sampling"]["feature_bins"] = args.sampling_feature_bins
+    if args.sampling_custom_sampler_path is not None:
+        spec["sampling"]["custom_sampler_path"] = normalize_spec_path(
+            workspace_root, args.sampling_custom_sampler_path
+        )
+    if args.sampling_custom_sampler_class is not None:
+        spec["sampling"]["custom_sampler_class"] = args.sampling_custom_sampler_class
+    if args.cognition_source_mode is not None:
+        spec["cognition"]["source_mode"] = args.cognition_source_mode
+    if args.seed_file is not None:
+        spec["cognition"]["seed_files"] = [
+            normalize_spec_path(workspace_root, value) for value in flatten_list(args.seed_file)
+        ]
+    if args.seed_note is not None:
+        spec["cognition"]["seed_notes"] = flatten_list(args.seed_note)
+    if args.confirmed is not None:
+        spec["approval"]["confirmed"] = args.confirmed
+
+    missing = compute_missing_fields_for_workspace(spec, workspace_root)
+    custom_sampler_error = validate_custom_sampler_for_workspace(spec, workspace_root)
+    if spec.get("approval", {}).get("confirmed") and missing:
+        detail = ""
+        if custom_sampler_error:
+            detail = f" Custom sampler validation failed: {custom_sampler_error}"
+        raise SystemExit(
+            "Cannot confirm preflight while required fields are missing: "
+            + ", ".join(missing)
+            + detail
+        )
+
+    if run_has_recorded_nodes(run_dir):
+        updated_sampling = sampling_config_fingerprint(spec)
+        if updated_sampling != original_sampling:
+            raise SystemExit(SAMPLING_CONFIG_IMMUTABLE_ERROR)
+
+    spec_file = save_run_spec(run_dir, spec)
+    summary_file = write_preflight_summary(run_dir, spec)
+    seed_file = initialize_cognition_seed_file(run_dir, spec)
+    return emit_json(
+        {
+            "confirmed": spec["approval"]["confirmed"],
+            "missing_fields": missing,
+            "custom_sampler_error": custom_sampler_error,
+            "preflight_summary": str(summary_file),
+            "run_dir": str(run_dir),
+            "run_spec": str(spec_file),
+            "seed_file": str(seed_file),
+        }
+    )
+
+
+def cmd_eval_inspect(args: argparse.Namespace) -> int:
+    preview = ""
+    exists = False
+    if args.script_path:
+        script_path = Path(args.script_path).resolve()
+        exists = script_path.exists()
+        if exists:
+            preview = "".join(script_path.read_text(encoding="utf-8").splitlines(True)[:20])
+    else:
+        script_path = None
+    return emit_json(
+        {
+            "command": args.command or "",
+            "exists": exists,
+            "preview": preview,
+            "script_path": str(script_path) if script_path else "",
+        }
+    )
+
+
+def cmd_eval_run(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    spec = require_evolve_ready(run_dir)
+    workspace_root = workspace_root_for_run(run_dir)
+    ensure_run_layout(run_dir)
+
+    source_code = Path(args.code_path)
+    if not source_code.is_absolute():
+        source_code = (workspace_root / source_code).resolve()
+    ensure_path_allowed(run_dir, source_code)
+
+    step_name = args.step_name or "manual_step"
+    step_dir = Path(run_dir) / "steps" / step_name
+    step_dir.mkdir(parents=True, exist_ok=True)
+    step_code_path = step_dir / "code"
+    if source_code != step_code_path:
+        shutil.copyfile(source_code, step_code_path)
+
+    results_path = step_dir / "results.json"
+    command = args.command or spec.get("evaluation", {}).get("command", "")
+    script_path = args.script_path or spec.get("evaluation", {}).get("script_path", "")
+    evaluation_timeout = args.timeout
+    if evaluation_timeout is None:
+        evaluation_timeout = int(spec.get("evaluation", {}).get("timeout_secs", 0) or 0)
+    if not command and script_path:
+        command = "python {quoted_script_path} {quoted_code_path} {quoted_results_path}"
+    if not command:
+        raise SystemExit("No evaluation command or script path is configured.")
+    if evaluation_timeout <= 0:
+        raise SystemExit("Evaluation timeout must be a positive number of seconds.")
+
+    formatted = command.format(
+        **command_context(
+            workspace_root=workspace_root,
+            run_dir=run_dir,
+            step_dir=step_dir,
+            code_path=step_code_path,
+            results_path=results_path,
+            script_path=script_path,
+            timeout_secs=evaluation_timeout,
+        )
+    )
+    (step_dir / "eval.command.txt").write_text(formatted, encoding="utf-8")
+
+    stdout = ""
+    stderr = ""
+    return_code = 0
+    try:
+        completed = subprocess.run(
+            formatted,
+            shell=True,
+            cwd=workspace_root,
+            capture_output=True,
+            text=True,
+            timeout=evaluation_timeout,
+        )
+        stdout = completed.stdout
+        stderr = completed.stderr
+        return_code = completed.returncode
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        return_code = 124
+
+    (step_dir / "eval.stdout").write_text(stdout, encoding="utf-8")
+    (step_dir / "eval.stderr").write_text(stderr, encoding="utf-8")
+
+    if results_path.exists():
+        results = json.loads(results_path.read_text(encoding="utf-8"))
+    else:
+        results = {}
+
+    if return_code != 0:
+        results.setdefault("success", False)
+        results.setdefault("eval_score", 0.0)
+        results.setdefault("score", results.get("eval_score", 0.0))
+        results.setdefault("error", stderr or f"Evaluator exited with code {return_code}")
+        results_path.write_text(json.dumps(results, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    append_round_log(
+        run_dir,
+        "eval_run",
+        {
+            "command": formatted,
+            "return_code": return_code,
+            "step_name": step_name,
+            "timeout_secs": evaluation_timeout,
+        },
+    )
+    return emit_json(
+        {
+            "results_path": str(results_path),
+            "return_code": return_code,
+            "step_dir": str(step_dir),
+            "success": return_code == 0,
+        }
+    )
+
+
+def cmd_cognition_init(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    ensure_run_layout(run_dir)
+    cognition = build_cognition(run_dir)
+    if args.reset:
+        cognition.reset()
+
+    seed_path = Path(args.seed_file) if args.seed_file else run_dir / "cognition_seed.md"
+    items = extract_seed_items(seed_path) if seed_path.exists() else []
+    if items:
+        cognition.add_batch(items)
+
+    append_round_log(
+        run_dir,
+        "cognition_init",
+        {"items_added": len(items), "seed_file": str(seed_path)},
+    )
+    return emit_json({"items_added": len(items), "total_items": len(cognition)})
+
+
+def cmd_cognition_add(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    ensure_run_layout(run_dir)
+    cognition = build_cognition(run_dir)
+    items: List[CognitionItem] = []
+    for text in flatten_list(args.item):
+        items.append(
+            CognitionItem(
+                content=text,
+                source=args.source or "",
+                metadata={"kind": args.kind} if args.kind else {},
+            )
+        )
+    if args.json_file:
+        payload = load_structured_file(Path(args.json_file))
+        if isinstance(payload, dict):
+            payload = [payload]
+        for raw_item in payload:
+            items.append(
+                CognitionItem(
+                    content=raw_item.get("content", ""),
+                    source=raw_item.get("source", ""),
+                    metadata=raw_item.get("metadata", {}),
+                )
+            )
+    cognition.add_batch(items)
+    append_round_log(run_dir, "cognition_add", {"items_added": len(items)})
+    return emit_json({"items_added": len(items), "total_items": len(cognition)})
+
+
+def cmd_cognition_search(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    cognition = build_cognition(run_dir)
+    matches = cognition.retrieve(args.query, top_k=args.top_k)
+    return emit_json(
+        {
+            "matches": [
+                {"content": item.content, "metadata": item.metadata, "score": score, "source": item.source}
+                for item, score in matches
+            ]
+        }
+    )
+
+
+def cmd_db_sample(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    spec = require_evolve_ready(run_dir)
+    db = build_database(run_dir, spec)
+    configured_algorithm = configured_sampling_algorithm(spec)
+    n = args.n or configured_sample_n(spec)
+    sampled = db.sample(n=n)
+    append_round_log(run_dir, "db_sample", {"n": n, "algorithm": configured_algorithm})
+    return emit_json({"nodes": [node.to_dict() for node in sampled]})
+
+
+def cmd_db_record(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    spec = require_evolve_ready(run_dir)
+    db = build_database(run_dir, spec)
+    snapshot = BestSnapshotManager(Path(run_dir) / "steps")
+    workspace_root = workspace_root_for_run(run_dir)
+
+    source_code = Path(args.code_path)
+    if not source_code.is_absolute():
+        source_code = (workspace_root / source_code).resolve()
+    ensure_path_allowed(run_dir, source_code)
+
+    step_name = args.step_name
+    step_dir = Path(run_dir) / "steps" / step_name
+    step_dir.mkdir(parents=True, exist_ok=True)
+    step_code_path = step_dir / "code"
+    if source_code != step_code_path:
+        shutil.copyfile(source_code, step_code_path)
+    code = step_code_path.read_text(encoding="utf-8")
+
+    results: Dict[str, Any] = {}
+    if args.results_file:
+        results_path = Path(args.results_file)
+        if not results_path.is_absolute():
+            results_path = (workspace_root / results_path).resolve()
+        if results_path.exists():
+            ensure_path_allowed(run_dir, results_path)
+            results = json.loads(results_path.read_text(encoding="utf-8"))
+            if results_path != step_dir / "results.json":
+                shutil.copyfile(results_path, step_dir / "results.json")
+
+    analysis = args.analysis or ""
+    if args.analysis_file:
+        analysis_path = Path(args.analysis_file)
+        if not analysis_path.is_absolute():
+            analysis_path = (workspace_root / analysis_path).resolve()
+        ensure_path_allowed(run_dir, analysis_path)
+        analysis = analysis_path.read_text(encoding="utf-8")
+    if analysis:
+        (step_dir / "analysis.md").write_text(analysis, encoding="utf-8")
+
+    score = args.score
+    if score is None:
+        score = float(results.get("score", results.get("eval_score", 0.0)))
+
+    node = Node(
+        name=args.name,
+        parent=args.parent or [],
+        motivation=args.motivation or "",
+        code=code,
+        results=results,
+        analysis=analysis,
+        score=score,
+        meta_info={"step_name": step_name},
+    )
+    node_id, previous_nodes = db.add_with_previous_nodes(node)
+    snapshot.init_from_nodes(previous_nodes)
+    node_file = step_dir / "node.json"
+    node_file.write_text(json.dumps(node.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    best_updated = snapshot.update_if_better(node, step_name=step_name, source_step_dir=step_dir)
+    if best_updated:
+        run_best_dir = Path(run_dir) / "best" / step_name
+        run_best_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(step_code_path, run_best_dir / "code")
+        results_copy = step_dir / "results.json"
+        if results_copy.exists():
+            shutil.copyfile(results_copy, run_best_dir / "results.json")
+    append_round_log(
+        run_dir,
+        "db_record",
+        {"node_id": node_id, "name": node.name, "score": node.score, "step_name": step_name},
+    )
+    return emit_json({"best_updated": best_updated, "node_id": node_id, "step_dir": str(step_dir)})
+
+
+def cmd_db_best(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    spec = require_evolve_ready(run_dir)
+    db = build_database(run_dir, spec)
+    nodes = db.get_all()
+    if not nodes:
+        return emit_json({"best": None})
+    best = max(nodes, key=lambda node: node.score)
+    return emit_json({"best": best.to_dict()})
+
+
+def cmd_db_stats(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    spec = require_evolve_ready(run_dir)
+    db = build_database(run_dir, spec)
+    nodes, sampler_stats = db.snapshot()
+    best_score = max((node.score for node in nodes), default=0.0)
+    return emit_json(
+        {
+            "best_score": best_score,
+            "sampler_stats": sampler_stats,
+            "total_nodes": len(nodes),
+        }
+    )
+
+
+def cmd_files_read(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    workspace_root = workspace_root_for_run(run_dir)
+    target = Path(args.path)
+    if not target.is_absolute():
+        target = (workspace_root / target).resolve()
+    ensure_path_allowed(run_dir, target)
+    return emit_json({"content": target.read_text(encoding="utf-8"), "path": str(target)})
+
+
+def cmd_files_write(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    require_evolve_ready(run_dir)
+    workspace_root = workspace_root_for_run(run_dir)
+    target = Path(args.path)
+    if not target.is_absolute():
+        target = (workspace_root / target).resolve()
+    ensure_path_allowed(run_dir, target)
+
+    if args.from_file:
+        content_source = Path(args.from_file)
+        if not content_source.is_absolute():
+            content_source = (workspace_root / content_source).resolve()
+        ensure_path_allowed(run_dir, content_source)
+        content = content_source.read_text(encoding="utf-8")
+    else:
+        content = args.content or ""
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    append_round_log(run_dir, "file_write", {"path": str(target)})
+    return emit_json({"bytes_written": len(content.encode("utf-8")), "path": str(target)})
+
+
+def cmd_files_diff(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    workspace_root = workspace_root_for_run(run_dir)
+    left = Path(args.path)
+    right = Path(args.other_path)
+    if not left.is_absolute():
+        left = (workspace_root / left).resolve()
+    if not right.is_absolute():
+        right = (workspace_root / right).resolve()
+    ensure_path_allowed(run_dir, left)
+    ensure_path_allowed(run_dir, right)
+
+    diff = "".join(
+        unified_diff(
+            left.read_text(encoding="utf-8").splitlines(True),
+            right.read_text(encoding="utf-8").splitlines(True),
+            fromfile=str(left),
+            tofile=str(right),
+        )
+    )
+    return emit_json({"diff": diff})
+
+
+def cmd_summary_final(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    spec = require_evolve_ready(run_dir)
+    db = build_database(run_dir, spec)
+    nodes = db.get_all()
+    best = max(nodes, key=lambda node: node.score) if nodes else None
+    summary_lines = [
+        "# Final Summary",
+        "",
+        f"- Objective: {spec.get('objective', '')}",
+        f"- Total nodes: {len(nodes)}",
+        f"- Best score: {best.score if best else 0.0}",
+        f"- Best node: {best.name if best else 'none'}",
+    ]
+    if best:
+        summary_lines.append(f"- Best motivation: {best.motivation}")
+    summary_path = Path(run_dir) / "final_summary.md"
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    append_round_log(run_dir, "summary_final", {"path": str(summary_path)})
+    return emit_json({"summary_path": str(summary_path)})
+
+
+def build_brief_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evolve-brief")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    normalize = subparsers.add_parser("normalize")
+    normalize.add_argument("--workspace-root")
+    normalize.add_argument("--run-name", required=True)
+    normalize.add_argument("--spec-file")
+    normalize.add_argument("--objective")
+    normalize.add_argument("--core-score")
+    normalize.add_argument("--secondary-metric", action="append")
+    normalize.add_argument("--evaluation-command")
+    normalize.add_argument("--evaluation-script-path")
+    normalize.add_argument("--evaluation-timeout-secs", type=int)
+    normalize.add_argument("--success-criterion", action="append")
+    normalize.add_argument("--max-rounds", type=int)
+    normalize.add_argument("--patience", type=int)
+    normalize.add_argument("--stop-condition", action="append")
+    normalize.add_argument("--writable-path", action="append")
+    normalize.add_argument("--primary-target", action="append")
+    normalize.add_argument("--sampling-algorithm")
+    normalize.add_argument("--sample-n", type=int)
+    normalize.add_argument("--sampling-feature", action="append")
+    normalize.add_argument("--sampling-feature-bins", type=int)
+    normalize.add_argument("--sampling-custom-sampler-path")
+    normalize.add_argument("--sampling-custom-sampler-class")
+    normalize.add_argument("--cognition-source-mode")
+    normalize.add_argument("--seed-file", action="append")
+    normalize.add_argument("--seed-note", action="append")
+    normalize.add_argument("--confirmed", type=parse_bool)
+    normalize.set_defaults(func=cmd_brief_normalize)
+    return parser
+
+
+def build_eval_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evolve-eval")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    inspect_cmd = subparsers.add_parser("inspect")
+    inspect_cmd.add_argument("--script-path")
+    inspect_cmd.add_argument("--command")
+    inspect_cmd.set_defaults(func=cmd_eval_inspect)
+
+    run_cmd = subparsers.add_parser("run")
+    run_cmd.add_argument("--run-dir", required=True)
+    run_cmd.add_argument("--code-path", required=True)
+    run_cmd.add_argument("--step-name")
+    run_cmd.add_argument("--command")
+    run_cmd.add_argument("--script-path")
+    run_cmd.add_argument("--timeout", type=int)
+    run_cmd.set_defaults(func=cmd_eval_run)
+    return parser
+
+
+def build_cognition_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evolve-cognition")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_cmd = subparsers.add_parser("init")
+    init_cmd.add_argument("--run-dir", required=True)
+    init_cmd.add_argument("--seed-file")
+    init_cmd.add_argument("--reset", action="store_true")
+    init_cmd.set_defaults(func=cmd_cognition_init)
+
+    add_cmd = subparsers.add_parser("add")
+    add_cmd.add_argument("--run-dir", required=True)
+    add_cmd.add_argument("--item", action="append")
+    add_cmd.add_argument("--json-file")
+    add_cmd.add_argument("--kind")
+    add_cmd.add_argument("--source")
+    add_cmd.set_defaults(func=cmd_cognition_add)
+
+    search_cmd = subparsers.add_parser("search")
+    search_cmd.add_argument("--run-dir", required=True)
+    search_cmd.add_argument("--query", required=True)
+    search_cmd.add_argument("--top-k", type=int, default=5)
+    search_cmd.set_defaults(func=cmd_cognition_search)
+    return parser
+
+
+def build_db_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evolve-db")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sample_cmd = subparsers.add_parser("sample")
+    sample_cmd.add_argument("--run-dir", required=True)
+    sample_cmd.add_argument("--n", type=int)
+    sample_cmd.set_defaults(func=cmd_db_sample)
+
+    record_cmd = subparsers.add_parser("record")
+    record_cmd.add_argument("--run-dir", required=True)
+    record_cmd.add_argument("--step-name", required=True)
+    record_cmd.add_argument("--name", required=True)
+    record_cmd.add_argument("--code-path", required=True)
+    record_cmd.add_argument("--motivation")
+    record_cmd.add_argument("--analysis")
+    record_cmd.add_argument("--analysis-file")
+    record_cmd.add_argument("--results-file")
+    record_cmd.add_argument("--score", type=float)
+    record_cmd.add_argument("--parent", type=int, action="append")
+    record_cmd.set_defaults(func=cmd_db_record)
+
+    best_cmd = subparsers.add_parser("best")
+    best_cmd.add_argument("--run-dir", required=True)
+    best_cmd.set_defaults(func=cmd_db_best)
+
+    stats_cmd = subparsers.add_parser("stats")
+    stats_cmd.add_argument("--run-dir", required=True)
+    stats_cmd.set_defaults(func=cmd_db_stats)
+    return parser
+
+
+def build_files_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evolve-files")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    read_cmd = subparsers.add_parser("read")
+    read_cmd.add_argument("--run-dir", required=True)
+    read_cmd.add_argument("--path", required=True)
+    read_cmd.set_defaults(func=cmd_files_read)
+
+    write_cmd = subparsers.add_parser("write")
+    write_cmd.add_argument("--run-dir", required=True)
+    write_cmd.add_argument("--path", required=True)
+    write_cmd.add_argument("--content")
+    write_cmd.add_argument("--from-file")
+    write_cmd.set_defaults(func=cmd_files_write)
+
+    diff_cmd = subparsers.add_parser("diff")
+    diff_cmd.add_argument("--run-dir", required=True)
+    diff_cmd.add_argument("--path", required=True)
+    diff_cmd.add_argument("--other-path", required=True)
+    diff_cmd.set_defaults(func=cmd_files_diff)
+    return parser
+
+
+def build_summary_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="evolve-summary")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    final_cmd = subparsers.add_parser("final")
+    final_cmd.add_argument("--run-dir", required=True)
+    final_cmd.set_defaults(func=cmd_summary_final)
+    return parser
+
+
+def main_for(entrypoint: str, argv: Optional[List[str]] = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    parsers = {
+        "brief": build_brief_parser,
+        "cognition": build_cognition_parser,
+        "db": build_db_parser,
+        "eval": build_eval_parser,
+        "files": build_files_parser,
+        "summary": build_summary_parser,
+    }
+    parser = parsers[entrypoint]()
+    args = parser.parse_args(argv)
+    return args.func(args)

--- a/src/workflow/workflows/evolve/scripts/evolve_core/cognition.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/cognition.py
@@ -1,0 +1,127 @@
+"""Persistent cognition store with semantic retrieval."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from threading import RLock
+from typing import Dict, List, Optional, Tuple
+
+from .embedding import EmbeddingService
+from .structures import CognitionItem
+from .vector_index import FAISSIndex
+
+
+class Cognition:
+    """Persistent cognition store with embedding-backed retrieval."""
+
+    def __init__(
+        self,
+        storage_dir: Path,
+        embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        embedding_dim: int = 384,
+        retrieval_top_k: int = 5,
+        score_threshold: float = 0.3,
+        faiss_index_type: str = "IP",
+    ):
+        self.storage_dir = Path(storage_dir)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.lock = RLock()
+        self.retrieval_top_k = retrieval_top_k
+        self.score_threshold = score_threshold
+        self.items: Dict[str, CognitionItem] = {}
+        self.embedding = EmbeddingService(
+            model_name=embedding_model,
+            dimension=embedding_dim,
+        )
+        self.faiss = FAISSIndex(
+            dimension=embedding_dim,
+            index_type=faiss_index_type,
+            storage_path=self.storage_dir / "faiss",
+        )
+        self.str_to_int: Dict[str, int] = {}
+        self.int_to_str: Dict[int, str] = {}
+        self.next_int_id = 0
+        self._load()
+
+    def add(self, item: CognitionItem) -> str:
+        with self.lock:
+            if not item.id:
+                item.id = str(uuid.uuid4())
+            self.items[item.id] = item
+            if item.content:
+                int_id = self._get_int_id(item.id)
+                self.faiss.add(int_id, self.embedding.encode(item.content))
+            self._save()
+            return item.id
+
+    def add_batch(self, items: List[CognitionItem]) -> List[str]:
+        return [self.add(item) for item in items]
+
+    def search(self, query: str, top_k: Optional[int] = None) -> List[CognitionItem]:
+        return [item for item, _ in self.retrieve(query, top_k=top_k)]
+
+    def retrieve(
+        self,
+        query: str,
+        top_k: Optional[int] = None,
+        score_threshold: Optional[float] = None,
+    ) -> List[Tuple[CognitionItem, float]]:
+        top_k = top_k or self.retrieval_top_k
+        threshold = self.score_threshold if score_threshold is None else score_threshold
+        results = self.faiss.search(self.embedding.encode(query), top_k, threshold)
+
+        enriched: List[Tuple[CognitionItem, float]] = []
+        for int_id, score in results:
+            item_id = self.int_to_str.get(int_id)
+            if item_id and item_id in self.items:
+                enriched.append((self.items[item_id], score))
+        return enriched
+
+    def get_all(self) -> List[CognitionItem]:
+        return list(self.items.values())
+
+    def reset(self) -> None:
+        with self.lock:
+            self.items.clear()
+            self.str_to_int.clear()
+            self.int_to_str.clear()
+            self.next_int_id = 0
+            self.faiss.reset()
+            data_file = self.storage_dir / "cognition.json"
+            if data_file.exists():
+                data_file.unlink()
+
+    def _get_int_id(self, item_id: str) -> int:
+        if item_id not in self.str_to_int:
+            self.str_to_int[item_id] = self.next_int_id
+            self.int_to_str[self.next_int_id] = item_id
+            self.next_int_id += 1
+        return self.str_to_int[item_id]
+
+    def _save(self) -> None:
+        payload = {
+            "items": {item_id: item.to_dict() for item_id, item in self.items.items()},
+            "str_to_int": self.str_to_int,
+            "int_to_str": {str(key): value for key, value in self.int_to_str.items()},
+            "next_int_id": self.next_int_id,
+        }
+        with open(self.storage_dir / "cognition.json", "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+        self.faiss.save()
+
+    def _load(self) -> None:
+        data_file = self.storage_dir / "cognition.json"
+        if not data_file.exists():
+            return
+        with open(data_file, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        for item_id, raw_item in payload.get("items", {}).items():
+            self.items[item_id] = CognitionItem.from_dict(raw_item)
+        self.str_to_int = payload.get("str_to_int", {})
+        self.int_to_str = {int(key): value for key, value in payload.get("int_to_str", {}).items()}
+        self.next_int_id = payload.get("next_int_id", 0)
+
+    def __len__(self) -> int:
+        return len(self.items)

--- a/src/workflow/workflows/evolve/scripts/evolve_core/database.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/database.py
@@ -1,0 +1,218 @@
+"""Persistent node database for skill-driven evolution runs."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, List, Optional, Tuple
+
+from .algorithms import get_sampler
+from .embedding import EmbeddingService
+from .file_lock import InterProcessFileLock
+from .structures import Node
+from .vector_index import FAISSIndex
+
+
+class Database:
+    """Persistent experiment database with sampler pluggability."""
+
+    def __init__(
+        self,
+        storage_dir: Path,
+        embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        embedding_dim: int = 384,
+        sampling_algorithm: str = "ucb1",
+        sampling_kwargs: Optional[Dict[str, Any]] = None,
+        faiss_index_type: str = "IP",
+        max_size: Optional[int] = None,
+    ):
+        self.storage_dir = Path(storage_dir)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.lock = RLock()
+        self.lock_path = self.storage_dir / ".database.lock"
+        self.nodes: Dict[int, Node] = {}
+        self.next_id = 0
+        self.max_size = max_size
+        self.embedding_dim = embedding_dim
+        self.faiss_index_type = faiss_index_type
+        self.embedding = EmbeddingService(
+            model_name=embedding_model,
+            dimension=embedding_dim,
+        )
+        self.sampling_algorithm = sampling_algorithm
+        self.sampling_kwargs = sampling_kwargs or {}
+        self.default_sampler = get_sampler(sampling_algorithm, **self.sampling_kwargs)
+        self.faiss = self._build_faiss_index()
+
+    def sample(self, n: int, algorithm: Optional[str] = None, **kwargs) -> List[Node]:
+        with self._database_guard():
+            nodes = list(self.nodes.values())
+            sampler = (
+                get_sampler(algorithm, **kwargs) if algorithm else self.default_sampler
+            )
+            selected = sampler.sample(nodes, n)
+            self._save_locked()
+            return self._clone_nodes(selected)
+
+    def add(self, node: Node) -> int:
+        node_id, _ = self.add_with_previous_nodes(node)
+        return node_id
+
+    def add_with_previous_nodes(self, node: Node) -> Tuple[int, List[Node]]:
+        with self._database_guard():
+            previous_nodes = self._clone_nodes(self.nodes.values())
+            if self.max_size is not None and len(self.nodes) >= self.max_size:
+                self._remove_worst_node_locked()
+
+            node.id = self.next_id
+            self.next_id += 1
+            self.nodes[node.id] = node
+            if hasattr(self.default_sampler, "on_node_added"):
+                self.default_sampler.on_node_added(node)
+
+            context_text = node.get_context_text()
+            if context_text:
+                vector = self.embedding.encode(context_text)
+                self.faiss.add(node.id, vector)
+
+            self._save_locked()
+            return node.id, previous_nodes
+
+    def get_all(self) -> List[Node]:
+        with self._database_guard():
+            return self._clone_nodes(self.nodes.values())
+
+    def get(self, node_id: int) -> Optional[Node]:
+        with self._database_guard():
+            node = self.nodes.get(node_id)
+            if node is None:
+                return None
+            return self._clone_node(node)
+
+    def remove(self, node_id: int) -> bool:
+        with self._database_guard():
+            if node_id not in self.nodes:
+                return False
+            node = self.nodes[node_id]
+            if hasattr(self.default_sampler, "on_node_removed"):
+                self.default_sampler.on_node_removed(node)
+            del self.nodes[node_id]
+            self.faiss.remove(node_id)
+            self._save_locked()
+            return True
+
+    def reset(self) -> None:
+        with self._database_guard(refresh=False):
+            if hasattr(self.default_sampler, "reset"):
+                self.default_sampler.reset()
+            self.nodes.clear()
+            self.next_id = 0
+            self.faiss.reset()
+            data_file = self.storage_dir / "nodes.json"
+            if data_file.exists():
+                data_file.unlink()
+
+    def get_sampler_stats(self) -> Optional[Dict[str, Any]]:
+        _, sampler_stats = self.snapshot()
+        return sampler_stats
+
+    def snapshot(self) -> Tuple[List[Node], Optional[Dict[str, Any]]]:
+        with self._database_guard():
+            return self._clone_nodes(self.nodes.values()), self._get_sampler_stats_locked()
+
+    def _remove_worst_node_locked(self) -> None:
+        if not self.nodes:
+            return
+        worst_id = min(self.nodes, key=lambda node_id: (self.nodes[node_id].score, node_id))
+        node = self.nodes[worst_id]
+        if hasattr(self.default_sampler, "on_node_removed"):
+            self.default_sampler.on_node_removed(node)
+        del self.nodes[worst_id]
+        self.faiss.remove(worst_id)
+
+    def _save_locked(self) -> None:
+        payload = {
+            "next_id": self.next_id,
+            "nodes": {str(node_id): node.to_dict() for node_id, node in self.nodes.items()},
+        }
+        if hasattr(self.default_sampler, "get_state"):
+            payload["sampler_state"] = self.default_sampler.get_state()
+
+        temp_path: Optional[Path] = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.storage_dir,
+                prefix="nodes.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                json.dump(payload, handle, ensure_ascii=False, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temp_path = Path(handle.name)
+
+            os.replace(temp_path, self.storage_dir / "nodes.json")
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
+
+        self.faiss.save()
+
+    def _load_locked(self) -> None:
+        data_file = self.storage_dir / "nodes.json"
+        self.nodes = {}
+        self.next_id = 0
+        self.default_sampler = get_sampler(self.sampling_algorithm, **self.sampling_kwargs)
+        self.faiss = self._build_faiss_index()
+        if not data_file.exists():
+            return
+        with open(data_file, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        self.next_id = payload.get("next_id", 0)
+        for node_id, node_data in payload.get("nodes", {}).items():
+            self.nodes[int(node_id)] = Node.from_dict(node_data)
+        if hasattr(self.default_sampler, "load_state") and "sampler_state" in payload:
+            self.default_sampler.load_state(payload["sampler_state"])
+        if hasattr(self.default_sampler, "rebuild_from_nodes"):
+            self.default_sampler.rebuild_from_nodes(list(self.nodes.values()))
+
+    def _build_faiss_index(self) -> FAISSIndex:
+        return FAISSIndex(
+            dimension=self.embedding_dim,
+            index_type=self.faiss_index_type,
+            storage_path=self.storage_dir / "faiss",
+        )
+
+    def _get_sampler_stats_locked(self) -> Optional[Dict[str, Any]]:
+        if hasattr(self.default_sampler, "get_island_stats"):
+            return self.default_sampler.get_island_stats(list(self.nodes.values()))
+        return None
+
+    @staticmethod
+    def _clone_node(node: Node) -> Node:
+        return Node.from_dict(copy.deepcopy(node.to_dict()))
+
+    def _clone_nodes(self, nodes: List[Node] | Any) -> List[Node]:
+        return [self._clone_node(node) for node in nodes]
+
+    @contextmanager
+    def _database_guard(self, refresh: bool = True):
+        with self.lock:
+            with InterProcessFileLock(self.lock_path):
+                if refresh:
+                    self._load_locked()
+                hold_ms = int(os.environ.get("EVOLVE_DB_TEST_HOLD_LOCK_MS", "0") or 0)
+                if hold_ms > 0:
+                    time.sleep(hold_ms / 1000.0)
+                yield
+
+    def __len__(self) -> int:
+        return len(self.get_all())

--- a/src/workflow/workflows/evolve/scripts/evolve_core/diff.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/diff.py
@@ -1,0 +1,57 @@
+"""Helpers for diff-style code edits."""
+
+from __future__ import annotations
+
+import re
+from difflib import unified_diff
+from typing import List, Optional, Tuple
+
+
+def extract_diffs(
+    llm_response: str,
+    pattern: str = r"<<<<<<< SEARCH\n(.*?)=======\n(.*?)>>>>>>> REPLACE",
+) -> List[Tuple[str, str]]:
+    matches = re.findall(pattern, llm_response, re.DOTALL)
+    return [(search.strip("\n"), replace.strip("\n")) for search, replace in matches]
+
+
+def apply_diff(
+    original_code: str,
+    llm_response: str,
+    pattern: str = r"<<<<<<< SEARCH\n(.*?)=======\n(.*?)>>>>>>> REPLACE",
+) -> str:
+    diff_blocks = extract_diffs(llm_response, pattern)
+    if not diff_blocks:
+        raise ValueError("No valid diff blocks found")
+
+    updated_code = original_code
+    for search, replace in diff_blocks:
+        if search not in updated_code:
+            raise ValueError("SEARCH block not found in target text")
+        updated_code = updated_code.replace(search, replace, 1)
+    return updated_code
+
+
+def parse_full_rewrite(llm_response: str, language: str = "python") -> Optional[str]:
+    pattern = rf"```{language}\n(.*?)```"
+    match = re.search(pattern, llm_response, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    stripped = llm_response.strip()
+    return stripped or None
+
+
+def format_diff_summary(diff_blocks: List[Tuple[str, str]]) -> str:
+    parts: List[str] = []
+    for search, replace in diff_blocks:
+        lines = list(
+            unified_diff(
+                search.splitlines(),
+                replace.splitlines(),
+                fromfile="before",
+                tofile="after",
+                lineterm="",
+            )
+        )
+        parts.append("\n".join(lines))
+    return "\n\n".join(parts)

--- a/src/workflow/workflows/evolve/scripts/evolve_core/embedding.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/embedding.py
@@ -1,0 +1,84 @@
+"""Embedding helpers with a graceful local fallback."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import List, Union
+
+import numpy as np
+
+try:
+    from sentence_transformers import SentenceTransformer
+
+    ST_AVAILABLE = True
+except Exception:
+    SentenceTransformer = None
+    ST_AVAILABLE = False
+
+
+class EmbeddingService:
+    """Encode text with sentence-transformers when available, else hash tokens."""
+
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        device: str = "cpu",
+        dimension: int = 384,
+    ):
+        self.dimension = dimension
+        self.model = None
+
+        if ST_AVAILABLE and SentenceTransformer is not None:
+            try:
+                self.model = SentenceTransformer(model_name, device=device)
+                self.dimension = self.model.get_sentence_embedding_dimension()
+            except Exception:
+                self.model = None
+
+    def encode(
+        self,
+        texts: Union[str, List[str]],
+        normalize: bool = True,
+    ) -> np.ndarray:
+        if isinstance(texts, str):
+            texts = [texts]
+
+        if self.model is not None:
+            embeddings = self.model.encode(
+                texts,
+                normalize_embeddings=normalize,
+                show_progress_bar=False,
+            )
+            return np.array(embeddings, dtype=np.float32)
+
+        vectors = np.vstack([self._fallback_encode_one(text) for text in texts]).astype(
+            np.float32
+        )
+        if normalize:
+            vectors = self._normalize(vectors)
+        return vectors
+
+    def get_dimension(self) -> int:
+        return self.dimension
+
+    def _fallback_encode_one(self, text: str) -> np.ndarray:
+        vector = np.zeros(self.dimension, dtype=np.float32)
+        tokens = re.findall(r"[A-Za-z0-9_]+", text.lower())
+        if not tokens:
+            return vector
+
+        for token in tokens:
+            hashed = hash(token)
+            index = abs(hashed) % self.dimension
+            sign = -1.0 if hashed % 2 else 1.0
+            weight = 1.0 + math.log1p(len(token))
+            vector[index] += sign * weight
+
+        return vector
+
+    @staticmethod
+    def _normalize(vectors: np.ndarray) -> np.ndarray:
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return vectors / norms

--- a/src/workflow/workflows/evolve/scripts/evolve_core/file_lock.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/file_lock.py
@@ -1,0 +1,45 @@
+"""Cross-process file locking helpers for the Evolve skill runtime."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+
+class InterProcessFileLock:
+    """Hold an exclusive lock on a sentinel file across processes."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self._handle = None
+
+    def __enter__(self) -> "InterProcessFileLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = open(self.path, "a+b")
+        self._handle.seek(0)
+        self._handle.write(b"\0")
+        self._handle.flush()
+        self._handle.seek(0)
+
+        if os.name == "nt":
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._handle is None:
+            return
+
+        self._handle.seek(0)
+        if os.name == "nt":
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        self._handle.close()
+        self._handle = None

--- a/src/workflow/workflows/evolve/scripts/evolve_core/run_state.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/run_state.py
@@ -1,0 +1,343 @@
+"""Run-spec persistence, preflight gating, and path guards."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+
+from .sampling_config import (
+    DEFAULT_ISLAND_FEATURE_BINS,
+    DEFAULT_ISLAND_FEATURE_DIMENSIONS,
+    sampling_summary_lines,
+    validate_custom_sampler_for_workspace as validate_sampling_custom_sampler_for_workspace,
+)
+
+
+DEFAULT_RUN_SPEC: Dict[str, Any] = {
+    "objective": "",
+    "evaluation": {
+        "core_score": "",
+        "secondary_metrics": [],
+        "command": "",
+        "script_path": "",
+        "timeout_secs": 0,
+        "success_criteria": [],
+    },
+    "budget": {
+        "max_rounds": 0,
+        "patience": 0,
+    },
+    "stop_conditions": [],
+    "mutation_scope": {
+        "writable_paths": [],
+        "primary_targets": [],
+    },
+    "sampling": {
+        "algorithm": "ucb1",
+        "sample_n": 3,
+        "feature_dimensions": list(DEFAULT_ISLAND_FEATURE_DIMENSIONS),
+        "feature_bins": DEFAULT_ISLAND_FEATURE_BINS,
+        "custom_sampler_path": "",
+        "custom_sampler_class": "",
+    },
+    "cognition": {
+        "source_mode": "",
+        "seed_files": [],
+        "seed_notes": [],
+    },
+    "approval": {
+        "confirmed": False,
+    },
+}
+
+REQUIRED_FIELD_CHECKS = {
+    "objective": lambda spec: bool(str(spec.get("objective", "")).strip()),
+    "evaluation.core_score": lambda spec: bool(
+        str(spec.get("evaluation", {}).get("core_score", "")).strip()
+    ),
+    "evaluation.command_or_script": lambda spec: bool(
+        str(spec.get("evaluation", {}).get("command", "")).strip()
+        or str(spec.get("evaluation", {}).get("script_path", "")).strip()
+    ),
+    "evaluation.timeout_secs": lambda spec: int(
+        spec.get("evaluation", {}).get("timeout_secs", 0) or 0
+    )
+    > 0,
+    "evaluation.success_criteria": lambda spec: bool(
+        spec.get("evaluation", {}).get("success_criteria")
+    ),
+    "budget.max_rounds": lambda spec: int(spec.get("budget", {}).get("max_rounds", 0) or 0)
+    > 0,
+    "budget.patience": lambda spec: int(spec.get("budget", {}).get("patience", 0) or 0) >= 0,
+    "stop_conditions": lambda spec: bool(spec.get("stop_conditions")),
+    "mutation_scope.writable_paths": lambda spec: bool(
+        spec.get("mutation_scope", {}).get("writable_paths")
+    ),
+    "mutation_scope.primary_targets": lambda spec: bool(
+        spec.get("mutation_scope", {}).get("primary_targets")
+    ),
+    "sampling.algorithm": lambda spec: bool(
+        str(spec.get("sampling", {}).get("algorithm", "")).strip()
+    ),
+    "sampling.sample_n": lambda spec: int(spec.get("sampling", {}).get("sample_n", 0) or 0) > 0,
+    "sampling.custom_sampler": lambda spec: (
+        str(spec.get("sampling", {}).get("algorithm", "")).strip() != "custom"
+        or (
+            bool(str(spec.get("sampling", {}).get("custom_sampler_path", "")).strip())
+            and bool(str(spec.get("sampling", {}).get("custom_sampler_class", "")).strip())
+        )
+    ),
+    "cognition.source_mode": lambda spec: bool(
+        str(spec.get("cognition", {}).get("source_mode", "")).strip()
+    ),
+}
+
+
+def default_run_spec() -> Dict[str, Any]:
+    return copy.deepcopy(DEFAULT_RUN_SPEC)
+
+
+def deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def build_run_dir(workspace_root: Path, run_name: str) -> Path:
+    return Path(workspace_root).resolve() / ".evolve_runs" / run_name
+
+
+def ensure_run_layout(run_dir: Path) -> Dict[str, Path]:
+    run_dir = Path(run_dir).resolve()
+    layout = {
+        "run_dir": run_dir,
+        "best": run_dir / "best",
+        "cognition_data": run_dir / "cognition_data",
+        "database_data": run_dir / "database_data",
+        "steps": run_dir / "steps",
+    }
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for path in layout.values():
+        path.mkdir(parents=True, exist_ok=True)
+    round_log = run_dir / "round_log.jsonl"
+    if not round_log.exists():
+        round_log.write_text("", encoding="utf-8")
+    return layout
+
+
+def workspace_root_for_run(run_dir: Path) -> Path:
+    run_dir = Path(run_dir).resolve()
+    return run_dir.parent.parent
+
+
+def spec_path(run_dir: Path) -> Path:
+    return Path(run_dir) / "run_spec.yaml"
+
+
+def load_run_spec(run_dir: Path) -> Dict[str, Any]:
+    path = spec_path(run_dir)
+    if not path.exists():
+        return default_run_spec()
+    with open(path, "r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle) or {}
+    return deep_merge(default_run_spec(), loaded)
+
+
+def save_run_spec(run_dir: Path, spec: Dict[str, Any]) -> Path:
+    path = spec_path(run_dir)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(spec, handle, allow_unicode=True, sort_keys=False)
+    return path
+
+
+def normalize_spec_path(workspace_root: Path, raw_path: str) -> str:
+    path = Path(raw_path)
+    if not path.is_absolute():
+        return raw_path.replace("\\", "/")
+
+    resolved = path.resolve()
+    workspace_root = Path(workspace_root).resolve()
+    try:
+        return resolved.relative_to(workspace_root).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def resolve_path(workspace_root: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (Path(workspace_root).resolve() / path).resolve()
+
+
+def compute_missing_fields(spec: Dict[str, Any]) -> List[str]:
+    return compute_missing_fields_for_workspace(spec)
+
+
+def compute_missing_fields_for_workspace(
+    spec: Dict[str, Any],
+    workspace_root: Optional[Path] = None,
+) -> List[str]:
+    missing = []
+    for field, check in REQUIRED_FIELD_CHECKS.items():
+        if not check(spec):
+            missing.append(field)
+    custom_sampler_error = validate_custom_sampler_for_workspace(spec, workspace_root)
+    if custom_sampler_error:
+        missing.append("sampling.custom_sampler_valid")
+    return missing
+
+
+def validate_custom_sampler_for_workspace(
+    spec: Dict[str, Any],
+    workspace_root: Optional[Path] = None,
+) -> str:
+    return validate_sampling_custom_sampler_for_workspace(spec, workspace_root)
+
+
+def write_preflight_summary(run_dir: Path, spec: Dict[str, Any]) -> Path:
+    workspace_root = workspace_root_for_run(run_dir)
+    missing = compute_missing_fields_for_workspace(spec, workspace_root)
+    confirmed = bool(spec.get("approval", {}).get("confirmed", False))
+    status = "READY" if confirmed and not missing else "PENDING"
+    lines = [
+        "# Preflight Summary",
+        "",
+        f"- Status: `{status}`",
+        f"- Objective: {spec.get('objective', '') or '(missing)'}",
+        f"- Core score: {spec.get('evaluation', {}).get('core_score', '') or '(missing)'}",
+        f"- Secondary metrics: {', '.join(spec.get('evaluation', {}).get('secondary_metrics', [])) or '(none)'}",
+        f"- Evaluation command: {spec.get('evaluation', {}).get('command', '') or '(missing)'}",
+        f"- Evaluation script: {spec.get('evaluation', {}).get('script_path', '') or '(missing)'}",
+        f"- Evaluation timeout (s): {spec.get('evaluation', {}).get('timeout_secs', 0) or '(missing)'}",
+        f"- Success criteria: {', '.join(spec.get('evaluation', {}).get('success_criteria', [])) or '(missing)'}",
+        f"- Budget: max_rounds={spec.get('budget', {}).get('max_rounds', 0)}, patience={spec.get('budget', {}).get('patience', 0)}",
+        f"- Stop conditions: {', '.join(spec.get('stop_conditions', [])) or '(missing)'}",
+        f"- Writable paths: {', '.join(spec.get('mutation_scope', {}).get('writable_paths', [])) or '(missing)'}",
+        f"- Primary targets: {', '.join(spec.get('mutation_scope', {}).get('primary_targets', [])) or '(missing)'}",
+        *sampling_summary_lines(spec, workspace_root),
+        f"- Cognition source mode: {spec.get('cognition', {}).get('source_mode', '') or '(missing)'}",
+        f"- Cognition seed files: {', '.join(spec.get('cognition', {}).get('seed_files', [])) or '(none)'}",
+        f"- Cognition seed notes: {', '.join(spec.get('cognition', {}).get('seed_notes', [])) or '(none)'}",
+        f"- Approval confirmed: {confirmed}",
+    ]
+    lines.extend(
+        [
+            "",
+            "## Missing fields",
+        ]
+    )
+    if missing:
+        lines.extend([f"- {field}" for field in missing])
+    else:
+        lines.append("- none")
+
+    path = Path(run_dir) / "preflight_summary.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def initialize_cognition_seed_file(run_dir: Path, spec: Dict[str, Any]) -> Path:
+    path = Path(run_dir) / "cognition_seed.md"
+    if path.exists():
+        return path
+
+    notes = spec.get("cognition", {}).get("seed_notes", [])
+    lines = [
+        "# Cognition Seed Draft",
+        "",
+        f"- source_mode: {spec.get('cognition', {}).get('source_mode', '') or 'pending'}",
+        "- Fill this file during preflight and keep the JSON blocks machine-readable.",
+        "",
+        "## Notes",
+    ]
+    if notes:
+        lines.extend([f"- {note}" for note in notes])
+    else:
+        lines.append("- Add user-provided or approved research notes here.")
+    lines.extend(
+        [
+            "",
+            "## JSON seeds",
+            "",
+            "```json",
+            "[",
+            '  {',
+            '    "content": "Replace this with a reusable heuristic or observation.",',
+            '    "source": "user",',
+            '    "metadata": {"kind": "heuristic"}',
+            "  }",
+            "]",
+            "```",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def require_evolve_ready(run_dir: Path) -> Dict[str, Any]:
+    spec = load_run_spec(run_dir)
+    missing = compute_missing_fields_for_workspace(spec, workspace_root_for_run(run_dir))
+    if missing:
+        raise ValueError(
+            "Preflight is incomplete. Missing fields: " + ", ".join(missing)
+        )
+    if not spec.get("approval", {}).get("confirmed", False):
+        raise PermissionError("Preflight is not confirmed yet.")
+    return spec
+
+
+def ensure_path_allowed(run_dir: Path, target_path: Path) -> Path:
+    spec = load_run_spec(run_dir)
+    run_dir = Path(run_dir).resolve()
+    target_path = Path(target_path).resolve()
+
+    if target_path.is_relative_to(run_dir):
+        return target_path
+
+    workspace_root = workspace_root_for_run(run_dir)
+    allowed_paths = spec.get("mutation_scope", {}).get("writable_paths", [])
+    resolved_roots = [resolve_path(workspace_root, raw_path) for raw_path in allowed_paths]
+
+    for allowed_root in resolved_roots:
+        if target_path.is_relative_to(allowed_root):
+            return target_path
+
+    raise PermissionError(
+        f"Path is outside the approved mutation scope: {target_path}"
+    )
+
+
+def append_round_log(run_dir: Path, event: str, payload: Dict[str, Any]) -> Path:
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "event": event,
+        "payload": payload,
+    }
+    path = Path(run_dir) / "round_log.jsonl"
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return path
+
+
+def load_structured_file(path: Path) -> Dict[str, Any]:
+    path = Path(path)
+    if path.suffix.lower() == ".json":
+        return json.loads(path.read_text(encoding="utf-8"))
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def flatten_list(values: Iterable[str] | None) -> List[str]:
+    if not values:
+        return []
+    return [value for value in values if value]

--- a/src/workflow/workflows/evolve/scripts/evolve_core/sampling_config.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/sampling_config.py
@@ -1,0 +1,173 @@
+"""Shared helpers for run-level sampling configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .algorithms.factory import load_custom_sampler_class
+
+
+DEFAULT_SAMPLING_ALGORITHM = "ucb1"
+DEFAULT_SAMPLE_N = 3
+DEFAULT_ISLAND_FEATURE_DIMENSIONS = ["complexity", "diversity"]
+DEFAULT_ISLAND_FEATURE_BINS = 10
+SAMPLING_CONFIG_IMMUTABLE_ERROR = (
+    "Sampling configuration is run-level and cannot change after nodes exist. "
+    "Start a new run if you want a different algorithm or island feature setup."
+)
+
+
+def _sampling_section(spec: Dict[str, Any]) -> Dict[str, Any]:
+    return spec.get("sampling", {})
+
+
+def _sampling_algorithm_value(spec: Dict[str, Any]) -> str:
+    return str(_sampling_section(spec).get("algorithm", "") or "").strip()
+
+
+def configured_sampling_algorithm(spec: Dict[str, Any]) -> str:
+    return _sampling_algorithm_value(spec) or DEFAULT_SAMPLING_ALGORITHM
+
+
+def configured_sample_n(spec: Dict[str, Any]) -> int:
+    return int(_sampling_section(spec).get("sample_n", DEFAULT_SAMPLE_N) or DEFAULT_SAMPLE_N)
+
+
+def sampling_config_fingerprint(spec: Dict[str, Any]) -> Dict[str, Any]:
+    sampling = _sampling_section(spec)
+    return {
+        "algorithm": sampling.get("algorithm", DEFAULT_SAMPLING_ALGORITHM),
+        "feature_dimensions": list(
+            sampling.get("feature_dimensions", []) or DEFAULT_ISLAND_FEATURE_DIMENSIONS
+        ),
+        "feature_bins": int(sampling.get("feature_bins", DEFAULT_ISLAND_FEATURE_BINS) or DEFAULT_ISLAND_FEATURE_BINS),
+        "custom_sampler_path": str(sampling.get("custom_sampler_path", "") or ""),
+        "custom_sampler_class": str(sampling.get("custom_sampler_class", "") or ""),
+    }
+
+
+def run_has_recorded_nodes(run_dir: Path) -> bool:
+    data_file = Path(run_dir) / "database_data" / "nodes.json"
+    if not data_file.exists():
+        return False
+    try:
+        payload = json.loads(data_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return True
+    return bool(payload.get("nodes", {}))
+
+
+def resolve_sampling_path(workspace_root: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    return (Path(workspace_root).resolve() / path).resolve()
+
+
+def custom_sampler_runtime_config(
+    spec: Dict[str, Any],
+    workspace_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    sampling = _sampling_section(spec)
+    custom_path = str(sampling.get("custom_sampler_path", "") or "").strip()
+    custom_class = str(sampling.get("custom_sampler_class", "") or "").strip()
+    if not custom_path:
+        return {}
+
+    resolved_path = (
+        resolve_sampling_path(Path(workspace_root), custom_path)
+        if workspace_root is not None
+        else Path(custom_path).resolve()
+    )
+    search_paths = [str(resolved_path.parent)]
+    if workspace_root is not None:
+        search_paths.append(str(Path(workspace_root).resolve()))
+    runtime_config: Dict[str, Any] = {
+        "custom_sampler_path": str(resolved_path),
+        "custom_sampler_search_paths": search_paths,
+    }
+    if custom_class:
+        runtime_config["custom_sampler_class"] = custom_class
+    return runtime_config
+
+
+def build_database_sampling_config(
+    spec: Dict[str, Any],
+    workspace_root: Path,
+) -> Tuple[str, Dict[str, Any]]:
+    algorithm = configured_sampling_algorithm(spec)
+    if algorithm == "island":
+        return (
+            algorithm,
+            {
+                "feature_dimensions": list(
+                    _sampling_section(spec).get("feature_dimensions")
+                    or DEFAULT_ISLAND_FEATURE_DIMENSIONS
+                ),
+                "feature_bins": int(
+                    _sampling_section(spec).get("feature_bins", DEFAULT_ISLAND_FEATURE_BINS)
+                    or DEFAULT_ISLAND_FEATURE_BINS
+                ),
+            },
+        )
+    if algorithm == "custom":
+        return algorithm, custom_sampler_runtime_config(spec, workspace_root)
+    return algorithm, {}
+
+
+def validate_custom_sampler_for_workspace(
+    spec: Dict[str, Any],
+    workspace_root: Optional[Path] = None,
+) -> str:
+    if configured_sampling_algorithm(spec) != "custom":
+        return ""
+
+    runtime_config = custom_sampler_runtime_config(spec, workspace_root)
+    custom_path = str(_sampling_section(spec).get("custom_sampler_path", "") or "").strip()
+    custom_class = str(_sampling_section(spec).get("custom_sampler_class", "") or "").strip()
+    if not custom_path or not custom_class:
+        return ""
+
+    try:
+        load_custom_sampler_class(
+            runtime_config["custom_sampler_path"],
+            custom_class,
+            search_paths=runtime_config.get("custom_sampler_search_paths"),
+        )
+    except Exception as exc:  # pragma: no cover - surfaced validation path
+        return str(exc)
+    return ""
+
+
+def sampling_summary_lines(
+    spec: Dict[str, Any],
+    workspace_root: Optional[Path] = None,
+) -> List[str]:
+    sampling = _sampling_section(spec)
+    sampling_algorithm = _sampling_algorithm_value(spec) or "(missing)"
+    lines = [
+        f"- Sampling algorithm: {sampling_algorithm}",
+        f"- Sample count: {sampling.get('sample_n', 0)}",
+    ]
+    if sampling_algorithm == "island":
+        feature_dimensions = sampling.get("feature_dimensions", []) or DEFAULT_ISLAND_FEATURE_DIMENSIONS
+        lines.extend(
+            [
+                f"- Island feature dimensions: {', '.join(feature_dimensions)}",
+                f"- Island feature bins: {sampling.get('feature_bins', DEFAULT_ISLAND_FEATURE_BINS)}",
+                "- Island built-ins: complexity=len(code), diversity=code-difference heuristic",
+            ]
+        )
+    elif sampling_algorithm == "custom":
+        lines.extend(
+            [
+                f"- Custom sampler path: {sampling.get('custom_sampler_path', '') or '(missing)'}",
+                f"- Custom sampler class: {sampling.get('custom_sampler_class', '') or '(missing)'}",
+            ]
+        )
+        custom_sampler_error = validate_custom_sampler_for_workspace(spec, workspace_root)
+        if custom_sampler_error:
+            lines.append(f"- Custom sampler validation error: {custom_sampler_error}")
+    return lines

--- a/src/workflow/workflows/evolve/scripts/evolve_core/structures.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/structures.py
@@ -1,0 +1,93 @@
+"""Core data structures for the Evolve skill runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Node:
+    """One recorded evolution node."""
+
+    name: str = ""
+    created_at: str = ""
+    parent: List[int] = field(default_factory=list)
+    motivation: str = ""
+    code: str = ""
+    results: Dict[str, Any] = field(default_factory=dict)
+    analysis: str = ""
+    meta_info: Dict[str, Any] = field(default_factory=dict)
+    id: Optional[int] = None
+    visit_count: int = 0
+    score: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            self.created_at = datetime.now().isoformat()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "created_at": self.created_at,
+            "parent": self.parent,
+            "motivation": self.motivation,
+            "code": self.code,
+            "results": self.results,
+            "analysis": self.analysis,
+            "meta_info": self.meta_info,
+            "visit_count": self.visit_count,
+            "score": self.score,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Node":
+        return cls(
+            id=data.get("id"),
+            name=data.get("name", ""),
+            created_at=data.get("created_at", ""),
+            parent=data.get("parent", []),
+            motivation=data.get("motivation", ""),
+            code=data.get("code", ""),
+            results=data.get("results", {}),
+            analysis=data.get("analysis", ""),
+            meta_info=data.get("meta_info", {}),
+            visit_count=data.get("visit_count", 0),
+            score=data.get("score", 0.0),
+        )
+
+    def get_context_text(self) -> str:
+        return " ".join(
+            value
+            for value in [self.name, self.motivation, self.analysis]
+            if value
+        )
+
+
+@dataclass
+class CognitionItem:
+    """One cognition item stored for semantic retrieval."""
+
+    content: str
+    source: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "content": self.content,
+            "source": self.source,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CognitionItem":
+        return cls(
+            id=data.get("id"),
+            content=data.get("content", ""),
+            source=data.get("source", ""),
+            metadata=data.get("metadata", {}),
+        )

--- a/src/workflow/workflows/evolve/scripts/evolve_core/vector_index.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_core/vector_index.py
@@ -1,0 +1,191 @@
+"""Vector index wrapper with FAISS and pickle-backed fallbacks."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from threading import RLock
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+try:
+    import faiss
+
+    FAISS_AVAILABLE = True
+except Exception:
+    faiss = None
+    FAISS_AVAILABLE = False
+
+
+class FAISSIndex:
+    """Manage semantic retrieval with FAISS when available, else brute force."""
+
+    def __init__(
+        self,
+        dimension: int = 384,
+        index_type: str = "IP",
+        storage_path: Optional[Path] = None,
+    ):
+        self.dimension = dimension
+        self.index_type = index_type
+        self.storage_path = Path(storage_path) if storage_path else None
+        self.lock = RLock()
+        self.use_faiss = FAISS_AVAILABLE
+        self.id_to_idx: Dict[int, int] = {}
+        self.idx_to_id: Dict[int, int] = {}
+        self.next_idx = 0
+        self.vectors: Dict[int, np.ndarray] = {}
+
+        if self.use_faiss:
+            self.index = self._create_faiss_index()
+        else:
+            self.index = None
+
+        if self.storage_path:
+            self._load()
+
+    def add(self, node_id: int, vector: np.ndarray) -> None:
+        with self.lock:
+            if node_id in self.id_to_idx or node_id in self.vectors:
+                return
+
+            normalized = self._normalize(vector.reshape(1, -1).astype(np.float32))[0]
+            if self.use_faiss and self.index is not None:
+                self.index.add(normalized.reshape(1, -1))
+                self.id_to_idx[node_id] = self.next_idx
+                self.idx_to_id[self.next_idx] = node_id
+                self.next_idx += 1
+            else:
+                self.vectors[node_id] = normalized
+
+    def search(
+        self,
+        query_vector: np.ndarray,
+        top_k: int = 5,
+        score_threshold: float = 0.0,
+    ) -> List[Tuple[int, float]]:
+        with self.lock:
+            if self.use_faiss and self.index is not None:
+                if self.index.ntotal == 0:
+                    return []
+                query = self._normalize(query_vector.reshape(1, -1).astype(np.float32))
+                k = min(top_k, self.index.ntotal)
+                scores, indices = self.index.search(query, k)
+                results: List[Tuple[int, float]] = []
+                for score, idx in zip(scores[0], indices[0]):
+                    if idx < 0 or score < score_threshold:
+                        continue
+                    node_id = self.idx_to_id.get(int(idx))
+                    if node_id is not None:
+                        results.append((node_id, float(score)))
+                return results
+
+            if not self.vectors:
+                return []
+
+            query = self._normalize(query_vector.reshape(1, -1).astype(np.float32))[0]
+            scored: List[Tuple[int, float]] = []
+            for node_id, vector in self.vectors.items():
+                if self.index_type == "IP":
+                    score = float(np.dot(query, vector))
+                else:
+                    score = -float(np.linalg.norm(query - vector))
+                if score >= score_threshold:
+                    scored.append((node_id, score))
+            scored.sort(key=lambda item: item[1], reverse=True)
+            return scored[:top_k]
+
+    def remove(self, node_id: int) -> None:
+        with self.lock:
+            if self.use_faiss and node_id in self.id_to_idx:
+                idx = self.id_to_idx.pop(node_id)
+                self.idx_to_id.pop(idx, None)
+            self.vectors.pop(node_id, None)
+
+    def save(self) -> None:
+        if not self.storage_path:
+            return
+
+        with self.lock:
+            self.storage_path.mkdir(parents=True, exist_ok=True)
+            if self.use_faiss and self.index is not None:
+                faiss.write_index(self.index, str(self.storage_path / "faiss.index"))
+                meta = {
+                    "id_to_idx": self.id_to_idx,
+                    "idx_to_id": self.idx_to_id,
+                    "next_idx": self.next_idx,
+                    "use_faiss": True,
+                    "dimension": self.dimension,
+                    "index_type": self.index_type,
+                }
+                with open(self.storage_path / "faiss_meta.pkl", "wb") as handle:
+                    pickle.dump(meta, handle)
+            else:
+                payload = {
+                    "vectors": {node_id: vector.tolist() for node_id, vector in self.vectors.items()},
+                    "use_faiss": False,
+                    "dimension": self.dimension,
+                    "index_type": self.index_type,
+                }
+                with open(self.storage_path / "vector_store.pkl", "wb") as handle:
+                    pickle.dump(payload, handle)
+
+    def reset(self) -> None:
+        with self.lock:
+            if self.use_faiss:
+                self.index = self._create_faiss_index()
+                self.id_to_idx.clear()
+                self.idx_to_id.clear()
+                self.next_idx = 0
+            else:
+                self.vectors.clear()
+
+            if self.storage_path and self.storage_path.exists():
+                for path in self.storage_path.glob("*"):
+                    if path.is_file():
+                        path.unlink()
+
+    def _load(self) -> None:
+        if not self.storage_path:
+            return
+
+        faiss_index = self.storage_path / "faiss.index"
+        faiss_meta = self.storage_path / "faiss_meta.pkl"
+        vector_store = self.storage_path / "vector_store.pkl"
+
+        if self.use_faiss and faiss_index.exists() and faiss_meta.exists():
+            try:
+                self.index = faiss.read_index(str(faiss_index))
+                with open(faiss_meta, "rb") as handle:
+                    meta = pickle.load(handle)
+                self.id_to_idx = meta.get("id_to_idx", {})
+                self.idx_to_id = meta.get("idx_to_id", {})
+                self.next_idx = meta.get("next_idx", 0)
+                return
+            except Exception:
+                self.use_faiss = False
+                self.index = None
+
+        if vector_store.exists():
+            with open(vector_store, "rb") as handle:
+                payload = pickle.load(handle)
+            self.use_faiss = False
+            self.vectors = {
+                int(node_id): np.array(vector, dtype=np.float32)
+                for node_id, vector in payload.get("vectors", {}).items()
+            }
+
+    def _create_faiss_index(self):
+        if not self.use_faiss:
+            return None
+        if self.index_type == "IP":
+            return faiss.IndexFlatIP(self.dimension)
+        return faiss.IndexFlatL2(self.dimension)
+
+    def _normalize(self, vectors: np.ndarray) -> np.ndarray:
+        if self.index_type == "IP":
+            norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            return vectors / norms
+        return vectors

--- a/src/workflow/workflows/evolve/scripts/evolve_result.py
+++ b/src/workflow/workflows/evolve/scripts/evolve_result.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Translate evolve_core helper output into IronCurtain result-file verdicts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _numeric_score(results: dict[str, Any]) -> float | None:
+    raw = results.get("eval_score", results.get("score"))
+    if isinstance(raw, bool) or raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
+def _run_helper(argv: list[str]) -> tuple[int, dict[str, Any] | None, str]:
+    completed = subprocess.run(argv, capture_output=True, text=True)
+    error = completed.stderr.strip()
+    try:
+        payload = json.loads(completed.stdout) if completed.stdout.strip() else None
+    except json.JSONDecodeError as exc:
+        payload = None
+        error = f"{error}\ninvalid helper JSON: {exc}".strip()
+    return completed.returncode, payload, error
+
+
+def evaluate(args: argparse.Namespace) -> int:
+    result_file = Path(args.result_file)
+    helper = SCRIPT_DIR / "evolve-eval"
+    helper_return_code, engine, helper_error = _run_helper(
+        [
+            sys.executable,
+            str(helper),
+            "run",
+            "--run-dir",
+            args.run_dir,
+            "--code-path",
+            args.code_path,
+            "--step-name",
+            args.step_name,
+            "--timeout",
+            str(args.timeout),
+        ]
+    )
+
+    payload: dict[str, Any] = {}
+    if isinstance(engine, dict):
+        payload.update(
+            {
+                "return_code": engine.get("return_code"),
+                "success": engine.get("success"),
+                "results_path": engine.get("results_path"),
+                "step_dir": engine.get("step_dir"),
+            }
+        )
+
+    if helper_return_code != 0 or not isinstance(engine, dict):
+        payload["error"] = helper_error or f"evolve-eval exited with code {helper_return_code}"
+        _write_json(result_file, {"verdict": "evaluator_blocked", "payload": payload, "passed": False})
+        return 0
+
+    engine_return_code = engine.get("return_code")
+    results_path = Path(engine.get("results_path") or Path(args.run_dir) / "steps" / args.step_name / "results.json")
+    results: dict[str, Any] = {}
+    if results_path.exists():
+        try:
+            loaded = _load_json(results_path)
+            if isinstance(loaded, dict):
+                results = loaded
+            else:
+                payload["error"] = f"results file is not a JSON object: {results_path}"
+        except Exception as exc:
+            payload["error"] = f"could not read results file {results_path}: {exc}"
+    else:
+        payload["error"] = f"results file not found: {results_path}"
+
+    score = _numeric_score(results)
+    if score is not None:
+        payload["score"] = score
+
+    if engine_return_code == 0 and score is not None:
+        verdict = "evaluated"
+        passed = True
+    else:
+        verdict = "evaluator_blocked"
+        passed = False
+        if "error" not in payload:
+            payload["error"] = results.get("error") or f"evaluator returned code {engine_return_code}"
+
+    _write_json(result_file, {"verdict": verdict, "payload": payload, "passed": passed})
+    return 0
+
+
+def record(args: argparse.Namespace) -> int:
+    result_file = Path(args.result_file)
+    helper = SCRIPT_DIR / "evolve-db"
+    helper_return_code, engine, helper_error = _run_helper(
+        [
+            sys.executable,
+            str(helper),
+            "record",
+            "--run-dir",
+            args.run_dir,
+            "--step-name",
+            args.step_name,
+            "--name",
+            args.name,
+            "--code-path",
+            args.code_path,
+            "--results-file",
+            args.results_file,
+        ]
+    )
+
+    payload: dict[str, Any] = {}
+    if isinstance(engine, dict):
+        payload.update(
+            {
+                "node_id": engine.get("node_id"),
+                "best_updated": engine.get("best_updated"),
+                "step_dir": engine.get("step_dir"),
+            }
+        )
+
+    if helper_return_code == 0 and isinstance(engine, dict) and engine.get("node_id") is not None:
+        verdict = "recorded"
+        passed = True
+    else:
+        verdict = "needs_repair"
+        passed = False
+        payload["error"] = helper_error or f"evolve-db exited with code {helper_return_code}"
+
+    _write_json(result_file, {"verdict": verdict, "payload": payload, "passed": passed})
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    eval_parser = subparsers.add_parser("evaluate")
+    eval_parser.add_argument("--run-dir", required=True)
+    eval_parser.add_argument("--step-name", required=True)
+    eval_parser.add_argument("--code-path", required=True)
+    eval_parser.add_argument("--result-file", required=True)
+    eval_parser.add_argument("--timeout", type=int, default=30)
+    eval_parser.set_defaults(func=evaluate)
+
+    record_parser = subparsers.add_parser("record")
+    record_parser.add_argument("--run-dir", required=True)
+    record_parser.add_argument("--step-name", required=True)
+    record_parser.add_argument("--name", required=True)
+    record_parser.add_argument("--code-path", required=True)
+    record_parser.add_argument("--results-file", required=True)
+    record_parser.add_argument("--result-file", required=True)
+    record_parser.set_defaults(func=record)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/workflow/workflows/evolve/scripts/requirements.txt
+++ b/src/workflow/workflows/evolve/scripts/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pyyaml

--- a/src/workflow/workflows/evolve/workflow.yaml
+++ b/src/workflow/workflows/evolve/workflow.yaml
@@ -1,0 +1,148 @@
+name: evolve
+description: 'Evolve - single-round evaluator-driven candidate search (first vertical slice).'
+initial: preflight
+
+settings:
+  mode: docker
+  dockerAgent: claude-code
+  sharedContainer: true
+  model: anthropic:claude-sonnet-4-6
+
+states:
+  preflight:
+    type: agent
+    description: Define the run spec and initialize the evolve run.
+    persona: global
+    prompt: |
+      You are configuring a single-round Evolve experiment. The task describes a
+      program-search objective with an evaluator that prints a score.
+
+      Do BOTH of these, in order, then finish with the required agent_status block:
+
+      1. Initialize the run by executing the evolve-brief helper. The run lives under
+         /workspace/.evolve_runs/main/. Use these flags, filling OBJECTIVE and EVAL_CMD
+         from the task:
+
+         /opt/workflow-venv/bin/python /workflow-scripts/evolve-brief normalize \
+           --workspace-root /workspace \
+           --run-name main \
+           --objective "OBJECTIVE" \
+           --core-score eval_score \
+           --evaluation-command "EVAL_CMD" \
+           --evaluation-timeout-secs 30 \
+           --success-criterion "eval_score >= 1.0" \
+           --max-rounds 1 \
+           --patience 1 \
+           --stop-condition "max_rounds" \
+           --writable-path .evolve_runs \
+           --primary-target candidate.py \
+           --sampling-algorithm greedy \
+           --sample-n 1 \
+           --cognition-source-mode none \
+           --confirmed true
+
+         EVAL_CMD must be a shell command that reads the candidate at {quoted_code_path},
+         runs it, and writes a JSON file at {quoted_results_path} containing an
+         "eval_score" number. The helper substitutes {quoted_code_path} and
+         {quoted_results_path} at eval time.
+
+      2. Confirm the command exited 0 and that /workspace/.evolve_runs/main/run_spec.yaml exists.
+
+      If the task is missing an objective or an evaluator you cannot construct, set verdict: blocked.
+      Otherwise set verdict: ready.
+    inputs: []
+    outputs: []
+    transitions:
+      - to: researcher
+        when: { verdict: ready }
+      - to: failed
+        when: { verdict: blocked }
+
+  researcher:
+    type: agent
+    description: Materialize one candidate program at the step code path.
+    persona: global
+    prompt: |
+      Write exactly one candidate program for this round.
+
+      Write the COMPLETE candidate file to:
+        /workspace/.evolve_runs/main/steps/step_0001/code
+
+      Create the directory if needed. Write only that one file, with no extra files
+      and no commentary in the file. The candidate must satisfy the objective in
+      /workspace/.evolve_runs/main/run_spec.yaml.
+
+      Finish with the required agent_status block.
+    inputs: []
+    outputs: []
+    maxVisits: 3
+    transitions:
+      - to: evaluate
+
+  evaluate:
+    type: deterministic
+    description: Run the configured evaluator on the candidate inside the shared container.
+    container: true
+    resultFile: .evolve_runs/main/steps/step_0001/result.json
+    run:
+      - [
+          '/opt/workflow-venv/bin/python',
+          '/workflow-scripts/evolve_result.py',
+          'evaluate',
+          '--run-dir',
+          '/workspace/.evolve_runs/main',
+          '--step-name',
+          'step_0001',
+          '--code-path',
+          '.evolve_runs/main/steps/step_0001/code',
+          '--result-file',
+          '/workspace/.evolve_runs/main/steps/step_0001/result.json',
+        ]
+    transitions:
+      - to: record_node
+        when: { verdict: evaluated }
+      - to: failed
+        when: { verdict: evaluator_blocked }
+      - to: failed
+        when: { verdict: result_file_error }
+      - to: failed
+
+  record_node:
+    type: deterministic
+    description: Commit the scored candidate as a node and update the best snapshot.
+    container: true
+    resultFile: .evolve_runs/main/steps/step_0001/record_result.json
+    run:
+      - [
+          '/opt/workflow-venv/bin/python',
+          '/workflow-scripts/evolve_result.py',
+          'record',
+          '--run-dir',
+          '/workspace/.evolve_runs/main',
+          '--step-name',
+          'step_0001',
+          '--name',
+          'round-1',
+          '--code-path',
+          '.evolve_runs/main/steps/step_0001/code',
+          '--results-file',
+          '.evolve_runs/main/steps/step_0001/results.json',
+          '--result-file',
+          '/workspace/.evolve_runs/main/steps/step_0001/record_result.json',
+        ]
+    transitions:
+      - to: done
+        when: { verdict: recorded }
+      - to: failed
+        when: { verdict: needs_repair }
+      - to: failed
+        when: { verdict: result_file_error }
+      - to: failed
+
+  done:
+    type: terminal
+    description: One candidate scored and recorded; best snapshot updated.
+
+  failed:
+    type: terminal
+    description: Preflight blocked, evaluator failed, or record failed.

--- a/test/workflow/evolve-result-bridge.test.ts
+++ b/test/workflow/evolve-result-bridge.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { parse as parseYaml } from 'yaml';
+import { validateDefinition } from '../../src/workflow/validate.js';
+import { lintWorkflow } from '../../src/workflow/lint.js';
+
+const PYTHON = process.env.PYTHON ?? 'python3';
+const WORKFLOW_DIR = resolve(__dirname, '..', '..', 'src', 'workflow', 'workflows', 'evolve');
+const BRIDGE_PATH = resolve(WORKFLOW_DIR, 'scripts', 'evolve_result.py');
+
+describe('evolve workflow manifest', () => {
+  it('validates and lints cleanly', () => {
+    const manifestPath = resolve(WORKFLOW_DIR, 'workflow.yaml');
+    const raw = parseYaml(readFileSync(manifestPath, 'utf-8'), { maxAliasCount: 0 });
+    const def = validateDefinition(raw);
+    const diagnostics = lintWorkflow(def, { personaExists: () => false, workflowFilePath: manifestPath });
+
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expect(diagnostics.map((d) => d.code)).not.toContain('WF011');
+    expect(diagnostics.map((d) => d.code)).not.toContain('WF012');
+  });
+
+  it('preflight prompt supplies the required confirmed run-spec fields', () => {
+    const manifestPath = resolve(WORKFLOW_DIR, 'workflow.yaml');
+    const raw = parseYaml(readFileSync(manifestPath, 'utf-8'), { maxAliasCount: 0 }) as {
+      states: { preflight: { prompt: string } };
+    };
+    const prompt = raw.states.preflight.prompt;
+
+    for (const flag of [
+      '--workspace-root /workspace',
+      '--run-name main',
+      '--objective "OBJECTIVE"',
+      '--core-score eval_score',
+      '--evaluation-command "EVAL_CMD"',
+      '--evaluation-timeout-secs 30',
+      '--success-criterion "eval_score >= 1.0"',
+      '--max-rounds 1',
+      '--patience 1',
+      '--stop-condition "max_rounds"',
+      '--writable-path .evolve_runs',
+      '--primary-target candidate.py',
+      '--sampling-algorithm greedy',
+      '--sample-n 1',
+      '--cognition-source-mode none',
+      '--confirmed true',
+    ]) {
+      expect(prompt).toContain(flag);
+    }
+  });
+});
+
+describe('evolve_result.py bridge', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'evolve-result-bridge-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeHarness(opts: { evalStub?: string; dbStub?: string }): string {
+    const scriptsDir = resolve(tmpDir, 'scripts');
+    mkdirSync(scriptsDir, { recursive: true });
+    cpSync(BRIDGE_PATH, resolve(scriptsDir, 'evolve_result.py'));
+    writeFileSync(
+      resolve(scriptsDir, 'evolve-eval'),
+      opts.evalStub ??
+        [
+          'import json, sys',
+          'from pathlib import Path',
+          "run_dir = Path(sys.argv[sys.argv.index('--run-dir') + 1])",
+          "step = sys.argv[sys.argv.index('--step-name') + 1]",
+          "result = run_dir / 'steps' / step / 'results.json'",
+          'result.parent.mkdir(parents=True, exist_ok=True)',
+          "result.write_text(json.dumps({'eval_score': 6, 'success': True}), encoding='utf-8')",
+          "print(json.dumps({'results_path': str(result), 'return_code': 0, 'step_dir': str(result.parent), 'success': True}))",
+        ].join('\n') + '\n',
+    );
+    writeFileSync(
+      resolve(scriptsDir, 'evolve-db'),
+      opts.dbStub ??
+        ['import json', "print(json.dumps({'node_id': 0, 'best_updated': True, 'step_dir': '/tmp/step'}))"].join('\n') +
+          '\n',
+    );
+    return scriptsDir;
+  }
+
+  function runBridge(
+    scriptsDir: string,
+    args: readonly string[],
+  ): { status: number | null; result: Record<string, unknown> } {
+    const resultFile = resolve(tmpDir, 'result.json');
+    const completed = spawnSync(
+      PYTHON,
+      [resolve(scriptsDir, 'evolve_result.py'), ...args, '--result-file', resultFile],
+      {
+        encoding: 'utf-8',
+      },
+    );
+    if (completed.error) throw completed.error;
+    expect(completed.stderr).toBe('');
+    expect(existsSync(resultFile)).toBe(true);
+    return {
+      status: completed.status,
+      result: JSON.parse(readFileSync(resultFile, 'utf-8')) as Record<string, unknown>,
+    };
+  }
+
+  function evalArgs(runDir = resolve(tmpDir, 'run')): string[] {
+    return ['evaluate', '--run-dir', runDir, '--step-name', 'step_0001', '--code-path', 'candidate.py'];
+  }
+
+  it('maps a numeric eval_score to verdict evaluated', () => {
+    const scriptsDir = writeHarness({});
+    const { status, result } = runBridge(scriptsDir, evalArgs());
+
+    expect(status).toBe(0);
+    expect(result).toMatchObject({
+      verdict: 'evaluated',
+      passed: true,
+      payload: { score: 6, return_code: 0, success: true },
+    });
+  });
+
+  it('keeps a low numeric score as evaluated, not evaluator_blocked', () => {
+    const scriptsDir = writeHarness({
+      evalStub:
+        [
+          'import json, sys',
+          'from pathlib import Path',
+          "run_dir = Path(sys.argv[sys.argv.index('--run-dir') + 1])",
+          "step = sys.argv[sys.argv.index('--step-name') + 1]",
+          "result = run_dir / 'steps' / step / 'results.json'",
+          'result.parent.mkdir(parents=True, exist_ok=True)',
+          "result.write_text(json.dumps({'eval_score': 0, 'success': False}), encoding='utf-8')",
+          "print(json.dumps({'results_path': str(result), 'return_code': 0, 'step_dir': str(result.parent), 'success': True}))",
+        ].join('\n') + '\n',
+    });
+
+    const { result } = runBridge(scriptsDir, evalArgs());
+    expect(result).toMatchObject({ verdict: 'evaluated', passed: true, payload: { score: 0 } });
+  });
+
+  it('maps evaluator subprocess failure to evaluator_blocked while exiting successfully', () => {
+    const scriptsDir = writeHarness({
+      evalStub:
+        [
+          'import json, sys',
+          'from pathlib import Path',
+          "run_dir = Path(sys.argv[sys.argv.index('--run-dir') + 1])",
+          "step = sys.argv[sys.argv.index('--step-name') + 1]",
+          "result = run_dir / 'steps' / step / 'results.json'",
+          'result.parent.mkdir(parents=True, exist_ok=True)',
+          "result.write_text(json.dumps({'eval_score': 0, 'success': False, 'error': 'boom'}), encoding='utf-8')",
+          "print(json.dumps({'results_path': str(result), 'return_code': 1, 'step_dir': str(result.parent), 'success': False}))",
+        ].join('\n') + '\n',
+    });
+
+    const { status, result } = runBridge(scriptsDir, evalArgs());
+    expect(status).toBe(0);
+    expect(result.verdict).toBe('evaluator_blocked');
+    expect(result.passed).toBe(false);
+  });
+
+  it('maps evolve-eval wrapper failure to evaluator_blocked while exiting successfully', () => {
+    const scriptsDir = writeHarness({
+      evalStub: "import sys\nprint('preflight is incomplete', file=sys.stderr)\nsys.exit(5)\n",
+    });
+
+    const { status, result } = runBridge(scriptsDir, evalArgs());
+    expect(status).toBe(0);
+    expect(result.verdict).toBe('evaluator_blocked');
+    expect(result.passed).toBe(false);
+  });
+
+  it('maps missing or nonnumeric results to evaluator_blocked', () => {
+    const missingScripts = writeHarness({
+      evalStub:
+        [
+          'import json, sys',
+          'from pathlib import Path',
+          "run_dir = Path(sys.argv[sys.argv.index('--run-dir') + 1])",
+          "step = sys.argv[sys.argv.index('--step-name') + 1]",
+          "result = run_dir / 'steps' / step / 'results.json'",
+          "print(json.dumps({'results_path': str(result), 'return_code': 0, 'step_dir': str(result.parent), 'success': True}))",
+        ].join('\n') + '\n',
+    });
+    expect(runBridge(missingScripts, evalArgs(resolve(tmpDir, 'missing-run'))).result.verdict).toBe(
+      'evaluator_blocked',
+    );
+
+    const nonnumericScripts = writeHarness({
+      evalStub:
+        [
+          'import json, sys',
+          'from pathlib import Path',
+          "run_dir = Path(sys.argv[sys.argv.index('--run-dir') + 1])",
+          "step = sys.argv[sys.argv.index('--step-name') + 1]",
+          "result = run_dir / 'steps' / step / 'results.json'",
+          'result.parent.mkdir(parents=True, exist_ok=True)',
+          "result.write_text(json.dumps({'eval_score': 'six'}), encoding='utf-8')",
+          "print(json.dumps({'results_path': str(result), 'return_code': 0, 'step_dir': str(result.parent), 'success': True}))",
+        ].join('\n') + '\n',
+    });
+    expect(runBridge(nonnumericScripts, evalArgs(resolve(tmpDir, 'nonnumeric-run'))).result.verdict).toBe(
+      'evaluator_blocked',
+    );
+  });
+
+  it('maps record success and failure to recorded/needs_repair verdicts', () => {
+    const successScripts = writeHarness({});
+    const success = runBridge(successScripts, [
+      'record',
+      '--run-dir',
+      resolve(tmpDir, 'run'),
+      '--step-name',
+      'step_0001',
+      '--name',
+      'round-1',
+      '--code-path',
+      'candidate.py',
+      '--results-file',
+      'results.json',
+    ]);
+
+    expect(success.status).toBe(0);
+    expect(success.result).toMatchObject({
+      verdict: 'recorded',
+      passed: true,
+      payload: { node_id: 0, best_updated: true },
+    });
+
+    const failureScripts = writeHarness({
+      dbStub: "import sys\nprint('db failed', file=sys.stderr)\nsys.exit(7)\n",
+    });
+    const failure = runBridge(failureScripts, [
+      'record',
+      '--run-dir',
+      resolve(tmpDir, 'run2'),
+      '--step-name',
+      'step_0001',
+      '--name',
+      'round-1',
+      '--code-path',
+      'candidate.py',
+      '--results-file',
+      'results.json',
+    ]);
+
+    expect(failure.status).toBe(0);
+    expect(failure.result.verdict).toBe('needs_repair');
+    expect(failure.result.passed).toBe(false);
+  });
+});

--- a/test/workflow/evolve-single-round.integration.test.ts
+++ b/test/workflow/evolve-single-round.integration.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { REAL_TMP, testCompiledPolicy, testToolAnnotations } from '../fixtures/test-policy.js';
+import { isDockerAvailable, isDockerImageAvailable } from '../helpers/docker-available.js';
+import type { IronCurtainConfig } from '../../src/config/types.js';
+import {
+  createDockerInfrastructure,
+  destroyDockerInfrastructure,
+  type DockerInfrastructure,
+} from '../../src/docker/docker-infrastructure.js';
+import {
+  WorkflowOrchestrator,
+  type CreateWorkflowInfrastructureInput,
+  type WorkflowLifecycleEvent,
+} from '../../src/workflow/orchestrator.js';
+import type { SessionOptions } from '../../src/session/types.js';
+import { approvedResponse, createDeps, MockSession, statusBlock, waitForCompletion } from './test-helpers.js';
+
+const IMAGE = 'ironcurtain-claude-code:latest';
+const TEST_HOME = `${REAL_TMP}/ironcurtain-evolve-single-round-${process.pid}`;
+const TASK = 'write solve(xs) returning the sum; the evaluator scores solve([1,2,3]) == 6';
+
+type CandidateKind = 'sum' | 'low-score' | 'crash';
+
+function findHostCaDir(): string | null {
+  const home = process.env.IRONCURTAIN_HOME ?? join(homedir(), '.ironcurtain');
+  const ca = join(home, 'ca');
+  return existsSync(ca) ? ca : null;
+}
+
+const hostCaDir = findHostCaDir();
+const dockerReady =
+  process.env.INTEGRATION_TEST === '1' && isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+
+function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): IronCurtainConfig {
+  return {
+    auditLogPath: join(workspaceDir, 'audit.jsonl'),
+    allowedDirectory: workspaceDir,
+    mcpServers: {},
+    protectedPaths: [],
+    generatedDir,
+    constitutionPath: join(generatedDir, 'constitution.md'),
+    agentModelId: 'anthropic:claude-sonnet-4-6',
+    escalationTimeoutSeconds: 300,
+    userConfig: {
+      agentModelId: 'anthropic:claude-sonnet-4-6',
+      policyModelId: 'anthropic:claude-sonnet-4-6',
+      anthropicApiKey: 'test-fake-key-no-network',
+      googleApiKey: '',
+      openaiApiKey: '',
+      escalationTimeoutSeconds: 300,
+      resourceBudget: {
+        maxTotalTokens: 1_000_000,
+        maxSteps: 200,
+        maxSessionSeconds: 1800,
+        maxEstimatedCostUsd: 5.0,
+        warnThresholdPercent: 80,
+      },
+      autoCompact: {
+        enabled: false,
+        thresholdTokens: 80_000,
+        keepRecentMessages: 10,
+        summaryModelId: 'anthropic:claude-haiku-4-5',
+      },
+      autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
+      auditRedaction: { enabled: false },
+      memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
+      packageInstall: {
+        enabled: false,
+        quarantineDays: 2,
+        allowedPackages: [],
+        deniedPackages: [],
+      },
+      serverCredentials: {},
+      dockerResources: { memoryMb: null, cpus: null },
+    },
+  } as unknown as IronCurtainConfig;
+}
+
+function writePreflightRunSpec(workspacePath: string): void {
+  const runDir = resolve(workspacePath, '.evolve_runs', 'main');
+  mkdirSync(resolve(runDir, 'steps'), { recursive: true });
+  mkdirSync(resolve(runDir, 'database_data'), { recursive: true });
+  mkdirSync(resolve(runDir, 'cognition_data'), { recursive: true });
+  mkdirSync(resolve(runDir, 'best'), { recursive: true });
+  writeFileSync(resolve(runDir, 'round_log.jsonl'), '');
+
+  const evaluationCommand = [
+    "python3 -c '",
+    'import json;',
+    'ns={{}};',
+    'exec(open({quoted_code_path}).read(), ns);',
+    's=ns["solve"]([1,2,3]);',
+    'json.dump({{"eval_score": float(s), "success": s == 6}}, open({quoted_results_path}, "w"))',
+    "'",
+  ].join('');
+  const runSpec = {
+    objective: TASK,
+    evaluation: {
+      core_score: 'eval_score',
+      secondary_metrics: [],
+      command: evaluationCommand,
+      script_path: '',
+      timeout_secs: 30,
+      success_criteria: ['eval_score >= 1.0'],
+    },
+    budget: { max_rounds: 1, patience: 1 },
+    stop_conditions: ['max_rounds'],
+    mutation_scope: {
+      writable_paths: ['.evolve_runs'],
+      primary_targets: ['candidate.py'],
+    },
+    sampling: {
+      algorithm: 'greedy',
+      sample_n: 1,
+      feature_dimensions: [],
+      feature_bins: 0,
+      custom_sampler_path: '',
+      custom_sampler_class: '',
+    },
+    cognition: { source_mode: 'none', seed_files: [], seed_notes: [] },
+    approval: { confirmed: true },
+  };
+  writeFileSync(resolve(runDir, 'run_spec.yaml'), JSON.stringify(runSpec, null, 2) + '\n');
+  writeFileSync(resolve(runDir, 'preflight_summary.md'), '# Preflight Summary\n\n- Status: `READY`\n');
+  writeFileSync(resolve(runDir, 'cognition_seed.md'), '# Cognition Seed Draft\n');
+}
+
+function writeCandidate(workspacePath: string, kind: CandidateKind): void {
+  const stepDir = resolve(workspacePath, '.evolve_runs', 'main', 'steps', 'step_0001');
+  mkdirSync(stepDir, { recursive: true });
+  const candidates: Record<CandidateKind, string> = {
+    sum: 'def solve(xs):\n    return sum(xs)\n',
+    'low-score': 'def solve(xs):\n    return 0\n',
+    crash: 'x = 1\n',
+  };
+  writeFileSync(resolve(stepDir, 'code'), candidates[kind]);
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+}
+
+describe.skipIf(!dockerReady)('evolve single-round workflow with real Docker container', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalAuth: string | undefined;
+  let originalApiKey: string | undefined;
+  const liveBundles = new Set<DockerInfrastructure>();
+
+  beforeAll(() => {
+    originalHome = process.env.IRONCURTAIN_HOME;
+    originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
+    originalApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.IRONCURTAIN_HOME = TEST_HOME;
+    process.env.IRONCURTAIN_DOCKER_AUTH = 'apikey';
+    process.env.ANTHROPIC_API_KEY = 'test-fake-key-no-network';
+    mkdirSync(TEST_HOME, { recursive: true });
+    cpSync(hostCaDir as string, join(TEST_HOME, 'ca'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    for (const bundle of liveBundles) {
+      await destroyDockerInfrastructure(bundle).catch(() => {});
+    }
+    liveBundles.clear();
+
+    if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = originalHome;
+    if (originalAuth === undefined) delete process.env.IRONCURTAIN_DOCKER_AUTH;
+    else process.env.IRONCURTAIN_DOCKER_AUTH = originalAuth;
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'evolve-single-round-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runEvolve(kind: CandidateKind): Promise<{ states: readonly string[]; workspaceDir: string }> {
+    const runDir = resolve(tmpDir, `run-${kind}`);
+    const workspaceDir = resolve(tmpDir, `workspace-${kind}`);
+    const generatedDir = resolve(TEST_HOME, `generated-${kind}`);
+    mkdirSync(runDir, { recursive: true });
+    mkdirSync(workspaceDir, { recursive: true });
+    mkdirSync(generatedDir, { recursive: true });
+    writeFileSync(resolve(generatedDir, 'compiled-policy.json'), JSON.stringify(testCompiledPolicy));
+    writeFileSync(resolve(generatedDir, 'tool-annotations.json'), JSON.stringify(testToolAnnotations));
+
+    const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) => {
+      const config = buildDockerSessionConfig(input.workspacePath, generatedDir);
+      const bundleDir = resolve(TEST_HOME, 'bundles', input.bundleId);
+      const escalationDir = resolve(bundleDir, 'escalations');
+      mkdirSync(bundleDir, { recursive: true });
+      mkdirSync(escalationDir, { recursive: true });
+      const bundle = await createDockerInfrastructure(
+        config,
+        { kind: 'docker', agent: 'claude-code' },
+        bundleDir,
+        input.workspacePath,
+        escalationDir,
+        input.bundleId,
+        input.workflowId,
+        input.scope,
+        input.resolvedSkills,
+        undefined,
+        input.workflowScriptsDir,
+      );
+      liveBundles.add(bundle);
+      return bundle;
+    });
+
+    const destroyInfra = vi.fn(async (bundle: DockerInfrastructure) => {
+      liveBundles.delete(bundle);
+      await destroyDockerInfrastructure(bundle);
+    });
+
+    let sessionCount = 0;
+    const createSession = vi.fn(async (options: SessionOptions) => {
+      const workspacePath = options.workspacePath;
+      if (!workspacePath) throw new Error('workflow agent session missing workspacePath');
+      sessionCount += 1;
+      if (sessionCount === 1) {
+        writePreflightRunSpec(workspacePath);
+        return new MockSession({ responses: () => statusBlock('ready', 'preflight confirmed') });
+      }
+      if (sessionCount === 2) {
+        writeCandidate(workspacePath, kind);
+        return new MockSession({ responses: () => approvedResponse('candidate written') });
+      }
+      throw new Error(`unexpected extra agent session ${sessionCount}`);
+    });
+
+    const orchestrator = new WorkflowOrchestrator(
+      createDeps(runDir, {
+        createSession,
+        createWorkflowInfrastructure: createInfra,
+        destroyWorkflowInfrastructure: destroyInfra,
+      }),
+    );
+    const states: string[] = [];
+    orchestrator.onEvent((event: WorkflowLifecycleEvent) => {
+      if (event.kind === 'state_entered') states.push(event.state);
+    });
+
+    const manifestPath = resolve(process.cwd(), 'src', 'workflow', 'workflows', 'evolve', 'workflow.yaml');
+    const workflowId = await orchestrator.start(manifestPath, TASK, workspaceDir);
+    await waitForCompletion(orchestrator, workflowId, 150_000);
+    await orchestrator.shutdownAll();
+    expect(sessionCount).toBe(2);
+    return { states, workspaceDir };
+  }
+
+  it('records a correct candidate and reaches done', async () => {
+    const { states, workspaceDir } = await runEvolve('sum');
+    const runDir = resolve(workspaceDir, '.evolve_runs', 'main');
+    const candidate = 'def solve(xs):\n    return sum(xs)\n';
+
+    expect(states.at(-1)).toBe('done');
+    expect(states).not.toContain('failed');
+    expect((readJson(resolve(runDir, 'steps', 'step_0001', 'result.json')) as { verdict: string }).verdict).toBe(
+      'evaluated',
+    );
+    expect((readJson(resolve(runDir, 'steps', 'step_0001', 'record_result.json')) as { verdict: string }).verdict).toBe(
+      'recorded',
+    );
+
+    const nodes = readJson(resolve(runDir, 'database_data', 'nodes.json')) as {
+      next_id: number;
+      nodes: Record<string, { score: number }>;
+    };
+    expect(nodes.next_id).toBe(1);
+    expect(Object.keys(nodes.nodes)).toEqual(['0']);
+    expect(nodes.nodes['0'].score).toBe(6);
+
+    expect(readFileSync(resolve(runDir, 'best', 'step_0001', 'code'), 'utf-8')).toBe(candidate);
+    expect((readJson(resolve(runDir, 'best', 'step_0001', 'results.json')) as { eval_score: number }).eval_score).toBe(
+      6,
+    );
+  }, 240_000);
+
+  it('records a low-score candidate and still reaches done', async () => {
+    const { states, workspaceDir } = await runEvolve('low-score');
+    const runDir = resolve(workspaceDir, '.evolve_runs', 'main');
+
+    expect(states.at(-1)).toBe('done');
+    const nodes = readJson(resolve(runDir, 'database_data', 'nodes.json')) as {
+      nodes: Record<string, { score: number }>;
+    };
+    expect(Object.keys(nodes.nodes)).toEqual(['0']);
+    expect(nodes.nodes['0'].score).toBe(0);
+    expect((readJson(resolve(runDir, 'steps', 'step_0001', 'result.json')) as { verdict: string }).verdict).toBe(
+      'evaluated',
+    );
+  }, 240_000);
+
+  it('routes evaluator crashes to failed without recording a node', async () => {
+    const { states, workspaceDir } = await runEvolve('crash');
+    const runDir = resolve(workspaceDir, '.evolve_runs', 'main');
+
+    expect(states.at(-1)).toBe('failed');
+    expect(states).toContain('evaluate');
+    expect(states).not.toContain('record_node');
+    expect((readJson(resolve(runDir, 'steps', 'step_0001', 'result.json')) as { verdict: string }).verdict).toBe(
+      'evaluator_blocked',
+    );
+    expect(existsSync(resolve(runDir, 'database_data', 'nodes.json'))).toBe(false);
+  }, 240_000);
+});

--- a/test/workflow/lint.test.ts
+++ b/test/workflow/lint.test.ts
@@ -829,6 +829,7 @@ describe('bundled workflows lint clean', () => {
     'test-email-summary',
     'deterministic-eval-smoke',
     'deterministic-verdict-smoke',
+    'evolve',
   ]) {
     it(`${name}: zero errors`, () => {
       const manifestPath = resolve(workflowsDir, name, 'workflow.yaml');


### PR DESCRIPTION
## What

The first vertical slice of the ASI-Evolve native workflow, and the first real consumer of the two merged runtime capabilities (containerized deterministic execution + script packaging #292; structured deterministic result contract #299). One evolution round, end to end: `preflight (agent) → researcher (agent) → evaluate (deterministic, container) → record_node (deterministic, container) → done`, plus a `failed` terminal. Design: `docs/designs/evolve-single-round-slice.md`.

## How

- Packages the real `evolve_core` engine (~2,700 LOC, **copied verbatim** from `donotcommit/ASI-Evolve/skills/evolve/scripts/evolve_core/`) into the workflow's `scripts/`, with the upstream **Apache-2.0 LICENSE and README** vendored alongside for attribution. Tier 0 deps (`numpy` + `pyyaml`) trigger the per-workflow image build.
- `evaluate` / `record_node` are `container: true` deterministic states that exec the engine via a thin `evolve_result.py` bridge (the only net-new Python) and route on `when:{verdict}` (`evaluated`/`evaluator_blocked`, `recorded`/`needs_repair`). The bridge keys the verdict on the engine's JSON `return_code`/`success` (not the wrapper exit code) and always exits 0 so `applyResultFile` reads the verdict file.
- Honors the signed-off maintainer decisions: engine-native `.evolve_runs/main/` layout (the engine hard-codes it; no override exists), and `preflight_review` deferred with `approval.confirmed=true` (the engine's `require_evolve_ready` still gates at the helper layer; the human gate returns in the next slice / for non-demo use).

## End-to-end gate — verified against real Docker

`test/workflow/evolve-single-round.integration.test.ts` (gated on `INTEGRATION_TEST=1`) is the binary completion gate, asserting **engine state**, not just terminal labels:
- correct candidate → `done`, exactly one node of **score 6** in the engine `nodes.json`, `best/step_0001/` updated;
- low score → `done` (score 0, recorded);
- evaluator crash → `failed` + `verdict: evaluator_blocked` + no `nodes.json`.

A guard-only `isPassed` impl could not pass it. **Reviewed (Opus) → ready-to-merge**; ran build, lint, unit (55/55), and the integration test **3/3 against real Docker**. Vendoring confirmed byte-faithful with the correct license.