### PR TITLE
feat(web-ui): auto-refresh workflow workspace artifacts on lifecycle events

### DIFF
--- a/packages/web-ui/src/lib/components/features/file-tree.svelte
+++ b/packages/web-ui/src/lib/components/features/file-tree.svelte
@@ -91,7 +91,13 @@
     } catch {
       // Keep the existing tree on a transient refresh failure.
     } finally {
-      if (version === loadVersion) refreshing = false;
+      if (version === loadVersion) {
+        refreshing = false;
+        // A reconcile that ran supersedes any initial full load it pre-empted,
+        // whose stale `finally` would otherwise leave `rootLoading` stuck true
+        // (spinner forever). Normally rootLoading is already false here.
+        rootLoading = false;
+      }
     }
   }
 

--- a/packages/web-ui/src/lib/components/features/file-tree.svelte
+++ b/packages/web-ui/src/lib/components/features/file-tree.svelte
@@ -4,10 +4,20 @@
 
   let {
     workflowId,
+    refreshKey = '',
+    refreshing = $bindable(false),
     onFileSelect,
     fetchFileTree,
   }: {
     workflowId: string;
+    // Bumps on a workflow lifecycle event or a manual Refresh click. A change
+    // triggers a *silent* reconcile that re-reads the root and every currently
+    // expanded directory, surfacing new/removed files while preserving each
+    // node's expansion state, identity (keyed DOM), and scroll position.
+    refreshKey?: string | number;
+    // Bound up to the parent so a shared Refresh control can reflect an
+    // in-flight reconcile.
+    refreshing?: boolean;
     onFileSelect: (path: string) => void;
     fetchFileTree: (workflowId: string, path?: string) => Promise<FileTreeResponseDto>;
   } = $props();
@@ -25,21 +35,105 @@
   let roots = $state<TreeNode[]>([]);
   let rootLoading = $state(true);
   let error = $state('');
