### PR TITLE
fix(workflow): keep bad-flag errors on the gate CLI's json/exit-code contract

### DIFF
--- a/src/workflow/cli-shared.ts
+++ b/src/workflow/cli-shared.ts
@@ -97,6 +97,9 @@ export function runCliPreflightLint(definitionPath: string, mode: LintMode): Wor
 
 type ParseArgsConfig = Parameters<typeof parseArgs>[0];
 
+/** The `options` map accepted by {@link parseArgsStrict} / {@link parseArgsResult}. */
+export type ParseArgsOptions = NonNullable<NonNullable<ParseArgsConfig>['options']>;
+
 export function parseArgsStrict(opts: Omit<ParseArgsConfig, 'strict'>): ReturnType<typeof parseArgs> {
   try {
     return parseArgs({ ...opts, strict: true });
@@ -105,5 +108,33 @@ export function parseArgsStrict(opts: Omit<ParseArgsConfig, 'strict'>): ReturnTy
     writeStderr(`${RED}${message}${RESET}`);
     writeStderr(`${DIM}Run with --help to see available options.${RESET}`);
     process.exit(1);
+  }
+}
+
+/**
+ * Outcome of {@link parseArgsResult}: either the parsed `values`/`positionals`,
+ * or a structured failure carrying the parse error message.
+ */
+export type ParseArgsResult =
+  | ({ readonly ok: true } & ReturnType<typeof parseArgs>)
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * Strict {@link parseArgs} that RETURNS a discriminated failure on an unknown/
+ * typo'd flag or a missing option value, instead of writing to stderr and
+ * calling `process.exit(1)` like {@link parseArgsStrict}.
+ *
+ * Kept as a separate sibling so the existing exit-on-error callers
+ * (`workflow-command`, `run-state-command`) are unaffected. Callers that own a
+ * structured output contract — e.g. the agent-facing daemon-gate commands,
+ * where every result must be a single JSON object on stdout with a
+ * usage-derived exit code — use this so a parse error can be reported on the
+ * right channel rather than crashing the process with a generic exit code.
+ */
+export function parseArgsResult(opts: Omit<ParseArgsConfig, 'strict'>): ParseArgsResult {
+  try {
+    return { ok: true, ...parseArgs({ ...opts, strict: true }) };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/workflow/daemon-gate-commands.ts
+++ b/src/workflow/daemon-gate-commands.ts
@@ -26,7 +26,7 @@ import {
   type DaemonEvent,
   type RpcResult,
 } from '../daemon-client/daemon-client.js';
-import { parseArgsStrict } from './cli-shared.js';
+import { parseArgsResult, type ParseArgsResult, type ParseArgsOptions } from './cli-shared.js';
 import type { WorkflowDetailDto } from '../web-ui/web-ui-types.js';
 import type { HumanGateRequestDto } from './types.js';
 
@@ -77,6 +77,61 @@ function fail(mode: OutputMode, error: string, extra: Record<string, unknown> = 
 function formatErrorText(error: string, extra: Record<string, unknown>): string {
   const message = typeof extra.message === 'string' ? extra.message : undefined;
   return message ? `Error: ${error}: ${message}` : `Error: ${error}`;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing (under the stdout/exit-code contract)
+// ---------------------------------------------------------------------------
+
+type ParsedGateArgs = Extract<ParseArgsResult, { readonly ok: true }>;
+
+type GateArgs =
+  | {
+      readonly ok: true;
+      readonly mode: OutputMode;
+      readonly values: ParsedGateArgs['values'];
+      readonly positionals: ParsedGateArgs['positionals'];
+    }
+  | { readonly ok: false; readonly exitCode: number };
+
+/**
+ * Cheap pre-scan for the `--json` flag, used to pick the output channel when
+ * strict parsing FAILS before {@link OutputMode} can be read from parsed
+ * values. A typo'd flag must still honor the caller's `--json` choice so the
+ * failure lands on the right channel (machine JSON on stdout vs human stderr).
+ */
+function detectOutputMode(args: string[]): OutputMode {
+  return { json: args.includes('--json') };
+}
+
+/**
+ * Parses a daemon-gate subcommand's args under this module's output contract.
+ *
+ * On an unknown/typo'd flag or a missing option value, reports a structured
+ * `INVALID_USAGE` (JSON on stdout when `--json`, human text on stderr) and exits
+ * {@link EXIT_USAGE} — rather than the bare stderr `process.exit(1)` that
+ * {@link parseArgsStrict} would do, which an agent driving the CLI cannot parse.
+ */
+function parseGateArgs(args: string[], options: ParseArgsOptions): GateArgs {
+  const result = parseArgsResult({ args, options, allowPositionals: true });
+  if (!result.ok) {
+    const mode = detectOutputMode(args);
+    return {
+      ok: false,
+      exitCode: fail(
+        mode,
+        'INVALID_USAGE',
+        { message: result.message, hint: 'Run with --help to see available options.' },
+        EXIT_USAGE,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    mode: { json: result.values.json === true },
+    values: result.values,
+    positionals: result.positionals,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -287,16 +342,13 @@ function extractDiagnostics(data: unknown): unknown[] | undefined {
 // ---------------------------------------------------------------------------
 
 async function runRun(args: string[]): Promise<number> {
-  const { values, positionals } = parseArgsStrict({
-    args,
-    options: {
-      json: { type: 'boolean' },
-      workspace: { type: 'string' },
-      'ensure-daemon': { type: 'boolean' },
-    },
-    allowPositionals: true,
+  const parsed = parseGateArgs(args, {
+    json: { type: 'boolean' },
+    workspace: { type: 'string' },
+    'ensure-daemon': { type: 'boolean' },
   });
-  const mode: OutputMode = { json: values.json === true };
+  if (!parsed.ok) return parsed.exitCode;
+  const { mode, values, positionals } = parsed;
 
   const definitionRef = positionals[0];
   const taskDescription = positionals[1];
@@ -357,15 +409,12 @@ async function runRun(args: string[]): Promise<number> {
 // ---------------------------------------------------------------------------
 
 async function runStatus(args: string[]): Promise<number> {
-  const { values, positionals } = parseArgsStrict({
-    args,
-    options: {
-      json: { type: 'boolean' },
-      'ensure-daemon': { type: 'boolean' },
-    },
-    allowPositionals: true,
+  const parsed = parseGateArgs(args, {
+    json: { type: 'boolean' },
+    'ensure-daemon': { type: 'boolean' },
   });
-  const mode: OutputMode = { json: values.json === true };
+  if (!parsed.ok) return parsed.exitCode;
+  const { mode, values, positionals } = parsed;
 
   const workflowId = positionals[0];
   if (!workflowId) {
@@ -405,16 +454,13 @@ function formatStatusText(p: StatusProjection): string {
 // ---------------------------------------------------------------------------
 
 async function runAwait(args: string[]): Promise<number> {
-  const { values, positionals } = parseArgsStrict({
-    args,
-    options: {
-      json: { type: 'boolean' },
-      timeout: { type: 'string' },
-      'ensure-daemon': { type: 'boolean' },
-    },
-    allowPositionals: true,
+  const parsed = parseGateArgs(args, {
+    json: { type: 'boolean' },
+    timeout: { type: 'string' },
+    'ensure-daemon': { type: 'boolean' },
   });
-  const mode: OutputMode = { json: values.json === true };
+  if (!parsed.ok) return parsed.exitCode;
+  const { mode, values, positionals } = parsed;
 
   const workflowId = positionals[0];
   if (!workflowId) {
@@ -565,17 +611,14 @@ function requiresPrompt(event: GateEvent): boolean {
 }
 
 async function runGate(args: string[]): Promise<number> {
-  const { values, positionals } = parseArgsStrict({
-    args,
-    options: {
-      json: { type: 'boolean' },
-      event: { type: 'string' },
-      prompt: { type: 'string' },
-      'ensure-daemon': { type: 'boolean' },
-    },
-    allowPositionals: true,
+  const parsed = parseGateArgs(args, {
+    json: { type: 'boolean' },
+    event: { type: 'string' },
+    prompt: { type: 'string' },
+    'ensure-daemon': { type: 'boolean' },
   });
-  const mode: OutputMode = { json: values.json === true };
+  if (!parsed.ok) return parsed.exitCode;
+  const { mode, values, positionals } = parsed;
 
   const workflowId = positionals[0];
   if (!workflowId) {
@@ -623,16 +666,13 @@ interface ArtifactContent {
 }
 
 async function runShow(args: string[]): Promise<number> {
-  const { values, positionals } = parseArgsStrict({
-    args,
-    options: {
-      json: { type: 'boolean' },
-      artifact: { type: 'string' },
-      'ensure-daemon': { type: 'boolean' },
-    },
-    allowPositionals: true,
+  const parsed = parseGateArgs(args, {
+    json: { type: 'boolean' },
+    artifact: { type: 'string' },
+    'ensure-daemon': { type: 'boolean' },
   });
-  const mode: OutputMode = { json: values.json === true };
+  if (!parsed.ok) return parsed.exitCode;
+  const { mode, values, positionals } = parsed;
 
   const workflowId = positionals[0];
   const artifactName = values.artifact;

--- a/src/workflow/daemon-gate-commands.ts
+++ b/src/workflow/daemon-gate-commands.ts
@@ -18,6 +18,7 @@
 import { spawn } from 'node:child_process';
 import { statSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
 
 import { resolveWorkflowPath } from './discovery.js';
 import {
@@ -95,13 +96,25 @@ type GateArgs =
   | { readonly ok: false; readonly exitCode: number };
 
 /**
- * Cheap pre-scan for the `--json` flag, used to pick the output channel when
- * strict parsing FAILS before {@link OutputMode} can be read from parsed
- * values. A typo'd flag must still honor the caller's `--json` choice so the
- * failure lands on the right channel (machine JSON on stdout vs human stderr).
+ * Picks the output channel when strict parsing FAILS, before {@link OutputMode}
+ * can be read from parsed values. A typo'd flag must still honor the caller's
+ * `--json` choice so the failure lands on the right channel (machine JSON on
+ * stdout vs human stderr).
+ *
+ * Uses a NON-strict re-parse — which never throws on the offending flag that
+ * triggered this path — rather than a literal `args.includes('--json')`. The
+ * loose parse still lets a known value-taking option consume its argument, so
+ * `--workspace --json` does NOT enable JSON mode (here `--json` is the
+ * workspace value, not a flag) and `--json=...` forms are handled. Falls back
+ * to a literal scan only if the loose parse itself cannot run.
  */
-function detectOutputMode(args: string[]): OutputMode {
-  return { json: args.includes('--json') };
+function detectOutputMode(args: string[], options: ParseArgsOptions): OutputMode {
+  try {
+    const { values } = parseArgs({ args, options, strict: false, allowPositionals: true });
+    return { json: values.json === true };
+  } catch {
+    return { json: args.includes('--json') };
+  }
 }
 
 /**
@@ -115,7 +128,7 @@ function detectOutputMode(args: string[]): OutputMode {
 function parseGateArgs(args: string[], options: ParseArgsOptions): GateArgs {
   const result = parseArgsResult({ args, options, allowPositionals: true });
   if (!result.ok) {
-    const mode = detectOutputMode(args);
+    const mode = detectOutputMode(args, options);
     return {
       ok: false,
       exitCode: fail(

--- a/test/workflow/daemon-gate-commands.integration.test.ts
+++ b/test/workflow/daemon-gate-commands.integration.test.ts
@@ -346,4 +346,23 @@ describe('daemon gate commands (command-layer integration)', () => {
     expect(bad.json.ok).toBe(false);
     expect(bad.json.error).toBe('INVALID_EVENT');
   }, 30_000);
+
+  it('unknown flag honors the JSON/exit-code contract instead of a bare exit 1', async () => {
+    // A typo'd flag is caught during arg parsing — BEFORE any daemon connect —
+    // so no server is booted. The failure must NOT escape the contract via a
+    // stderr-only `process.exit(1)`: with `--json` it is a single structured
+    // JSON object on stdout with the usage exit code (2), so an agent driving
+    // the CLI can parse it.
+    const bad = await runCommand('run', [FIXTURE_PATH, 'Draft a thing', '--jsno', '--json']);
+    expect(bad.exitCode).toBe(2);
+    expect(bad.json.ok).toBe(false);
+    expect(bad.json.error).toBe('INVALID_USAGE');
+    expect(typeof bad.json.message).toBe('string');
+
+    // Without `--json` the failure stays off stdout entirely (human stderr only),
+    // and the exit code is still the usage code (2), never the generic 1.
+    const quiet = await runCommand('status', ['some-id', '--bogus']);
+    expect(quiet.exitCode).toBe(2);
+    expect(quiet.stdout.trim()).toBe('');
+  });
 });

--- a/test/workflow/daemon-gate-commands.integration.test.ts
+++ b/test/workflow/daemon-gate-commands.integration.test.ts
@@ -365,4 +365,16 @@ describe('daemon gate commands (command-layer integration)', () => {
     expect(quiet.exitCode).toBe(2);
     expect(quiet.stdout.trim()).toBe('');
   });
+
+  it('does not treat a `--json` consumed as an option value as the JSON flag', async () => {
+    // Edge case: `--json` is the VALUE of the value-taking `--workspace` option,
+    // not a flag. When a later bad flag (`--bogus`) makes strict parsing fail,
+    // the channel must be chosen by a real parse — NOT a literal scan that would
+    // see `--json` in argv and wrongly emit machine JSON to stdout. The caller
+    // never requested JSON mode, so the failure stays on stderr (stdout empty),
+    // still with the usage exit code.
+    const masked = await runCommand('run', [FIXTURE_PATH, 'Draft a thing', '--workspace', '--json', '--bogus']);
+    expect(masked.exitCode).toBe(2);
+    expect(masked.stdout.trim()).toBe('');
+  });
 });


### PR DESCRIPTION
Closes #305.

## Problem
The agent-facing daemon-gate commands (`run` / `status` / `await` / `gate` / `show` in `src/workflow/daemon-gate-commands.ts`) honor a strict contract: every result is a single newline-terminated JSON object on **stdout** (when `--json`) with a usage-/phase-derived exit code (`EXIT_USAGE = 2`).

Argument parsing went through `parseArgsStrict` (`src/workflow/cli-shared.ts`), which on an unknown/typo'd flag (e.g. `--jsno`) or a missing option value calls `process.exit(1)` — writing only to **stderr**, with **no JSON on stdout** and the generic exit code `1`. An agent that mistypes a flag can't parse the failure and sees the wrong channel + exit code.

## Solution
As the issue notes, `parseArgsStrict` is shared across every subcommand, so the fix is a parse variant that *returns* an error instead of exiting, scoped so the other commands are unaffected:

- Add `parseArgsResult` to `cli-shared.ts` — a non-exiting sibling of `parseArgsStrict` that returns a discriminated `{ ok: true, values, positionals } | { ok: false, message }`. `parseArgsStrict` is left untouched, so the existing exit-on-error callers (`workflow-command`, `run-state-command`) keep their behavior.
- Route every daemon-gate subcommand through a small `parseGateArgs` helper that parses with `parseArgsResult` and, on failure, reports a structured `INVALID_USAGE` via the module's existing `fail(...)` — machine JSON on stdout when `--json`, human text on stderr — and returns `EXIT_USAGE` (2). The `--json` channel is derived from a cheap pre-scan of the raw args, so the failure still lands on the caller's chosen channel even though parsing never produced `values`.

A bad flag now behaves exactly like the other usage errors in this module (`INVALID_EVENT`, `INVALID_PARAMS`): structured, parseable, exit 2.

## Testing
- New regression case in `test/workflow/daemon-gate-commands.integration.test.ts`: an unknown flag yields a structured `INVALID_USAGE` JSON object on stdout with exit code 2 under `--json`, and stays off stdout (human stderr only) with the same exit code when `--json` is absent. Parsing fails before any daemon connect, so the case needs no booted server.
- `npx tsc --noEmit` clean; `eslint` + `prettier --check` clean on changed files.
- `npx vitest run test/workflow/` — 576 passed (full workflow suite, no regressions).