### PR TITLE
feat(web-ui): hide test workflows, add workflow README modal, polish workflow pages

### DIFF
--- a/packages/web-ui/e2e/workflows.spec.ts
+++ b/packages/web-ui/e2e/workflows.spec.ts
@@ -388,3 +388,64 @@ test.describe('Workflow List Actions', () => {
     await expect(abortButton).not.toBeVisible({ timeout: 5_000 });
   });
 });
+
+test.describe('Workflow README', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await resetMockServer(request);
+    await connectWithToken(page);
+    await navigateToWorkflowsList(page);
+  });
+
+  test('README info button opens a modal with rendered content for a workflow that ships one', async ({ page }) => {
+    // Selecting design-and-code (hasReadme: true) enables the README button.
+    await page.getByLabel('Workflow definition').selectOption({ label: 'design-and-code' });
+    const readmeButton = page.getByTestId('readme-info-button');
+    await expect(readmeButton).toBeEnabled();
+    await readmeButton.click();
+
+    // The modal renders the README markdown (an <h1> from "# Design & Code").
+    const body = page.getByTestId('workflow-readme-content');
+    await expect(body).toBeVisible({ timeout: 5_000 });
+    await expect(body.getByRole('heading', { name: 'Design & Code' })).toBeVisible();
+  });
+
+  test('README button is disabled for a workflow without a README', async ({ page }) => {
+    await page.getByLabel('Workflow definition').selectOption({ label: 'code-review' });
+    await expect(page.getByTestId('readme-info-button')).toBeDisabled();
+  });
+
+  test('selecting a definition shows its description and source', async ({ page }) => {
+    await page.getByLabel('Workflow definition').selectOption({ label: 'design-and-code' });
+    const meta = page.getByTestId('selected-definition-meta');
+    await expect(meta).toBeVisible();
+    await expect(meta).toContainText('bundled');
+  });
+});
+
+test.describe('Hidden workflows are suppressed', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await resetMockServer(request);
+    await connectWithToken(page);
+    await navigateToWorkflowsList(page);
+  });
+
+  test('the start picker omits hidden smoke workflows', async ({ page }) => {
+    const optionLabels = await page.getByLabel('Workflow definition').locator('option').allInnerTexts();
+    expect(optionLabels.some((t) => t.includes('deterministic-verdict-smoke'))).toBe(false);
+    // Sanity: a real workflow is still offered.
+    expect(optionLabels.some((t) => t.includes('design-and-code'))).toBe(true);
+  });
+
+  test('the past-runs table omits hidden smoke runs', async ({ page }) => {
+    await expect(page.getByTestId('past-runs-section')).toBeVisible();
+    // A non-hidden past run renders (sanity that the table populated)...
+    await expect(
+      page
+        .getByTestId('past-runs-section')
+        .getByText(/circle of fifths/i)
+        .first(),
+    ).toBeVisible({ timeout: 5_000 });
+    // ...but the seeded hidden smoke run's task text must not appear anywhere.
+    await expect(page.getByText(/deterministic verdict smoke run/i)).toHaveCount(0);
+  });
+});

--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -593,6 +593,40 @@ const CODE_REVIEW_GRAPH = {
   ],
 };
 
+// Workflows that ship a co-packaged README (mirrors the bundled design-and-code
+// package). Drives `hasReadme` on definitions/details and `workflows.readme`.
+const README_WORKFLOW_NAMES = new Set(['design-and-code']);
+
+// Workflows hidden from the web UI (smoke tests / fixtures). The real daemon
+// filters these out of listDefinitions / list / listResumable while still
+// listing them in the CLI; the mock mirrors that suppression so the UI's
+// "no test workflows visible" behavior is exercisable end-to-end.
+const HIDDEN_WORKFLOW_NAMES = new Set(['deterministic-verdict-smoke']);
+
+// Canned README markdown returned by `workflows.readme` for README workflows.
+const MOCK_README = `# Design & Code
+
+A four-phase workflow: **plan → design → implement → review**, with human gates
+between the planning stages and an automated coder–critic loop at the end.
+
+## Phases
+
+| Phase | Role | Output |
+|-------|------|--------|
+| Plan | Planner — orders the work into steps | \`plan.md\` |
+| Design | Architect — interfaces and types | \`spec.md\` |
+| Implement | Engineer — code + unit tests | \`src/\` |
+| Review | Reviewer — correctness and quality | \`review.md\` |
+
+## Human gates
+
+- **Plan review** — approve the approach before design.
+- **Design review** — approve interfaces before implementation.
+
+> Tip: write a detailed task description — the planner only sees the task text
+> and whatever already exists in the workspace.
+`;
+
 function buildWorkflowDetailDto(wf: MockWorkflow, gate?: MockGate) {
   const isDesignAndCode = wf.name.includes('design');
   const graph = isDesignAndCode ? DESIGN_AND_CODE_GRAPH : CODE_REVIEW_GRAPH;
@@ -625,6 +659,7 @@ function buildWorkflowDetailDto(wf: MockWorkflow, gate?: MockGate) {
     },
     gate: gate ?? undefined,
     workspacePath: `/tmp/ironcurtain-workflow/${wf.workflowId}`,
+    hasReadme: README_WORKFLOW_NAMES.has(wf.name),
   };
 }
 
@@ -766,6 +801,23 @@ function buildPastRunFixtures(): MockPastRun[] {
       timestamp: new Date(Date.now() - 1800_000).toISOString(),
       durationMs: 540_000,
       workspacePath: '/home/user/projects/checkpoint-retention',
+    },
+    // Hidden smoke-test run: present on disk but suppressed from the UI because
+    // its workflow is marked `hidden: true`. The listResumable handler filters
+    // it out (mirroring the daemon), so it should never reach the past-runs table.
+    {
+      workflowId: 'wf-past-smoke-hidden',
+      name: 'deterministic-verdict-smoke',
+      phase: 'completed',
+      currentState: 'completed',
+      lastState: 'completed',
+      taskDescription: 'TESTING ONLY - deterministic verdict smoke run',
+      round: 1,
+      maxRounds: 1,
+      totalTokens: 1200,
+      timestamp: new Date(Date.now() - 600_000).toISOString(),
+      durationMs: 15_000,
+      workspacePath: '/tmp/smoke',
     },
   ];
 }
@@ -1195,24 +1247,29 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
 
     // Workflow methods
     case 'workflows.listDefinitions':
+      // Mirrors the daemon: hidden (smoke/fixture) workflows are never returned
+      // here, and each entry carries `hasReadme`.
       return [
         {
           name: 'design-and-code',
           description: 'Plan -> Design -> Implement -> Review workflow',
-          path: '/opt/ironcurtain/workflows/design-and-code.yaml',
+          path: '/opt/ironcurtain/workflows/design-and-code/workflow.yaml',
           source: 'bundled',
+          hasReadme: README_WORKFLOW_NAMES.has('design-and-code'),
         },
         {
           name: 'code-review',
           description: 'Automated code review with multiple reviewers',
-          path: '/opt/ironcurtain/workflows/code-review.yaml',
+          path: '/opt/ironcurtain/workflows/code-review/workflow.yaml',
           source: 'bundled',
+          hasReadme: README_WORKFLOW_NAMES.has('code-review'),
         },
         {
           name: 'my-custom-flow',
           description: 'Custom workflow for internal tooling',
-          path: '/home/user/.ironcurtain/workflows/my-custom-flow.yaml',
+          path: '/home/user/.ironcurtain/workflows/my-custom-flow/workflow.yaml',
           source: 'user',
+          hasReadme: README_WORKFLOW_NAMES.has('my-custom-flow'),
         },
       ];
 
@@ -1220,7 +1277,8 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
       if (replayConfig) {
         return replayController ? [replayController.getStatus()] : [];
       }
-      return [...workflows.values()];
+      // Suppress hidden workflows' runs, mirroring the daemon.
+      return [...workflows.values()].filter((wf) => !HIDDEN_WORKFLOW_NAMES.has(wf.name));
     }
 
     case 'workflows.get': {
@@ -1401,7 +1459,8 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
 
     case 'workflows.listResumable': {
       if (replayConfig) return [];
-      return buildPastRunFixtures();
+      // Suppress hidden workflows' past runs, mirroring the daemon.
+      return buildPastRunFixtures().filter((r) => !HIDDEN_WORKFLOW_NAMES.has(r.name));
     }
 
     case 'workflows.messageLog': {
@@ -1426,6 +1485,25 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
         hasMore = filtered.some((e) => e.ts < cursor);
       }
       return { entries, hasMore };
+    }
+
+    case 'workflows.readme': {
+      const definitionPath = typeof params.definitionPath === 'string' ? params.definitionPath : undefined;
+      const wfId = typeof params.workflowId === 'string' ? params.workflowId : undefined;
+      // Resolve the workflow name from whichever address form was provided.
+      let name: string | undefined;
+      if (definitionPath) {
+        // Mock manifest paths look like `.../<name>/workflow.yaml`.
+        name = definitionPath.match(/\/([^/]+)\/workflow\.ya?ml$/)?.[1];
+      } else if (wfId) {
+        name = workflows.get(wfId)?.name ?? buildPastRunFixtures().find((r) => r.workflowId === wfId)?.name;
+      } else {
+        return errorResult('INVALID_PARAMS', 'Provide exactly one of definitionPath or workflowId');
+      }
+      if (name && README_WORKFLOW_NAMES.has(name)) {
+        return { content: MOCK_README };
+      }
+      return errorResult('README_NOT_FOUND', `No README for ${name ?? 'workflow'}`);
     }
 
     case 'workflows.import':