+  // Bumped by every load/reconcile; an in-flight async pass that finds its
+  // version stale abandons its writes so a newer pass always wins.
+  let loadVersion = 0;
+  let lastId: string | undefined;
+  let lastRefreshKey: string | number | undefined;
 
   $effect(() => {
     const id = workflowId;
+    const key = refreshKey;
+    if (id !== lastId) {
+      // First mount or a workflow switch: full load with a spinner.
+      lastId = id;
+      lastRefreshKey = key;
+      void fullLoad(id);
+      return;
+    }
+    if (key !== lastRefreshKey) {
+      // Same workflow, external refresh signal: reconcile silently.
+      lastRefreshKey = key;
+      void reconcile(id);
+    }
+  });
+
+  async function fullLoad(id: string): Promise<void> {
+    const version = ++loadVersion;
     rootLoading = true;
     error = '';
-    fetchFileTree(id)
-      .then((res) => {
-        roots = res.entries.map((e) => entryToNode(e, ''));
-        rootLoading = false;
-      })
-      .catch((err) => {
-        error = err instanceof Error ? err.message : String(err);
-        rootLoading = false;
-      });
-  });
+    try {
+      const res = await fetchFileTree(id);
+      if (version !== loadVersion) return;
+      roots = res.entries.map((e) => entryToNode(e, ''));
+    } catch (err) {
+      if (version !== loadVersion) return;
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (version === loadVersion) rootLoading = false;
+    }
+  }
+
+  async function reconcile(id: string): Promise<void> {
+    const version = ++loadVersion;
+    refreshing = true;
+    try {
+      const res = await fetchFileTree(id);
+      if (version !== loadVersion) return;
+      const merged = await mergeLevel(id, roots, res.entries, '', version);
+      // A newer pass may have started while we were merging; don't clobber it.
+      if (version !== loadVersion) return;
+      roots = merged;
+    } catch {
+      // Keep the existing tree on a transient refresh failure.
+    } finally {
+      if (version === loadVersion) refreshing = false;
+    }
+  }
+
+  // Reconcile a fresh directory listing against existing nodes. Unchanged
+  // entries keep their node object (preserving expansion + already-loaded
+  // children and keeping the keyed DOM stable); expanded directories are
+  // re-fetched recursively so newly created files appear; entries absent from
+  // the new listing fall away because the result is rebuilt from `entries`.
+  // Sibling directories are re-fetched concurrently rather than one at a time.
+  async function mergeLevel(
+    id: string,
+    existing: TreeNode[],
+    entries: readonly FileTreeEntryDto[],
+    parentPath: string,
+    version: number,
+  ): Promise<TreeNode[]> {
+    const byPath = new Map(existing.map((n) => [n.path, n]));
+    const result: TreeNode[] = [];
+    const childFetches: Promise<void>[] = [];
+    for (const entry of entries) {
+      const path = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+      const prev = byPath.get(path);
+      if (prev && prev.type === entry.type) {
+        prev.size = entry.size;
+        if (prev.type === 'directory' && prev.expanded && prev.children !== null) {
+          const node = prev;
+          childFetches.push(
+            (async () => {
+              try {
+                const sub = await fetchFileTree(id, node.path);
+                if (version !== loadVersion) return;
+                node.children = await mergeLevel(id, node.children ?? [], sub.entries, node.path, version);
+              } catch {
+                // Keep previously loaded children if this sub-fetch fails.
+              }
+            })(),
+          );
+        }
+        result.push(prev);
+      } else {
+        result.push(entryToNode(entry, parentPath));
+      }
+    }
+    await Promise.all(childFetches);
+    return result;
+  }
 
   function entryToNode(entry: FileTreeEntryDto, parentPath: string): TreeNode {
     const path = parentPath ? `${parentPath}/${entry.name}` : entry.name;

--- a/packages/web-ui/src/lib/components/features/file-tree.svelte
+++ b/packages/web-ui/src/lib/components/features/file-tree.svelte
@@ -62,6 +62,10 @@
     const version = ++loadVersion;
     rootLoading = true;
     error = '';
+    // A workflow switch can pre-empt an in-flight reconcile whose `finally`
+    // is now stale (won't clear `refreshing`); reset it here so the Refresh
+    // spinner doesn't stick on for the new workflow.
+    refreshing = false;
     try {
       const res = await fetchFileTree(id);
       if (version !== loadVersion) return;

--- a/packages/web-ui/src/lib/components/features/file-tree.svelte
+++ b/packages/web-ui/src/lib/components/features/file-tree.svelte
@@ -129,7 +129,13 @@
               try {
                 const sub = await fetchFileTree(id, node.path);
                 if (version !== loadVersion) return;
-                node.children = await mergeLevel(id, node.children ?? [], sub.entries, node.path, version);
+                const childResult = await mergeLevel(id, node.children ?? [], sub.entries, node.path, version);
+                // Re-check after the recursive merge: a newer pass may have
+                // superseded us while it was awaiting, and a stale pass must
+                // not mutate the live tree (the assignment below is otherwise
+                // unguarded, unlike the top-level `roots = merged`).
+                if (version !== loadVersion) return;
+                node.children = childResult;
               } catch {
                 // Keep previously loaded children if this sub-fetch fails.
               }

--- a/packages/web-ui/src/lib/components/features/file-tree.test.ts
+++ b/packages/web-ui/src/lib/components/features/file-tree.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import FileTree from './file-tree.svelte';
+import type { FileTreeEntryDto, FileTreeResponseDto } from '$lib/types.js';
+
+type DirMap = Record<string, FileTreeEntryDto[]>;
+
+/**
+ * Build a fetchFileTree mock backed by a mutable directory map keyed by path
+ * (root is the empty string). Mutating the map between renders simulates files
+ * being created/removed in the workspace while a workflow runs.
+ */
+function makeFetch(map: DirMap) {
+  return vi.fn(async (_workflowId: string, path?: string): Promise<FileTreeResponseDto> => {
+    return { entries: map[path ?? ''] ?? [] };
+  });
+}
+
+async function expandDir(label: string): Promise<void> {
+  const span = await screen.findByText(label);
+  const button = span.closest('button');
+  expect(button, `expected a clickable row for ${label}`).toBeTruthy();
+  await fireEvent.click(button!);
+}
+
+describe('FileTree', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lists root entries', async () => {
+    const fetchFileTree = makeFetch({
+      '': [
+        { name: 'src', type: 'directory' },
+        { name: 'README.md', type: 'file', size: 10 },
+      ],
+    });
+    render(FileTree, { props: { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree } });
+
+    expect(await screen.findByText('src/')).toBeTruthy();
+    expect(screen.getByText('README.md')).toBeTruthy();
+  });
+
+  it('surfaces a newly created top-level file on a refreshKey change', async () => {
+    const map: DirMap = { '': [{ name: 'src', type: 'directory' }] };
+    const fetchFileTree = makeFetch(map);
+    const base = { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree };
+    const { rerender } = render(FileTree, { props: { ...base, refreshKey: 'k0' } });
+
+    expect(await screen.findByText('src/')).toBeTruthy();
+    expect(screen.queryByText('NEW.md')).toBeNull();
+
+    map[''] = [
+      { name: 'src', type: 'directory' },
+      { name: 'NEW.md', type: 'file', size: 3 },
+    ];
+    await rerender({ ...base, refreshKey: 'k1' });
+
+    expect(await screen.findByText('NEW.md')).toBeTruthy();
+  });
+
+  it('reconciles new files into an expanded directory while keeping it expanded', async () => {
+    const map: DirMap = {
+      '': [{ name: 'src', type: 'directory' }],
+      src: [{ name: 'a.ts', type: 'file', size: 1 }],
+    };
+    const fetchFileTree = makeFetch(map);
+    const base = { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree };
+    const { rerender } = render(FileTree, { props: { ...base, refreshKey: 'k0' } });
+
+    await expandDir('src/');
+    expect(await screen.findByText('a.ts')).toBeTruthy();
+
+    // A new file lands in src/ while it is expanded.
+    map.src = [
+      { name: 'a.ts', type: 'file', size: 1 },
+      { name: 'b.ts', type: 'file', size: 2 },
+    ];
+    await rerender({ ...base, refreshKey: 'k1' });
+
+    // The new file appears and the directory stays expanded (a.ts still shown).
+    expect(await screen.findByText('b.ts')).toBeTruthy();
+    expect(screen.getByText('a.ts')).toBeTruthy();
+    expect(screen.getByText('src/')).toBeTruthy();
+  });
+
+  it('reconciles removed files out of an expanded directory', async () => {
+    const map: DirMap = {
+      '': [{ name: 'src', type: 'directory' }],
+      src: [
+        { name: 'a.ts', type: 'file', size: 1 },
+        { name: 'gone.ts', type: 'file', size: 2 },
+      ],
+    };
+    const fetchFileTree = makeFetch(map);
+    const base = { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree };
+    const { rerender } = render(FileTree, { props: { ...base, refreshKey: 'k0' } });
+
+    await expandDir('src/');
+    expect(await screen.findByText('gone.ts')).toBeTruthy();
+
+    map.src = [{ name: 'a.ts', type: 'file', size: 1 }];
+    await rerender({ ...base, refreshKey: 'k1' });
+
+    await waitFor(() => expect(screen.queryByText('gone.ts')).toBeNull());
+    expect(screen.getByText('a.ts')).toBeTruthy();
+  });
+
+  it('does not re-fetch when refreshKey is unchanged across a rerender', async () => {
+    const fetchFileTree = makeFetch({ '': [{ name: 'src', type: 'directory' }] });
+    const base = { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree, refreshKey: 'k0' };
+    const { rerender } = render(FileTree, { props: { ...base } });
+
+    expect(await screen.findByText('src/')).toBeTruthy();
+    expect(fetchFileTree).toHaveBeenCalledTimes(1);
+
+    await rerender({ ...base });
+
+    await waitFor(() => expect(fetchFileTree).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/web-ui/src/lib/components/features/file-tree.test.ts
+++ b/packages/web-ui/src/lib/components/features/file-tree.test.ts
@@ -118,4 +118,23 @@ describe('FileTree', () => {
 
     await waitFor(() => expect(fetchFileTree).toHaveBeenCalledTimes(1));
   });
+
+  it('renders the tree when a reconcile pre-empts an in-flight initial load', async () => {
+    let call = 0;
+    const fetchFileTree = vi.fn((_workflowId: string, _path?: string): Promise<FileTreeResponseDto> => {
+      call += 1;
+      // The initial full load never resolves; the reconcile that pre-empts it
+      // must still surface its tree (and clear the initial-load spinner).
+      if (call === 1) return new Promise<FileTreeResponseDto>(() => {});
+      return Promise.resolve({ entries: [{ name: 'src', type: 'directory' }] });
+    });
+    const base = { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree };
+    const { rerender } = render(FileTree, { props: { ...base, refreshKey: 'k0' } });
+
+    // Initial fetch is pending — bump refreshKey to start the pre-empting reconcile.
+    await rerender({ ...base, refreshKey: 'k1' });
+
+    // Without rootLoading being cleared, this stays stuck on the spinner forever.
+    expect(await screen.findByText('src/')).toBeTruthy();
+  });
 });

--- a/packages/web-ui/src/lib/components/features/file-tree.test.ts
+++ b/packages/web-ui/src/lib/components/features/file-tree.test.ts
@@ -137,4 +137,58 @@ describe('FileTree', () => {
     // Without rootLoading being cleared, this stays stuck on the spinner forever.
     expect(await screen.findByText('src/')).toBeTruthy();
   });
+
+  it('does not let a superseded reconcile clobber a newer one’s nested children', async () => {
+    // 'sub' fetches are resolved by hand so we can suspend one reconcile's deep
+    // recursion while a newer reconcile overtakes it — the exact window where a
+    // stale pass could otherwise write node.children after a newer pass won.
+    const subResolvers: Array<(r: FileTreeResponseDto) => void> = [];
+    // Keys are full node paths, matching what the component fetches.
+    const data: DirMap = {
+      '': [{ name: 'src', type: 'directory' }],
+      src: [{ name: 'sub', type: 'directory' }],
+      'src/sub': [{ name: 'a.ts', type: 'file', size: 1 }],
+    };
+    const fetchFileTree = vi.fn((_workflowId: string, path?: string): Promise<FileTreeResponseDto> => {
+      const p = path ?? '';
+      if (p === 'src/sub') return new Promise<FileTreeResponseDto>((resolve) => subResolvers.push(resolve));
+      return Promise.resolve({ entries: data[p] ?? [] });
+    });
+    const base = { workflowId: 'wf-1', onFileSelect: vi.fn(), fetchFileTree };
+    const { rerender } = render(FileTree, { props: { ...base, refreshKey: 'k0' } });
+
+    // Open src, then sub (resolving sub's initial expansion fetch).
+    await expandDir('src/');
+    await expandDir('sub/');
+    await waitFor(() => expect(subResolvers).toHaveLength(1));
+    subResolvers[0]({ entries: data['src/sub'] });
+    expect(await screen.findByText('a.ts')).toBeTruthy();
+
+    // Reconcile v2: it reads src as [sub] then suspends on its sub fetch.
+    await rerender({ ...base, refreshKey: 'k1' });
+    await waitFor(() => expect(subResolvers).toHaveLength(2));
+
+    // A new top-level file lands in src/ before the *next* reconcile reads it.
+    data.src = [
+      { name: 'sub', type: 'directory' },
+      { name: 'b.ts', type: 'file', size: 2 },
+    ];
+
+    // Reconcile v3: reads the updated src (with b.ts) and its own sub fetch.
+    await rerender({ ...base, refreshKey: 'k2' });
+    await waitFor(() => expect(subResolvers).toHaveLength(3));
+
+    // Let v3 finish first; b.ts is now in the tree.
+    subResolvers[2]({ entries: data['src/sub'] });
+    expect(await screen.findByText('b.ts')).toBeTruthy();
+
+    // The stale v2 sub fetch now resolves. Its src listing predates b.ts, so an
+    // unguarded write would drop b.ts; the post-merge version check must stop it.
+    subResolvers[1]({ entries: data['src/sub'] });
+    // Drain microtasks so any stale write (all promise continuations) lands.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.getByText('b.ts')).toBeTruthy();
+    expect(screen.getByText('a.ts')).toBeTruthy();
+  });
 });

