### PR TITLE
fix(docker): handle benign GID collisions in agent UID/GID remap (#291)

### DIFF
--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -5,7 +5,9 @@ USER root
 RUN npm install -g @anthropic-ai/claude-code
 
 # The entrypoint script copies runtime-generated config into the right
-# location before the agent is invoked via docker exec.
+# location before the agent is invoked via docker exec. It sources the
+# shared UID/GID remap helper, so that must be present too.
+COPY entrypoint-uid-remap.sh /usr/local/bin/ironcurtain-uid-remap.sh
 COPY entrypoint-claude-code.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker/Dockerfile.codex
+++ b/docker/Dockerfile.codex
@@ -5,6 +5,9 @@ FROM ironcurtain-base:latest
 USER root
 RUN npm install -g @openai/codex
 
+# The entrypoint sources the shared UID/GID remap helper, so that must be
+# present in the image too.
+COPY entrypoint-uid-remap.sh /usr/local/bin/ironcurtain-uid-remap.sh
 COPY entrypoint-codex.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker/Dockerfile.goose
+++ b/docker/Dockerfile.goose
@@ -23,7 +23,9 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-# Entrypoint: bridges UDS proxy, writes Goose config, hands off to CMD
+# Entrypoint: bridges UDS proxy, writes Goose config, hands off to CMD.
+# It sources the shared UID/GID remap helper, so that must be present too.
+COPY entrypoint-uid-remap.sh /usr/local/bin/ironcurtain-uid-remap.sh
 COPY entrypoint-goose.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/docker/entrypoint-claude-code.sh
+++ b/docker/entrypoint-claude-code.sh
@@ -4,51 +4,12 @@
 # Non-PTY mode: CMD is "sleep infinity" (agent commands arrive via docker exec).
 # PTY mode: CMD is the socat PTY command from buildPtyCommand().
 
-# Runtime UID remap (Linux only).
-#
-# Issue #232: when the host UID is not 1000, bind-mounted directories
-# (e.g., the conversation-state dir) appear inside the container owned
-# by the host UID, and the baked codespace user (UID 1000) cannot write
-# to them. The host-side launcher passes `--user 0:0` plus the host
-# UID/GID via IRONCURTAIN_AGENT_UID / IRONCURTAIN_AGENT_GID so this
-# block (running as root) can renumber the codespace account to match
-# the host before dropping privileges. On macOS, Docker Desktop's
-# VirtioFS translates UIDs transparently and the env vars are not set,
-# so this block is skipped.
-if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
-  if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
-    # Renumber the codespace user/group to the host UID/GID, then fix
-    # ownership on the baked home dir and workspace mount so the
-    # remapped codespace user can read/write them. Bind-mounted
-    # subdirectories (conversation state, sockets, orientation) keep
-    # their host-side ownership, which now matches codespace.
-    #
-    # FAIL HARD on remap errors. Previously these commands ran without
-    # return-code checks: if `usermod -u $HOST_UID codespace` collided
-    # with an existing image user (plausible for system UIDs like 33
-    # `www-data` or 100 `systemd-network`), the entrypoint would
-    # silently continue, then `chown` and `runuser -u codespace`
-    # would operate on the still-UID-1000 codespace — recreating the
-    # original issue #232 bug with no diagnostic. Abort with an explicit
-    # error instead so the operator sees what went wrong.
-    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace || {
-      echo "[ironcurtain] groupmod failed: cannot remap codespace group to GID $IRONCURTAIN_AGENT_GID (already in use?)" >&2
-      exit 1
-    }
-    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace || {
-      echo "[ironcurtain] usermod failed: cannot remap codespace user to UID $IRONCURTAIN_AGENT_UID (already in use?)" >&2
-      exit 1
-    }
-    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace || {
-      echo "[ironcurtain] chown failed: cannot reset ownership of /home/codespace and /workspace to $IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" >&2
-      exit 1
-    }
-  fi
-  # Re-exec the entrypoint as the (possibly remapped) codespace user.
-  # The remainder of this script runs under codespace, so $HOME and
-  # sudoers (which keys on the username) resolve correctly.
-  exec runuser -u codespace -- "$0" "$@"
-fi
+# Runtime UID/GID remap (Linux only). The shared helper renumbers the
+# baked codespace user/group to match the host UID/GID (issue #232) and
+# re-execs this entrypoint as codespace. Sourced so it shares this
+# script's $0/$@; see the helper for the full rationale (issues #232 and
+# #291). No-op on macOS and when already running as codespace.
+. /usr/local/bin/ironcurtain-uid-remap.sh
 
 # Bridge UDS to local TCP so HTTPS_PROXY works
 MITM_SOCK="/run/ironcurtain/mitm-proxy.sock"

--- a/docker/entrypoint-codex.sh
+++ b/docker/entrypoint-codex.sh
@@ -1,25 +1,11 @@
 #!/bin/bash
 # IronCurtain entrypoint for Codex CLI containers.
 
-# Runtime UID remap (Linux only). See entrypoint-claude-code.sh for the
-# detailed rationale.
-if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
-  if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
-    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace || {
-      echo "[ironcurtain] groupmod failed: cannot remap codespace group to GID $IRONCURTAIN_AGENT_GID (already in use?)" >&2
-      exit 1
-    }
-    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace || {
-      echo "[ironcurtain] usermod failed: cannot remap codespace user to UID $IRONCURTAIN_AGENT_UID (already in use?)" >&2
-      exit 1
-    }
-    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace || {
-      echo "[ironcurtain] chown failed: cannot reset ownership of /home/codespace and /workspace to $IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" >&2
-      exit 1
-    }
-  fi
-  exec runuser -u codespace -- "$0" "$@"
-fi
+# Runtime UID/GID remap (Linux only). Shared with the other agent
+# entrypoints so the remap logic cannot drift (issues #232 and #291).
+# Sourced so it shares this script's $0/$@; no-op on macOS and when
+# already running as codespace.
+. /usr/local/bin/ironcurtain-uid-remap.sh
 
 MITM_SOCK="/run/ironcurtain/mitm-proxy.sock"
 PROXY_PORT=18080

--- a/docker/entrypoint-goose.sh
+++ b/docker/entrypoint-goose.sh
@@ -2,30 +2,11 @@
 # IronCurtain entrypoint for Goose containers.
 # Sets up proxy bridges, writes Goose config, then hands off to CMD.
 
-# Runtime UID remap (Linux only). See entrypoint-claude-code.sh for the
-# full rationale (issue #232). Skipped on macOS where Docker Desktop
-# translates UIDs and the env vars are not set.
-if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
-  if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
-    # Fail hard on remap errors — see entrypoint-claude-code.sh for the
-    # full rationale. Without explicit checks, a UID collision (host UID
-    # already in use by a system user baked into the image) silently
-    # recreates the original issue #232 bug.
-    groupmod -g "$IRONCURTAIN_AGENT_GID" codespace || {
-      echo "[ironcurtain] groupmod failed: cannot remap codespace group to GID $IRONCURTAIN_AGENT_GID (already in use?)" >&2
-      exit 1
-    }
-    usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace || {
-      echo "[ironcurtain] usermod failed: cannot remap codespace user to UID $IRONCURTAIN_AGENT_UID (already in use?)" >&2
-      exit 1
-    }
-    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace || {
-      echo "[ironcurtain] chown failed: cannot reset ownership of /home/codespace and /workspace to $IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" >&2
-      exit 1
-    }
-  fi
-  exec runuser -u codespace -- "$0" "$@"
-fi
+# Runtime UID/GID remap (Linux only). Shared with the other agent
+# entrypoints so the remap logic cannot drift (issues #232 and #291).
+# Sourced so it shares this script's $0/$@; no-op on macOS and when
+# already running as codespace.
+. /usr/local/bin/ironcurtain-uid-remap.sh
 
 # 1. Bridge MITM proxy UDS to local TCP (same as Claude Code entrypoint)
 MITM_SOCK="/run/ironcurtain/mitm-proxy.sock"

--- a/docker/entrypoint-uid-remap.sh
+++ b/docker/entrypoint-uid-remap.sh
@@ -1,0 +1,93 @@
+# shellcheck shell=bash
+# Shared runtime UID/GID remap block for IronCurtain agent entrypoints
+# (Linux only). SOURCED — not executed — from each agent's
+# /usr/local/bin/entrypoint.sh so the three adapters (claude-code, goose,
+# codex) cannot drift apart. Issue #291 was caused by exactly that drift:
+# only the goose entrypoint got the GID-collision fix in the field report.
+#
+# Sourcing contract:
+#   - This file is `source`d near the top of the parent entrypoint, so
+#     `$0` and `$@` resolve to the PARENT entrypoint's path and args. The
+#     `exec runuser -u codespace -- "$0" "$@"` below therefore re-execs the
+#     parent entrypoint (/usr/local/bin/entrypoint.sh) with its original
+#     args — which is what we want. `exec` replaces the current process even
+#     when reached from a sourced file.
+#   - After the re-exec, the parent entrypoint runs again and sources this
+#     file again, but `id -u` is no longer 0, so the whole block is a no-op
+#     the second time through and execution falls past it to the rest of the
+#     parent entrypoint (now running as codespace).
+#
+# Issue #232: when the host UID is not 1000, bind-mounted directories
+# (e.g., the conversation-state dir) appear inside the container owned by
+# the host UID, and the baked codespace user (UID 1000) cannot write to
+# them. The host-side launcher passes `--user 0:0` plus the host UID/GID via
+# IRONCURTAIN_AGENT_UID / IRONCURTAIN_AGENT_GID so this block (running as
+# root) can renumber the codespace account to match the host before
+# dropping privileges. On macOS, Docker Desktop's VirtioFS translates UIDs
+# transparently and the env vars are not set, so this block is skipped.
+if [ "$(id -u)" = "0" ] && [ -n "$IRONCURTAIN_AGENT_UID" ] && [ -n "$IRONCURTAIN_AGENT_GID" ]; then
+  if [ "$IRONCURTAIN_AGENT_UID" != "1000" ] || [ "$IRONCURTAIN_AGENT_GID" != "1000" ]; then
+    # Renumber the codespace user/group to the host UID/GID, then fix
+    # ownership on the baked home dir and workspace mount so the remapped
+    # codespace user can read/write them. Bind-mounted subdirectories
+    # (conversation state, sockets, orientation) keep their host-side
+    # ownership, which now matches codespace.
+    #
+    # GID and UID collisions are handled asymmetrically because they mean
+    # different things:
+    #
+    #   - A GID collision is BENIGN. It just means the host's primary group
+    #     already exists inside the image (issue #291: the universal
+    #     devcontainer image bakes `users:x:100`, and on nixos/WSL and many
+    #     Linux desktops the invoking user's primary group is GID 100).
+    #     Sharing a group is ordinary Unix, so we point codespace's PRIMARY
+    #     group at the existing group via `usermod -g` (which REQUIRES the
+    #     target GID to already exist). Only when the GID is free do we
+    #     renumber codespace's own group via `groupmod -g`. Previously this
+    #     unconditionally ran `groupmod -g`, which fails with
+    #     "GID already exists" and aborted startup.
+    #
+    #   - A UID collision is DANGEROUS and must FAIL HARD. It means the host
+    #     UID is already a distinct baked-in account (e.g. www-data=33).
+    #     Silently continuing would leave codespace at UID 1000 and then
+    #     `chown` / `runuser -u codespace` would operate on the wrong
+    #     account — recreating the original issue #232 bug with no
+    #     diagnostic. This is the regression guard from commit 2f463f3.
+    current_gid="$(id -g codespace)"
+    if [ "$current_gid" != "$IRONCURTAIN_AGENT_GID" ]; then
+      if getent group "$IRONCURTAIN_AGENT_GID" >/dev/null 2>&1; then
+        # GID already exists in the image (benign collision): reuse it as
+        # codespace's primary group instead of renumbering codespace's own
+        # group onto an occupied GID.
+        usermod -g "$IRONCURTAIN_AGENT_GID" codespace || {
+          echo "[ironcurtain] usermod failed: cannot set codespace primary group to existing GID $IRONCURTAIN_AGENT_GID" >&2
+          exit 1
+        }
+      else
+        # GID is free: renumber codespace's own group to it.
+        groupmod -g "$IRONCURTAIN_AGENT_GID" codespace || {
+          echo "[ironcurtain] groupmod failed: cannot remap codespace group to GID $IRONCURTAIN_AGENT_GID (already in use?)" >&2
+          exit 1
+        }
+      fi
+    fi
+
+    current_uid="$(id -u codespace)"
+    if [ "$current_uid" != "$IRONCURTAIN_AGENT_UID" ]; then
+      usermod -u "$IRONCURTAIN_AGENT_UID" -g "$IRONCURTAIN_AGENT_GID" codespace || {
+        echo "[ironcurtain] usermod failed: cannot remap codespace user to UID $IRONCURTAIN_AGENT_UID (already in use?)" >&2
+        exit 1
+      }
+    fi
+
+    chown -R "$IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" /home/codespace /workspace || {
+      echo "[ironcurtain] chown failed: cannot reset ownership of /home/codespace and /workspace to $IRONCURTAIN_AGENT_UID:$IRONCURTAIN_AGENT_GID" >&2
+      exit 1
+    }
+  fi
+  # Re-exec the entrypoint as the (possibly remapped) codespace user. The
+  # remainder of the parent entrypoint runs under codespace, so $HOME and
+  # sudoers (which keys on the username) resolve correctly. `$0`/`$@` are
+  # the parent entrypoint's because this file is sourced, not executed.
+  exec runuser -u codespace -- "$0" "$@"
+fi

--- a/test/uid-remap.goose.integration.test.ts
+++ b/test/uid-remap.goose.integration.test.ts
@@ -388,7 +388,7 @@ describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #
       // `codespace`. The name proves which branch ran (asserted below).
       const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
       observations.idCodespaceUid = /uid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
-      const gidMatch = /gid=(\d+)\((\w+)\)/.exec(idOut.stdout);
+      const gidMatch = /gid=(\d+)\(([^)]+)\)/.exec(idOut.stdout);
       observations.idCodespaceGid = gidMatch?.[1];
       observations.idCodespaceGidName = gidMatch?.[2];
 

