### PR TITLE
fix(docker): install workflow dependencies at runtime instead of baking a per-workflow image

### DIFF
--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -13,7 +13,6 @@ import {
   readdirSync,
   readFileSync,
   copyFileSync,
-  cpSync,
   mkdtempSync,
   rmSync,
   mkdirSync,
@@ -194,6 +193,19 @@ export interface PreContainerInfrastructure {
     readonly hostDir: string;
     readonly target: string;
   };
+  /** Host-side cached Python venv mounted at /opt/workflow-venv for workflow helpers. */
+  readonly workflowPythonVenvMount?: {
+    readonly hostDir: string;
+    readonly target: string;
+    readonly cacheKey: string;
+  };
+  /** Host-side cached node_modules mounted for workflow helper scripts. */
+  readonly workflowNodeModulesMount?: {
+    readonly hostDir: string;
+    readonly target: string;
+    readonly cacheKey: string;
+    readonly hasPackageLock: boolean;
+  };
   /**
    * Re-stages the bundle's skills with the given resolved set.
    * No-op when `skillsMount` is undefined or when the set is byte-identical
@@ -293,6 +305,16 @@ const DOCKER_HOST_GATEWAY = 'host.docker.internal';
 
 /** Bundle-relative subdir name for the skills staging dir. */
 const BUNDLE_SKILLS_SUBDIR = 'skills';
+
+/** Conservative default PATH used when prepending the workflow venv. */
+const DEFAULT_CONTAINER_PATH =
+  '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/codespace/.local/bin';
+
+/** Container path for runtime-provisioned workflow Python dependencies. */
+const WORKFLOW_PYTHON_VENV_DIR = '/opt/workflow-venv';
+
+/** Container path for runtime-provisioned workflow Node dependencies. */
+const WORKFLOW_NODE_MODULES_DIR = '/opt/workflow-node_modules';
 
 /**
  * Prepares the shared (non-container) parts of Docker session infrastructure.
@@ -629,9 +651,13 @@ export async function prepareDockerInfrastructure(
     const proxyAddress = useTcp && proxy.port !== undefined ? `${DOCKER_HOST_GATEWAY}:${proxy.port}` : undefined;
     const { systemPrompt } = prepareSession(adapter, serverListings, bundleDir, config, workspaceDir, proxyAddress);
 
-    // Ensure Docker image is built and up-to-date
+    // Ensure the stock agent image is built and up-to-date. Workflow
+    // dependencies are provisioned at runtime into mounted caches below;
+    // they are no longer baked into per-workflow Docker images.
     const agentImage = await adapter.getImage();
-    const image = await ensureWorkflowImage(agentImage, scriptsDir, docker, ca);
+    const agentBuildHash = await ensureImage(agentImage, docker, ca);
+    const image = agentImage;
+    const workflowDependencyMounts = prepareWorkflowDependencyMounts(agentBuildHash, scriptsDir, getIronCurtainHome());
 
     const orientationDir = resolve(bundleDir, 'orientation');
 
@@ -696,6 +722,7 @@ export async function prepareDockerInfrastructure(
       conversationStateConfig,
       skillsMount,
       scriptsMount,
+      ...workflowDependencyMounts,
       restageSkills,
       setTokenSessionId: (id) => {
         mitmProxy.setTokenSessionId(id);
@@ -770,13 +797,24 @@ export async function createDockerInfrastructure(
     scriptsDir,
   );
 
+  let containerResources: ContainerResources | undefined;
   try {
-    const containerResources = await createSessionContainers(core, config);
-    return { ...core, ...containerResources };
+    containerResources = await createSessionContainers(core, config);
+    const infra = { ...core, ...containerResources };
+    await provisionWorkflowDependencies(infra);
+    return infra;
   } catch (error) {
     // Any partial container/sidecar/network cleanup happened inside
-    // createSessionContainers(). Here we just tear down the proxies that
-    // prepareDockerInfrastructure() started, to avoid leaking them.
+    // createSessionContainers(). If provisioning failed after a complete
+    // container bundle was created, clean that bundle here before tearing
+    // down the proxies.
+    if (containerResources) {
+      await cleanupContainers(core.docker, {
+        containerId: containerResources.containerId,
+        sidecarContainerId: containerResources.sidecarContainerId ?? null,
+        networkName: containerResources.internalNetwork ?? null,
+      });
+    }
     await core.mitmProxy.stop().catch(() => {});
     await core.proxy.stop().catch(() => {});
     throw error;
@@ -1086,6 +1124,20 @@ export async function createSessionContainers(
     if (core.scriptsMount) {
       mounts.push({ source: core.scriptsMount.hostDir, target: core.scriptsMount.target, readonly: true });
     }
+    if (core.workflowPythonVenvMount) {
+      mounts.push({
+        source: core.workflowPythonVenvMount.hostDir,
+        target: core.workflowPythonVenvMount.target,
+        readonly: false,
+      });
+    }
+    if (core.workflowNodeModulesMount) {
+      mounts.push({
+        source: core.workflowNodeModulesMount.hostDir,
+        target: core.workflowNodeModulesMount.target,
+        readonly: false,
+      });
+    }
 
     // Linux-only UID-remap wiring (issue #232). On Linux, run the
     // container as root and pass the host UID/GID via env so the
@@ -1106,7 +1158,14 @@ export async function createSessionContainers(
       name: mainContainerName,
       network: network ?? 'none',
       mounts,
-      env: { ...env, ...uidRemap.env },
+      env: {
+        ...env,
+        ...(core.workflowPythonVenvMount
+          ? { PATH: `${core.workflowPythonVenvMount.target}/bin:${DEFAULT_CONTAINER_PATH}` }
+          : {}),
+        ...(core.workflowNodeModulesMount ? { NODE_PATH: core.workflowNodeModulesMount.target } : {}),
+        ...uidRemap.env,
+      },
       user: uidRemap.user,
       command: ['sleep', 'infinity'],
       ...bundleLabels,
@@ -1355,54 +1414,12 @@ export async function ensureWorkflowImage(
   docker: DockerManager,
   ca: CertificateAuthority,
 ): Promise<string> {
-  const agentBuildHash = await ensureImage(agentImage, docker, ca);
-  if (scriptsDir === undefined || !existsSync(scriptsDir)) return agentImage;
-
-  const requirementsPath = resolve(scriptsDir, 'requirements.txt');
-  const packageJsonPath = resolve(scriptsDir, 'package.json');
-  const hasPythonManifest = existsSync(requirementsPath);
-  const hasNodeManifest = existsSync(packageJsonPath);
-  if (!hasPythonManifest && !hasNodeManifest) return agentImage;
-
-  const workflowHash = computeWorkflowImageHash(agentBuildHash, scriptsDir);
-  const workflowImage = `ironcurtain-wf-${workflowHash.slice(0, 12)}:latest`;
-  if (!(await isImageStale(workflowImage, docker, workflowHash))) return workflowImage;
-
-  logger.info(`Building workflow dependency image ${workflowImage}...`);
-  const tmpContext = mkdtempSync(resolve(tmpdir(), 'ironcurtain-workflow-build-'));
-  try {
-    cpSync(scriptsDir, tmpContext, { recursive: true });
-    const dockerfile = [
-      `FROM ${agentImage}`,
-      'USER root',
-      'COPY . /opt/workflow-scripts-build',
-      'RUN if [ -f /opt/workflow-scripts-build/requirements.txt ]; then ' +
-        'uv venv /opt/workflow-venv && ' +
-        'VIRTUAL_ENV=/opt/workflow-venv uv pip install -r /opt/workflow-scripts-build/requirements.txt; ' +
-        'fi',
-      'RUN if [ -f /opt/workflow-scripts-build/package.json ]; then ' +
-        'cd /opt/workflow-scripts-build && ' +
-        'if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi && ' +
-        'mv node_modules /opt/workflow-node_modules; ' +
-        'fi',
-      'ENV PATH=/opt/workflow-venv/bin:${PATH}',
-      'ENV NODE_PATH=/opt/workflow-node_modules',
-      'USER codespace',
-      '',
-    ].join('\n');
-    const dockerfilePath = resolve(tmpContext, 'Dockerfile');
-    writeFileSync(dockerfilePath, dockerfile);
-    await docker.buildImage(workflowImage, dockerfilePath, tmpContext, {
-      'ironcurtain.build-hash': workflowHash,
-    });
-  } finally {
-    rmSync(tmpContext, { recursive: true, force: true });
-  }
-  logger.info(`Workflow dependency image ${workflowImage} built successfully`);
-  return workflowImage;
+  await ensureImage(agentImage, docker, ca);
+  void scriptsDir;
+  return agentImage;
 }
 
-export function computeWorkflowImageHash(agentBuildHash: string, scriptsDir: string): string {
+export function computeWorkflowDependencyHash(agentBuildHash: string, scriptsDir: string): string {
   const hash = createHash('sha256');
   hash.update(`agent:${agentBuildHash}\n`);
   for (const manifest of ['requirements.txt', 'package.json', 'package-lock.json']) {
@@ -1413,6 +1430,128 @@ export function computeWorkflowImageHash(agentBuildHash: string, scriptsDir: str
     hash.update('\n');
   }
   return hash.digest('hex');
+}
+
+interface WorkflowDependencyMounts {
+  readonly workflowPythonVenvMount?: PreContainerInfrastructure['workflowPythonVenvMount'];
+  readonly workflowNodeModulesMount?: PreContainerInfrastructure['workflowNodeModulesMount'];
+}
+
+function prepareWorkflowDependencyMounts(
+  agentBuildHash: string,
+  scriptsDir: string | undefined,
+  ironcurtainHome: string,
+): WorkflowDependencyMounts {
+  if (scriptsDir === undefined || !existsSync(scriptsDir)) return {};
+
+  const requirementsPath = resolve(scriptsDir, 'requirements.txt');
+  const packageJsonPath = resolve(scriptsDir, 'package.json');
+  const packageLockPath = resolve(scriptsDir, 'package-lock.json');
+  const hasPythonManifest = existsSync(requirementsPath);
+  const hasNodeManifest = existsSync(packageJsonPath);
+  if (!hasPythonManifest && !hasNodeManifest) return {};
+
+  const dependencyHash = computeWorkflowDependencyHash(agentBuildHash, scriptsDir);
+  const cacheRoot = resolve(ironcurtainHome, 'workflow-deps', dependencyHash.slice(0, 24));
+  mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
+
+  let workflowPythonVenvMount: PreContainerInfrastructure['workflowPythonVenvMount'];
+  let workflowNodeModulesMount: PreContainerInfrastructure['workflowNodeModulesMount'];
+  if (hasPythonManifest) {
+    const hostDir = resolve(cacheRoot, 'python-venv');
+    mkdirSync(hostDir, { recursive: true, mode: 0o700 });
+    workflowPythonVenvMount = {
+      hostDir,
+      target: WORKFLOW_PYTHON_VENV_DIR,
+      cacheKey: dependencyHash,
+    };
+  }
+  if (hasNodeManifest) {
+    const hostDir = resolve(cacheRoot, 'node_modules');
+    mkdirSync(hostDir, { recursive: true, mode: 0o700 });
+    workflowNodeModulesMount = {
+      hostDir,
+      target: WORKFLOW_NODE_MODULES_DIR,
+      cacheKey: dependencyHash,
+      hasPackageLock: existsSync(packageLockPath),
+    };
+  }
+  return {
+    ...(workflowPythonVenvMount ? { workflowPythonVenvMount } : {}),
+    ...(workflowNodeModulesMount ? { workflowNodeModulesMount } : {}),
+  };
+}
+
+async function provisionWorkflowDependencies(infra: DockerInfrastructure): Promise<void> {
+  if (!infra.workflowPythonVenvMount && !infra.workflowNodeModulesMount) return;
+
+  if (infra.workflowPythonVenvMount) {
+    await provisionWorkflowPythonDependencies(infra);
+  }
+  if (infra.workflowNodeModulesMount) {
+    await provisionWorkflowNodeDependencies(infra);
+  }
+}
+
+async function provisionWorkflowPythonDependencies(infra: DockerInfrastructure): Promise<void> {
+  const mount = infra.workflowPythonVenvMount;
+  if (!mount) return;
+  const sentinel = `${mount.target}/.ironcurtain-provisioned-${mount.cacheKey}`;
+  const command = [
+    'set -eu',
+    `if [ -f ${quote([sentinel])} ]; then exit 0; fi`,
+    `find ${quote([mount.target])} -mindepth 1 -maxdepth 1 -exec rm -rf {} +`,
+    `UV_NATIVE_TLS=1 uv venv ${quote([mount.target])}`,
+    `VIRTUAL_ENV=${quote([mount.target])} UV_NATIVE_TLS=1 uv pip install -r ${quote([`${CONTAINER_SCRIPTS_DIR}/requirements.txt`])}`,
+    `touch ${quote([sentinel])}`,
+  ].join('\n');
+
+  logger.info(`Provisioning workflow Python dependencies into ${mount.target}`);
+  const result = await infra.docker.exec(
+    infra.containerId,
+    ['/bin/sh', '-lc', command],
+    1_200_000,
+    'codespace',
+    CONTAINER_WORKSPACE_DIR,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Workflow Python dependency provisioning failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+async function provisionWorkflowNodeDependencies(infra: DockerInfrastructure): Promise<void> {
+  const mount = infra.workflowNodeModulesMount;
+  if (!mount) return;
+  const sentinel = `${mount.target}/.ironcurtain-provisioned-${mount.cacheKey}`;
+  const installCommand = mount.hasPackageLock ? 'npm ci --omit=dev' : 'npm install --omit=dev';
+  const command = [
+    'set -eu',
+    `if [ -f ${quote([sentinel])} ]; then exit 0; fi`,
+    'tmp="$(mktemp -d)"',
+    'cleanup() { rm -rf "$tmp"; }',
+    'trap cleanup EXIT',
+    `cp ${quote([`${CONTAINER_SCRIPTS_DIR}/package.json`])} "$tmp/package.json"`,
+    mount.hasPackageLock ? `cp ${quote([`${CONTAINER_SCRIPTS_DIR}/package-lock.json`])} "$tmp/package-lock.json"` : '',
+    'cd "$tmp"',
+    installCommand,
+    `find ${quote([mount.target])} -mindepth 1 -maxdepth 1 -exec rm -rf {} +`,
+    `cp -a node_modules/. ${quote([mount.target])}/`,
+    `touch ${quote([sentinel])}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  logger.info(`Provisioning workflow Node dependencies into ${mount.target}`);
+  const result = await infra.docker.exec(
+    infra.containerId,
+    ['/bin/sh', '-lc', command],
+    1_200_000,
+    'codespace',
+    CONTAINER_WORKSPACE_DIR,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Workflow Node dependency provisioning failed: ${result.stderr || result.stdout}`);
+  }
 }
 
 async function ensureBaseImage(

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -1162,7 +1162,7 @@ export async function createSessionContainers(
         // PATH — including the NVM directory where `node`/`npm` live on the x86
         // devcontainer base. Bare-`node` workflow helpers would then fail to
         // resolve. The workflow venv bin is instead prepended to the live
-        // `$PATH` at exec time (see buildWorkflowPathPrefixedCommand), which is
+        // `$PATH` at exec time (see buildWorkflowExecCommand), which is
         // base-image-agnostic and preserves the image's own PATH.
         ...(core.workflowNodeModulesMount ? { NODE_PATH: core.workflowNodeModulesMount.target } : {}),
         ...uidRemap.env,

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -49,6 +49,7 @@ import { clampDockerResources } from './resource-limits.js';
 import { errorMessage } from '../utils/error-message.js';
 import { createCachedStager } from '../skills/staging.js';
 import type { ResolvedSkill } from '../skills/types.js';
+import { withProvisionLock } from './provision-lock.js';
 import * as logger from '../logger.js';
 
 /**
@@ -305,10 +306,6 @@ const DOCKER_HOST_GATEWAY = 'host.docker.internal';
 
 /** Bundle-relative subdir name for the skills staging dir. */
 const BUNDLE_SKILLS_SUBDIR = 'skills';
-
-/** Conservative default PATH used when prepending the workflow venv. */
-const DEFAULT_CONTAINER_PATH =
-  '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/codespace/.local/bin';
 
 /** Container path for runtime-provisioned workflow Python dependencies. */
 const WORKFLOW_PYTHON_VENV_DIR = '/opt/workflow-venv';
@@ -801,7 +798,7 @@ export async function createDockerInfrastructure(
   try {
     containerResources = await createSessionContainers(core, config);
     const infra = { ...core, ...containerResources };
-    await provisionWorkflowDependencies(infra);
+    await provisionWorkflowDependencies(infra, config.userConfig.packageInstall.enabled);
     return infra;
   } catch (error) {
     // Any partial container/sidecar/network cleanup happened inside
@@ -1160,9 +1157,13 @@ export async function createSessionContainers(
       mounts,
       env: {
         ...env,
-        ...(core.workflowPythonVenvMount
-          ? { PATH: `${core.workflowPythonVenvMount.target}/bin:${DEFAULT_CONTAINER_PATH}` }
-          : {}),
+        // Do NOT override PATH here. Docker `-e PATH=...` REPLACES the image's
+        // PATH (it does not append), which would discard the base image's real
+        // PATH — including the NVM directory where `node`/`npm` live on the x86
+        // devcontainer base. Bare-`node` workflow helpers would then fail to
+        // resolve. The workflow venv bin is instead prepended to the live
+        // `$PATH` at exec time (see buildWorkflowPathPrefixedCommand), which is
+        // base-image-agnostic and preserves the image's own PATH.
         ...(core.workflowNodeModulesMount ? { NODE_PATH: core.workflowNodeModulesMount.target } : {}),
         ...uidRemap.env,
       },
@@ -1371,7 +1372,7 @@ export async function ensureDockerImage(agentId: AgentId, userConfig: ResolvedUs
  * agent-specific image. Content-hash labels on each image drive staleness
  * detection so repeated calls skip rebuilds when nothing has changed.
  */
-async function ensureImage(image: string, docker: DockerManager, ca: CertificateAuthority): Promise<string> {
+export async function ensureImage(image: string, docker: DockerManager, ca: CertificateAuthority): Promise<string> {
   const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
   const dockerDir = resolve(packageRoot, 'docker');
 
@@ -1408,17 +1409,6 @@ async function ensureImage(image: string, docker: DockerManager, ca: Certificate
   return agentBuildHash;
 }
 
-export async function ensureWorkflowImage(
-  agentImage: string,
-  scriptsDir: string | undefined,
-  docker: DockerManager,
-  ca: CertificateAuthority,
-): Promise<string> {
-  await ensureImage(agentImage, docker, ca);
-  void scriptsDir;
-  return agentImage;
-}
-
 export function computeWorkflowDependencyHash(agentBuildHash: string, scriptsDir: string): string {
   const hash = createHash('sha256');
   hash.update(`agent:${agentBuildHash}\n`);
@@ -1430,6 +1420,42 @@ export function computeWorkflowDependencyHash(agentBuildHash: string, scriptsDir
     hash.update('\n');
   }
   return hash.digest('hex');
+}
+
+/**
+ * Wraps an in-container command so the workflow dependency bins are prepended
+ * to the container's LIVE `$PATH` at exec time, rather than replacing the
+ * image's PATH at container-creation time.
+ *
+ * Why a runtime shell instead of an `-e PATH=...` env: Docker `-e` REPLACES the
+ * image PATH (it does not append), which would discard the base image's own
+ * PATH — including the NVM directory where `node`/`npm` live on the x86
+ * devcontainer base. Expanding `$PATH` inside the container at exec time is
+ * base-image-agnostic: it preserves whatever PATH the image ships and merely
+ * prepends the workflow venv bin (for bare `python`) and the installed Node
+ * package bins (`node_modules/.bin`).
+ *
+ * Returns the original command unchanged when neither dependency mount is
+ * present, so non-dependency workflows keep the plain exec path.
+ *
+ * Shell-safety: the only interpolated values are the hardcoded container
+ * constants `WORKFLOW_PYTHON_VENV_DIR` / `WORKFLOW_NODE_MODULES_DIR`. The
+ * caller's command and its arguments are passed verbatim as positional
+ * parameters consumed by `exec "$@"` — never string-interpolated — so no
+ * word-splitting or injection is possible.
+ */
+export function buildWorkflowExecCommand(
+  bundle: Pick<DockerInfrastructure, 'workflowPythonVenvMount' | 'workflowNodeModulesMount'>,
+  command: readonly string[],
+): readonly string[] {
+  const prefixDirs: string[] = [];
+  if (bundle.workflowPythonVenvMount) prefixDirs.push(`${WORKFLOW_PYTHON_VENV_DIR}/bin`);
+  if (bundle.workflowNodeModulesMount) prefixDirs.push(`${WORKFLOW_NODE_MODULES_DIR}/.bin`);
+  if (prefixDirs.length === 0 || command.length === 0) return command;
+
+  const pathPrefix = prefixDirs.join(':');
+  // `exec "$@"` runs the original argv verbatim; the leading `sh` is $0.
+  return ['/bin/sh', '-lc', `export PATH=${pathPrefix}:"$PATH"; exec "$@"`, 'sh', ...command];
 }
 
 interface WorkflowDependencyMounts {
@@ -1482,8 +1508,28 @@ function prepareWorkflowDependencyMounts(
   };
 }
 
-async function provisionWorkflowDependencies(infra: DockerInfrastructure): Promise<void> {
+async function provisionWorkflowDependencies(
+  infra: DockerInfrastructure,
+  packageInstallEnabled: boolean,
+): Promise<void> {
   if (!infra.workflowPythonVenvMount && !infra.workflowNodeModulesMount) return;
+
+  // Runtime provisioning installs through the MITM registry proxy, which is
+  // only wired when packageInstall is enabled (see prepareDockerInfrastructure
+  // — `registries`/`packageValidation` are left undefined otherwise). The
+  // mounts above only exist when the workflow actually ships a
+  // requirements.txt / package.json, so reaching here with package install
+  // disabled means the run genuinely needs deps it can never fetch under
+  // `--network=none`. Fail fast with an actionable message rather than letting
+  // `uv pip install` / `npm install` die with an opaque network error.
+  if (!packageInstallEnabled) {
+    throw new Error(
+      'This workflow requires installing dependencies at runtime ' +
+        '(a requirements.txt and/or package.json is present in its scripts), ' +
+        'but packageInstall is disabled. Enable packageInstall in your IronCurtain ' +
+        'config to run workflows that declare runtime dependencies.',
+    );
+  }
 
   if (infra.workflowPythonVenvMount) {
     await provisionWorkflowPythonDependencies(infra);
@@ -1506,17 +1552,24 @@ async function provisionWorkflowPythonDependencies(infra: DockerInfrastructure):
     `touch ${quote([sentinel])}`,
   ].join('\n');
 
-  logger.info(`Provisioning workflow Python dependencies into ${mount.target}`);
-  const result = await infra.docker.exec(
-    infra.containerId,
-    ['/bin/sh', '-lc', command],
-    1_200_000,
-    'codespace',
-    CONTAINER_WORKSPACE_DIR,
-  );
-  if (result.exitCode !== 0) {
-    throw new Error(`Workflow Python dependency provisioning failed: ${result.stderr || result.stdout}`);
-  }
+  // Serialize concurrent provisioning of this content-keyed cache across runs.
+  // The lock is host-side because in-container flock does not propagate across
+  // containers on a Docker Desktop bind mount; the in-shell sentinel check
+  // provides the short-circuit, the host lock makes the second run wait for the
+  // first so it observes the populated cache instead of racing on the clean.
+  await withProvisionLock(mount.hostDir, async () => {
+    logger.info(`Provisioning workflow Python dependencies into ${mount.target}`);
+    const result = await infra.docker.exec(
+      infra.containerId,
+      ['/bin/sh', '-lc', command],
+      1_200_000,
+      'codespace',
+      CONTAINER_WORKSPACE_DIR,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`Workflow Python dependency provisioning failed: ${result.stderr || result.stdout}`);
+    }
+  });
 }
 
 async function provisionWorkflowNodeDependencies(infra: DockerInfrastructure): Promise<void> {
@@ -1541,17 +1594,21 @@ async function provisionWorkflowNodeDependencies(infra: DockerInfrastructure): P
     .filter(Boolean)
     .join('\n');
 
-  logger.info(`Provisioning workflow Node dependencies into ${mount.target}`);
-  const result = await infra.docker.exec(
-    infra.containerId,
-    ['/bin/sh', '-lc', command],
-    1_200_000,
-    'codespace',
-    CONTAINER_WORKSPACE_DIR,
-  );
-  if (result.exitCode !== 0) {
-    throw new Error(`Workflow Node dependency provisioning failed: ${result.stderr || result.stdout}`);
-  }
+  // Host-side serialization of this content-keyed cache (see the Python path
+  // for the bind-mount-flock rationale).
+  await withProvisionLock(mount.hostDir, async () => {
+    logger.info(`Provisioning workflow Node dependencies into ${mount.target}`);
+    const result = await infra.docker.exec(
+      infra.containerId,
+      ['/bin/sh', '-lc', command],
+      1_200_000,
+      'codespace',
+      CONTAINER_WORKSPACE_DIR,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`Workflow Node dependency provisioning failed: ${result.stderr || result.stdout}`);
+    }
+  });
 }
 
 async function ensureBaseImage(

--- a/src/docker/provision-lock.ts
+++ b/src/docker/provision-lock.ts
@@ -20,11 +20,20 @@
  * dependency on other domain modules) so the `docker/` layer stays decoupled.
  */
 
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 /** Polling interval while waiting for a contended lock. */
 const RETRY_INTERVAL_MS = 200;
+
+/**
+ * Grace window for a lock directory that exists but has no readable `meta.json`
+ * yet: the holder created the dir (atomic `mkdir`) and is about to write its
+ * metadata. Within this window the lock is treated as freshly held and is never
+ * stolen; past it, a meta-less dir is an orphaned mid-acquisition (the holder
+ * crashed between `mkdir` and the metadata write) and is reclaimable.
+ */
+const ACQUIRE_GRACE_MS = 5_000;
 
 interface LockMetadata {
   readonly pid: number;
@@ -37,9 +46,10 @@ function isPidAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (err: unknown) {
-    // ESRCH → no such process. EPERM → process exists but is owned by another
-    // user (still alive). Anything else → treat as alive to avoid stealing.
-    return (err as NodeJS.ErrnoException).code === 'EPERM';
+    // ESRCH → no such process (dead). EPERM → process exists but is owned by
+    // another user (still alive). Any other unexpected error → treat as alive
+    // so a transient probe failure never lets a waiter steal a live holder.
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
   }
 }
 
@@ -53,23 +63,37 @@ function forceRelease(lockDir: string): void {
 }
 
 /**
- * Returns true when an existing lock is stale: the owning process is dead, the
- * metadata is unreadable, or the lock has been held past `staleMs`.
+ * Returns true when an existing lock is stale and may be reclaimed: the owning
+ * process is dead, or the lock has been held past `staleMs`. When `meta.json`
+ * is not yet readable, the lock is reclaimed only if its directory is older than
+ * `ACQUIRE_GRACE_MS` — otherwise the holder is mid-acquisition (it created the
+ * dir but has not written metadata yet) and must not be stolen.
  */
 function isLockStale(lockDir: string, staleMs: number): boolean {
+  let meta: LockMetadata;
   try {
-    const meta = JSON.parse(readFileSync(resolve(lockDir, 'meta.json'), 'utf-8')) as LockMetadata;
-    if (!isPidAlive(meta.pid)) return true;
-    return Date.now() - meta.timestamp > staleMs;
+    meta = JSON.parse(readFileSync(resolve(lockDir, 'meta.json'), 'utf-8')) as LockMetadata;
   } catch {
-    return true;
+    // meta.json missing or unparseable. Do NOT treat that as stale outright, or
+    // a waiter could steal a lock during the holder's mkdir→write window. Fall
+    // back to the lock dir's own age: reclaim only an orphaned dir whose holder
+    // crashed before writing metadata.
+    try {
+      return Date.now() - statSync(lockDir).mtimeMs > ACQUIRE_GRACE_MS;
+    } catch {
+      // Lock dir vanished entirely → not held.
+      return true;
+    }
   }
+  if (!isPidAlive(meta.pid)) return true;
+  return Date.now() - meta.timestamp > staleMs;
 }
 
 /**
  * Single non-blocking attempt to acquire the lock. Atomic `mkdir` is the
- * authoritative acquisition; stale detection only runs after EEXIST so there
- * is no TOCTOU window.
+ * authoritative acquisition; stale detection only runs after EEXIST. The window
+ * between a holder's `mkdir` and its `meta.json` write is covered by
+ * `isLockStale`'s grace fallback, so a just-acquired lock is never stolen.
  */
 function tryAcquire(lockDir: string, staleMs: number): boolean {
   try {

--- a/src/docker/provision-lock.ts
+++ b/src/docker/provision-lock.ts
@@ -1,0 +1,153 @@
+/**
+ * Host-side advisory lock for the shared, content-keyed workflow dependency
+ * cache.
+ *
+ * The cache directory is keyed solely by `computeWorkflowDependencyHash` and
+ * is shared across concurrent workflow runs. Without serialization, two
+ * concurrent runs with identical dependencies both observe the absent
+ * provisioned-sentinel and race on `rm -rf` + venv/`node_modules` creation,
+ * corrupting the cache for both.
+ *
+ * In-container `flock` on the bind-mounted cache dir does NOT serialize across
+ * containers on Docker Desktop / macOS (VirtioFS does not propagate file locks
+ * across the host bind mount — verified empirically). Concurrent runs do,
+ * however, share the same host process tree, so a HOST-side lock on the cache
+ * directory serializes them regardless of container/VirtioFS semantics.
+ *
+ * Uses `mkdir` (atomic on POSIX) to create a sibling lock directory containing
+ * a metadata file with the owning PID and timestamp, enabling stale-lock
+ * detection when a holder crashes without releasing. Self-contained (no
+ * dependency on other domain modules) so the `docker/` layer stays decoupled.
+ */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** Polling interval while waiting for a contended lock. */
+const RETRY_INTERVAL_MS = 200;
+
+interface LockMetadata {
+  readonly pid: number;
+  readonly timestamp: number;
+}
+
+/** Returns true if a process with the given PID is alive (signal 0 probe). */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    // ESRCH → no such process. EPERM → process exists but is owned by another
+    // user (still alive). Anything else → treat as alive to avoid stealing.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/** Best-effort recursive removal of a lock directory. */
+function forceRelease(lockDir: string): void {
+  try {
+    rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+/**
+ * Returns true when an existing lock is stale: the owning process is dead, the
+ * metadata is unreadable, or the lock has been held past `staleMs`.
+ */
+function isLockStale(lockDir: string, staleMs: number): boolean {
+  try {
+    const meta = JSON.parse(readFileSync(resolve(lockDir, 'meta.json'), 'utf-8')) as LockMetadata;
+    if (!isPidAlive(meta.pid)) return true;
+    return Date.now() - meta.timestamp > staleMs;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Single non-blocking attempt to acquire the lock. Atomic `mkdir` is the
+ * authoritative acquisition; stale detection only runs after EEXIST so there
+ * is no TOCTOU window.
+ */
+function tryAcquire(lockDir: string, staleMs: number): boolean {
+  try {
+    mkdirSync(lockDir);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    if (!isLockStale(lockDir, staleMs)) return false;
+    forceRelease(lockDir);
+    try {
+      mkdirSync(lockDir);
+    } catch (retryErr: unknown) {
+      if ((retryErr as NodeJS.ErrnoException).code === 'EEXIST') return false;
+      throw retryErr;
+    }
+  }
+
+  const meta: LockMetadata = { pid: process.pid, timestamp: Date.now() };
+  try {
+    writeFileSync(resolve(lockDir, 'meta.json'), JSON.stringify(meta));
+  } catch {
+    forceRelease(lockDir);
+    return false;
+  }
+  return true;
+}
+
+/** Options for {@link withProvisionLock}. */
+export interface ProvisionLockOptions {
+  /**
+   * Max time to wait to acquire a contended lock before giving up. Must exceed
+   * the worst-case provisioning time so a waiter does not abandon while the
+   * holder is mid-install. Defaults to 25 minutes.
+   */
+  readonly maxWaitMs?: number;
+  /**
+   * Time after which an unreleased lock is considered stale (crashed holder).
+   * Must also exceed the worst-case provisioning time so a slow-but-alive
+   * holder is never stolen from. Defaults to 25 minutes; PID-liveness reclaims
+   * crashed holders well before this.
+   */
+  readonly staleMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 25 * 60_000;
+
+/**
+ * Runs `fn` while holding a host-side advisory lock at `{cacheDir}.lock/`.
+ *
+ * Serializes concurrent provisioning of the same content-keyed cache so the
+ * second run blocks until the first finishes, then observes the populated
+ * cache (sentinel present) and short-circuits. Releases the lock in a finally
+ * block. Throws if the lock cannot be acquired within `maxWaitMs`.
+ */
+export async function withProvisionLock<T>(
+  cacheDir: string,
+  fn: () => Promise<T>,
+  options: ProvisionLockOptions = {},
+): Promise<T> {
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_TIMEOUT_MS;
+  const staleMs = options.staleMs ?? DEFAULT_TIMEOUT_MS;
+  const lockDir = `${cacheDir}.lock`;
+  const deadline = Date.now() + maxWaitMs;
+
+  let acquired = false;
+  while (Date.now() < deadline) {
+    if (tryAcquire(lockDir, staleMs)) {
+      acquired = true;
+      break;
+    }
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, RETRY_INTERVAL_MS));
+  }
+  if (!acquired) {
+    throw new Error(`Failed to acquire workflow provisioning lock: ${lockDir} (timed out after ${maxWaitMs}ms)`);
+  }
+
+  try {
+    return await fn();
+  } finally {
+    forceRelease(lockDir);
+  }
+}

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -78,7 +78,11 @@ import {
   type AgentId,
   type TransientFailureKind,
 } from '../docker/agent-adapter.js';
-import { ensureSecureBundleDir, type DockerInfrastructure } from '../docker/docker-infrastructure.js';
+import {
+  buildWorkflowExecCommand,
+  ensureSecureBundleDir,
+  type DockerInfrastructure,
+} from '../docker/docker-infrastructure.js';
 import {
   buildWorkflowMachine,
   type AgentInvokeInput,
@@ -2503,9 +2507,12 @@ export class WorkflowOrchestrator implements WorkflowController {
     if (warning) writeStderr(`[workflow] ${warning}`);
 
     return this.reduceDeterministicCommands(input.commands, async (cmdArray) => {
+      // Prepend the workflow venv / node bins to the container's live $PATH so
+      // bare `node` / `python` helpers resolve regardless of base-image arch
+      // (the image's own PATH is preserved — see buildWorkflowExecCommand).
       const result = await bundle.docker.exec(
         bundle.containerId,
-        cmdArray,
+        buildWorkflowExecCommand(bundle, cmdArray),
         input.timeoutMs,
         'codespace',
         CONTAINER_WORKSPACE_DIR,

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -10,7 +10,7 @@ import {
   destroyDockerInfrastructure,
   resolveRealKey,
   canRefreshOAuth,
-  computeWorkflowImageHash,
+  computeWorkflowDependencyHash,
   ensureWorkflowImage,
 } from '../src/docker/docker-infrastructure.js';
 import type { AgentAdapter, ConversationStateConfig } from '../src/docker/agent-adapter.js';
@@ -577,6 +577,45 @@ describe('createSessionContainers', () => {
     expect(scriptsMount).toEqual({ source: scriptsDir, target: '/workflow-scripts', readonly: true });
   });
 
+  it('uses the stock agent image while mounting workflow dependency caches', async () => {
+    const { docker, createCalls } = makeMockDocker();
+    const core = makeMockCore({ tempDir, useTcp: false, docker });
+    const pythonVenvDir = join(tempDir, 'workflow-deps', 'python-venv');
+    const nodeModulesDir = join(tempDir, 'workflow-deps', 'node_modules');
+    mkdirSync(pythonVenvDir, { recursive: true });
+    mkdirSync(nodeModulesDir, { recursive: true });
+
+    await createSessionContainers(
+      {
+        ...core,
+        workflowPythonVenvMount: {
+          hostDir: pythonVenvDir,
+          target: '/opt/workflow-venv',
+          cacheKey: 'abc123',
+        },
+        workflowNodeModulesMount: {
+          hostDir: nodeModulesDir,
+          target: '/opt/workflow-node_modules',
+          cacheKey: 'abc123',
+          hasPackageLock: false,
+        },
+      },
+      makeMockConfig(),
+    );
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].image).toBe('ironcurtain-claude-code:latest');
+    expect(createCalls[0].image).not.toMatch(/^ironcurtain-wf-/);
+    expect(createCalls[0].mounts).toEqual(
+      expect.arrayContaining([
+        { source: pythonVenvDir, target: '/opt/workflow-venv', readonly: false },
+        { source: nodeModulesDir, target: '/opt/workflow-node_modules', readonly: false },
+      ]),
+    );
+    expect(createCalls[0].env.PATH).toContain('/opt/workflow-venv/bin');
+    expect(createCalls[0].env.NODE_PATH).toBe('/opt/workflow-node_modules');
+  });
+
   // --- UID remap (issue #232) ---
   it('does NOT pass --user 0:0 or UID env in TCP (macOS) mode', async () => {
     // On macOS, VirtioFS handles UID translation and `--user 0:0` would
@@ -881,10 +920,10 @@ describe('destroyDockerInfrastructure', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Per-workflow dependency image hashing (design §6.3, test plan §11 #5)
+// Per-workflow runtime dependency cache hashing
 // ---------------------------------------------------------------------------
 
-describe('computeWorkflowImageHash', () => {
+describe('computeWorkflowDependencyHash', () => {
   let scriptsDir: string;
 
   beforeEach(() => {
@@ -899,8 +938,8 @@ describe('computeWorkflowImageHash', () => {
     writeFileSync(join(scriptsDir, 'requirements.txt'), 'numpy==1.26.0\n');
     writeFileSync(join(scriptsDir, 'package.json'), '{ "dependencies": { "ajv": "^8" } }\n');
 
-    const first = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
-    const second = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const first = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
+    const second = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     expect(first).toBe(second);
     // sha256 hex digest
@@ -909,20 +948,20 @@ describe('computeWorkflowImageHash', () => {
 
   it('changes the hash when requirements.txt content changes', () => {
     writeFileSync(join(scriptsDir, 'requirements.txt'), 'numpy==1.26.0\n');
-    const before = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const before = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     writeFileSync(join(scriptsDir, 'requirements.txt'), 'numpy==2.0.0\n');
-    const after = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const after = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     expect(after).not.toBe(before);
   });
 
   it('changes the hash when package.json content changes', () => {
     writeFileSync(join(scriptsDir, 'package.json'), '{ "dependencies": { "ajv": "^8" } }\n');
-    const before = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const before = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     writeFileSync(join(scriptsDir, 'package.json'), '{ "dependencies": { "ajv": "^9" } }\n');
-    const after = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const after = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     expect(after).not.toBe(before);
   });
@@ -930,24 +969,24 @@ describe('computeWorkflowImageHash', () => {
   it('changes the hash when the parent agent hash changes (parent chaining)', () => {
     writeFileSync(join(scriptsDir, 'requirements.txt'), 'numpy==1.26.0\n');
 
-    const withAgentA = computeWorkflowImageHash('agent-hash-A', scriptsDir);
-    const withAgentB = computeWorkflowImageHash('agent-hash-B', scriptsDir);
+    const withAgentA = computeWorkflowDependencyHash('agent-hash-A', scriptsDir);
+    const withAgentB = computeWorkflowDependencyHash('agent-hash-B', scriptsDir);
 
     expect(withAgentA).not.toBe(withAgentB);
   });
 
   it('folds package-lock.json into the hash when present', () => {
     writeFileSync(join(scriptsDir, 'package.json'), '{ "dependencies": { "ajv": "^8" } }\n');
-    const withoutLock = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const withoutLock = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     writeFileSync(join(scriptsDir, 'package-lock.json'), '{ "lockfileVersion": 3 }\n');
-    const withLock = computeWorkflowImageHash('agent-hash-abc', scriptsDir);
+    const withLock = computeWorkflowDependencyHash('agent-hash-abc', scriptsDir);
 
     expect(withLock).not.toBe(withoutLock);
   });
 });
 
-describe('ensureWorkflowImage no-manifest fast path', () => {
+describe('ensureWorkflowImage runtime-dependency path', () => {
   let tempDir: string;
 
   beforeEach(() => {
@@ -959,7 +998,7 @@ describe('ensureWorkflowImage no-manifest fast path', () => {
   });
 
   // The mock Docker stamps build labels per tag; we assert no per-workflow
-  // image tag (`ironcurtain-wf-*`) is ever built on the fast path.
+  // image tag (`ironcurtain-wf-*`) is ever built, even when manifests exist.
   function builtWorkflowImageTags(docker: DockerManager): string[] {
     const built: string[] = [];
     const original = docker.buildImage.bind(docker);
@@ -986,6 +1025,21 @@ describe('ensureWorkflowImage no-manifest fast path', () => {
     mkdirSync(scriptsDir);
     // A helper script but no requirements.txt / package.json.
     writeFileSync(join(scriptsDir, 'run_eval.py'), 'print("hi")\n');
+
+    const docker = createMockDocker();
+    const ca = createMockCA(tempDir);
+    const built = builtWorkflowImageTags(docker);
+
+    const image = await ensureWorkflowImage('ironcurtain-claude-code:latest', scriptsDir, docker, ca);
+
+    expect(image).toBe('ironcurtain-claude-code:latest');
+    expect(built).toEqual([]);
+  });
+
+  it('returns the shared agent image and builds no workflow image when requirements.txt exists', async () => {
+    const scriptsDir = join(tempDir, 'scripts');
+    mkdirSync(scriptsDir);
+    writeFileSync(join(scriptsDir, 'requirements.txt'), 'numpy\npyyaml\n');
 
     const docker = createMockDocker();
     const ca = createMockCA(tempDir);

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -11,7 +11,8 @@ import {
   resolveRealKey,
   canRefreshOAuth,
   computeWorkflowDependencyHash,
-  ensureWorkflowImage,
+  buildWorkflowExecCommand,
+  ensureImage,
 } from '../src/docker/docker-infrastructure.js';
 import type { AgentAdapter, ConversationStateConfig } from '../src/docker/agent-adapter.js';
 import type { DockerProxy } from '../src/docker/code-mode-proxy.js';
@@ -612,7 +613,11 @@ describe('createSessionContainers', () => {
         { source: nodeModulesDir, target: '/opt/workflow-node_modules', readonly: false },
       ]),
     );
-    expect(createCalls[0].env.PATH).toContain('/opt/workflow-venv/bin');
+    // PATH must NOT be overridden: Docker `-e PATH=...` REPLACES (not appends)
+    // the image PATH, which would discard the base image's real PATH (e.g. the
+    // NVM node dir on the x86 devcontainer base). The workflow venv bin is
+    // prepended to the live $PATH at exec time instead (buildWorkflowExecCommand).
+    expect(createCalls[0].env.PATH).toBeUndefined();
     expect(createCalls[0].env.NODE_PATH).toBe('/opt/workflow-node_modules');
   });
 
@@ -986,68 +991,98 @@ describe('computeWorkflowDependencyHash', () => {
   });
 });
 
-describe('ensureWorkflowImage runtime-dependency path', () => {
+// Runtime workflow dependencies are installed into mounted caches at container
+// start (see provisionWorkflowDependencies); no per-workflow image is ever
+// built. `ensureImage` only ever materializes the shared agent image (and its
+// base), never an `ironcurtain-wf-*` tag.
+describe('ensureImage builds no per-workflow image', () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'wf-image-fastpath-'));
+    tempDir = mkdtempSync(join(tmpdir(), 'ensure-image-'));
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  // The mock Docker stamps build labels per tag; we assert no per-workflow
-  // image tag (`ironcurtain-wf-*`) is ever built, even when manifests exist.
-  function builtWorkflowImageTags(docker: DockerManager): string[] {
+  // The mock Docker stamps build labels per tag; capture every built tag so we
+  // can assert no per-workflow image tag (`ironcurtain-wf-*`) is produced.
+  function trackBuiltTags(docker: DockerManager): string[] {
     const built: string[] = [];
     const original = docker.buildImage.bind(docker);
     docker.buildImage = async (tag, df, ctx, labels) => {
-      if (tag.startsWith('ironcurtain-wf-')) built.push(tag);
+      built.push(tag);
       return original(tag, df, ctx, labels);
     };
     return built;
   }
 
-  it('returns the shared agent image unchanged when scriptsDir is undefined', async () => {
+  it('returns the shared agent image and builds only the agent + base images', async () => {
     const docker = createMockDocker();
     const ca = createMockCA(tempDir);
-    const built = builtWorkflowImageTags(docker);
+    const built = trackBuiltTags(docker);
 
-    const image = await ensureWorkflowImage('ironcurtain-claude-code:latest', undefined, docker, ca);
+    const buildHash = await ensureImage('ironcurtain-claude-code:latest', docker, ca);
 
-    expect(image).toBe('ironcurtain-claude-code:latest');
-    expect(built).toEqual([]);
+    expect(typeof buildHash).toBe('string');
+    expect(buildHash.length).toBeGreaterThan(0);
+    expect(built).toContain('ironcurtain-claude-code:latest');
+    expect(built.some((tag) => tag.startsWith('ironcurtain-wf-'))).toBe(false);
   });
 
-  it('returns the shared agent image when scripts/ has no dependency manifest', async () => {
-    const scriptsDir = join(tempDir, 'scripts');
-    mkdirSync(scriptsDir);
-    // A helper script but no requirements.txt / package.json.
-    writeFileSync(join(scriptsDir, 'run_eval.py'), 'print("hi")\n');
-
+  it('skips the rebuild when images are already up to date (content-hash labels)', async () => {
     const docker = createMockDocker();
     const ca = createMockCA(tempDir);
-    const built = builtWorkflowImageTags(docker);
 
-    const image = await ensureWorkflowImage('ironcurtain-claude-code:latest', scriptsDir, docker, ca);
+    // First call builds; second call must be a no-op (labels already stamped).
+    await ensureImage('ironcurtain-claude-code:latest', docker, ca);
+    const built = trackBuiltTags(docker);
+    await ensureImage('ironcurtain-claude-code:latest', docker, ca);
 
-    expect(image).toBe('ironcurtain-claude-code:latest');
     expect(built).toEqual([]);
   });
+});
 
-  it('returns the shared agent image and builds no workflow image when requirements.txt exists', async () => {
-    const scriptsDir = join(tempDir, 'scripts');
-    mkdirSync(scriptsDir);
-    writeFileSync(join(scriptsDir, 'requirements.txt'), 'numpy\npyyaml\n');
+describe('buildWorkflowExecCommand', () => {
+  const pythonMount = { hostDir: '/host/venv', target: '/opt/workflow-venv', cacheKey: 'abc' } as const;
+  const nodeMount = {
+    hostDir: '/host/node_modules',
+    target: '/opt/workflow-node_modules',
+    cacheKey: 'abc',
+    hasPackageLock: false,
+  } as const;
 
-    const docker = createMockDocker();
-    const ca = createMockCA(tempDir);
-    const built = builtWorkflowImageTags(docker);
+  it('returns the command unchanged when no dependency mount is present', () => {
+    const cmd = ['node', '/workflow-scripts/format_report.js'];
+    expect(buildWorkflowExecCommand({}, cmd)).toEqual(cmd);
+  });
 
-    const image = await ensureWorkflowImage('ironcurtain-claude-code:latest', scriptsDir, docker, ca);
+  it('prepends the live $PATH (not a replacement) so the image PATH is preserved', () => {
+    const wrapped = buildWorkflowExecCommand({ workflowPythonVenvMount: pythonMount }, [
+      'node',
+      '/workflow-scripts/format_report.js',
+    ]);
 
-    expect(image).toBe('ironcurtain-claude-code:latest');
-    expect(built).toEqual([]);
+    // Shell wrapper expands $PATH at runtime rather than hardcoding a PATH.
+    expect(wrapped[0]).toBe('/bin/sh');
+    expect(wrapped[1]).toBe('-lc');
+    expect(wrapped[2]).toContain('export PATH=/opt/workflow-venv/bin:"$PATH"');
+    expect(wrapped[2]).toContain('exec "$@"');
+    // Original argv is passed verbatim as positional params after the `sh` $0.
+    expect(wrapped.slice(3)).toEqual(['sh', 'node', '/workflow-scripts/format_report.js']);
+  });
+
+  it('prepends both the venv bin and the node_modules/.bin when both mounts exist', () => {
+    const wrapped = buildWorkflowExecCommand(
+      { workflowPythonVenvMount: pythonMount, workflowNodeModulesMount: nodeMount },
+      ['python', '-c', 'print(1)'],
+    );
+    expect(wrapped[2]).toContain('export PATH=/opt/workflow-venv/bin:/opt/workflow-node_modules/.bin:"$PATH"');
+    expect(wrapped.slice(3)).toEqual(['sh', 'python', '-c', 'print(1)']);
+  });
+
+  it('returns an empty command unchanged (no shell wrapper)', () => {
+    expect(buildWorkflowExecCommand({ workflowPythonVenvMount: pythonMount }, [])).toEqual([]);
   });
 });

--- a/test/docker/provision-lock.test.ts
+++ b/test/docker/provision-lock.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { withProvisionLock } from '../../src/docker/provision-lock.js';
 
@@ -13,6 +13,7 @@ describe('withProvisionLock', () => {
 
   afterEach(() => {
     rmSync(cacheDir, { recursive: true, force: true });
+    rmSync(`${cacheDir}.lock`, { recursive: true, force: true });
   });
 
   it('runs the critical section and releases the lock afterward', async () => {
@@ -96,5 +97,34 @@ describe('withProvisionLock', () => {
     );
 
     await holder;
+  });
+
+  it('does not steal a freshly-created lock dir that has no meta.json yet (mkdir→write race)', async () => {
+    // Simulate a holder that has created the lock dir but not yet written meta.json.
+    mkdirSync(`${cacheDir}.lock`);
+    // A waiter must treat the fresh meta-less dir as held (mid-acquisition), not stale.
+    await expect(
+      withProvisionLock(cacheDir, async () => 'stolen', { maxWaitMs: 100, staleMs: 60_000 }),
+    ).rejects.toThrow(/Failed to acquire workflow provisioning lock/);
+  });
+
+  it('reclaims an orphaned meta-less lock dir older than the grace window', async () => {
+    const lockDir = `${cacheDir}.lock`;
+    mkdirSync(lockDir);
+    // Backdate the dir mtime past ACQUIRE_GRACE_MS to simulate a holder that
+    // crashed between mkdir and the meta.json write.
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, old, old);
+    const result = await withProvisionLock(cacheDir, async () => 'reclaimed', { maxWaitMs: 2_000, staleMs: 60_000 });
+    expect(result).toBe('reclaimed');
+  });
+
+  it('reclaims a lock whose holder process is dead', async () => {
+    const lockDir = `${cacheDir}.lock`;
+    mkdirSync(lockDir);
+    // A PID that is essentially guaranteed not to be running → probe yields ESRCH.
+    writeFileSync(resolve(lockDir, 'meta.json'), JSON.stringify({ pid: 2 ** 30, timestamp: Date.now() }));
+    const result = await withProvisionLock(cacheDir, async () => 'reclaimed', { maxWaitMs: 2_000, staleMs: 60_000 });
+    expect(result).toBe('reclaimed');
   });
 });

--- a/test/docker/provision-lock.test.ts
+++ b/test/docker/provision-lock.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { withProvisionLock } from '../../src/docker/provision-lock.js';
+
+describe('withProvisionLock', () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), 'provision-lock-'));
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('runs the critical section and releases the lock afterward', async () => {
+    let ran = false;
+    const result = await withProvisionLock(cacheDir, async () => {
+      ran = true;
+      // Lock dir exists while held.
+      expect(existsSync(`${cacheDir}.lock`)).toBe(true);
+      return 'done';
+    });
+
+    expect(ran).toBe(true);
+    expect(result).toBe('done');
+    // Lock released after the critical section.
+    expect(existsSync(`${cacheDir}.lock`)).toBe(false);
+  });
+
+  it('releases the lock even when the critical section throws', async () => {
+    await expect(
+      withProvisionLock(cacheDir, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(existsSync(`${cacheDir}.lock`)).toBe(false);
+  });
+
+  it('serializes two concurrent critical sections on the same cache dir', async () => {
+    const events: string[] = [];
+    const enter = (tag: string) => events.push(`enter-${tag}`);
+    const exit = (tag: string) => events.push(`exit-${tag}`);
+
+    const slow = withProvisionLock(cacheDir, async () => {
+      enter('A');
+      await new Promise((r) => setTimeout(r, 150));
+      exit('A');
+    });
+    // Start B shortly after A so A wins the lock first.
+    await new Promise((r) => setTimeout(r, 20));
+    const fast = withProvisionLock(cacheDir, async () => {
+      enter('B');
+      exit('B');
+    });
+
+    await Promise.all([slow, fast]);
+
+    // B must not interleave inside A's critical section.
+    expect(events).toEqual(['enter-A', 'exit-A', 'enter-B', 'exit-B']);
+  });
+
+  it('lets concurrent sections on DIFFERENT cache dirs run in parallel', async () => {
+    const other = mkdtempSync(join(tmpdir(), 'provision-lock-other-'));
+    try {
+      const events: string[] = [];
+      const a = withProvisionLock(cacheDir, async () => {
+        events.push('enter-A');
+        await new Promise((r) => setTimeout(r, 100));
+        events.push('exit-A');
+      });
+      const b = withProvisionLock(other, async () => {
+        events.push('enter-B');
+        events.push('exit-B');
+      });
+      await Promise.all([a, b]);
+      // Distinct locks → B runs while A is still sleeping (interleaved).
+      expect(events.indexOf('enter-B')).toBeLessThan(events.indexOf('exit-A'));
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it('times out when the lock cannot be acquired within maxWaitMs', async () => {
+    // Hold the lock for longer than the waiter's tolerance.
+    const holder = withProvisionLock(cacheDir, async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    await expect(withProvisionLock(cacheDir, async () => 'never', { maxWaitMs: 100, staleMs: 60_000 })).rejects.toThrow(
+      /Failed to acquire workflow provisioning lock/,
+    );
+
+    await holder;
+  });
+});

--- a/test/docker/workflow-runtime-deps.integration.test.ts
+++ b/test/docker/workflow-runtime-deps.integration.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { execFile as execFileCb } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
@@ -8,6 +18,7 @@ import { REAL_TMP, testCompiledPolicy, testToolAnnotations } from '../fixtures/t
 import { isDockerAvailable, isDockerImageAvailable } from '../helpers/docker-available.js';
 import type { IronCurtainConfig } from '../../src/config/types.js';
 import {
+  buildWorkflowExecCommand,
   createDockerInfrastructure,
   destroyDockerInfrastructure,
   type DockerInfrastructure,
@@ -66,7 +77,7 @@ function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): I
       packageInstall: {
         enabled: true,
         quarantineDays: 2,
-        allowedPackages: ['numpy'],
+        allowedPackages: ['numpy', 'six'],
         deniedPackages: [],
       },
       serverCredentials: {},
@@ -83,6 +94,21 @@ async function workflowImageTags(): Promise<Set<string>> {
 async function containerConfigImage(containerId: string): Promise<string> {
   const { stdout } = await execFile('docker', ['inspect', '-f', '{{.Config.Image}}', containerId]);
   return stdout.trim();
+}
+
+/** Lists the host-side workflow dependency cache dirs (one per content hash). */
+function listDependencyCacheDirs(): string[] {
+  const cacheRoot = join(TEST_HOME, 'workflow-deps');
+  if (!existsSync(cacheRoot)) return [];
+  return readdirSync(cacheRoot).sort();
+}
+
+/** Returns the provisioned-sentinel file path inside a python venv cache, or null. */
+function findVenvSentinel(cacheKeyDir: string): string | null {
+  const venvDir = join(TEST_HOME, 'workflow-deps', cacheKeyDir, 'python-venv');
+  if (!existsSync(venvDir)) return null;
+  const sentinel = readdirSync(venvDir).find((name) => name.startsWith('.ironcurtain-provisioned-'));
+  return sentinel ? join(venvDir, sentinel) : null;
 }
 
 async function readPackageAudit(bundleDir: string): Promise<readonly Record<string, unknown>[]> {
@@ -202,5 +228,109 @@ describe.skipIf(!dockerReady)('workflow runtime dependency provisioning with rea
           (entry.source === 'metadata-filter' || entry.source === 'tarball-backstop'),
       ),
     ).toBe(true);
+
+    // A bare `node` invocation must resolve from the container's real PATH
+    // (the venv bin / node_modules .bin are prepended at exec time, the image
+    // PATH is preserved). This guards the PATH-replacement regression.
+    const nodeVersion = await bundle.docker.exec(
+      bundle.containerId,
+      buildWorkflowExecCommand(bundle, ['node', '--version']),
+      30_000,
+      'codespace',
+      '/workspace',
+    );
+    expect(nodeVersion.exitCode).toBe(0);
+    expect(nodeVersion.stdout.trim()).toMatch(/^v\d+/);
+  }, 300_000);
+
+  // Helper: stand up a bundle whose scripts carry the given requirements.txt.
+  async function makeBundleWithRequirements(label: string, requirements: string): Promise<DockerInfrastructure> {
+    const workspaceDir = resolve(tmpDir, `workspace-${label}`);
+    const generatedDir = resolve(TEST_HOME, 'generated');
+    const bundleDir = resolve(TEST_HOME, 'bundles', label);
+    const escalationDir = resolve(bundleDir, 'escalations');
+    const scriptsDir = resolve(tmpDir, `scripts-${label}`);
+    for (const dir of [workspaceDir, generatedDir, bundleDir, escalationDir, scriptsDir]) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(resolve(generatedDir, 'compiled-policy.json'), JSON.stringify(testCompiledPolicy));
+    writeFileSync(resolve(generatedDir, 'tool-annotations.json'), JSON.stringify(testToolAnnotations));
+    writeFileSync(resolve(scriptsDir, 'requirements.txt'), requirements);
+
+    const bundle = await createDockerInfrastructure(
+      buildDockerSessionConfig(workspaceDir, generatedDir),
+      { kind: 'docker', agent: 'claude-code' },
+      bundleDir,
+      workspaceDir,
+      escalationDir,
+      `${label}-bundle` as BundleId,
+      `${label}-workflow` as WorkflowId,
+      'primary',
+      [],
+      undefined,
+      scriptsDir,
+    );
+    liveBundles.add(bundle);
+    return bundle;
+  }
+
+  it('reuses the content-keyed cache on identical deps and re-provisions on a deps change', async () => {
+    // First run with numpy: installs into a fresh content-keyed cache.
+    const first = await makeBundleWithRequirements('cache-reuse-a', 'numpy\n');
+    const firstImport = await first.docker.exec(
+      first.containerId,
+      ['/opt/workflow-venv/bin/python', '-c', 'import numpy; print("ok")'],
+      60_000,
+      'codespace',
+      '/workspace',
+    );
+    expect(firstImport.exitCode).toBe(0);
+
+    // The numpy-only cache is content-keyed, so it is the single cache dir for
+    // this requirements set (it may already exist from the prior test, which
+    // also installs numpy into the same shared TEST_HOME — that is exactly the
+    // cross-run reuse this test asserts).
+    const cacheDirsAfterFirst = listDependencyCacheDirs();
+    const numpyCacheDir = cacheDirsAfterFirst.find((dir) => findVenvSentinel(dir) !== null);
+    expect(numpyCacheDir).toBeDefined();
+    const sentinelPath = findVenvSentinel(numpyCacheDir as string);
+    expect(sentinelPath).not.toBeNull();
+    const sentinelMtimeBefore = statSync(sentinelPath as string).mtimeMs;
+
+    // Second run with the SAME requirements: same content hash → same cache
+    // dir. The sentinel short-circuits, so the venv is NOT rebuilt (sentinel
+    // mtime unchanged) and no new cache dir appears.
+    const second = await makeBundleWithRequirements('cache-reuse-b', 'numpy\n');
+    expect(second.workflowPythonVenvMount?.hostDir).toBe(first.workflowPythonVenvMount?.hostDir);
+
+    const cacheDirsAfterSecond = listDependencyCacheDirs();
+    expect(cacheDirsAfterSecond).toEqual(cacheDirsAfterFirst);
+    expect(statSync(sentinelPath as string).mtimeMs).toBe(sentinelMtimeBefore);
+    // numpy is already importable in the reused venv.
+    const secondImport = await second.docker.exec(
+      second.containerId,
+      ['/opt/workflow-venv/bin/python', '-c', 'import numpy; print("ok")'],
+      60_000,
+      'codespace',
+      '/workspace',
+    );
+    expect(secondImport.exitCode).toBe(0);
+
+    // Third run with CHANGED requirements: different content hash → a NEW cache
+    // dir is created (re-provision), the original cache is left intact.
+    const third = await makeBundleWithRequirements('cache-reuse-c', 'numpy\nsix\n');
+    expect(third.workflowPythonVenvMount?.hostDir).not.toBe(first.workflowPythonVenvMount?.hostDir);
+    const cacheDirsAfterThird = listDependencyCacheDirs();
+    expect(cacheDirsAfterThird.length).toBe(cacheDirsAfterFirst.length + 1);
+    expect(cacheDirsAfterThird).toEqual(expect.arrayContaining(cacheDirsAfterFirst));
+    // The new venv really has the changed deps (six importable alongside numpy).
+    const thirdImport = await third.docker.exec(
+      third.containerId,
+      ['/opt/workflow-venv/bin/python', '-c', 'import numpy, six; print("ok")'],
+      60_000,
+      'codespace',
+      '/workspace',
+    );
+    expect(thirdImport.exitCode).toBe(0);
   }, 300_000);
 });

--- a/test/docker/workflow-runtime-deps.integration.test.ts
+++ b/test/docker/workflow-runtime-deps.integration.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { execFile as execFileCb } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { REAL_TMP, testCompiledPolicy, testToolAnnotations } from '../fixtures/test-policy.js';
+import { isDockerAvailable, isDockerImageAvailable } from '../helpers/docker-available.js';
+import type { IronCurtainConfig } from '../../src/config/types.js';
+import {
+  createDockerInfrastructure,
+  destroyDockerInfrastructure,
+  type DockerInfrastructure,
+} from '../../src/docker/docker-infrastructure.js';
+import type { BundleId } from '../../src/session/types.js';
+import type { WorkflowId } from '../../src/workflow/types.js';
+
+const execFile = promisify(execFileCb);
+
+const IMAGE = 'ironcurtain-claude-code:latest';
+const TEST_HOME = `${REAL_TMP}/ironcurtain-workflow-runtime-deps-${process.pid}`;
+
+function findHostCaDir(): string | null {
+  const home = process.env.IRONCURTAIN_HOME ?? join(homedir(), '.ironcurtain');
+  const ca = join(home, 'ca');
+  return existsSync(ca) ? ca : null;
+}
+
+const hostCaDir = findHostCaDir();
+const dockerReady =
+  process.env.INTEGRATION_TEST === '1' && isDockerAvailable() && isDockerImageAvailable(IMAGE) && hostCaDir !== null;
+
+function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): IronCurtainConfig {
+  return {
+    auditLogPath: join(workspaceDir, 'audit.jsonl'),
+    allowedDirectory: workspaceDir,
+    mcpServers: {},
+    protectedPaths: [],
+    generatedDir,
+    constitutionPath: join(generatedDir, 'constitution.md'),
+    agentModelId: 'anthropic:claude-sonnet-4-6',
+    escalationTimeoutSeconds: 300,
+    userConfig: {
+      agentModelId: 'anthropic:claude-sonnet-4-6',
+      policyModelId: 'anthropic:claude-sonnet-4-6',
+      anthropicApiKey: 'test-fake-key-no-network',
+      googleApiKey: '',
+      openaiApiKey: '',
+      escalationTimeoutSeconds: 300,
+      resourceBudget: {
+        maxTotalTokens: 1_000_000,
+        maxSteps: 100,
+        maxSessionSeconds: 1800,
+        maxEstimatedCostUsd: 5.0,
+        warnThresholdPercent: 80,
+      },
+      autoCompact: {
+        enabled: false,
+        thresholdTokens: 80_000,
+        keepRecentMessages: 10,
+        summaryModelId: 'anthropic:claude-haiku-4-5',
+      },
+      autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
+      auditRedaction: { enabled: false },
+      memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
+      packageInstall: {
+        enabled: true,
+        quarantineDays: 2,
+        allowedPackages: ['numpy'],
+        deniedPackages: [],
+      },
+      serverCredentials: {},
+      dockerResources: { memoryMb: null, cpus: null },
+    },
+  } as unknown as IronCurtainConfig;
+}
+
+async function workflowImageTags(): Promise<Set<string>> {
+  const { stdout } = await execFile('docker', ['image', 'ls', '--format', '{{.Repository}}:{{.Tag}}']);
+  return new Set(stdout.split('\n').filter((line) => line.startsWith('ironcurtain-wf-')));
+}
+
+async function containerConfigImage(containerId: string): Promise<string> {
+  const { stdout } = await execFile('docker', ['inspect', '-f', '{{.Config.Image}}', containerId]);
+  return stdout.trim();
+}
+
+async function readPackageAudit(bundleDir: string): Promise<readonly Record<string, unknown>[]> {
+  const auditPath = resolve(bundleDir, 'package-audit.jsonl');
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (existsSync(auditPath)) {
+      const lines = readFileSync(auditPath, 'utf-8')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+      if (lines.length > 0) {
+        return lines.map((line) => JSON.parse(line) as Record<string, unknown>);
+      }
+    }
+    await new Promise((resolveTimer) => setTimeout(resolveTimer, 250));
+  }
+  return [];
+}
+
+describe.skipIf(!dockerReady)('workflow runtime dependency provisioning with real Docker', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalAuth: string | undefined;
+  let originalApiKey: string | undefined;
+  const liveBundles = new Set<DockerInfrastructure>();
+
+  beforeAll(() => {
+    originalHome = process.env.IRONCURTAIN_HOME;
+    originalAuth = process.env.IRONCURTAIN_DOCKER_AUTH;
+    originalApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.IRONCURTAIN_HOME = TEST_HOME;
+    process.env.IRONCURTAIN_DOCKER_AUTH = 'apikey';
+    process.env.ANTHROPIC_API_KEY = 'test-fake-key-no-network';
+    mkdirSync(TEST_HOME, { recursive: true });
+    cpSync(hostCaDir as string, join(TEST_HOME, 'ca'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    for (const bundle of liveBundles) {
+      await destroyDockerInfrastructure(bundle).catch(() => {});
+    }
+    liveBundles.clear();
+
+    if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = originalHome;
+    if (originalAuth === undefined) delete process.env.IRONCURTAIN_DOCKER_AUTH;
+    else process.env.IRONCURTAIN_DOCKER_AUTH = originalAuth;
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = originalApiKey;
+
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'workflow-runtime-deps-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('installs requirements through the registry proxy into the mounted venv without a workflow image', async () => {
+    const beforeImages = await workflowImageTags();
+    const workspaceDir = resolve(tmpDir, 'workspace');
+    const generatedDir = resolve(TEST_HOME, 'generated');
+    const bundleDir = resolve(TEST_HOME, 'bundles', 'runtime-deps');
+    const escalationDir = resolve(bundleDir, 'escalations');
+    const scriptsDir = resolve(tmpDir, 'scripts');
+    mkdirSync(workspaceDir, { recursive: true });
+    mkdirSync(generatedDir, { recursive: true });
+    mkdirSync(bundleDir, { recursive: true });
+    mkdirSync(escalationDir, { recursive: true });
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(resolve(generatedDir, 'compiled-policy.json'), JSON.stringify(testCompiledPolicy));
+    writeFileSync(resolve(generatedDir, 'tool-annotations.json'), JSON.stringify(testToolAnnotations));
+    writeFileSync(resolve(scriptsDir, 'requirements.txt'), 'numpy\n');
+
+    const bundle = await createDockerInfrastructure(
+      buildDockerSessionConfig(workspaceDir, generatedDir),
+      { kind: 'docker', agent: 'claude-code' },
+      bundleDir,
+      workspaceDir,
+      escalationDir,
+      'runtime-deps-bundle' as BundleId,
+      'runtime-deps-workflow' as WorkflowId,
+      'primary',
+      [],
+      undefined,
+      scriptsDir,
+    );
+    liveBundles.add(bundle);
+
+    expect(bundle.image).toBe(IMAGE);
+    expect(await containerConfigImage(bundle.containerId)).toBe(IMAGE);
+
+    const importResult = await bundle.docker.exec(
+      bundle.containerId,
+      ['/opt/workflow-venv/bin/python', '-c', 'import numpy; print(numpy.__version__)'],
+      60_000,
+      'codespace',
+      '/workspace',
+    );
+    expect(importResult.exitCode).toBe(0);
+    expect(importResult.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+
+    const afterImages = await workflowImageTags();
+    expect([...afterImages].filter((tag) => !beforeImages.has(tag))).toEqual([]);
+
+    const audit = await readPackageAudit(bundleDir);
+    expect(
+      audit.some(
+        (entry) =>
+          entry.registry === 'pypi' &&
+          entry.packageName === 'numpy' &&
+          entry.decision === 'allow' &&
+          (entry.source === 'metadata-filter' || entry.source === 'tarball-backstop'),
+      ),
+    ).toBe(true);
+  }, 300_000);
+});

--- a/test/sandbox-integration.test.ts
+++ b/test/sandbox-integration.test.ts
@@ -50,6 +50,17 @@ function makeSandboxedConfig(overrides: Partial<ResolvedSandboxParams> = {}): Re
   };
 }
 
+function hasReachableSshAgentKey(): boolean {
+  if (process.platform !== 'darwin' || !process.env.SSH_AUTH_SOCK) return false;
+  try {
+    return execFileSync('ssh-add', ['-l'], { encoding: 'utf-8', timeout: 5_000 }).includes('SHA256:');
+  } catch {
+    return false;
+  }
+}
+
+const canExerciseSshAgentSocket = hasReachableSshAgentKey();
+
 // ── checkSandboxAvailability ─────────────────────────────────────────────
 
 describe('checkSandboxAvailability', () => {
@@ -957,7 +968,7 @@ describe.skipIf(!sandboxAvailable)('sandbox integration (requires bubblewrap+soc
 
   // Verify that SSH agent socket is accessible from within the sandbox
   // when allowUnixSockets includes the socket's parent directory.
-  it.skipIf(process.platform !== 'darwin' || !process.env.SSH_AUTH_SOCK)(
+  it.skipIf(!canExerciseSshAgentSocket)(
     'sandboxed process can reach SSH agent socket via allowUnixSockets',
     () => {
       const sshAuthSock = process.env.SSH_AUTH_SOCK!;
@@ -1004,7 +1015,7 @@ describe.skipIf(!sandboxAvailable)('sandbox integration (requires bubblewrap+soc
   );
 
   // Verify that WITHOUT allowUnixSockets, the SSH agent socket is NOT accessible.
-  it.skipIf(process.platform !== 'darwin' || !process.env.SSH_AUTH_SOCK)(
+  it.skipIf(!canExerciseSshAgentSocket)(
     'sandboxed process cannot reach SSH agent socket without allowUnixSockets',
     () => {
       // Write settings WITHOUT allowUnixSockets by writing the file manually

--- a/test/workflow/deterministic-verdict-smoke.integration.test.ts
+++ b/test/workflow/deterministic-verdict-smoke.integration.test.ts
@@ -65,9 +65,9 @@ function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): I
       auditRedaction: { enabled: false },
       memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
       packageInstall: {
-        enabled: false,
+        enabled: true,
         quarantineDays: 2,
-        allowedPackages: [],
+        allowedPackages: ['numpy', 'ajv'],
         deniedPackages: [],
       },
       serverCredentials: {},

--- a/test/workflow/evolve-human-surface.integration.test.ts
+++ b/test/workflow/evolve-human-surface.integration.test.ts
@@ -88,9 +88,9 @@ function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): I
       auditRedaction: { enabled: false },
       memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
       packageInstall: {
-        enabled: false,
+        enabled: true,
         quarantineDays: 2,
-        allowedPackages: [],
+        allowedPackages: ['numpy', 'pyyaml'],
         deniedPackages: [],
       },
       serverCredentials: {},

--- a/test/workflow/evolve-multi-round.integration.test.ts
+++ b/test/workflow/evolve-multi-round.integration.test.ts
@@ -89,9 +89,9 @@ function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): I
       auditRedaction: { enabled: false },
       memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
       packageInstall: {
-        enabled: false,
+        enabled: true,
         quarantineDays: 2,
-        allowedPackages: [],
+        allowedPackages: ['numpy', 'pyyaml'],
         deniedPackages: [],
       },
       serverCredentials: {},

--- a/test/workflow/evolve-single-round.integration.test.ts
+++ b/test/workflow/evolve-single-round.integration.test.ts
@@ -75,9 +75,9 @@ function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): I
       auditRedaction: { enabled: false },
       memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
       packageInstall: {
-        enabled: false,
+        enabled: true,
         quarantineDays: 2,
-        allowedPackages: [],
+        allowedPackages: ['numpy', 'pyyaml'],
         deniedPackages: [],
       },
       serverCredentials: {},


### PR DESCRIPTION
Makes the `evolve` workflow generic with respect to dependencies: per-workflow Python/Node deps are now **installed at run time through the registry proxy** into the running bundle container, instead of being baked into a per-workflow Docker image at build time. Pointing the workflow at a different dependency set no longer requires an image rebuild, and every install is mediated + audited by the existing registry proxy (allowlist/denylist/age-gate) rather than bypassed by an image build.

## What changed
- **Removed image baking.** `ensureWorkflowImage`'s dep-baking (and the `ironcurtain-wf-*` image, Dockerfile `RUN uv pip install`, staleness/hash machinery) is gone. The bundle container runs from the generic agent base image.
- **Runtime provisioning.** A once-per-run `provisionWorkflowDependencies` step installs `requirements.txt` (and `package.json`, if present) through the proxy into a **persistent venv on a mounted, content-keyed cache** (`~/.ironcurtain/workflow-deps/<hash>/`), reused across runs and surviving container recreation. Deterministic states' python/node resolve from it.
- The base agent image already ships `uv`/`python3`/`npm`/`node`; no base-image change needed.

## Review hardening (2nd commit)
An Opus code review (verdict: approve-with-nits; shell-safety and base-image toolchain verified clean) surfaced four items, all fixed:
1. **Precondition guard** — clear, actionable error when a workflow ships deps but `packageInstall` is disabled (dep-free workflows still run with it off).
2. **Cross-run cache lock** (`provision-lock.ts`) — serializes concurrent identical-deps provisioning. Host-side (atomic-mkdir + PID-liveness) because in-container `flock` does not serialize across containers on macOS Docker Desktop bind mounts.
3. **Removed the now-dead `ensureWorkflowImage` no-op.**
4. **PATH fix** — prepend the venv/node bins to the container's *live* `$PATH` at exec time (`buildWorkflowExecCommand`, base-image-agnostic) instead of replacing PATH with a hardcoded constant, so bare `node`/`npm` still resolve on the x86 base.

## Validation
- Build, lint, prettier: clean. Unit: **4756 pass** (+ new `provision-lock` serialization/timeout and `buildWorkflowExecCommand` tests).
- **Real-Docker integration: 13/13** across `workflow-runtime-deps` (proves: bundle runs the base image, `import numpy` works from the mounted venv, install traversed the registry proxy, **no `ironcurtain-wf-*` image created**) + the evolve suite + `deterministic-verdict-smoke`. New tests cover cache reuse on identical deps and re-provision on a deps change.