### PR TITLE
refactor(evolve): linearize the per-round pipeline into a chain

### DIFF
--- a/src/workflow/workflows/evolve/workflow.yaml
+++ b/src/workflow/workflows/evolve/workflow.yaml
@@ -8,13 +8,15 @@ settings:
   sharedContainer: true
   model: anthropic:claude-sonnet-4-6
   # Safety backstop for a wedged round pipeline, NOT the round budget.
-  # isRoundLimitReached trips when the most-visited state reaches this count. In
-  # the linear round chain every state (orchestrator, sample, researcher,
-  # evaluate, analyzer, analysis_record) is entered once per evolution round, so
-  # this bounds a wedged run at ~maxRounds rounds. Set well above
-  # run_spec.budget.max_rounds so a legitimate long run is never capped before
-  # the orchestrator emits `complete`; the real round budget is enforced by the
-  # orchestrator against run_spec.budget.max_rounds.
+  # isRoundLimitReached trips when the MAX visit count across all states reaches
+  # this number. On the happy path every state is entered once per evolution
+  # round, so this bounds a clean run at ~maxRounds rounds; mid-round recovery
+  # (evaluator_blocked -> human_escalation -> resume) re-visits evaluate and the
+  # orchestrator, so a run with many recoveries trips the backstop in fewer
+  # rounds. It is set well above run_spec.budget.max_rounds either way, so a
+  # legitimate run is never capped before the orchestrator emits `complete`; the
+  # real round budget is enforced by the orchestrator against
+  # run_spec.budget.max_rounds.
   maxRounds: 200
 
 states:

--- a/src/workflow/workflows/evolve/workflow.yaml
+++ b/src/workflow/workflows/evolve/workflow.yaml
@@ -1,5 +1,5 @@
 name: evolve
-description: 'Evolve - multi-round evaluator-driven candidate search via an orchestrator hub: sampling, cognition, and per-round analysis.'
+description: 'Evolve - multi-round evaluator-driven candidate search: a linear per-round pipeline (sample, researcher, evaluate, analyzer, record) with a round-boundary orchestrator enforcing budget and stop conditions.'
 initial: provision
 
 settings:
@@ -7,12 +7,14 @@ settings:
   dockerAgent: claude-code
   sharedContainer: true
   model: anthropic:claude-sonnet-4-6
-  # Safety backstop for a wedged orchestrator hub, NOT the round budget.
-  # isRoundLimitReached trips when the most-visited state (the orchestrator,
-  # entered ~4 times per evolution round) reaches this count. Set well above
-  # 4 * run_spec.budget.max_rounds + 1 so a legitimate long run is never capped
-  # before the orchestrator emits `complete`; the real round budget is enforced
-  # by the orchestrator against run_spec.budget.max_rounds.
+  # Safety backstop for a wedged round pipeline, NOT the round budget.
+  # isRoundLimitReached trips when the most-visited state reaches this count. In
+  # the linear round chain every state (orchestrator, sample, researcher,
+  # evaluate, analyzer, analysis_record) is entered once per evolution round, so
+  # this bounds a wedged run at ~maxRounds rounds. Set well above
+  # run_spec.budget.max_rounds so a legitimate long run is never capped before
+  # the orchestrator emits `complete`; the real round budget is enforced by the
+  # orchestrator against run_spec.budget.max_rounds.
   maxRounds: 200
 
 states:
@@ -298,13 +300,16 @@ states:
 
   orchestrator:
     type: agent
-    description: Central router. Reads the durable run state and routes the next phase.
+    description: Round-boundary controller - after each recorded round (and at the start) it enforces the budget and stop conditions, routing to continue, complete, or escalate.
     persona: global
     prompt: |
-      You are the Evolve orchestrator - the central router for a bounded multi-round
-      search. On every turn you read the durable run state and emit exactly ONE routing
-      verdict in your agent_status block. You do not write candidates, run evaluators,
-      or record nodes; you only decide what happens next.
+      You are the Evolve orchestrator - the round-boundary controller for a bounded
+      multi-round search. You are entered at the start of the run and again after each
+      round is durably recorded; you read the durable run state and emit exactly ONE
+      routing verdict in your agent_status block. You do not write candidates, run
+      evaluators, or record nodes. The per-round pipeline runs on its own - sample ->
+      researcher -> evaluate -> analyzer -> analysis_record - and returns here only
+      once the round is committed.
 
       Read these files first:
         - /workspace/.evolve_runs/main/run_spec.yaml - budget.max_rounds is N.