--- a/packages/web-ui/src/lib/components/features/file-viewer.svelte
+++ b/packages/web-ui/src/lib/components/features/file-viewer.svelte
@@ -50,6 +50,9 @@
       loading = true;
       error = '';
       content = null;
+      // Clear any leftover silent-refresh indicator from a pre-empted fetch so
+      // the header doesn't show "refreshing" during a full-load spinner.
+      refreshing = false;
     } else {
       refreshing = true;
     }

--- a/packages/web-ui/src/lib/components/features/file-viewer.svelte
+++ b/packages/web-ui/src/lib/components/features/file-viewer.svelte
@@ -5,38 +5,74 @@
   let {
     workflowId,
     path,
+    refreshKey = '',
     fetchFileContent,
   }: {
     workflowId: string;
     path: string;
+    // Bumps whenever an external signal (workflow lifecycle event or a manual
+    // Refresh click) wants the open file re-read. A change to refreshKey alone
+    // triggers a *silent* refresh: the current content stays on screen and is
+    // swapped in place when the new fetch resolves, so there's no spinner flash.
+    refreshKey?: string | number;
     fetchFileContent: (workflowId: string, path: string) => Promise<FileContentResponseDto>;
   } = $props();
 
   let content = $state<FileContentResponseDto | null>(null);
   let loading = $state(true);
