### PR TITLE
fix(sandbox): stop leaking UTCP manual prefix in tool-error suggestions

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -9,7 +9,6 @@
 
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { randomUUID } from 'node:crypto';
 import '@utcp/mcp'; // Register MCP call template type with UTCP SDK
 import { CodeModeUtcpClient } from '@utcp/code-mode';
 import { Protocol } from '@modelcontextprotocol/sdk/shared/protocol.js';
@@ -220,7 +219,7 @@ function buildNamespaceAliasSnippet(
  * `manualName` is the UTCP manual name (unsanitized, may contain hyphens).
  * `utcpGlobalName` is the sanitized form UTCP uses as a V8 global.
  */
-function buildInterfacePatchSnippet(
+export function buildInterfacePatchSnippet(
   callableToRawMap: Record<string, string>,
   manualName: string,
   utcpGlobalName: string,
@@ -261,7 +260,11 @@ function buildInterfacePatchSnippet(
             if (rawName) return _origGetToolInterface(rawName);
           }
 
-          // Build helpful error with suggestions
+          // Build helpful error with suggestions. Only ever surface
+          // friendly callable names (e.g. "filesystem.read_file"); never
+          // the internal UTCP names carrying the per-sandbox manual prefix
+          // (e.g. "tools_<id>.filesystem_read_file"), which are useless and
+          // confusing for the agent to copy into its next call.
           var allNames = Object.keys(_callableToRaw);
           var suggestions = [];
           var needle = toolName.toLowerCase();
@@ -269,13 +272,14 @@ function buildInterfacePatchSnippet(
             needle = needle.slice(_manualPrefix.length);
           }
           for (var i = 0; i < allNames.length && suggestions.length < 3; i++) {
-            var candidate = allNames[i].toLowerCase();
-            if (candidate.indexOf(_manualPrefix.toLowerCase()) === 0) {
-              candidate = candidate.slice(_manualPrefix.length);
+            var name = allNames[i];
+            // Skip internal UTCP names (manual- or global-prefixed).
+            if (name.indexOf(_manualPrefix) === 0 || name.indexOf(_utcpGlobalPrefix) === 0) {
+              continue;
             }
-            if (allNames[i].toLowerCase().indexOf(needle) !== -1 ||
-                needle.indexOf(candidate) !== -1) {
-              suggestions.push(allNames[i]);
+            var candidate = name.toLowerCase();
+            if (candidate.indexOf(needle) !== -1 || needle.indexOf(candidate) !== -1) {
+              suggestions.push(name);
             }
           }
           var msg = "Unknown tool '" + toolName + "'.";
@@ -338,10 +342,17 @@ export function buildHelpSnippet(helpData: HelpData): string {
 }
 
 /**
- * Prefix for per-sandbox virtual UTCP manual names. A random suffix is
- * appended per Sandbox instance so two sandboxes running in the same
- * Node process (e.g., the daemon hosting multiple sessions) can coexist
- * without their `coordinatorByManual` bindings colliding.
+ * Prefix for per-sandbox virtual UTCP manual names. A short counter
+ * suffix is appended per Sandbox instance so two sandboxes running in the
+ * same Node process (e.g., the daemon hosting multiple sessions) can
+ * coexist without their `coordinatorByManual` bindings colliding.
+ *
+ * Uniqueness only needs to hold within a single process (the binding map
+ * is in-memory, per process) -- it does NOT need to be globally unique or
+ * unguessable, so a monotonic counter is sufficient and keeps the name
+ * tiny. A short name matters because UTCP creates `global.<name>` in the
+ * V8 isolate; if it ever surfaces (e.g. an agent enumerating globals) we
+ * want `tools_3`, not a 32-char UUID.
  *
  * The prefix + suffix are already valid identifier characters
  * (underscores, letters, digits) so UTCP's own name sanitization
@@ -351,6 +362,9 @@ export function buildHelpSnippet(helpData: HelpData): string {
  */
 const VIRTUAL_MANUAL_PREFIX = 'tools_';
 
+/** Monotonic per-process counter making each sandbox's manual name unique. */
+let manualNameCounter = 0;
+
 export class Sandbox {
   private client: CodeModeUtcpClient | null = null;
   private toolCatalog: string = '';
@@ -358,12 +372,12 @@ export class Sandbox {
   private helpData: HelpData = { serverDescriptions: {}, toolsByServer: {} };
   private coordinator: ToolCallCoordinator | null = null;
   /**
-   * Per-sandbox UTCP manual name (e.g., `tools_abc123_...`). Unique
-   * per instance so concurrent sandboxes don't overwrite each other's
-   * coordinator binding. The same name is used as the V8 global UTCP
-   * creates in the isolate; snippets reference it directly.
+   * Per-sandbox UTCP manual name (e.g., `tools_3`). Unique per instance
+   * (within the process) so concurrent sandboxes don't overwrite each
+   * other's coordinator binding. The same name is used as the V8 global
+   * UTCP creates in the isolate; snippets reference it directly.
    */
-  private readonly manualName = `${VIRTUAL_MANUAL_PREFIX}${randomUUID().replace(/-/g, '_')}`;
+  private readonly manualName = `${VIRTUAL_MANUAL_PREFIX}${++manualNameCounter}`;
 
   /**
    * Exposes the policy coordinator once the sandbox is initialized.

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { toCallableName } from '../src/sandbox/index.js';
+import vm from 'node:vm';
+import { toCallableName, toUtcpCallable, buildInterfacePatchSnippet } from '../src/sandbox/index.js';
 
 describe('toCallableName', () => {
   it('returns simple names unchanged after sanitization', () => {
@@ -158,5 +159,88 @@ describe('buildInterfacePatchSnippet (via behavior)', () => {
     const rawName = 'tools.read_file';
     const callableName = toCallableName(rawName);
     expect(callableName).toBe(rawName);
+  });
+});
+
+describe('buildInterfacePatchSnippet (real generated snippet)', () => {
+  // These tests run the ACTUAL string produced by buildInterfacePatchSnippet
+  // inside a vm context, against a mock __getToolInterface, instead of
+  // reimplementing the logic. The manual name deliberately uses the
+  // UUID-style form to prove that the per-sandbox manual prefix never leaks
+  // into the agent-facing surface.
+  const MANUAL = 'tools_0b89f22a_e76e_417e_8369_71668b24627c';
+  const PREFIX = `${MANUAL}.`;
+
+  // Raw UTCP tool names as the IronCurtain protocol produces them:
+  // "<manual>.<server>.<tool>".
+  const rawNames = [`${PREFIX}git.git_add`, `${PREFIX}git.git_status`, `${PREFIX}filesystem.read_file`];
+
+  const interfaceMap: Record<string, string> = {
+    [`${PREFIX}git.git_add`]: 'function git_add(args: { pathspec: string[] }): void',
+    [`${PREFIX}git.git_status`]: 'function git_status(): string',
+    [`${PREFIX}filesystem.read_file`]: 'function read_file(args: { path: string }): string',
+  };
+
+  // Build callableToRaw exactly the way buildToolCatalogAndPatch does.
+  function buildCallableToRaw(): Record<string, string> {
+    const callableToRaw: Record<string, string> = {};
+    for (const raw of rawNames) {
+      const callableName = toCallableName(raw);
+      const utcpCallable = toUtcpCallable(raw);
+      if (callableName !== raw) callableToRaw[callableName] = raw;
+      if (utcpCallable !== raw && utcpCallable !== callableName) callableToRaw[utcpCallable] = raw;
+    }
+    return callableToRaw;
+  }
+
+  // Compiles the real snippet and returns the patched __getToolInterface.
+  function makePatchedFn(): (toolName: string) => string | null {
+    const callableToRaw = buildCallableToRaw();
+    const utcpGlobalName = MANUAL; // sanitize() is a no-op on this name
+    const snippet = buildInterfacePatchSnippet(callableToRaw, MANUAL, utcpGlobalName);
+
+    const g: { __getToolInterface: (name: string) => string | null } = {
+      __getToolInterface: (name: string) => interfaceMap[name] ?? null,
+    };
+    const context: { global: typeof g } = { global: g };
+    vm.createContext(context);
+    vm.runInContext(snippet, context);
+    return g.__getToolInterface;
+  }
+
+  it('resolves raw, friendly, and old-UTCP callable names', () => {
+    const fn = makePatchedFn();
+    // Raw names still resolve.
+    expect(fn(`${PREFIX}git.git_add`)).toBe(interfaceMap[`${PREFIX}git.git_add`]);
+    // Friendly callable names resolve.
+    expect(fn('git.add')).toBe(interfaceMap[`${PREFIX}git.git_add`]);
+    expect(fn('filesystem.read_file')).toBe(interfaceMap[`${PREFIX}filesystem.read_file`]);
+    // Old UTCP underscore form resolves (backward compat).
+    expect(fn(`${PREFIX}git_git_add`)).toBe(interfaceMap[`${PREFIX}git.git_add`]);
+  });
+
+  it('suggests the friendly name on a near-miss', () => {
+    const fn = makePatchedFn();
+    const msg = fn('git.ad');
+    expect(msg).toContain('Did you mean:');
+    expect(msg).toContain('git.add');
+  });
+
+  it('never leaks the manual prefix in suggestions (regression)', () => {
+    const fn = makePatchedFn();
+    // A typo that fuzzy-matches multiple tools. Before the fix, the raw
+    // "tools_<uuid>.git_git_add" key was offered as a suggestion.
+    for (const typo of ['git.ad', 'git', 'read_fil', 'fileystem.read_file']) {
+      const msg = fn(typo);
+      expect(msg).not.toContain(MANUAL);
+      expect(msg).not.toContain(PREFIX);
+    }
+  });
+
+  it('falls back to the catalog hint when nothing matches', () => {
+    const fn = makePatchedFn();
+    const msg = fn('totally_unknown_xyz');
+    expect(msg).toContain('Use the callable name format');
+    expect(msg).not.toContain(MANUAL);
   });
 });


### PR DESCRIPTION
## Problem

When a Code Mode agent fumbles a tool name, `__getToolInterface` returns a "Did you mean: …" suggestion. Those suggestions were drawn from **all** `callableToRaw` keys, which include the internal UTCP names carrying the per-sandbox manual prefix — e.g. `tools_0b89f22a_e76e_417e_8369_71668b24627c.filesystem_read_file`.

So precisely on the error/retry path — where coding agents land often — we were handing back a 32-char-UUID-bearing raw name as a "suggestion" the agent might copy into its next call. It's useless to call, confusing, and wastes tokens.

(The `tools_<uuid>` name itself is only ever an internal UTCP manual name / V8 global; the agent's real interface is `execute_code` + clean `server.tool` names. The error-suggestion path was the one place it leaked into model-facing text.)

## Fixes

1. **Suggestions surface only friendly names.** The suggestion loop now skips any key beginning with the manual/global prefix and offers only friendly callable names (`filesystem.read_file`, `git.add`).

2. **Shrink the manual name.** The per-sandbox suffix only needs to be unique *within the process* (it keys the in-memory `coordinatorByManual` map — each `callToolChain` runs in a fresh `isolated-vm` Isolate, so there's no cross-sandbox global collision to defend against). Replaced the 32-char `randomUUID()` with a monotonic counter (`tools_1`, `tools_2`, …) and removed the now-unused `randomUUID` import. This removes the footgun entirely even if the global is ever enumerated.

## Tests

Exported `buildInterfacePatchSnippet` and added a block that compiles and runs the **real** generated snippet in a `vm` context against a mock `__getToolInterface` (the prior test reimplemented the logic inline and never exercised the actual string). Coverage:

- raw / friendly / old-UTCP name resolution still works
- near-miss suggests the friendly name
- **regression:** suggestions never contain the manual prefix (verified the old loop did leak it for inputs like `git` and `read_fil`)
- empty-match fallback hint contains no prefix

## Verification

- `vitest run test/sandbox.test.ts` → 16 passed
- `tsc --noEmit` → clean
- `eslint` / `prettier` → clean