### PR TITLE
fix(workflow): drain Docker teardown before CLI exit to stop network leaks

### DIFF
--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -394,8 +394,15 @@ export function createDockerManager(
     async removeNetwork(name: string): Promise<void> {
       try {
         await exec('docker', ['network', 'rm', name], { timeout: 10_000 });
-      } catch {
-        // Ignore errors -- network may already be removed
+      } catch (err: unknown) {
+        // Non-fatal: callers invoke this in best-effort teardown paths and
+        // depend on it never throwing. But a genuine failure here orphans the
+        // network (there is no stale-network reaper, unlike removeStaleContainer),
+        // so surface it rather than swallowing silently. "not found" is benign
+        // (already removed) and stays quiet.
+        if (isExecError(err) && /not found|no such network/i.test(err.stderr)) return;
+        const detail = isExecError(err) ? err.stderr.trim() || err.message : String(err);
+        logger.warn(`removeNetwork: failed to remove "${name}": ${detail}`);
       }
     },
 

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -678,6 +678,18 @@ interface WorkflowInstance {
    */
   aborted: boolean;
   /**
+   * Tracks the fire-and-forget Docker teardown started by
+   * `handleWorkflowComplete` on a normal terminal. The terminal handler runs
+   * inside the synchronous actor subscription and so cannot await teardown;
+   * it stores the promise here instead. `shutdownAll` drains it so the CLI's
+   * `process.exit()` does not race the in-flight teardown and orphan the
+   * per-run `--internal` Docker network. Note that `destroyWorkflowInfrastructure`
+   * snapshot-and-clears `bundlesByScope` synchronously, so a redundant destroy
+   * pass no-ops while the real work stays captured in this promise — awaiting
+   * it is the only way to observe teardown completion.
+   */
+  teardownPromise?: Promise<void>;
+  /**
    * Stamped by `throwIfQuotaExhausted` when an agent turn reports
    * upstream quota exhaustion. `handleWorkflowComplete` consults this
    * to force an abort-like terminal phase and preserve the checkpoint,
@@ -1673,6 +1685,14 @@ export class WorkflowOrchestrator implements WorkflowController {
         return instance ? this.destroyWorkflowInfrastructure(instance) : Promise.resolve();
       }),
     );
+    // Drain any fire-and-forget teardown started by `handleWorkflowComplete`
+    // on a normal terminal. Because `destroyWorkflowInfrastructure`
+    // snapshot-and-clears `bundlesByScope` up front, the explicit pass above
+    // no-ops for an already-completed workflow whose teardown is still in
+    // flight — so we must await the stored promise to guarantee the Docker
+    // network/container removal has actually finished before the caller (the
+    // CLI) calls process.exit().
+    await Promise.allSettled(ids.map((id) => this.workflows.get(id)?.teardownPromise ?? Promise.resolve()));
   }
 
   // -----------------------------------------------------------------------
@@ -2688,8 +2708,10 @@ export class WorkflowOrchestrator implements WorkflowController {
     // Tear down workflow-scoped Docker infrastructure. Runs asynchronously
     // because the actor subscription is sync; destroyWorkflowInfrastructure
     // is error-tolerant so unhandled rejections should not occur, but we
-    // still catch defensively for a belt-and-suspenders guarantee.
-    void this.destroyWorkflowInfrastructure(instance).catch((err: unknown) => {
+    // still catch defensively for a belt-and-suspenders guarantee. The
+    // promise is retained on the instance so `shutdownAll` can await it
+    // before the CLI exits (see `teardownPromise`).
+    instance.teardownPromise = this.destroyWorkflowInfrastructure(instance).catch((err: unknown) => {
       writeStderr(
         `[workflow] destroyWorkflowInfrastructure unexpectedly threw for ${workflowId}: ${toErrorMessage(err)}`,
       );

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -239,6 +239,15 @@ async function runStart(args: string[]): Promise<void> {
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
+  // Exit only AFTER the finally so workflow + Docker teardown (shutdownAll)
+  // fully drains first. Calling process.exit() inside the try — as this code
+  // used to — terminates the process synchronously and cuts off the async
+  // teardown in the finally, orphaning each run's per-session --internal
+  // Docker network (which has no stale-reaper) until Docker's address pools
+  // are exhausted.
+  // Definitely assigned before the post-finally `process.exit`: the only way
+  // to skip that assignment is a throw, which propagates past it.
+  let exitCode: number;
   try {
     writeStdout(`${BOLD}${MAGENTA}Starting workflow${RESET}`);
     writeStdout(`${DIM}Task: ${taskDescription}${RESET}`);
@@ -254,13 +263,13 @@ async function runStart(args: string[]): Promise<void> {
 
     printSummary(orchestrator, workflowId, artifactDir);
 
-    const exitCode = computeExitCode(orchestrator, workflowId, controller.signal);
-    process.exit(exitCode);
+    exitCode = computeExitCode(orchestrator, workflowId, controller.signal);
   } finally {
     rl.close();
     await orchestrator.shutdownAll().catch(() => {});
     writeStdout(`${DIM}Artifacts preserved at: ${baseDir}${RESET}`);
   }
+  process.exit(exitCode);
 }
 
 async function runResume(args: string[]): Promise<void> {
@@ -343,6 +352,11 @@ async function runResume(args: string[]): Promise<void> {
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
+  // Exit only AFTER the finally so teardown (shutdownAll) fully drains first.
+  // See runStart for why process.exit() inside the try leaks Docker networks.
+  // Definitely assigned before the post-finally `process.exit`: the only way
+  // to skip that assignment is a throw, which propagates past it.
+  let exitCode: number;
   try {
     writeStdout(`${BOLD}${MAGENTA}Resuming...${RESET}`);
     writeStdout('');
@@ -356,13 +370,13 @@ async function runResume(args: string[]): Promise<void> {
 
     printSummary(orchestrator, selected.workflowId, artifactDir);
 
-    const exitCode = computeExitCode(orchestrator, selected.workflowId, controller.signal);
-    process.exit(exitCode);
+    exitCode = computeExitCode(orchestrator, selected.workflowId, controller.signal);
   } finally {
     rl.close();
     await orchestrator.shutdownAll().catch(() => {});
     writeStdout(`${DIM}Artifacts preserved at: ${baseDir}${RESET}`);
   }
+  process.exit(exitCode);
 }
 
 function runInspect(args: string[]): void {

--- a/test/workflow/orchestrator-shared-container.test.ts
+++ b/test/workflow/orchestrator-shared-container.test.ts
@@ -447,6 +447,83 @@ describe('WorkflowOrchestrator shared-container mode', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Test 6b: shutdownAll drains the terminal handler's in-flight teardown
+  //
+  // Regression for the leaked-Docker-network bug: on a normal terminal,
+  // handleWorkflowComplete kicks off destroyWorkflowInfrastructure as a
+  // fire-and-forget (the actor subscription is synchronous). Because
+  // destroyWorkflowInfrastructure snapshot-and-clears bundlesByScope up
+  // front, shutdownAll's redundant destroy pass no-ops — so shutdownAll
+  // MUST await the retained teardownPromise, otherwise the CLI's
+  // process.exit() races the still-running `docker network rm` and orphans
+  // the per-run --internal network.
+  // -------------------------------------------------------------------------
+
+  it('shutdownAll awaits the in-flight teardown started by a normal terminal', async () => {
+    const defPath = writeDefinitionFile(tmpDir, dockerWorkflowDef);
+
+    const createInfra = vi.fn(async (input: CreateWorkflowInfrastructureInput) =>
+      makeStubInfrastructure(input.workflowId, input.bundleId),
+    );
+
+    // Gate the teardown so it cannot finish until we release it. This models
+    // the slow `docker stop`/`rm`/`network rm` calls inside cleanupContainers.
+    let releaseDestroy!: () => void;
+    const destroyGate = new Promise<void>((r) => {
+      releaseDestroy = r;
+    });
+    let destroyFinished = false;
+    const destroyInfra = vi.fn(async () => {
+      await destroyGate;
+      destroyFinished = true;
+    });
+
+    const sessionFactory = vi.fn(async () =>
+      createArtifactAwareSession([{ text: approvedResponse('done'), artifacts: ['result'] }], tmpDir),
+    );
+
+    const orchestrator = new WorkflowOrchestrator(
+      createDeps(tmpDir, {
+        createSession: sessionFactory,
+        createWorkflowInfrastructure: createInfra,
+        destroyWorkflowInfrastructure: destroyInfra,
+      }),
+    );
+    activeOrchestrator = orchestrator;
+
+    const workflowId = await orchestrator.start(defPath, 'task');
+    await waitForCompletion(orchestrator, workflowId);
+
+    // The terminal handler has dispatched destroy, but it is blocked on the
+    // gate (still in flight).
+    const start = Date.now();
+    while (destroyInfra.mock.calls.length === 0 && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(destroyInfra).toHaveBeenCalledTimes(1);
+    expect(destroyFinished).toBe(false);
+
+    // shutdownAll must NOT resolve while the teardown is still running.
+    let shutdownResolved = false;
+    const shutdownPromise = orchestrator.shutdownAll().then(() => {
+      shutdownResolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(shutdownResolved).toBe(false);
+    expect(destroyFinished).toBe(false);
+
+    // Release the teardown; now shutdownAll can complete — and only after the
+    // teardown has fully finished.
+    releaseDestroy();
+    await shutdownPromise;
+    activeOrchestrator = undefined;
+
+    expect(shutdownResolved).toBe(true);
+    expect(destroyFinished).toBe(true);
+    expect(destroyInfra).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
   // Test 7: Builtin workflows ignore the sharedContainer flag
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Validation runs were leaking detached `ironcurtain-*` Docker networks (0 attached containers) until Docker's address pools were exhausted.

**Root cause:** `ironcurtain workflow start` / `resume` called `process.exit(exitCode)` *inside* the `try` block, before the `finally`'s `await orchestrator.shutdownAll()`:

```js
try {
  ...
  process.exit(exitCode);          // ← terminates synchronously HERE
} finally {
  await orchestrator.shutdownAll(); // ← never completes
}
```

`process.exit()` terminates the process synchronously, so the asynchronous Docker teardown never finished. In `cleanupContainers`, `removeNetwork` runs **last** — after `docker stop`/`rm` on both the agent container and the socat sidecar — so the per-session `--internal` network (macOS TCP mode only) was the resource most reliably orphaned. There is no stale-network reaper (unlike `removeStaleContainer`), and network names are unique per bundle, so every interrupted/exited run leaked one network permanently.

The normal-completion path had its own race: the terminal handler tears down infra **fire-and-forget** (`void destroyWorkflowInfrastructure(...)`), and `destroyWorkflowInfrastructure` snapshot-and-clears `bundlesByScope` *synchronously* — so `shutdownAll`'s redundant destroy pass no-ops while the real `docker network rm` is still in flight.

## Fix

- **`workflow-command.ts`** — move `process.exit()` out of the `try` (both `runStart` and `runResume`) so `shutdownAll()` fully drains before the process dies.
- **`orchestrator.ts`** — retain the terminal handler's teardown promise on the instance (`teardownPromise`) and have `shutdownAll` `await` it, so completion of the in-flight `docker network rm` is observable before exit.
- **`docker-manager.ts`** (defense in depth) — `removeNetwork` no longer swallows all errors silently: benign "not found" stays quiet, genuine failures are `logger.warn`-ed (still non-throwing, as best-effort callers require).

## Testing

- New regression test in `orchestrator-shared-container.test.ts`: gates the teardown and asserts `shutdownAll` does **not** resolve until the terminal handler's in-flight teardown completes. Verified it **fails** with the drain reverted and **passes** with the fix.
- `tsc --noEmit` clean, ESLint clean, 241 tests across the touched suites passing.

## Not included

A stale-network reaper (a `removeStaleNetwork` analog to `removeStaleContainer`) to mop up networks already orphaned by past crashes/SIGKILLs. Doing it safely requires labeling networks at creation and pruning only label-matched, zero-container ones — a larger change with concurrency caveats. The changes here stop the leak at the source.