+  let refreshing = $state(false);
   let error = $state('');
   let fetchVersion = 0;
+  let lastId: string | undefined;
+  let lastPath: string | undefined;
+  let lastKey: string | number | undefined;
 
   $effect(() => {
     const id = workflowId;
     const filePath = path;
+    // refreshKey is read to register it as a reactive dependency so a bump
+    // re-reads the *same* file.
+    const key = refreshKey;
+    // A changed workflow/file is a hard reload (blank + spinner). Re-reading
+    // the same file (refreshKey bumped) is a silent refresh that keeps the old
+    // content visible until the new content arrives.
+    const isReload = id !== lastId || filePath !== lastPath;
+    const keyChanged = key !== lastKey;
+    // Guard against effect re-runs that change nothing relevant (e.g. an
+    // unrelated parent re-render): only fetch when the file or the refresh
+    // signal actually changed.
+    if (!isReload && !keyChanged) return;
+    lastId = id;
+    lastPath = filePath;
+    lastKey = key;
     const version = ++fetchVersion;
-    loading = true;
-    error = '';
-    content = null;
+    if (isReload) {
+      loading = true;
+      error = '';
+      content = null;
+    } else {
+      refreshing = true;
+    }
 
     fetchFileContent(id, filePath)
       .then((res) => {
-        if (version === fetchVersion) {
-          content = res;
-          loading = false;
-        }
+        if (version !== fetchVersion) return;
+        content = res;
+        error = '';
+        loading = false;
+        refreshing = false;
       })
       .catch((err) => {
-        if (version === fetchVersion) {
+        if (version !== fetchVersion) return;
+        // Only surface errors on a hard reload. A transient silent-refresh
+        // failure keeps the last good content on screen rather than replacing
+        // it with an error banner.
+        if (isReload) {
           error = err instanceof Error ? err.message : String(err);
-          loading = false;
+          content = null;
         }
+        loading = false;
+        refreshing = false;
       });
   });
 </script>
@@ -45,6 +81,11 @@
   <!-- File path header -->
   <div class="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/30 shrink-0">
     <span class="text-xs text-muted-foreground font-mono truncate" title={path}>{path}</span>
+    {#if refreshing}
+      <span class="ml-auto flex items-center gap-1 text-[10px] text-muted-foreground shrink-0" title="Reloading file">
+        <Spinner size="xs" /> refreshing
+      </span>
+    {/if}
   </div>
 
   <!-- Content area -->

--- a/packages/web-ui/src/lib/components/features/file-viewer.test.ts
+++ b/packages/web-ui/src/lib/components/features/file-viewer.test.ts
@@ -88,4 +88,35 @@ describe('FileViewer', () => {
     expect(await screen.findByText('body:b.txt')).toBeTruthy();
     expect(fetchFileContent).toHaveBeenCalledTimes(2);
   });
+
+  it('clears the refreshing indicator when a hard reload pre-empts an in-flight silent refresh', async () => {
+    let resolveHardReload: ((v: FileContentResponseDto) => void) | undefined;
+    let call = 0;
+    const fetchFileContent = vi.fn(() => {
+      call += 1;
+      if (call === 1) return Promise.resolve(textContent('a'));
+      // call 2 (silent refresh) and call 3 (hard reload) both hang.
+      if (call === 2) return new Promise<FileContentResponseDto>(() => {});
+      return new Promise<FileContentResponseDto>((res) => {
+        resolveHardReload = res;
+      });
+    });
+    const base = { workflowId: 'wf-1', fetchFileContent };
+    const { rerender } = render(FileViewer, { props: { ...base, path: 'a.txt', refreshKey: 'k0' } });
+
+    expect(await screen.findByText('a')).toBeTruthy();
+
+    // Silent refresh (same path, bumped key) — its fetch stays pending, so the
+    // "refreshing" indicator turns on.
+    await rerender({ ...base, path: 'a.txt', refreshKey: 'k1' });
+    expect(screen.getByText(/refreshing/i)).toBeTruthy();
+
+    // A path change is a hard reload; it must clear the leftover indicator
+    // even though the pre-empted silent fetch never resolves.
+    await rerender({ ...base, path: 'b.txt', refreshKey: 'k1' });
+    expect(screen.queryByText(/refreshing/i)).toBeNull();
+
+    resolveHardReload?.(textContent('b'));
+    expect(await screen.findByText('b')).toBeTruthy();
+  });
 });