@@ -315,11 +320,10 @@ states:
           precomputed stop_reason; do NOT recompute target, patience, or max-round
           logic yourself.
 
-      Also inspect /workspace/.evolve_runs/main/current/. It is overwritten each round:
-        - context.json means sampling for the in-flight round is done.
-        - result.json means evaluation for the in-flight round is done.
-        - analysis.md means analysis for the in-flight round is done.
-        - analysis_record.json means the round was recorded.
+      One recovery case: if a human just approved an evaluator-blocked round, you are
+      entered mid-round with a candidate written but not yet scored. Detect this by
+      /workspace/.evolve_runs/main/current/context.json present AND result.json absent,
+      and emit evaluate to resume that round rather than starting a new one.
 
       If a human directive in this message requests more rounds, that directive
       overrides any stop_reason for THIS turn only: emit design to start one more
@@ -332,11 +336,10 @@ states:
       Decide and emit one verdict:
         - complete  - if stop_signals.json exists and its stop_reason is non-null,
                       unless a human extension directive is still active.
-        - design    - if no round is in-flight and no active stop_reason should
+        - design    - to start the next round, when no active stop_reason should
                       complete the run.
-        - evaluate  - if the in-flight round has a candidate written but no result.json yet.
-        - analyze   - if the in-flight round has a result.json but no analysis.md yet.
-        - record    - if the in-flight round has an analysis.md but is not yet committed.
+        - evaluate  - only to resume an evaluator-blocked round (the recovery case
+                      above): a candidate is written but result.json is absent.
         - escalate  - only if the run is unrecoverable.
 
       Finish with the required agent_status block carrying exactly one of those verdicts.
@@ -349,10 +352,6 @@ states:
         when: { verdict: design }
       - to: evaluate
         when: { verdict: evaluate }
-      - to: analyzer
-        when: { verdict: analyze }
-      - to: analysis_record
-        when: { verdict: record }
       - to: final_summary
         when: { verdict: complete }
       - to: human_escalation
@@ -418,7 +417,7 @@ states:
     outputs: []
     maxVisits: 3
     transitions:
-      - to: orchestrator
+      - to: evaluate
 
   evaluate:
     type: deterministic
@@ -438,7 +437,7 @@ states:
           '/workspace/.evolve_runs/main/current/result.json',
         ]
     transitions:
-      - to: orchestrator
+      - to: analyzer
         when: { verdict: evaluated }
       - to: human_escalation
         when: { verdict: evaluator_blocked }
@@ -468,7 +467,7 @@ states:
     outputs: []
     maxVisits: 3
     transitions:
-      - to: orchestrator
+      - to: analysis_record
 
   analysis_record:
     type: deterministic

--- a/test/workflow/evolve-result-bridge.test.ts
+++ b/test/workflow/evolve-result-bridge.test.ts
@@ -30,7 +30,7 @@ describe('evolve workflow manifest', () => {
     expect(diagnostics.map((d) => d.code)).not.toContain('WF012');
   });
 