--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -1490,6 +1490,10 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
     case 'workflows.readme': {
       const definitionPath = typeof params.definitionPath === 'string' ? params.definitionPath : undefined;
       const wfId = typeof params.workflowId === 'string' ? params.workflowId : undefined;
+      // Match the daemon's Zod refine: exactly one address form (not zero, not both).
+      if ((definitionPath ? 1 : 0) + (wfId ? 1 : 0) !== 1) {
+        return errorResult('INVALID_PARAMS', 'Provide exactly one of definitionPath or workflowId');
+      }
       // Resolve the workflow name from whichever address form was provided.
       let name: string | undefined;
       if (definitionPath) {
@@ -1497,8 +1501,6 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
         name = definitionPath.match(/\/([^/]+)\/workflow\.ya?ml$/)?.[1];
       } else if (wfId) {
         name = workflows.get(wfId)?.name ?? buildPastRunFixtures().find((r) => r.workflowId === wfId)?.name;
-      } else {
-        return errorResult('INVALID_PARAMS', 'Provide exactly one of definitionPath or workflowId');
       }
       if (name && README_WORKFLOW_NAMES.has(name)) {
         return { content: MOCK_README };

--- a/packages/web-ui/src/lib/components/features/workflow-readme-modal.svelte
+++ b/packages/web-ui/src/lib/components/features/workflow-readme-modal.svelte
@@ -4,6 +4,7 @@
   import { Spinner } from '$lib/components/ui/spinner/index.js';
   import { renderMarkdown } from '$lib/markdown.js';
   import BookOpen from 'phosphor-svelte/lib/BookOpen';
+  import X from 'phosphor-svelte/lib/X';
 
   let {
     open,
@@ -55,8 +56,6 @@
       if (token === loadToken) loading = false;
     }
   }
-
-  const hasContent = $derived(content !== null && content.trim().length > 0);
 </script>
 
 <Modal {open} {onclose} class="max-w-3xl">
@@ -75,9 +74,7 @@
       aria-label="Close README"
       class="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
     >
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-        <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-      </svg>
+      <X size={16} />
     </button>
   </div>
 
@@ -90,7 +87,7 @@
       <div class="py-6 text-sm text-destructive" data-testid="workflow-readme-error">
         Could not load README: {error}
       </div>
-    {:else if hasContent && content !== null}
+    {:else if content !== null && content.trim().length > 0}
       <article class="prose-markdown text-sm" data-testid="workflow-readme-content">
         {@html renderMarkdown(content)}
       </article>

--- a/packages/web-ui/src/lib/components/features/workflow-readme-modal.svelte
+++ b/packages/web-ui/src/lib/components/features/workflow-readme-modal.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { Modal } from '$lib/components/ui/modal/index.js';
+  import { Spinner } from '$lib/components/ui/spinner/index.js';
+  import { renderMarkdown } from '$lib/markdown.js';
+  import BookOpen from 'phosphor-svelte/lib/BookOpen';
+
+  let {
+    open,
+    onclose,
+    title,
+    fetchReadme,
+  }: {
+    /** Whether the modal is visible. */
+    open: boolean;
+    /** Called when the user dismisses (backdrop, Escape, or close button). */
+    onclose: () => void;
+    /** Workflow name shown in the modal header. */
+    title: string;
+    /** Lazily resolves the raw README markdown. Invoked once per open. */
+    fetchReadme: () => Promise<string>;
+  } = $props();
+
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let content = $state<string | null>(null);
+  // Monotonic token guards against out-of-order responses when the modal is
+  // re-opened (or re-targeted) before an in-flight fetch resolves.
+  let loadToken = 0;
+
+  $effect(() => {
+    // Re-fetch each time the modal opens (or its target changes). We read
+    // `open` and `title` for reactivity, then run the fetch untracked so the
+    // `fetchReadme` prop identity never becomes a dependency — otherwise an
+    // unrelated parent re-render while the modal is open would refetch.
+    const isOpen = open;
+    void title;
+    if (!isOpen) return;
+    untrack(() => {
+      void load();
+    });
+  });
+
+  async function load(): Promise<void> {
+    const token = ++loadToken;
+    loading = true;
+    error = null;
+    content = null;
+    try {
+      const md = await fetchReadme();
+      if (token === loadToken) content = md;
+    } catch (e) {
+      if (token === loadToken) error = e instanceof Error ? e.message : String(e);
+    } finally {
+      if (token === loadToken) loading = false;
+    }
+  }
+
+  const hasContent = $derived(content !== null && content.trim().length > 0);
+</script>
+
+<Modal {open} {onclose} class="max-w-3xl">
+  <!-- Custom header: icon + title + close, so the README gets a book affordance. -->
+  <div class="flex items-center justify-between gap-3 px-5 py-3 border-b border-border">
+    <div class="flex items-center gap-2 min-w-0">
+      <BookOpen size={18} weight="duotone" class="text-primary shrink-0" />
+      <h2 class="text-sm font-semibold truncate">
+        {title}
+        <span class="text-muted-foreground font-normal">· README</span>
+      </h2>
+    </div>
+    <button
+      type="button"
+      onclick={onclose}
+      aria-label="Close README"
+      class="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+    >
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="max-h-[68vh] overflow-y-auto px-5 py-4" data-testid="workflow-readme-body">
+    {#if loading}
+      <div class="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+        <Spinner size="sm" /> Loading README…
+      </div>
+    {:else if error}
+      <div class="py-6 text-sm text-destructive" data-testid="workflow-readme-error">
+        Could not load README: {error}
+      </div>
+    {:else if hasContent && content !== null}
+      <article class="prose-markdown text-sm" data-testid="workflow-readme-content">
+        {@html renderMarkdown(content)}
+      </article>
+    {:else}
+      <div class="py-6 text-sm text-muted-foreground">This workflow has no README content.</div>
+    {/if}
+  </div>
+</Modal>

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -21,6 +21,7 @@ import type {
   WorkflowSummaryDto,
   WorkflowDetailDto,
   WorkflowDefinitionDto,
+  WorkflowReadmeDto,
   HumanGateRequestDto,
   FileTreeResponseDto,
   FileContentResponseDto,
@@ -420,6 +421,18 @@ export async function listPersonas(): Promise<PersonaListItem[]> {
 
 export async function listWorkflowDefinitions(): Promise<WorkflowDefinitionDto[]> {
   return getWsClient().request<WorkflowDefinitionDto[]>('workflows.listDefinitions');
+}
+
+/**
+ * Fetches a workflow's co-packaged README markdown, addressed either by its
+ * definition manifest path (Start picker, no running workflow) or by a
+ * running/past workflow id (detail view). Exactly one argument is sent.
+ */
+export async function getWorkflowReadme(target: {
+  definitionPath?: string;
+  workflowId?: string;
+}): Promise<WorkflowReadmeDto> {
+  return getWsClient().request<WorkflowReadmeDto>('workflows.readme', target);
 }
 
 export async function listWorkflows(): Promise<WorkflowSummaryDto[]> {

--- a/packages/web-ui/src/lib/types.ts
+++ b/packages/web-ui/src/lib/types.ts
@@ -306,6 +306,8 @@ export type WorkflowDetailDto = WorkflowCardDto & {
   readonly context: WorkflowContextDto;
   readonly gate?: HumanGateRequestDto;
   readonly workspacePath: string;
+  /** True when the workflow's source package ships a `README.md` (fetch via `workflows.readme`). */
+  readonly hasReadme: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -447,6 +449,14 @@ export interface WorkflowDefinitionDto {
   readonly description: string;
   readonly path: string;
   readonly source: WorkflowSource;
+  /** True when the package ships a `README.md` (fetch with `workflows.readme`). */
+  readonly hasReadme: boolean;
+}
+
+/** README markdown for a workflow, returned by `workflows.readme`. */
+export interface WorkflowReadmeDto {
+  /** Raw markdown source; the client renders + sanitizes it. */
+  readonly content: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web-ui/src/routes/WorkflowDetail.svelte
+++ b/packages/web-ui/src/routes/WorkflowDetail.svelte
@@ -9,6 +9,7 @@
     getWorkflowFileContent,
     getWorkflowArtifacts,
     getWorkflowMessageLog,
+    getWorkflowReadme,
   } from '$lib/stores.svelte.js';
   import { RpcError } from '$lib/ws-client.js';
   import { phaseBadgeVariant } from '$lib/utils.js';
@@ -21,7 +22,14 @@
   import GateReviewPanel from '$lib/components/features/gate-review-panel.svelte';
   import WorkspaceBrowser from '$lib/components/features/workspace-browser.svelte';
   import MessageLogTimeline from '$lib/components/features/message-log-timeline.svelte';
+  import WorkflowReadmeModal from '$lib/components/features/workflow-readme-modal.svelte';
   import { renderMarkdown } from '$lib/markdown.js';
+  import Info from 'phosphor-svelte/lib/Info';
+  import ArrowsClockwise from 'phosphor-svelte/lib/ArrowsClockwise';
+  import Lightning from 'phosphor-svelte/lib/Lightning';
+  import FolderOpen from 'phosphor-svelte/lib/FolderOpen';
+  import Note from 'phosphor-svelte/lib/Note';
+  import SealCheck from 'phosphor-svelte/lib/SealCheck';
 
   const MESSAGE_LOG_PAGE_SIZE = 200;
 
@@ -45,6 +53,7 @@
   // exact corruption cause without parsing the message string.
   let corruptionMessage = $state('');
   let resolveError = $state('');
+  let readmeOpen = $state(false);
   let workspaceExpanded = $state(false);
   let expandedMessages = $state(new Set<number>());
 
@@ -214,6 +223,18 @@
     <Button variant="ghost" size="sm" onclick={onback}>&larr; Back</Button>
     <h2 class="text-xl font-semibold tracking-tight">{summary.name}</h2>
     <Badge variant={phaseBadgeVariant(summary.phase)}>{summary.phase.replace('_', ' ')}</Badge>
+    {#if detail?.hasReadme}
+      <Button
+        variant="outline"
+        size="sm"
+        type="button"
+        data-testid="readme-info-button"
+        title="View workflow README"
+        onclick={() => (readmeOpen = true)}
+      >
+        <Info size={15} weight="duotone" class="mr-1" /> README
+      </Button>
+    {/if}
     <span class="text-sm text-muted-foreground ml-auto">
       State: <span class="font-mono">{summary.currentState}</span>
     </span>
@@ -290,33 +311,43 @@
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <Card>
           <CardContent>
-            <p class="text-xs text-muted-foreground">Round</p>
-            <p class="text-lg font-semibold">{detail.context.round}/{detail.context.maxRounds}</p>
+            <p class="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <ArrowsClockwise size={14} weight="duotone" /> Round
+            </p>
+            <p class="text-lg font-semibold tabular-nums">{detail.context.round}/{detail.context.maxRounds}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent>
-            <p class="text-xs text-muted-foreground">Total Tokens</p>
-            <p class="text-lg font-semibold">{detail.context.totalTokens.toLocaleString()}</p>
+            <p class="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <Lightning size={14} weight="duotone" /> Total Tokens
+            </p>
+            <p class="text-lg font-semibold tabular-nums">{detail.context.totalTokens.toLocaleString()}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent>
-            <p class="text-xs text-muted-foreground">Workspace</p>
-            <p class="text-sm font-mono truncate" title={detail.workspacePath}>{detail.workspacePath}</p>
+            <p class="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <FolderOpen size={14} weight="duotone" /> Workspace
+            </p>
+            <p class="text-sm font-mono truncate" title={detail.workspacePath}>{detail.workspacePath || '--'}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent>
-            <p class="text-xs text-muted-foreground">Description</p>
+            <p class="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <Note size={14} weight="duotone" /> Description
+            </p>
             <p class="text-sm truncate" title={detail.description}>{detail.description || '--'}</p>
           </CardContent>
         </Card>
         {#if latestVerdict}
           {@const confidenceText = formatConfidence(latestVerdict.confidence)}
-          <Card data-testid="latest-verdict-card">
+          <Card data-testid="latest-verdict-card" class="border-primary/30">
             <CardContent>
-              <p class="text-xs text-muted-foreground">Latest verdict</p>
+              <p class="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+                <SealCheck size={14} weight="duotone" class="text-primary" /> Latest verdict
+              </p>
               <p class="text-sm font-semibold truncate" title={latestVerdict.verdict}>
                 <span data-testid="latest-verdict-value">{latestVerdict.verdict}</span>
                 {#if confidenceText}
@@ -438,4 +469,11 @@
       {/if}
     </Card>
   {/if}
+
+  <WorkflowReadmeModal
+    open={readmeOpen}
+    onclose={() => (readmeOpen = false)}
+    title={summary.name}
+    fetchReadme={async () => (await getWorkflowReadme({ workflowId })).content}
+  />
 </div>

--- a/packages/web-ui/src/routes/WorkflowDetail.test.ts
+++ b/packages/web-ui/src/routes/WorkflowDetail.test.ts
@@ -56,6 +56,7 @@ vi.mock('$lib/stores.svelte.js', () => ({
   getWorkflowArtifacts: (...args: unknown[]) => mockGetWorkflowArtifacts(...args),
   getWorkflowMessageLog: (...args: unknown[]) =>
     mockGetWorkflowMessageLog(...(args as [string, { before?: string; limit?: number } | undefined])),
+  getWorkflowReadme: () => Promise.resolve({ content: '# Readme' }),
 }));
 
 vi.mock('$lib/utils.js', async (importOriginal) => {
@@ -129,6 +130,7 @@ function makeDetail(overrides: Partial<WorkflowDetailDto> = {}): WorkflowDetailD
       visitCounts: {},
     },
     workspacePath: '/tmp/wf-workspace',
+    hasReadme: false,
     ...overrides,
   };
 }

--- a/packages/web-ui/src/routes/Workflows.svelte
+++ b/packages/web-ui/src/routes/Workflows.svelte
@@ -8,6 +8,7 @@
     listResumableWorkflows,
     resumeWorkflow as rpcResumeWorkflow,
     importWorkflow as rpcImportWorkflow,
+    getWorkflowReadme,
   } from '../lib/stores.svelte.js';
   import type { WorkflowSummaryDto, WorkflowDefinitionDto, PastRunDto } from '$lib/types.js';
   import { phaseBadgeVariant } from '$lib/utils.js';
@@ -21,6 +22,7 @@
     countByPhase,
     formatConfidence,
     formatDurationMs,
+    formatRelativeTime,
     buildSummaryPlaceholder,
     synthesizeSummaryFromPastRun,
     synthesizeSummaryFromId,
@@ -33,8 +35,12 @@
   import { Alert } from '$lib/components/ui/alert/index.js';
   import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '$lib/components/ui/table/index.js';
   import WorkflowDetail from './WorkflowDetail.svelte';
+  import WorkflowReadmeModal from '$lib/components/features/workflow-readme-modal.svelte';
   import Copy from 'phosphor-svelte/lib/Copy';
   import Check from 'phosphor-svelte/lib/Check';
+  import Info from 'phosphor-svelte/lib/Info';
+  import Rocket from 'phosphor-svelte/lib/Rocket';
+  import TreeStructure from 'phosphor-svelte/lib/TreeStructure';
 
   const CUSTOM_PATH_SENTINEL = '__custom__';
 
@@ -45,6 +51,8 @@
   let workspacePath = $state('');
   let starting = $state(false);
   let actionError = $state('');
+  // README modal for the currently-selected definition in the Start form.
+  let readmeOpen = $state(false);
   // Track the gate set that was visible when the user dismissed the detail view.
   // The auto-select effect will not re-select until the set of pending gates changes.
   let dismissedGateIds: Set<string> | null = $state(null);
@@ -119,6 +127,9 @@
 
   const isCustomPath = $derived(selectedDefinition === CUSTOM_PATH_SENTINEL);
   const effectivePath = $derived(isCustomPath ? customPath.trim() : selectedDefinition);
+  // The selected bundled/user definition (undefined for the custom-path option
+  // or no selection). Drives the description helper text and README affordance.
+  const selectedDef = $derived(definitions.find((d) => d.path === selectedDefinition));
 
   $effect(() => {
     refreshWorkflows();
@@ -351,31 +362,55 @@
         <CardTitle>Start Workflow</CardTitle>
       </CardHeader>
       <CardContent>
-        <div class="space-y-3">
+        <div class="space-y-4">
           <div>
             <label for="def-select" class="block text-sm text-muted-foreground mb-1">Workflow definition</label>
-            <select
-              id="def-select"
-              bind:value={selectedDefinition}
-              class="w-full px-3 py-2.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/40 focus:border-ring transition-all"
-            >
-              <option value="">Select a workflow...</option>
-              {#if bundledDefs.length > 0}
-                <optgroup label="Bundled">
-                  {#each bundledDefs as def (def.path)}
-                    <option value={def.path}>{def.name} -- {def.description}</option>
-                  {/each}
-                </optgroup>
-              {/if}
-              {#if userDefs.length > 0}
-                <optgroup label="User">
-                  {#each userDefs as def (def.path)}
-                    <option value={def.path}>{def.name} -- {def.description}</option>
-                  {/each}
-                </optgroup>
-              {/if}
-              <option value={CUSTOM_PATH_SENTINEL}>Other (custom path)...</option>
-            </select>
+            <div class="flex items-stretch gap-2">
+              <select
+                id="def-select"
+                bind:value={selectedDefinition}
+                class="flex-1 min-w-0 px-3 py-2.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/40 focus:border-ring transition-all"
+              >
+                <option value="">Select a workflow…</option>
+                {#if bundledDefs.length > 0}
+                  <optgroup label="Bundled">
+                    {#each bundledDefs as def (def.path)}
+                      <option value={def.path}>{def.name}</option>
+                    {/each}
+                  </optgroup>
+                {/if}
+                {#if userDefs.length > 0}
+                  <optgroup label="User">
+                    {#each userDefs as def (def.path)}
+                      <option value={def.path}>{def.name}</option>
+                    {/each}
+                  </optgroup>
+                {/if}
+                <option value={CUSTOM_PATH_SENTINEL}>Other (custom path)…</option>
+              </select>
+              <Button
+                variant="outline"
+                size="icon"
+                type="button"
+                class="shrink-0"
+                aria-label="View workflow README"
+                title={selectedDef?.hasReadme ? 'View README' : 'No README for this workflow'}
+                disabled={!selectedDef?.hasReadme}
+                data-testid="readme-info-button"
+                onclick={() => (readmeOpen = true)}
+              >
+                <Info size={18} weight="duotone" />
+              </Button>
+            </div>
+            {#if selectedDef}
+              <div
+                class="mt-2 flex items-start gap-2 text-xs text-muted-foreground"
+                data-testid="selected-definition-meta"
+              >
+                <Badge variant="outline" class="shrink-0 capitalize">{selectedDef.source}</Badge>
+                <span class="leading-relaxed">{selectedDef.description}</span>
+              </div>
+            {/if}
           </div>
           {#if isCustomPath}
             <div>
@@ -388,16 +423,19 @@
             <textarea
               id="task-desc"
               bind:value={taskDescription}
-              placeholder="Describe the task in detail..."
+              placeholder="Describe the task in detail…"
               rows="4"
               class="w-full px-3 py-2.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/40 focus:border-ring placeholder:text-muted-foreground/50 transition-all disabled:opacity-50 resize-y min-h-[80px]"
             ></textarea>
           </div>
           <div>
-            <label for="ws-path" class="block text-sm text-muted-foreground mb-1">Workspace path (optional)</label>
+            <label for="ws-path" class="block text-sm text-muted-foreground mb-1">
+              Workspace path <span class="text-muted-foreground/60">(optional)</span>
+            </label>
             <Input id="ws-path" bind:value={workspacePath} placeholder="/path/to/workspace" />
           </div>
           <Button onclick={handleStart} loading={starting} disabled={!effectivePath || !taskDescription.trim()}>
+            {#if !starting}<Rocket size={16} weight="duotone" class="mr-1.5" />{/if}
             Start Workflow
           </Button>
         </div>
@@ -473,7 +511,11 @@
       {#if activeWorkflows.length === 0}
         <Card>
           <CardContent>
-            <p class="text-center text-muted-foreground py-8">No active workflows. Start one above.</p>
+            <div class="flex flex-col items-center gap-2 py-10 text-center">
+              <TreeStructure size={28} weight="duotone" class="text-muted-foreground/40" />
+              <p class="text-sm text-muted-foreground">No active workflows</p>
+              <p class="text-xs text-muted-foreground/70">Start one with the form above.</p>
+            </div>
           </CardContent>
         </Card>
       {:else}
@@ -508,8 +550,8 @@
                   {wf.maxRounds > 0 ? `${wf.round}/${wf.maxRounds}` : '--'}
                 </TableCell>
                 <TableCell>{@render verdictBadge(wf.latestVerdict)}</TableCell>
-                <TableCell class="text-muted-foreground text-sm">
-                  {new Date(wf.startedAt).toLocaleTimeString()}
+                <TableCell class="text-muted-foreground text-sm whitespace-nowrap">
+                  <span title={new Date(wf.startedAt).toLocaleString()}>{formatRelativeTime(wf.startedAt)}</span>
                 </TableCell>
                 <TableCell class="text-right">
                   {#if wf.phase === 'running' || wf.phase === 'waiting_human'}
@@ -594,8 +636,8 @@
                     <TableCell class="text-muted-foreground text-sm">
                       {formatDurationMs(row.durationMs) || '--'}
                     </TableCell>
-                    <TableCell class="text-muted-foreground text-sm">
-                      {new Date(row.timestamp).toLocaleString()}
+                    <TableCell class="text-muted-foreground text-sm whitespace-nowrap">
+                      <span title={new Date(row.timestamp).toLocaleString()}>{formatRelativeTime(row.timestamp)}</span>
                     </TableCell>
                     <TableCell class="text-right space-x-1.5 whitespace-nowrap">
                       <Button
@@ -656,5 +698,12 @@
         </CardContent>
       </Card>
     </section>
+
+    <WorkflowReadmeModal
+      open={readmeOpen}
+      onclose={() => (readmeOpen = false)}
+      title={selectedDef?.name ?? 'Workflow'}
+      fetchReadme={async () => (await getWorkflowReadme({ definitionPath: selectedDefinition })).content}
+    />
   </div>
 {/if}

--- a/packages/web-ui/src/routes/Workflows.test.ts
+++ b/packages/web-ui/src/routes/Workflows.test.ts
@@ -52,6 +52,7 @@ vi.mock('$lib/stores.svelte.js', () => ({
   listResumableWorkflows: () => mockListResumable(),
   resumeWorkflow: (...a: unknown[]) => mockResumeWorkflow(...(a as [string])),
   importWorkflow: (...a: unknown[]) => mockImportWorkflow(...(a as [string])),
+  getWorkflowReadme: () => Promise.resolve({ content: '# Readme' }),
 }));
 
 // WorkflowDetail pulls in workspace-browser etc. Replace with a noop stub so we

--- a/packages/web-ui/src/routes/workflows-helpers.test.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.test.ts
@@ -223,6 +223,11 @@ describe('workflows-helpers', () => {
       expect(formatRelativeTime(ago(3 * 3_600_000), now)).toBe('3h ago');
       expect(formatRelativeTime(ago(2 * 86_400_000), now)).toBe('2d ago');
     });
+    it('floors at unit boundaries (no early roll-over)', () => {
+      expect(formatRelativeTime(ago(60_000), now)).toBe('1m ago');
+      expect(formatRelativeTime(ago(59 * 60_000 + 59_000), now)).toBe('59m ago');
+      expect(formatRelativeTime(ago(23 * 3_600_000 + 59 * 60_000), now)).toBe('23h ago');
+    });
     it('falls back to a locale date beyond a week', () => {
       const old = ago(10 * 86_400_000);
       expect(formatRelativeTime(old, now)).toBe(new Date(old).toLocaleDateString());

--- a/packages/web-ui/src/routes/workflows-helpers.test.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   countByPhase,
   formatConfidence,
   formatDurationMs,
+  formatRelativeTime,
 } from './workflows-helpers.js';
 import type { PastRunDto, WorkflowSummaryDto, PastRunPhase, LiveWorkflowPhase } from '$lib/types.js';
 
@@ -206,6 +207,29 @@ describe('workflows-helpers', () => {
     it('returns empty for undefined or negative', () => {
       expect(formatDurationMs(undefined)).toBe('');
       expect(formatDurationMs(-1)).toBe('');
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    const now = new Date('2026-06-17T12:00:00.000Z').getTime();
+    const ago = (ms: number): string => new Date(now - ms).toISOString();
+
+    it('reports recent times as "just now"', () => {
+      expect(formatRelativeTime(ago(5_000), now)).toBe('just now');
+      expect(formatRelativeTime(ago(44_000), now)).toBe('just now');
+    });
+    it('reports minutes, hours, and days', () => {
+      expect(formatRelativeTime(ago(5 * 60_000), now)).toBe('5m ago');
+      expect(formatRelativeTime(ago(3 * 3_600_000), now)).toBe('3h ago');
+      expect(formatRelativeTime(ago(2 * 86_400_000), now)).toBe('2d ago');
+    });
+    it('falls back to a locale date beyond a week', () => {
+      const old = ago(10 * 86_400_000);
+      expect(formatRelativeTime(old, now)).toBe(new Date(old).toLocaleDateString());
+    });
+    it('returns -- for empty or unparseable input', () => {
+      expect(formatRelativeTime('', now)).toBe('--');
+      expect(formatRelativeTime('not-a-date', now)).toBe('--');
     });
   });
 });

--- a/packages/web-ui/src/routes/workflows-helpers.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.ts
@@ -204,3 +204,24 @@ export function formatDurationMs(ms: number | undefined): string {
   if (m > 0) return `${m}m ${s.toString().padStart(2, '0')}s`;
   return `${s}s`;
 }
+
+/**
+ * Formats an ISO timestamp as a compact relative string ("just now", "3m ago",
+ * "2h ago", "5d ago"), falling back to a locale date for entries older than a
+ * week. Returns '--' for empty / unparseable input. Pair with an absolute
+ * `title` tooltip for the exact time. `now` is injectable for deterministic tests.
+ */
+export function formatRelativeTime(iso: string, now: number = Date.now()): string {
+  if (!iso) return '--';
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '--';
+  const diffSec = Math.round((now - t) / 1000);
+  if (diffSec < 45) return 'just now';
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(t).toLocaleDateString();
+}

--- a/packages/web-ui/src/routes/workflows-helpers.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.ts
@@ -215,13 +215,15 @@ export function formatRelativeTime(iso: string, now: number = Date.now()): strin
   if (!iso) return '--';
   const t = new Date(iso).getTime();
   if (Number.isNaN(t)) return '--';
-  const diffSec = Math.round((now - t) / 1000);
-  if (diffSec < 45) return 'just now';
-  const diffMin = Math.round(diffSec / 60);
+  // Floor each unit so we never round up across a boundary (e.g. 59m 31s must
+  // read "59m ago", not "1h ago"). The sub-minute window absorbs the floor=0 case.
+  const diffSec = Math.floor((now - t) / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
   if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.round(diffMin / 60);
+  const diffHr = Math.floor(diffMin / 60);
   if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.round(diffHr / 24);
+  const diffDay = Math.floor(diffHr / 24);
   if (diffDay < 7) return `${diffDay}d ago`;
   return new Date(t).toLocaleDateString();
 }

--- a/src/web-ui/dispatch/workflow-dispatch.ts
+++ b/src/web-ui/dispatch/workflow-dispatch.ts
@@ -301,15 +301,19 @@ export async function workflowDispatch(
     return definitions;
   }
 
-  // workflows.readme addressed by definitionPath needs no workflow manager
-  // (Start picker, no running workflow). The workflowId form is handled in
-  // the switch below, where the manager is available.
+  // workflows.readme is handled here, in one place: the definitionPath form
+  // (Start picker) needs no workflow manager, while the workflowId form
+  // (detail view) does. The schema's refine guarantees exactly one is set.
   if (method === 'workflows.readme') {
-    const parsed = validateParams(workflowReadmeSchema, params);
-    if (parsed.definitionPath) {
-      return readReadmeForDefinitionPath(parsed.definitionPath);
+    const { definitionPath, workflowId } = validateParams(workflowReadmeSchema, params);
+    if (definitionPath) {
+      return readReadmeForDefinitionPath(definitionPath);
     }
-    // workflowId form: validated to be present by the schema's refine.
+    if (!ctx.workflowManager) {
+      throw new RpcError('INTERNAL_ERROR', 'Workflow system not available');
+    }
+    const mgr = ctx.workflowManager;
+    return readReadmeForWorkflowId(mgr.getOrchestrator(), mgr, workflowId as WorkflowId);
   }
 
   if (!ctx.workflowManager) {
@@ -334,16 +338,6 @@ export async function workflowDispatch(
         }
       }
       return summaries;
-    }
-
-    case 'workflows.readme': {
-      // definitionPath form is handled before the manager guard above; only
-      // the workflowId form reaches here.
-      const { workflowId } = validateParams(workflowReadmeSchema, params);
-      if (!workflowId) {
-        throw new RpcError('INVALID_PARAMS', 'workflowId is required');
-      }
-      return readReadmeForWorkflowId(controller, manager, workflowId as WorkflowId);
     }
 
     case 'workflows.get': {

--- a/src/web-ui/dispatch/workflow-dispatch.ts
+++ b/src/web-ui/dispatch/workflow-dispatch.ts
@@ -23,6 +23,8 @@ import {
   type LatestVerdictDto,
   type LiveWorkflowPhase,
   type PastRunPhase,
+  type WorkflowDefinitionDto,
+  type WorkflowReadmeDto,
   RpcError,
   MethodNotFoundError,
 } from '../web-ui-types.js';
@@ -42,6 +44,7 @@ import {
   summaryForId,
   type WorkflowRunSummary,
 } from '../../workflow/workflow-discovery.js';
+import { discoverWorkflows, findWorkflowByName, readWorkflowReadme } from '../../workflow/discovery.js';
 import { extractStateGraph } from '../state-graph.js';
 import type { StateGraphDto } from '../web-ui-types.js';
 import { isWithinDirectory } from '../../types/argument-roles.js';
@@ -132,7 +135,93 @@ const workflowMessageLogSchema = z.object({
   limit: z.number().int().positive().max(2000).optional(),
 });
 
+// `workflows.readme`: fetch a workflow's co-packaged README markdown. Address it
+// either by definition manifest path (Start picker, no running workflow) or by a
+// running/past workflow id (detail view). Exactly one must be provided.
+const workflowReadmeSchema = z
+  .object({
+    definitionPath: z.string().min(1).optional(),
+    workflowId: z.string().min(1).optional(),
+  })
+  .refine((v) => (v.definitionPath ? 1 : 0) + (v.workflowId ? 1 : 0) === 1, {
+    message: 'Provide exactly one of definitionPath or workflowId',
+  });
+
 const DEFAULT_MESSAGE_LOG_LIMIT = 200;
+
+/**
+ * Manifest names of workflows marked `hidden: true`. Used to suppress
+ * smoke-test / fixture workflows' *runs* from the web UI's active and
+ * past-run listings (the definition picker filters on the entry directly).
+ * Run records carry `definition.name`, which equals the discovery entry's
+ * directory name by convention — see {@link findWorkflowByName}.
+ */
+function hiddenWorkflowNames(): Set<string> {
+  return new Set(
+    discoverWorkflows()
+      .filter((entry) => entry.hidden)
+      .map((entry) => entry.name),
+  );
+}
+
+/** True when a workflow's source package ships a README (best-effort name lookup). */
+function workflowHasReadme(name: string): boolean {
+  return findWorkflowByName(name)?.hasReadme ?? false;
+}
+
+/** Reads README markdown for a discovered manifest, or throws `README_NOT_FOUND`. */
+function readmeDtoOrThrow(manifestPath: string, name: string): WorkflowReadmeDto {
+  const content = readWorkflowReadme(manifestPath);
+  if (content === undefined) {
+    throw new RpcError('README_NOT_FOUND', `Workflow "${name}" has no README`);
+  }
+  return { content };
+}
+
+/**
+ * Serves a README addressed by definition manifest path (Start picker).
+ * Only *discovered* workflows are served — never an arbitrary client path —
+ * which both validates the input and confines reads to the workflow trees.
+ */
+function readReadmeForDefinitionPath(definitionPath: string): WorkflowReadmeDto {
+  const target = resolve(definitionPath);
+  const entry = discoverWorkflows().find((e) => resolve(e.path) === target);
+  if (!entry) {
+    throw new RpcError('WORKFLOW_NOT_FOUND', `Unknown workflow definition: ${definitionPath}`);
+  }
+  return readmeDtoOrThrow(entry.path, entry.name);
+}
+
+/** Resolves a running/past workflow id to its definition name (manifest `name:`). */
+function resolveWorkflowName(
+  controller: ReturnType<WorkflowManager['getOrchestrator']>,
+  manager: WorkflowManager,
+  id: WorkflowId,
+): string | undefined {
+  const detail = controller.getDetail(id);
+  if (detail) return detail.definition.name;
+  const result = manager.loadPastRun(id);
+  if ('error' in result) return undefined;
+  return result.definition.name;
+}
+
+/** Serves a README addressed by running/past workflow id (detail view). */
+function readReadmeForWorkflowId(
+  controller: ReturnType<WorkflowManager['getOrchestrator']>,
+  manager: WorkflowManager,
+  id: WorkflowId,
+): WorkflowReadmeDto {
+  const name = resolveWorkflowName(controller, manager, id);
+  if (!name) {
+    throw new RpcError('WORKFLOW_NOT_FOUND', `Workflow ${id} not found`);
+  }
+  const entry = findWorkflowByName(name);
+  if (!entry) {
+    // Run references a workflow no longer discoverable (e.g. a one-off custom path).
+    throw new RpcError('README_NOT_FOUND', `No README available for workflow ${id}`);
+  }
+  return readmeDtoOrThrow(entry.path, entry.name);
+}
 
 // ---------------------------------------------------------------------------
 // Extended dispatch context
@@ -196,10 +285,31 @@ export async function workflowDispatch(
   method: string,
   params: Record<string, unknown>,
 ): Promise<unknown> {
-  // workflows.listDefinitions does not need a running workflow manager
+  // workflows.listDefinitions does not need a running workflow manager.
+  // `hidden` workflows (smoke tests / fixtures) are filtered out — they
+  // remain runnable from the CLI but never appear in the web UI picker.
   if (method === 'workflows.listDefinitions') {
-    const { discoverWorkflows } = await import('../../workflow/discovery.js');
-    return discoverWorkflows();
+    const definitions: WorkflowDefinitionDto[] = discoverWorkflows()
+      .filter((entry) => !entry.hidden)
+      .map((entry) => ({
+        name: entry.name,
+        description: entry.description,
+        path: entry.path,
+        source: entry.source,
+        hasReadme: entry.hasReadme,
+      }));
+    return definitions;
+  }
+
+  // workflows.readme addressed by definitionPath needs no workflow manager
+  // (Start picker, no running workflow). The workflowId form is handled in
+  // the switch below, where the manager is available.
+  if (method === 'workflows.readme') {
+    const parsed = validateParams(workflowReadmeSchema, params);
+    if (parsed.definitionPath) {
+      return readReadmeForDefinitionPath(parsed.definitionPath);
+    }
+    // workflowId form: validated to be present by the schema's refine.
   }
 
   if (!ctx.workflowManager) {
@@ -211,15 +321,29 @@ export async function workflowDispatch(
   switch (method) {
     case 'workflows.list': {
       const activeIds = controller.listActive();
+      // Suppress hidden workflows' runs (smoke tests / fixtures) from the UI.
+      const hidden = hiddenWorkflowNames();
       const summaries: WorkflowSummaryDto[] = [];
       for (const id of activeIds) {
         const status = controller.getStatus(id);
         if (status) {
           const detail = controller.getDetail(id);
-          summaries.push(buildSummaryDto(id, status, detail));
+          const dto = buildSummaryDto(id, status, detail);
+          if (hidden.has(dto.name)) continue;
+          summaries.push(dto);
         }
       }
       return summaries;
+    }
+
+    case 'workflows.readme': {
+      // definitionPath form is handled before the manager guard above; only
+      // the workflowId form reaches here.
+      const { workflowId } = validateParams(workflowReadmeSchema, params);
+      if (!workflowId) {
+        throw new RpcError('INVALID_PARAMS', 'workflowId is required');
+      }
+      return readReadmeForWorkflowId(controller, manager, workflowId as WorkflowId);
     }
 
     case 'workflows.get': {
@@ -442,6 +566,7 @@ function buildDetailDto(id: WorkflowId, status: WorkflowStatus, detail?: Workflo
       : { taskDescription: '', round: 0, maxRounds: 0, totalTokens: 0, visitCounts: {} },
     gate: status.phase === 'waiting_human' ? toHumanGateRequestDto(status.gate) : undefined,
     workspacePath: detail?.workspacePath ?? '',
+    hasReadme: workflowHasReadme(base.name),
   };
 }
 
@@ -630,6 +755,7 @@ export function buildDetailFromPastRun(
       },
       gate: undefined,
       workspacePath: checkpoint.workspacePath ?? '',
+      hasReadme: workflowHasReadme(definition.name),
     };
   }
 
@@ -662,6 +788,7 @@ export function buildDetailFromPastRun(
     context: { taskDescription, round: 0, maxRounds: 0, totalTokens: 0, visitCounts: {} },
     gate: undefined,
     workspacePath: recoveredWorkspace,
+    hasReadme: workflowHasReadme(definition.name),
   };
 }
 
@@ -869,6 +996,8 @@ function buildResumableList(manager: WorkflowManager): PastRunDto[] {
   const baseDir = manager.getBaseDir();
   const runs = discoverWorkflowRuns(baseDir);
   const activeIds = new Set<WorkflowId>(controller.listActive());
+  // Suppress hidden workflows' past runs (smoke tests / fixtures) from the UI.
+  const hidden = hiddenWorkflowNames();
   const dtos: PastRunDto[] = [];
 
   for (const run of runs) {
@@ -882,7 +1011,9 @@ function buildResumableList(manager: WorkflowManager): PastRunDto[] {
       }
       continue;
     }
-    dtos.push(buildPastRunDto(run.workflowId, result, run));
+    const dto = buildPastRunDto(run.workflowId, result, run);
+    if (hidden.has(dto.name)) continue;
+    dtos.push(dto);
   }
 
   dtos.sort((a, b) => b.timestamp.localeCompare(a.timestamp));

--- a/src/web-ui/web-ui-types.ts
+++ b/src/web-ui/web-ui-types.ts
@@ -57,6 +57,7 @@ export type MethodName =
   | 'workflows.listDefinitions'
   | 'workflows.listResumable'
   | 'workflows.messageLog'
+  | 'workflows.readme'
   | 'personas.get'
   | 'personas.compile';
 
@@ -95,6 +96,7 @@ export type ErrorCode =
   | 'WORKFLOW_CORRUPTED'
   | 'WORKFLOW_NOT_AT_GATE'
   | 'ARTIFACT_NOT_FOUND'
+  | 'README_NOT_FOUND'
   | 'PERSONA_NOT_FOUND'
   | 'FILE_TOO_LARGE'
   | 'INVALID_PARAMS'
@@ -236,6 +238,8 @@ export type WorkflowDetailDto = WorkflowCardDto & {
   readonly context: WorkflowContextDto;
   readonly gate?: HumanGateRequestDto;
   readonly workspacePath: string;
+  /** True when the workflow's source package ships a `README.md` (lazily fetched via `workflows.readme`). */
+  readonly hasReadme: boolean;
 };
 
 /** Minimal representation of the state machine graph for frontend rendering. */
@@ -359,6 +363,14 @@ export interface WorkflowDefinitionDto {
   readonly description: string;
   readonly path: string;
   readonly source: 'bundled' | 'user' | 'custom';
+  /** True when the package ships a `README.md` (fetch with `workflows.readme`). */
+  readonly hasReadme: boolean;
+}
+
+/** README markdown for a workflow, returned by `workflows.readme`. */
+export interface WorkflowReadmeDto {
+  /** Raw markdown source; the client renders + sanitizes it. */
+  readonly content: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/workflow/discovery.ts
+++ b/src/workflow/discovery.ts
@@ -19,6 +19,7 @@ import { dirname, resolve, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import YAML from 'yaml';
 import { getUserWorkflowsDir } from '../config/paths.js';
+import { isWithinDirectory } from '../types/argument-roles.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -229,13 +230,23 @@ export function findWorkflowByName(name: string): WorkflowEntry | undefined {
 /**
  * Reads the README.md co-packaged with a workflow, given the absolute path
  * to its manifest. Returns the raw markdown, or `undefined` when no README
- * is present, it exceeds {@link MAX_README_BYTES}, or it cannot be read.
+ * is present, it resolves (via symlink) outside the workflow package, it
+ * exceeds {@link MAX_README_BYTES}, or it cannot be read.
+ *
+ * The containment check is the security boundary for `workflows.readme`: a
+ * symlinked README must not let the daemon serve arbitrary host files.
+ * `isWithinDirectory` resolves both paths to their canonical real form, so a
+ * symlink escaping the package dir is rejected while a legitimate in-package
+ * symlink still resolves.
  */
 export function readWorkflowReadme(manifestPath: string): string | undefined {
-  const readme = findReadme(getWorkflowPackageDir(manifestPath));
+  const packageDir = getWorkflowPackageDir(manifestPath);
+  const readme = findReadme(packageDir);
   if (!readme) return undefined;
+  if (!isWithinDirectory(readme, packageDir)) return undefined;
   try {
-    if (statSync(readme).size > MAX_README_BYTES) return undefined;
+    const stats = statSync(readme);
+    if (!stats.isFile() || stats.size > MAX_README_BYTES) return undefined;
     return readFileSync(readme, 'utf-8');
   } catch {
     return undefined;

--- a/src/workflow/discovery.ts
+++ b/src/workflow/discovery.ts
@@ -111,17 +111,22 @@ export function getWorkflowPackageDir(workflowFilePath: string): string {
   return dirname(workflowFilePath);
 }
 
+/** Returns the first `<dir>/<basename>` that exists on disk, or `undefined`. */
+function findFirstExisting(dir: string, basenames: readonly string[]): string | undefined {
+  for (const basename of basenames) {
+    const candidate = resolve(dir, basename);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
 /**
  * Locates the manifest file inside a workflow package directory.
  * Returns the absolute path to `workflow.yaml` or `workflow.yml` if
  * present (yaml takes precedence on collision), `undefined` otherwise.
  */
 function findManifest(packageDir: string): string | undefined {
-  for (const basename of MANIFEST_BASENAMES) {
-    const candidate = resolve(packageDir, basename);
-    if (existsSync(candidate)) return candidate;
-  }
-  return undefined;
+  return findFirstExisting(packageDir, MANIFEST_BASENAMES);
 }
 
 /**
@@ -130,11 +135,7 @@ function findManifest(packageDir: string): string | undefined {
  * `undefined` otherwise.
  */
 function findReadme(packageDir: string): string | undefined {
-  for (const basename of README_BASENAMES) {
-    const candidate = resolve(packageDir, basename);
-    if (existsSync(candidate)) return candidate;
-  }
-  return undefined;
+  return findFirstExisting(packageDir, README_BASENAMES);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/workflow/discovery.ts
+++ b/src/workflow/discovery.ts
@@ -31,6 +31,14 @@ export interface WorkflowEntry {
   readonly description: string;
   readonly path: string;
   readonly source: WorkflowSource;
+  /**
+   * Manifest `hidden: true` — the workflow is a smoke-test / fixture that
+   * should not surface in the web UI. The CLI still lists it. Defaults to
+   * false for manifests that omit the field.
+   */
+  readonly hidden: boolean;
+  /** A `README.md` is co-packaged alongside the manifest. */
+  readonly hasReadme: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,6 +47,12 @@ export interface WorkflowEntry {
 
 /** Manifest filenames probed inside a workflow package directory. */
 const MANIFEST_BASENAMES = ['workflow.yaml', 'workflow.yml'] as const;
+
+/** README filenames probed inside a workflow package directory (yaml-style precedence). */
+const README_BASENAMES = ['README.md', 'readme.md'] as const;
+
+/** Hard cap on README size returned to clients (defensive; READMEs are tiny). */
+const MAX_README_BYTES = 512 * 1024;
 
 /** Recognized YAML extensions for ad-hoc file-path workflow refs. */
 const YAML_EXTENSIONS = new Set(['.yaml', '.yml']);
@@ -110,6 +124,19 @@ function findManifest(packageDir: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Locates a co-packaged README inside a workflow package directory.
+ * Returns the absolute path to `README.md` / `readme.md` if present,
+ * `undefined` otherwise.
+ */
+function findReadme(packageDir: string): string | undefined {
+  for (const basename of README_BASENAMES) {
+    const candidate = resolve(packageDir, basename);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Discovery
 // ---------------------------------------------------------------------------
@@ -150,14 +177,17 @@ function scanDirectory(dir: string, source: WorkflowSource): WorkflowEntry[] {
     if (!manifest) continue;
 
     let description = '';
+    let hidden = false;
     try {
       const raw = parseDefinitionFile(manifest) as Record<string, unknown>;
       if (typeof raw.description === 'string') description = raw.description;
+      if (raw.hidden === true) hidden = true;
     } catch {
       // Skip packages with unparseable manifests
       continue;
     }
-    out.push({ name, description, path: manifest, source });
+    const hasReadme = findReadme(packageDir) !== undefined;
+    out.push({ name, description, path: manifest, source, hidden, hasReadme });
   }
 
   return out;
@@ -182,6 +212,33 @@ export function discoverWorkflows(): WorkflowEntry[] {
   }
 
   return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Finds a discovered workflow by its directory name (which, by convention,
+ * matches the manifest `name:` field — the value carried on workflow run
+ * records). Used to resolve a running/past workflow back to its source
+ * package (e.g. to read its README). User entries shadow bundled ones, per
+ * {@link discoverWorkflows}.
+ */
+export function findWorkflowByName(name: string): WorkflowEntry | undefined {
+  return discoverWorkflows().find((entry) => entry.name === name);
+}
+
+/**
+ * Reads the README.md co-packaged with a workflow, given the absolute path
+ * to its manifest. Returns the raw markdown, or `undefined` when no README
+ * is present, it exceeds {@link MAX_README_BYTES}, or it cannot be read.
+ */
+export function readWorkflowReadme(manifestPath: string): string | undefined {
+  const readme = findReadme(getWorkflowPackageDir(manifestPath));
+  if (!readme) return undefined;
+  try {
+    if (statSync(readme).size > MAX_README_BYTES) return undefined;
+    return readFileSync(readme, 'utf-8');
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -90,6 +90,13 @@ export function createWorkflowId(): WorkflowId {
 export interface WorkflowDefinition {
   readonly name: string;
   readonly description: string;
+  /**
+   * When true, the workflow is omitted from the web UI — both the start
+   * picker and the active/past-run tables. The CLI `workflow list` still
+   * shows it. Use for smoke-test / fixture workflows that should remain
+   * runnable from the CLI without cluttering the UI. Default: false.
+   */
+  readonly hidden?: boolean;
   readonly initial: string;
   readonly states: Record<string, WorkflowStateDefinition>;
   readonly settings?: WorkflowSettings;

--- a/src/workflow/validate.ts
+++ b/src/workflow/validate.ts
@@ -118,6 +118,7 @@ const workflowSettingsSchema = z
 const workflowDefinitionSchema = z.object({
   name: z.string().min(1),
   description: z.string(),
+  hidden: z.boolean().optional(),
   initial: z.string(),
   states: z.record(z.string(), stateDefinitionSchema),
   settings: workflowSettingsSchema,

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -681,9 +681,21 @@ function runList(): void {
   const header = `${'NAME'.padEnd(nameWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  DESCRIPTION`;
   writeStdout(`${BOLD}${header}${RESET}`);
 
+  let anyHidden = false;
   for (const wf of workflows) {
-    const line = `${wf.name.padEnd(nameWidth)}  ${wf.source.padEnd(sourceWidth)}  ${wf.description}`;
+    // `hidden` workflows are runnable from the CLI but suppressed in the web
+    // UI; flag them here so CLI users know which ones won't appear there.
+    const marker = wf.hidden ? ` ${DIM}(hidden from web UI)${RESET}` : '';
+    if (wf.hidden) anyHidden = true;
+    const line = `${wf.name.padEnd(nameWidth)}  ${wf.source.padEnd(sourceWidth)}  ${wf.description}${marker}`;
     writeStdout(line);
+  }
+
+  if (anyHidden) {
+    writeStdout('');
+    writeStdout(
+      `${DIM}Workflows marked "hidden from web UI" run from the CLI but are excluded from the daemon web UI.${RESET}`,
+    );
   }
 }
 

--- a/src/workflow/workflows/design-and-code/README.md
+++ b/src/workflow/workflows/design-and-code/README.md
@@ -1,0 +1,50 @@
+# Design & Code
+
+A four-phase software workflow that takes a task from **plan → design → implement → review**, with human approval gates between the planning stages and an automated coder–critic loop at the end.
+
+Run it from the web UI (**Start Workflow → `design-and-code`**) or the CLI:
+
+```bash
+ironcurtain workflow start design-and-code "Add a rate limiter to the API gateway"
+```
+
+## What it does
+
+The workflow drives a Docker-isolated `claude-code` agent through distinct roles, persisting its artifacts under `.workflow/` in the workspace and writing code directly at the workspace root.
+
+| Phase | State | Role | Output |
+|-------|-------|------|--------|
+| 1 | `plan` | Project planner — breaks the task into ordered, numbered steps | `.workflow/plan/plan.md` |
+| — | `plan_review` | **Human gate** — approve, request a revision, or abort | — |
+| 2 | `design` | Architect — module structure, interfaces, typed signatures | `.workflow/spec/spec.md` |
+| — | `design_review` | **Human gate** — approve, request a revision, or abort | — |
+| 3 | `implement` | Engineer — writes the code and unit tests, runs them | `src/`, tests |
+| 4 | `review` | Reviewer — checks correctness, edge cases, quality, coverage | `.workflow/reviews/review.md` |
+
+## Human gates
+
+Two gates pause the run for your decision:
+
+- **Plan review** — sign off on the approach before any design work.
+- **Design review** — sign off on the interfaces and types before implementation.
+
+At each gate the presented artifact (`plan` or `spec`) is shown for inspection. Choose **Approve** to advance, **Request Revision** to send the agent back with feedback, or **Abort** to stop.
+
+## The coder–critic loop
+
+After implementation, the **reviewer** judges the code against the spec:
+
+- **`approved`** → the workflow completes (`done`).
+- **`rejected`** → control returns to `implement` with the review feedback, and the cycle repeats.
+
+The loop is bounded by `maxRounds` (**3**). If the reviewer is still rejecting when the limit is reached, the workflow raises an **escalation gate** so a human can approve as-is, force another revision, or abort — it never loops forever.
+
+## At a glance
+
+- **Mode:** Docker (`claude-code` agent, `--network=none`)
+- **Persona:** `global` for every agent state
+- **Max rounds:** 3 (implement ⇄ review)
+- **Artifacts:** `plan`, `spec`, `reviews` — all under `.workflow/`
+- **Terminal states:** `done` (success) · `aborted` (stopped at a gate)
+
+> Tip: write a detailed task description. The planner only sees the task text and whatever already exists in the workspace, so specifics about scope, constraints, and acceptance criteria pay off downstream.

--- a/src/workflow/workflows/deterministic-eval-smoke/workflow.yaml
+++ b/src/workflow/workflows/deterministic-eval-smoke/workflow.yaml
@@ -1,5 +1,6 @@
 name: deterministic-eval-smoke
 description: 'TESTING ONLY - minimal agent plus deterministic in-container helper execution.'
+hidden: true
 initial: author
 
 settings:

--- a/src/workflow/workflows/deterministic-verdict-smoke/workflow.yaml
+++ b/src/workflow/workflows/deterministic-verdict-smoke/workflow.yaml
@@ -1,5 +1,6 @@
 name: deterministic-verdict-smoke
 description: 'TESTING ONLY - deterministic state routes on a helper-written verdict file.'
+hidden: true
 initial: author
 
 settings:

--- a/src/workflow/workflows/test-email-summary/workflow.yaml
+++ b/src/workflow/workflows/test-email-summary/workflow.yaml
@@ -1,5 +1,6 @@
 name: test-email-summary
 description: 'TESTING ONLY — fetch a small set of emails (exec-assistant) then summarize them to a file (global). Used to smoke-test the agent skills feature; not a real workflow. The task description supplies the scope (which emails: sent/received, count, time range, etc.).'
+hidden: true
 initial: fetch
 
 settings:

--- a/test/workflow-hidden-readme.test.ts
+++ b/test/workflow-hidden-readme.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the `hidden` workflow flag and co-packaged README support:
+ *   - discovery surfaces `hidden` + `hasReadme` and `readWorkflowReadme`/
+ *     `findWorkflowByName` resolve correctly (temp user workflows);
+ *   - `workflows.listDefinitions` dispatch filters hidden workflows and maps
+ *     `hasReadme`, and `workflows.readme` serves / rejects READMEs by path
+ *     (integration against the real bundled workflows).
+ */
+
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { discoverWorkflows, findWorkflowByName, readWorkflowReadme } from '../src/workflow/discovery.js';
+import { workflowDispatch, type WorkflowDispatchContext } from '../src/web-ui/dispatch/workflow-dispatch.js';
+import { RpcError, type WorkflowDefinitionDto, type WorkflowReadmeDto } from '../src/web-ui/web-ui-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+let originalHome: string | undefined;
+
+/** Writes `<userRoot>/<name>/workflow.yaml` (+ optional README.md). */
+function writePackage(name: string, opts: { description?: string; hidden?: boolean; readme?: string } = {}): string {
+  const dir = resolve(tempDir, 'workflows', name);
+  mkdirSync(dir, { recursive: true });
+  const manifest = resolve(dir, 'workflow.yaml');
+  const lines = [`name: ${name}`, `description: "${opts.description ?? 'a test workflow'}"`];
+  if (opts.hidden) lines.push('hidden: true');
+  lines.push('initial: start', 'states: {}', '');
+  writeFileSync(manifest, lines.join('\n'));
+  if (opts.readme !== undefined) writeFileSync(resolve(dir, 'README.md'), opts.readme);
+  return manifest;
+}
+
+// `workflows.listDefinitions` and `workflows.readme` (definitionPath form) do
+// not consult the workflow manager, so an empty context is sufficient.
+const emptyCtx = {} as WorkflowDispatchContext;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(resolve(tmpdir(), 'ironcurtain-hidden-readme-'));
+  // Point the user workflows dir at an empty temp tree so user-installed
+  // workflows on the dev machine don't make assertions flaky.
+  originalHome = process.env.IRONCURTAIN_HOME;
+  process.env.IRONCURTAIN_HOME = tempDir;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+  else process.env.IRONCURTAIN_HOME = originalHome;
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+describe('discovery: hidden flag + README detection', () => {
+  it('marks hidden:true manifests and detects a co-packaged README', () => {
+    writePackage('visible-flow', { readme: '# Visible' });
+    writePackage('secret-flow', { hidden: true });
+
+    const all = discoverWorkflows();
+    const visible = all.find((e) => e.name === 'visible-flow');
+    const secret = all.find((e) => e.name === 'secret-flow');
+
+    expect(visible?.hidden).toBe(false);
+    expect(visible?.hasReadme).toBe(true);
+    expect(secret?.hidden).toBe(true);
+    expect(secret?.hasReadme).toBe(false);
+  });
+
+  it('readWorkflowReadme returns the markdown; findWorkflowByName resolves the package', () => {
+    const manifest = writePackage('doc-flow', { readme: '# Title\n\nBody text' });
+
+    expect(readWorkflowReadme(manifest)).toContain('# Title');
+    expect(readWorkflowReadme(manifest)).toContain('Body text');
+
+    const entry = findWorkflowByName('doc-flow');
+    expect(entry).toBeDefined();
+    expect(entry?.path).toBe(manifest);
+    expect(entry?.hasReadme).toBe(true);
+  });
+
+  it('readWorkflowReadme returns undefined when there is no README', () => {
+    const manifest = writePackage('no-doc-flow');
+    expect(readWorkflowReadme(manifest)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch: workflows.listDefinitions (against real bundled workflows)
+// ---------------------------------------------------------------------------
+
+describe('workflows.listDefinitions dispatch', () => {
+  it('excludes hidden bundled workflows and includes hasReadme', async () => {
+    const defs = (await workflowDispatch(emptyCtx, 'workflows.listDefinitions', {})) as WorkflowDefinitionDto[];
+    const names = defs.map((d) => d.name);
+
+    // Bundled production workflow with a README ships in the repo.
+    expect(names).toContain('design-and-code');
+    expect(defs.find((d) => d.name === 'design-and-code')?.hasReadme).toBe(true);
+
+    // The three smoke / fixture workflows are marked hidden and must not appear.
+    expect(names).not.toContain('deterministic-verdict-smoke');
+    expect(names).not.toContain('deterministic-eval-smoke');
+    expect(names).not.toContain('test-email-summary');
+
+    // Every returned entry carries the hasReadme field.
+    for (const d of defs) {
+      expect(typeof d.hasReadme).toBe('boolean');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch: workflows.readme
+// ---------------------------------------------------------------------------
+
+describe('workflows.readme dispatch', () => {
+  it('serves the README for a discovered definition path', async () => {
+    const defs = (await workflowDispatch(emptyCtx, 'workflows.listDefinitions', {})) as WorkflowDefinitionDto[];
+    const dac = defs.find((d) => d.name === 'design-and-code');
+    expect(dac).toBeDefined();
+    if (!dac) return;
+
+    const res = (await workflowDispatch(emptyCtx, 'workflows.readme', {
+      definitionPath: dac.path,
+    })) as WorkflowReadmeDto;
+    expect(res.content).toContain('Design & Code');
+  });
+
+  it('rejects an unknown definition path (no arbitrary file reads)', async () => {
+    await expect(
+      workflowDispatch(emptyCtx, 'workflows.readme', { definitionPath: '/nope/workflow.yaml' }),
+    ).rejects.toBeInstanceOf(RpcError);
+  });
+
+  it('rejects when neither definitionPath nor workflowId is provided', async () => {
+    await expect(workflowDispatch(emptyCtx, 'workflows.readme', {})).rejects.toBeInstanceOf(RpcError);
+  });
+});

--- a/test/workflow-hidden-readme.test.ts
+++ b/test/workflow-hidden-readme.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, it, expect } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -87,6 +87,22 @@ describe('discovery: hidden flag + README detection', () => {
 
   it('readWorkflowReadme returns undefined when there is no README', () => {
     const manifest = writePackage('no-doc-flow');
+    expect(readWorkflowReadme(manifest)).toBeUndefined();
+  });
+
+  it('refuses a README symlinked outside the workflow package', () => {
+    // A file outside any workflow package that a symlinked README could leak.
+    const secret = resolve(tempDir, 'secret.txt');
+    writeFileSync(secret, 'TOP SECRET');
+    const dir = resolve(tempDir, 'workflows', 'evil-flow');
+    mkdirSync(dir, { recursive: true });
+    const manifest = resolve(dir, 'workflow.yaml');
+    writeFileSync(manifest, 'name: evil-flow\ndescription: "x"\ninitial: start\nstates: {}\n');
+    symlinkSync(secret, resolve(dir, 'README.md'));
+
+    // The symlink exists (so hasReadme is true), but reading it must be refused
+    // because it resolves outside the package dir — no arbitrary host reads.
+    expect(findWorkflowByName('evil-flow')?.hasReadme).toBe(true);
     expect(readWorkflowReadme(manifest)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Improves the IronCurtain web UI's workflow pages along four lines:

1. **Hide test/smoke workflows from the web UI.** Adds an explicit `hidden` flag to the workflow manifest schema, carried through discovery (`WorkflowEntry.hidden`). The web-UI dispatch filters hidden workflows out of `workflows.listDefinitions` and filters their runs out of `workflows.list` / `workflows.listResumable` — so the three smoke/fixture workflows (`deterministic-verdict-smoke`, `deterministic-eval-smoke`, `test-email-summary`, now tagged `hidden: true`) no longer appear in the picker or the active/past-run tables. The CLI `workflow list` still shows them, marked `(hidden from web UI)`.

2. **Workflow README modal.** If a workflow ships a co-packaged `README.md`, it's surfaced via an info affordance. Discovery detects a sibling README (`WorkflowEntry.hasReadme`), exposed on the definition + detail DTOs, with a lazy `workflows.readme` RPC addressable by definition path (Start picker) or workflow id (detail view). Only discovered workflows are served — no arbitrary file reads. A reusable `workflow-readme-modal` renders sanitized markdown (reusing the existing `Modal` primitive + `renderMarkdown`). A real `README.md` is seeded into the `design-and-code` workflow.

3. **Ergonomic polish** of the workflow pages: a clean name-only definition selector with a source badge + description helper text, relative timestamps (absolute on hover), nicer empty states, and icon-led context cards on the detail view.

4. **Exercisable via the mock WS server.** The mock mirrors the full new protocol (`hasReadme`, hidden-filtering on list/listResumable, `workflows.readme`, a seeded hidden smoke past-run), so the whole iteration is drivable at `localhost:5173` with no daemon.

## Testing

- Full backend suite green (incl. new `test/workflow-hidden-readme.test.ts` — discovery + dispatch filtering + readme RPC).
- Web-UI unit tests green (incl. new `formatRelativeTime` tests; updated route mocks).
- Playwright e2e: 28 workflow specs green, including 5 new ones (README modal opens with rendered content, disabled when no README, definition meta, picker omits hidden, past-runs omit hidden).
- `svelte-check` 0 errors · ESLint + Prettier clean · `npm run build` green (README + hidden manifests confirmed copied to `dist`).

A `/simplify` review pass is included as a follow-up commit (consolidated the `workflows.readme` dispatch, deduped `findManifest`/`findReadme`, used the phosphor `X` icon, dropped a redundant derived).

## Follow-up (not in this PR)

A review flagged that hidden-filtering and README-by-workflow-id currently match a workflow's package by display `name` (directory name == manifest `name:` by convention) and re-run discovery, when the manifest `definitionPath` is already available on the live instance / checkpoint. Resolving by `definitionPath` would be strictly more correct and remove a re-scan, but it touches the orchestrator's `WorkflowDetail` interface — left as a deliberate follow-up since the convention is well-commented and fine for the current PoC.