--- a/packages/web-ui/src/lib/components/features/file-viewer.test.ts
+++ b/packages/web-ui/src/lib/components/features/file-viewer.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import FileViewer from './file-viewer.svelte';
+import type { FileContentResponseDto } from '$lib/types.js';
+
+// Stable prop refs across rerenders: a changing function prop would itself be a
+// reactive dependency of the fetch effect and re-trigger it, masking what we're
+// actually testing (refreshKey / path driven re-fetches).
+function textContent(body: string): FileContentResponseDto {
+  return { content: body, language: 'text' };
+}
+
+describe('FileViewer', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and renders the file content for the given path', async () => {
+    const fetchFileContent = vi.fn(async () => textContent('hello world'));
+    render(FileViewer, { props: { workflowId: 'wf-1', path: 'a.txt', fetchFileContent } });
+
+    expect(await screen.findByText('hello world')).toBeTruthy();
+    expect(fetchFileContent).toHaveBeenCalledWith('wf-1', 'a.txt');
+    expect(fetchFileContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads the same file and swaps in new content when refreshKey changes', async () => {
+    let body = 'v1';
+    const fetchFileContent = vi.fn(async () => textContent(body));
+    const base = { workflowId: 'wf-1', path: 'a.txt', fetchFileContent };
+    const { rerender } = render(FileViewer, { props: { ...base, refreshKey: 'k0' } });
+
+    expect(await screen.findByText('v1')).toBeTruthy();
+    expect(fetchFileContent).toHaveBeenCalledTimes(1);
+
+    body = 'v2';
+    await rerender({ ...base, refreshKey: 'k1' });
+
+    expect(await screen.findByText('v2')).toBeTruthy();
+    expect(fetchFileContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-fetch when refreshKey is unchanged across a rerender', async () => {
+    const fetchFileContent = vi.fn(async () => textContent('stable'));
+    const base = { workflowId: 'wf-1', path: 'a.txt', fetchFileContent, refreshKey: 'k0' };
+    const { rerender } = render(FileViewer, { props: { ...base } });
+
+    expect(await screen.findByText('stable')).toBeTruthy();
+    await rerender({ ...base });
+
+    // Give any stray effect a chance to fire before asserting it did not.
+    await waitFor(() => expect(fetchFileContent).toHaveBeenCalledTimes(1));
+  });
+
+  it('keeps the previous content on screen during an in-flight silent refresh', async () => {
+    let resolveSecond: ((v: FileContentResponseDto) => void) | undefined;
+    let call = 0;
+    const fetchFileContent = vi.fn(() => {
+      call += 1;
+      if (call === 1) return Promise.resolve(textContent('old'));
+      return new Promise<FileContentResponseDto>((res) => {
+        resolveSecond = res;
+      });
+    });
+    const base = { workflowId: 'wf-1', path: 'a.txt', fetchFileContent };
+    const { rerender } = render(FileViewer, { props: { ...base, refreshKey: 'k0' } });
+
+    expect(await screen.findByText('old')).toBeTruthy();
+
+    // Trigger a silent refresh whose fetch is still pending.
+    await rerender({ ...base, refreshKey: 'k1' });
+    // The old content must remain visible — no blank / spinner flash.
+    expect(screen.getByText('old')).toBeTruthy();
+
+    resolveSecond?.(textContent('new'));
+    expect(await screen.findByText('new')).toBeTruthy();
+  });
+
+  it('re-fetches when the path changes', async () => {
+    const fetchFileContent = vi.fn(async (_id: string, p: string) => textContent(`body:${p}`));
+    const base = { workflowId: 'wf-1', fetchFileContent };
+    const { rerender } = render(FileViewer, { props: { ...base, path: 'a.txt' } });
+
+    expect(await screen.findByText('body:a.txt')).toBeTruthy();
+
+    await rerender({ ...base, path: 'b.txt' });
+
+    expect(await screen.findByText('body:b.txt')).toBeTruthy();
+    expect(fetchFileContent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web-ui/src/lib/components/features/gate-review-panel.svelte
+++ b/packages/web-ui/src/lib/components/features/gate-review-panel.svelte
@@ -16,6 +16,7 @@
     workflowName,
     workflowId,
     stateDescription,
+    refreshSignal = '',
     onResolve,
     fetchArtifacts,
     fetchFileTree,
@@ -25,6 +26,8 @@
     workflowName: string;
     workflowId: string;
     stateDescription?: string;
+    // Forwarded to the embedded workspace browser so the Files tab auto-refreshes.
+    refreshSignal?: string | number;
     onResolve: (event: string, prompt?: string) => void | Promise<void>;
     fetchArtifacts?: (workflowId: string, artifactName: string) => Promise<ArtifactContentDto>;
     fetchFileTree?: (workflowId: string, path?: string) => Promise<FileTreeResponseDto>;
@@ -265,7 +268,7 @@
   {:else if activeTab === 'files' && fetchFileTree && fetchFileContent}
     <!-- Workspace file browser -->
     <div class="h-[400px]">
-      <WorkspaceBrowser {workflowId} {fetchFileTree} {fetchFileContent} />
+      <WorkspaceBrowser {workflowId} {refreshSignal} {fetchFileTree} {fetchFileContent} />
     </div>
   {/if}
 

--- a/packages/web-ui/src/lib/components/features/workspace-browser.svelte
+++ b/packages/web-ui/src/lib/components/features/workspace-browser.svelte
@@ -2,37 +2,74 @@
   import type { FileTreeResponseDto, FileContentResponseDto } from '$lib/types.js';
   import FileTree from './file-tree.svelte';
   import FileViewer from './file-viewer.svelte';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import ArrowsClockwise from 'phosphor-svelte/lib/ArrowsClockwise';
 
   let {
     workflowId,
+    refreshSignal = '',
     fetchFileTree,
     fetchFileContent,
   }: {
     workflowId: string;
+    // External auto-refresh trigger (e.g. a workflow lifecycle key from the
+    // detail view). Folded together with the manual refresh counter into the
+    // key handed to the tree and viewer.
+    refreshSignal?: string | number;
     fetchFileTree: (workflowId: string, path?: string) => Promise<FileTreeResponseDto>;
     fetchFileContent: (workflowId: string, path: string) => Promise<FileContentResponseDto>;
   } = $props();
 
   let selectedPath = $state<string | null>(null);
+  let manualRefreshCount = $state(0);
+  let treeRefreshing = $state(false);
+
+  // Any change here re-reads the tree and the open file. Auto-refreshes ride on
+  // refreshSignal; the Refresh button bumps manualRefreshCount.
+  const refreshKey = $derived(`${refreshSignal}#${manualRefreshCount}`);
 
   function handleFileSelect(path: string): void {
     selectedPath = path;
+  }
+
+  function refreshNow(): void {
+    manualRefreshCount += 1;
   }
 </script>
 
 <div class="flex h-full min-h-[300px] border border-border rounded-lg overflow-hidden">
   <!-- File tree panel -->
   <div class="w-64 shrink-0 border-r border-border overflow-y-auto bg-muted/10">
-    <div class="px-3 py-2 border-b border-border">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-border">
       <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Files</span>
+      <Button
+        variant="ghost"
+        size="icon"
+        type="button"
+        class="shrink-0 h-6 w-6 text-muted-foreground"
+        loading={treeRefreshing}
+        title="Reload files and the open file"
+        aria-label="Refresh files"
+        onclick={refreshNow}
+      >
+        {#if !treeRefreshing}
+          <ArrowsClockwise size={14} weight="bold" />
+        {/if}
+      </Button>
     </div>
-    <FileTree {workflowId} onFileSelect={handleFileSelect} {fetchFileTree} />
+    <FileTree
+      {workflowId}
+      {refreshKey}
+      bind:refreshing={treeRefreshing}
+      onFileSelect={handleFileSelect}
+      {fetchFileTree}
+    />
   </div>
 
   <!-- File viewer panel -->
   <div class="flex-1 min-w-0 overflow-hidden">
     {#if selectedPath}
-      <FileViewer {workflowId} path={selectedPath} {fetchFileContent} />
+      <FileViewer {workflowId} path={selectedPath} {refreshKey} {fetchFileContent} />
     {:else}
       <div class="flex items-center justify-center h-full text-sm text-muted-foreground">
         Select a file to view its contents

--- a/packages/web-ui/src/routes/WorkflowDetail.svelte
+++ b/packages/web-ui/src/routes/WorkflowDetail.svelte
@@ -126,6 +126,23 @@
       });
   });
 
+  // Auto-refresh signal for the workspace browser. It changes whenever the
+  // workflow advances in a way that has likely mutated the workspace — a state
+  // transition (currentState/phase), a fresh agent verdict (latestVerdict), a
+  // gate, a terminal phase — or when the socket reconnects (we may have missed
+  // events). The browser silently re-reads the file tree and the open file on
+  // each change; no backend file-watching is involved.
+  const workspaceRefreshSignal = $derived(
+    [
+      summary.currentState,
+      summary.phase,
+      summary.latestVerdict?.stateId ?? '',
+      summary.latestVerdict?.verdict ?? '',
+      summary.latestVerdict?.confidence ?? '',
+      connectionGeneration.value,
+    ].join('|'),
+  );
+
   async function loadMessageLogPage(before?: string): Promise<void> {
     messageLogLoading = true;
     messageLogError = '';
@@ -272,6 +289,7 @@
         {workflowId}
         workflowName={summary.name}
         stateDescription={gateStateDescription}
+        refreshSignal={workspaceRefreshSignal}
         onResolve={handleGateResolve}
         fetchArtifacts={getWorkflowArtifacts}
         fetchFileTree={getWorkflowFileTree}
@@ -385,6 +403,7 @@
           <div class="h-[400px]">
             <WorkspaceBrowser
               {workflowId}
+              refreshSignal={workspaceRefreshSignal}
               fetchFileTree={getWorkflowFileTree}
               fetchFileContent={getWorkflowFileContent}
             />


### PR DESCRIPTION
## Problem

The workflow details view's workspace/file browser was **fetch-once-then-cache**, so changed files never refreshed:

- The open file (`FileViewer`) re-read only when you selected a *different* file — the same file never refreshed.
- The file tree (`FileTree`) cached each directory's children on first expansion and never re-fetched, so files an agent created/deleted mid-run never appeared.
- There was no manual refresh affordance either.

(Noticed while watching the filesystem viewer during a live run.)

## Approach — event-driven + manual button, **no backend changes**

`WorkflowDetail` derives a refresh signal from the already-reactive `summary` fields that change at exactly the moments the workspace mutates — `currentState`, `phase`, `latestVerdict` — plus `connectionGeneration` (socket reconnect). That signal is threaded through `WorkspaceBrowser` (and the gate review **Files** tab via `GateReviewPanel`) into the tree and viewer, combined with a manual-refresh counter.

- **`FileViewer`** — silently re-reads the open file when the signal changes: the previous content stays on screen until the new content arrives (no spinner flash). A small "refreshing" indicator shows in the file header.
- **`FileTree`** — silently reconciles: re-reads the root and every currently-expanded directory (**concurrently**), surfacing new/removed files while preserving expansion state, node identity (stable keyed DOM), and scroll position. Stale async passes are version-guarded so a newer pass always wins.
- **Manual Refresh button** — uses the shared `Button` primitive (`variant="ghost" size="icon"`, `loading` for the spinner); always available, so it also works on completed runs.

The workspace section only mounts when expanded, so auto-refresh costs nothing when collapsed.

## Files

| File | Change |
|---|---|
| `file-viewer.svelte` | `refreshKey` prop; silent re-read with change-guard + refreshing indicator |
| `file-tree.svelte` | `refreshKey` prop; silent recursive reconcile (concurrent sub-dir fetches) preserving expansion; bindable `refreshing` |
| `workspace-browser.svelte` | `refreshSignal` prop, manual-refresh counter, Refresh button, combined key |
| `gate-review-panel.svelte` | threads `refreshSignal` to the embedded browser |
| `WorkflowDetail.svelte` | derives the refresh signal, passes to both consumers |
| `file-viewer.test.ts`, `file-tree.test.ts` *(new)* | 10 tests exercising the real reactive refresh behavior |

## Testing

- `svelte-check`: 0 errors · ESLint + Prettier: clean · `vite build`: succeeds
- **358 web-ui tests pass** (10 new), covering: auto-refresh on signal change, silent in-flight refresh (no flash), path change, tree reconcile surfacing new / removing deleted files while staying expanded, and the no-redundant-fetch guard.

## Follow-up (not in scope)

Refreshing on every `workflow.agent_completed` even when no verdict is emitted would need a small frontend `event-handler` change; today those moments are covered by state transitions + the manual button.