--- a/test/uid-remap.goose.integration.test.ts
+++ b/test/uid-remap.goose.integration.test.ts
@@ -81,6 +81,20 @@ const REMAP_UID = 1500;
 const COLLIDING_UID = 33;
 
 /**
+ * A GID known to already exist in the base image as the `users` group
+ * (GID 100 on the Debian-derived bases used for the agent images). This is
+ * the exact issue #291 scenario: on nixos/WSL and many Linux desktops the
+ * invoking user's primary group is GID 100, so the host passes
+ * IRONCURTAIN_AGENT_GID=100. A GID collision is benign — the entrypoint
+ * must reuse the existing group (via `usermod -g`) rather than aborting
+ * with the old unconditional `groupmod -g` which failed with "GID already
+ * exists". The reuse-branch assertion below verifies the group name is the
+ * pre-existing one, so this test fails loudly rather than silently routing
+ * through groupmod if a future base image ever stops shipping `users:x:100`.
+ */
+const EXISTING_GID = 100;
+
+/**
  * Polls until the entrypoint has finished running `usermod`/`groupmod`/`chown`
  * and has exec'd the CMD. The universal devcontainer image has a large
  * `/home/codespace` (Conda, NVM, Hugo, etc.) that `usermod -u` scans for
@@ -154,6 +168,7 @@ const gooseDockerReady =
 interface RemapObservations {
   idCodespaceUid?: string;
   idCodespaceGid?: string;
+  idCodespaceGidName?: string;
   passwdUid?: string;
   homeStatUid?: string;
   runuserUid?: string;
@@ -309,11 +324,147 @@ describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #
   });
 
   /**
+   * Issue #291 success path: a GID collision is BENIGN and must NOT abort
+   * startup. We force a remap to a free UID (1500) but to GID 100
+   * (`users`), which the base image already bakes in. The old entrypoint
+   * ran `groupmod -g 100 codespace` unconditionally and died with
+   * "GID '100' already exists"; the fix detects the existing group and
+   * reuses it as codespace's primary group via `usermod -g 100`. The
+   * entrypoint must then chown /home/codespace and /workspace to
+   * REMAP_UID:100 and `runuser -u codespace` must land on REMAP_UID with
+   * primary group 100. Goose mirror of the Claude Code test.
+   */
+  describe('forced remap with a colliding GID (issue #291)', () => {
+    let homeDir: string;
+    let workspaceDir: string;
+    let containerName: string;
+    let originalUid: number;
+    let originalGid: number;
+    const observations: RemapObservations = {};
+
+    beforeAll(async () => {
+      // Capture the real UID/GID for the workspace chown-back during cleanup.
+      originalUid = process.getuid?.() ?? 1000;
+      originalGid = process.getgid?.() ?? 1000;
+
+      homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-uidremap-goose-gid-test-'));
+      workspaceDir = join(homeDir, 'workspace');
+      mkdirSync(workspaceDir, { recursive: true });
+      containerName = `ironcurtain-uidremap-goose-gid-${process.pid}-${Date.now()}`;
+
+      // Run the entrypoint as root with a free UID but a GID (100) that
+      // already exists in the image. CMD is `sleep 180` so the container
+      // stays up long enough for `docker exec` to inspect post-remap state.
+      await execFile(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '-d',
+          '--name',
+          containerName,
+          '--user',
+          '0:0',
+          '-e',
+          `IRONCURTAIN_AGENT_UID=${REMAP_UID}`,
+          '-e',
+          `IRONCURTAIN_AGENT_GID=${EXISTING_GID}`,
+          '-v',
+          `${workspaceDir}:/workspace`,
+          IMAGE,
+          'sleep',
+          '180',
+        ],
+        { timeout: 30_000 },
+      );
+
+      // Wait for the full remap (including the recursive chown of
+      // /workspace) before reading state.
+      await waitForRemapComplete(containerName, REMAP_UID, 90_000);
+
+      // Capture the numeric primary GID and the group NAME: after
+      // `usermod -g 100` the name is the pre-existing group (`users`),
+      // whereas the old `groupmod -g` path would have left it as
+      // `codespace`. The name proves which branch ran (asserted below).
+      const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
+      observations.idCodespaceUid = /uid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
+      const gidMatch = /gid=(\d+)\((\w+)\)/.exec(idOut.stdout);
+      observations.idCodespaceGid = gidMatch?.[1];
+      observations.idCodespaceGidName = gidMatch?.[2];
+
+      const passwdOut = await dockerExecAs(containerName, '0:0', 'sh', '-c', 'getent passwd codespace | cut -d: -f3');
+      observations.passwdUid = passwdOut.stdout.trim();
+
+      const homeStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/home/codespace');
+      observations.homeStatUid = homeStat.stdout.trim();
+
+      const wsStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/workspace');
+      observations.workspaceStatUid = wsStat.stdout.trim();
+
+      const runuserUid = await dockerExecAs(containerName, 'codespace', 'id', '-u');
+      const runuserName = await dockerExecAs(containerName, 'codespace', 'whoami');
+      observations.runuserUid = runuserUid.stdout.trim();
+      observations.runuserName = runuserName.stdout.trim();
+    }, 120_000);
+
+    afterAll(async () => {
+      // Restore workspace ownership BEFORE removing the container; the
+      // entrypoint's `chown -R ${REMAP_UID}:${EXISTING_GID} /workspace`
+      // propagates through the bind mount, so without this restore the
+      // host tempdir is left owned by REMAP_UID and rmSync fails EACCES.
+      if (containerName) {
+        try {
+          await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
+        } catch {
+          /* container gone or chown failed */
+        }
+        try {
+          await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+        } catch {
+          /* container already gone */
+        }
+      }
+      if (homeDir) rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it(`renumbered codespace user to UID ${REMAP_UID} despite the GID collision`, () => {
+      expect(observations.idCodespaceUid).toBe(String(REMAP_UID));
+      expect(observations.passwdUid).toBe(String(REMAP_UID));
+    });
+
+    it(`reused existing group: codespace primary GID is ${EXISTING_GID} (usermod -g path, not groupmod)`, () => {
+      expect(observations.idCodespaceGid).toBe(String(EXISTING_GID));
+      // The group NAME proves which branch ran: `usermod -g` reuse points
+      // codespace at the pre-existing group (`users`); the free-GID
+      // `groupmod -g` path would show `codespace`. Asserting it is NOT
+      // `codespace` keeps the test honest if a future base image drops
+      // `users:x:100` (which would otherwise still pass green).
+      expect(observations.idCodespaceGidName).toBeDefined();
+      expect(observations.idCodespaceGidName).not.toBe('codespace');
+    });
+
+    it(`chown -R reset /home/codespace ownership to ${REMAP_UID}`, () => {
+      expect(observations.homeStatUid).toBe(String(REMAP_UID));
+    });
+
+    it(`chown -R reset /workspace ownership to ${REMAP_UID}`, () => {
+      expect(observations.workspaceStatUid).toBe(String(REMAP_UID));
+    });
+
+    it('dropping privileges via runuser/--user codespace lands on the remapped UID', () => {
+      expect(observations.runuserUid).toBe(String(REMAP_UID));
+      expect(observations.runuserName).toBe('codespace');
+    });
+  });
+
+  /**
    * Failure-diagnostic path: a UID collision (33 == `www-data` in the base
-   * image) makes `groupmod`/`usermod` fail. The entrypoint must exit
-   * non-zero and emit the `[ironcurtain] {usermod,groupmod} failed:`
-   * diagnostic so operators see what went wrong instead of silently
-   * running with a broken UID mapping.
+   * image) makes `usermod -u` fail. The entrypoint must exit non-zero and
+   * emit the `[ironcurtain] usermod failed:` diagnostic so operators see
+   * what went wrong instead of silently running with a broken UID mapping.
+   * (GID 33 also belongs to www-data, but a GID collision is now benign —
+   * the entrypoint reuses the group via `usermod -g` and proceeds to the
+   * UID remap, which is where the hard failure surfaces.)
    */
   describe('UID collision is reported as a hard error', () => {
     let containerName: string;
@@ -334,11 +485,13 @@ describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #
 
     it(`entrypoint exits non-zero and logs a diagnostic when UID ${COLLIDING_UID} collides with a baked user`, async () => {
       // Run the entrypoint as root (`--user 0:0`) with a colliding
-      // IRONCURTAIN_AGENT_UID. `groupmod` runs first; gid 33 also
-      // belongs to `www-data`, so the diagnostic will be `groupmod
-      // failed:` (the entrypoint fails on the first collision). Either
-      // error proves the hard-error contract: silent fall-through is
-      // the regression we're guarding against.
+      // IRONCURTAIN_AGENT_UID. GID 33 (www-data) already exists, so the
+      // entrypoint treats the GID as a benign collision and reuses the
+      // group via `usermod -g 33`; the hard failure then surfaces on
+      // `usermod -u 33 codespace`, which collides with the baked
+      // www-data user. Either diagnostic proves the hard-error contract:
+      // silent fall-through to a broken UID mapping is the regression we
+      // guard against.
       let result: { stdout: string; stderr: string; exitCode: number };
       try {
         const ok = await execFile(
@@ -368,9 +521,11 @@ describe.skipIf(!gooseDockerReady)('Goose agent container UID/GID remap (issue #
       // Container must exit non-zero. The entrypoint script uses `exit 1`
       // explicitly on each failure branch.
       expect(result.exitCode).not.toBe(0);
-      // Stderr must contain one of the diagnostic lines — we accept
-      // either `usermod failed:` or `groupmod failed:` because groupmod
-      // runs first and gid 33 also collides with www-data.
+      // Stderr must contain one of the diagnostic lines. With the issue
+      // #291 fix the UID collision surfaces as `usermod failed:`; we keep
+      // the regex permissive (also matching `groupmod failed:`) so the
+      // contract assertion is robust to future ordering changes — silent
+      // fall-through is what we guard against.
       const combined = `${result.stdout}\n${result.stderr}`;
       expect(combined).toMatch(/\[ironcurtain\] (usermod|groupmod) failed:/);
     }, 60_000);

--- a/test/uid-remap.integration.test.ts
+++ b/test/uid-remap.integration.test.ts
@@ -395,7 +395,7 @@ describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () =
       // name proves the reuse branch actually ran (see assertion below).
       const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
       observations.idCodespaceUid = /uid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
-      const gidMatch = /gid=(\d+)\((\w+)\)/.exec(idOut.stdout);
+      const gidMatch = /gid=(\d+)\(([^)]+)\)/.exec(idOut.stdout);
       observations.idCodespaceGid = gidMatch?.[1];
       observations.idCodespaceGidName = gidMatch?.[2];
 

--- a/test/uid-remap.integration.test.ts
+++ b/test/uid-remap.integration.test.ts
@@ -80,6 +80,21 @@ const REMAP_UID = 1500;
 const COLLIDING_UID = 33;
 
 /**
+ * A GID known to already exist in the base image as the `users` group:
+ * GID 100 is `users` on both the x86 universal devcontainer image and the
+ * Debian `node:22-trixie` arm64 base. This is the exact issue #291
+ * scenario: on nixos/WSL and many Linux desktops the invoking user's
+ * primary group is GID 100, so the host passes IRONCURTAIN_AGENT_GID=100.
+ * A GID collision is benign — the entrypoint must reuse the existing group
+ * (via `usermod -g`) rather than aborting with the old unconditional
+ * `groupmod -g` which failed with "GID already exists". The reuse-branch
+ * assertion below verifies the group name is the pre-existing one, so this
+ * test fails loudly rather than silently routing through groupmod if a
+ * future base image ever stops shipping `users:x:100`.
+ */
+const EXISTING_GID = 100;
+
+/**
  * Polls until the entrypoint has finished running `usermod`/`groupmod`/`chown`
  * and has exec'd the CMD. The universal devcontainer image has a large
  * `/home/codespace` (Conda, NVM, Hugo, etc.) that `usermod -u` scans for
@@ -154,6 +169,7 @@ const dockerReady = !useTcpTransport() && isDockerAvailable() && isDockerImageAv
 interface RemapObservations {
   idCodespaceUid?: string;
   idCodespaceGid?: string;
+  idCodespaceGidName?: string;
   passwdUid?: string;
   homeStatUid?: string;
   runuserUid?: string;
@@ -311,11 +327,157 @@ describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () =
   });
 
   /**
+   * Issue #291 success path: a GID collision is BENIGN and must NOT abort
+   * startup. We force a remap to a free UID (1500) but to GID 100
+   * (`users`), which the base image already bakes in. The old entrypoint
+   * ran `groupmod -g 100 codespace` unconditionally and died with
+   * "GID '100' already exists"; the fix detects the existing group and
+   * reuses it as codespace's primary group via `usermod -g 100`. The
+   * entrypoint must then chown /home/codespace and /workspace to
+   * REMAP_UID:100 and `runuser -u codespace` must land on REMAP_UID with
+   * primary group 100. Driven via a direct `docker run`, mirroring the
+   * non-baked-UID success path above.
+   */
+  describe('forced remap with a colliding GID (issue #291)', () => {
+    let homeDir: string;
+    let workspaceDir: string;
+    let containerName: string;
+    let originalUid: number;
+    let originalGid: number;
+    const observations: RemapObservations = {};
+
+    beforeAll(async () => {
+      // Capture the real UID/GID for the workspace chown-back during cleanup.
+      originalUid = process.getuid?.() ?? 1000;
+      originalGid = process.getgid?.() ?? 1000;
+
+      homeDir = mkdtempSync(join(tmpdir(), 'ironcurtain-uidremap-gid-test-'));
+      workspaceDir = join(homeDir, 'workspace');
+      mkdirSync(workspaceDir, { recursive: true });
+      containerName = `ironcurtain-uidremap-gid-${process.pid}-${Date.now()}`;
+
+      // Run the entrypoint as root with a free UID but a GID (100) that
+      // already exists in the image. CMD is `sleep 180` so the container
+      // stays up long enough for `docker exec` to inspect post-remap state.
+      await execFile(
+        'docker',
+        [
+          'run',
+          '--rm',
+          '-d',
+          '--name',
+          containerName,
+          '--user',
+          '0:0',
+          '-e',
+          `IRONCURTAIN_AGENT_UID=${REMAP_UID}`,
+          '-e',
+          `IRONCURTAIN_AGENT_GID=${EXISTING_GID}`,
+          '-v',
+          `${workspaceDir}:/workspace`,
+          IMAGE,
+          'sleep',
+          '180',
+        ],
+        { timeout: 30_000 },
+      );
+
+      // Wait for the entrypoint to finish the full remap (including the
+      // recursive chown of /workspace) before reading state. Polling on
+      // /workspace ownership observes the final post-condition the
+      // assertions depend on.
+      await waitForRemapComplete(containerName, REMAP_UID, 90_000);
+
+      // `id codespace` reflects the renumbered passwd entry. Capture both
+      // the numeric primary GID and the group NAME: after `usermod -g 100`
+      // the name is the pre-existing group (`users`), whereas the old
+      // `groupmod -g` path would have left it as `codespace`. Asserting the
+      // name proves the reuse branch actually ran (see assertion below).
+      const idOut = await dockerExecAs(containerName, '0:0', 'id', 'codespace');
+      observations.idCodespaceUid = /uid=(\d+)\(codespace\)/.exec(idOut.stdout)?.[1];
+      const gidMatch = /gid=(\d+)\((\w+)\)/.exec(idOut.stdout);
+      observations.idCodespaceGid = gidMatch?.[1];
+      observations.idCodespaceGidName = gidMatch?.[2];
+
+      // /etc/passwd is the canonical source for the renumbered UID.
+      const passwdOut = await dockerExecAs(containerName, '0:0', 'sh', '-c', 'getent passwd codespace | cut -d: -f3');
+      observations.passwdUid = passwdOut.stdout.trim();
+
+      // chown -R should have flipped /home/codespace to REMAP_UID.
+      const homeStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/home/codespace');
+      observations.homeStatUid = homeStat.stdout.trim();
+
+      // chown -R should also have flipped /workspace (the bind mount).
+      const wsStat = await dockerExecAs(containerName, '0:0', 'stat', '-c', '%u', '/workspace');
+      observations.workspaceStatUid = wsStat.stdout.trim();
+
+      // `--user codespace` resolves the name against the renumbered passwd
+      // entry, functionally equivalent to `runuser -u codespace`.
+      const runuserUid = await dockerExecAs(containerName, 'codespace', 'id', '-u');
+      const runuserName = await dockerExecAs(containerName, 'codespace', 'whoami');
+      observations.runuserUid = runuserUid.stdout.trim();
+      observations.runuserName = runuserName.stdout.trim();
+    }, 120_000);
+
+    afterAll(async () => {
+      // Restore workspace ownership BEFORE removing the container; the
+      // entrypoint's `chown -R ${REMAP_UID}:${EXISTING_GID} /workspace`
+      // propagates through the bind mount, so without this restore the
+      // host tempdir is left owned by REMAP_UID and rmSync fails EACCES.
+      if (containerName) {
+        try {
+          await dockerExecAs(containerName, '0:0', 'chown', '-R', `${originalUid}:${originalGid}`, '/workspace');
+        } catch {
+          /* container gone or chown failed — proceed with teardown */
+        }
+        try {
+          await execFile('docker', ['rm', '-f', containerName], { timeout: 10_000 });
+        } catch {
+          /* container already gone */
+        }
+      }
+      if (homeDir) rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it(`renumbered codespace user to UID ${REMAP_UID} despite the GID collision`, () => {
+      expect(observations.idCodespaceUid).toBe(String(REMAP_UID));
+      expect(observations.passwdUid).toBe(String(REMAP_UID));
+    });
+
+    it(`reused existing group: codespace primary GID is ${EXISTING_GID} (usermod -g path, not groupmod)`, () => {
+      expect(observations.idCodespaceGid).toBe(String(EXISTING_GID));
+      // The group NAME proves which branch ran. The `usermod -g` reuse path
+      // points codespace at the pre-existing group (`users`); the free-GID
+      // `groupmod -g` path would instead show `codespace`. Asserting it is
+      // NOT `codespace` keeps this test honest if a future base image ever
+      // drops `users:x:100` (which would silently route through groupmod and
+      // otherwise still pass green, losing the regression's teeth).
+      expect(observations.idCodespaceGidName).toBeDefined();
+      expect(observations.idCodespaceGidName).not.toBe('codespace');
+    });
+
+    it(`chown -R reset /home/codespace ownership to ${REMAP_UID}`, () => {
+      expect(observations.homeStatUid).toBe(String(REMAP_UID));
+    });
+
+    it(`chown -R reset /workspace ownership to ${REMAP_UID}`, () => {
+      expect(observations.workspaceStatUid).toBe(String(REMAP_UID));
+    });
+
+    it('dropping privileges via runuser/--user codespace lands on the remapped UID', () => {
+      expect(observations.runuserUid).toBe(String(REMAP_UID));
+      expect(observations.runuserName).toBe('codespace');
+    });
+  });
+
+  /**
    * Failure-diagnostic path: a UID collision (33 == `www-data` in the base
-   * image) makes `groupmod`/`usermod` fail. The entrypoint must exit
-   * non-zero and emit the `[ironcurtain] {usermod,groupmod} failed:`
-   * diagnostic added in commit 2f463f3 so operators see what went wrong
-   * instead of silently running with a broken UID mapping.
+   * image) makes `usermod -u` fail. The entrypoint must exit non-zero and
+   * emit the `[ironcurtain] usermod failed:` diagnostic so operators see
+   * what went wrong instead of silently running with a broken UID mapping.
+   * (GID 33 also belongs to www-data, but a GID collision is now benign —
+   * the entrypoint reuses the group via `usermod -g` and proceeds to the
+   * UID remap, which is where the hard failure surfaces.)
    */
   describe('UID collision is reported as a hard error', () => {
     let containerName: string;
@@ -336,11 +498,13 @@ describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () =
 
     it(`entrypoint exits non-zero and logs a diagnostic when UID ${COLLIDING_UID} collides with a baked user`, async () => {
       // Run the entrypoint as root (`--user 0:0`) with a colliding
-      // IRONCURTAIN_AGENT_UID. `groupmod` runs first; gid 33 also belongs to
-      // `www-data`, so the diagnostic will be `groupmod failed:` (the
-      // entrypoint fails on the first collision). Either error proves the
-      // hard-error contract: silent fall-through is the regression we're
-      // guarding against.
+      // IRONCURTAIN_AGENT_UID. GID 33 (www-data) already exists, so the
+      // entrypoint treats the GID as a benign collision and reuses the
+      // group via `usermod -g 33`; the hard failure then surfaces on
+      // `usermod -u 33 codespace`, which collides with the baked www-data
+      // user. Either diagnostic proves the hard-error contract: silent
+      // fall-through to a broken UID mapping is the regression we guard
+      // against.
       let result: { stdout: string; stderr: string; exitCode: number };
       try {
         const ok = await execFile(
@@ -370,9 +534,11 @@ describe.skipIf(!dockerReady)('Agent container UID/GID remap (issue #232)', () =
       // Container must exit non-zero. The entrypoint script uses `exit 1`
       // explicitly on each failure branch.
       expect(result.exitCode).not.toBe(0);
-      // Stderr must contain one of the diagnostic lines added in 2f463f3 —
-      // we accept either `usermod failed:` or `groupmod failed:` because
-      // groupmod runs first and gid 33 also collides with www-data.
+      // Stderr must contain one of the diagnostic lines added in 2f463f3.
+      // With the issue #291 fix the UID collision surfaces as
+      // `usermod failed:`; we keep the regex permissive (also matching
+      // `groupmod failed:`) so the contract assertion is robust to future
+      // ordering changes — silent fall-through is what we guard against.
       const combined = `${result.stdout}\n${result.stderr}`;
       expect(combined).toMatch(/\[ironcurtain\] (usermod|groupmod) failed:/);
     }, 60_000);


### PR DESCRIPTION
## Summary

Fixes #291. The #232 runtime UID/GID remap unconditionally ran `groupmod -g $IRONCURTAIN_AGENT_GID codespace`, which **aborts container startup** when that GID is already occupied by a baked-in image group. The universal devcontainer image ships `users:x:100`, so on hosts where the invoking user's primary group is GID 100 — nixos/WSL and many Linux desktops — the entrypoint died with `groupmod: GID '100' already exists` and the agent container never came up.

**Key insight: GID collisions are benign; UID collisions are not.**
- If the target GID already exists, point codespace's *primary* group at it via `usermod -g` (which requires the group to pre-exist). Only `groupmod -g` when the GID is free.
- UID collisions still **fail hard** — that's the #232 regression guard against silently falling through to a broken mapping (e.g. host UID matching a baked `www-data`).

## Eliminating the drift

The remap block was triplicated across the three agent entrypoints (`claude-code`, `goose`, `codex`), and that drift *is* the root cause of #291: a field fix to one entrypoint never reaches the others. This PR extracts the block into a single shared `docker/entrypoint-uid-remap.sh`, `source`d by all three (and `COPY`'d into all three images). The shared helper is byte-equivalent to the originals except for the GID fix. `computeBuildHash` already hashes every `docker/*.sh`, so editing the helper invalidates all three images — no stale-image risk.

## Tests

- New GID-collision success-path integration tests (claude-code + goose) that assert the reuse branch actually ran — by checking the resulting **group name** (`users`, not `codespace`), so the test fails loudly rather than silently routing through `groupmod` if a future base image ever drops `users:x:100`.
- Updated the UID-collision failure test for the new ordering (the hard failure now surfaces on `usermod -u`).

## Validation on real Docker

The vitest integration suite is Linux-gated (`!useTcpTransport()`), so it skips on the macOS dev host. The scenarios were executed directly against freshly-built `ironcurtain-claude-code` and `ironcurtain-goose` images (Docker Desktop Linux VM), which is exactly what those tests drive internally:

| Scenario | Before (old image) | After |
|---|---|---|
| GID-100 collision (#291) | `groupmod: GID '100' already exists` → exit 1 | `uid=1500(codespace) gid=100(users)` → exit 0 |
| Free GID 1500 (normal remap) | exit 0 | `gid=1500(codespace)` → exit 0 |
| UID-33 collision (www-data) | exit 1 | exit 1, `[ironcurtain] usermod failed: ...` |

Confirmed identical results on both the claude-code and goose images (shared helper). The literal vitest integration files run on CI/Linux.

Closes #291.