-  it('manifest wires the multi-round hub and confirmed run-spec fields', () => {
+  it('manifest wires the linear round chain and confirmed run-spec fields', () => {
     const manifestPath = resolve(WORKFLOW_DIR, 'workflow.yaml');
     const raw = parseYaml(readFileSync(manifestPath, 'utf-8'), { maxAliasCount: 0 }) as {
       settings: { maxRounds: number };
@@ -47,6 +47,7 @@ describe('evolve workflow manifest', () => {
         evaluate: { transitions: Array<{ to: string; when?: { verdict?: string } }> };
         researcher: { prompt: string; transitions: Array<{ to: string }> };
         analyzer: { transitions: Array<{ to: string }> };
+        analysis_record: { transitions: Array<{ to: string; when?: { verdict?: string } }> };
         preflight_review: {
           type: string;
           present: string[];
@@ -75,11 +76,12 @@ describe('evolve workflow manifest', () => {
     expect(raw.states.preflight.outputs).toEqual(['run_spec', 'cognition_seed']);
     expect(raw.states.preflight.transitions[0]).toMatchObject({ to: 'preflight_review', when: { verdict: 'ready' } });
     expect(raw.states.orchestrator.transitions[0]).toEqual({ to: 'failed', guard: 'isRoundLimitReached' });
+    // Round-boundary controller: design (next round), evaluate (resume an
+    // evaluator-blocked round only), complete, escalate. The mid-round verdicts
+    // (analyze/record) are gone — those steps now chain directly.
     expect(raw.states.orchestrator.transitions.map((t) => t.when?.verdict).filter(Boolean)).toEqual([
       'design',
       'evaluate',
-      'analyze',
-      'record',
       'complete',
       'escalate',
     ]);
@@ -87,11 +89,15 @@ describe('evolve workflow manifest', () => {
     expect(raw.states.orchestrator.transitions.find((t) => t.when?.verdict === 'escalate')?.to).toBe(
       'human_escalation',
     );
+    // Linear round chain: sample -> researcher -> evaluate -> analyzer ->
+    // analysis_record -> orchestrator. Only the durable record returns to the hub.
+    expect(raw.states.researcher.transitions).toEqual([{ to: 'evaluate' }]);
+    expect(raw.states.evaluate.transitions.find((t) => t.when?.verdict === 'evaluated')?.to).toBe('analyzer');
     expect(raw.states.evaluate.transitions.find((t) => t.when?.verdict === 'evaluator_blocked')?.to).toBe(
       'human_escalation',
     );
-    expect(raw.states.researcher.transitions).toEqual([{ to: 'orchestrator' }]);
-    expect(raw.states.analyzer.transitions).toEqual([{ to: 'orchestrator' }]);
+    expect(raw.states.analyzer.transitions).toEqual([{ to: 'analysis_record' }]);
+    expect(raw.states.analysis_record.transitions.find((t) => t.when?.verdict === 'recorded')?.to).toBe('orchestrator');
     expect(raw.states.preflight_review).toMatchObject({
       type: 'human_gate',
       acceptedEvents: ['APPROVE', 'FORCE_REVISION', 'ABORT'],


### PR DESCRIPTION
## What

The `evolve` orchestrator was a **hub** re-entered ~4–5 times per round to re-derive a fixed sequence (`design → evaluate → analyze → record`). This linearizes the happy path so each step chains directly:

```
sample → researcher → evaluate → analyzer → analysis_record → orchestrator
```

The orchestrator is now a **round-boundary controller**, entered once per round to enforce the budget/stop conditions (`design` = next round / `complete` / `escalate`). It keeps the `evaluate` verdict solely to resume an evaluator-blocked round after a human APPROVE — the only mid-round recovery point. The `analyze`/`record` verdicts are removed.

## Why

- **Fewer LLM calls.** The orchestrator is an agent (LLM) call; re-deriving a deterministic sequence 4–5× per round is wasted work. Measured on a 5-round circle-packing run: orchestrator invocations dropped from ~4.2–4.3/round to **1.2/round** (~75% fewer orchestrator calls), saving ~140k fresh / ~1.3–1.6M raw input tokens per 5-round run, plus 3 fewer agent round-trips/round of latency.
- **Removes a failure mode.** The hub let the LLM mis-route a pipeline that never actually varies; the chain makes progression deterministic.
- **Makes a round a composable unit.** With a hub-free round-chain, the orchestrator can later fan out N concurrent round-chains and barrier-join — parallelism without breaking the single-active-state model. This refactor is the precondition for that.

## Safety / recovery preserved

- `evaluate → human_escalation` (evaluator_blocked) and the error → `failed` edges are unchanged.
- `human_escalation --APPROVE--> orchestrator` still resumes a blocked round: the orchestrator detects "candidate written, no result.json" and emits `evaluate`.
- Crash-resume re-enters the checkpointed state directly (not the orchestrator), so no recovery path depends on the dropped verdicts.
- `analyze`/`record` have no escalation path (they go straight to `failed`), so dropping them from the orchestrator loses nothing.
- The `isRoundLimitReached` backstop comment is updated: with all states now entered once/round, it bounds a wedged run at ~`maxRounds` rounds (real budget is still the orchestrator's `complete` against `run_spec.budget.max_rounds`).

## Validation

- `npm test` workflow suite green (685 passed); manifest assertions updated to pin the linear chain.
- `workflow lint` clean.
- Re-ran the circle-packing demo end-to-end (5 rounds, completed). Transition log confirms the chain with the orchestrator entered once/round; multi-parent recombination still fires under greedy `sample_n 3`.