### PR TITLE
feat(memory): memory_ingest decomposition tool + representative corpus tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ docs/vuln-discovery-onboarding/*.pdf
 
 # Local scratch / staged experiments — never committed
 donotcommit/
+
+# Claude conversation exports + ingested memory DBs (SENSITIVE — never commit)
+**/claude-export/
+**/conversations.json
+**/memories.json
+*.memdb
+*.memdb-*

--- a/docs/brainstorm/memory-inferred-metadata-proposal.md
+++ b/docs/brainstorm/memory-inferred-metadata-proposal.md
@@ -1,0 +1,208 @@
+# Proposal: Auto-inferred metadata for `memory-mcp-server`
+
+**Status:** Brainstorm / proposal for discussion
+**Scope:** Should memories get (1) automatically inferred **tags**, (2) an inferred **title**, and (3) be decomposed from raw input into atomic memories via an **`ingest`/`remember` tool**?
+**Origin:** Cross-study of [`OpenAnonymity/nanomem`](https://github.com/OpenAnonymity/nanomem) vs. our `@provos/memory-mcp-server`.
+**Note:** Nothing outside this project depends on the memory interface, so schema changes are on the table.
+
+---
+
+## TL;DR — recommendation
+
+1. **Decomposition — yes, and the highest-value of the three (Question 3).** Add a separate, explicitly-LLM **`ingest`/`remember` tool** that takes a raw blob (conversation, document, session summary) and fans it out into atomic memories. Keep the existing `store` fast and LLM-free; unlike tags/titles, decomposition must happen **at ingestion, before embedding**, so it cannot be deferred to consolidation.
+2. **Tags — yes, infer them, but the inference must converge on an existing vocabulary, not invent free-form labels.** Run it in the **deferred consolidation pass** (which already makes a batched LLM call and already has the namespace loaded), never on the synchronous write path. Caller-supplied tags stay authoritative; inference only fills the gap and canonicalizes.
+3. **Titles — yes, but lazily and conditionally, not for every memory.** A title earns its keep for **compacted/long** memories (where it's nearly free and genuinely aids scanning); for short atomic facts it's mostly a restatement of `content`, so derive it mechanically or skip it.
+4. The single most important *tag-consistency* decision is **vocabulary convergence**. Naive LLM tagging produces "preference" / "preferences" / "user-pref" sprawl that makes our AND-filter and stats *worse*, not better.
+
+The reasoning below explains why these are the right calls given that **our retrieval is already semantic** (so metadata doesn't have to carry recall the way it does in nanomem) and our **write path is deliberately LLM-free**.
+
+---
+
+## 1. What the two systems actually do
+
+### nanomem (the source of the ideas)
+
+| Dimension | nanomem |
+|---|---|
+| Storage | Plain **markdown files**. No embeddings, no vector store, no ANN anywhere. |
+| Record | A markdown **bullet** with pipe-delimited metadata: `text \| topic= \| tier= \| status= \| source= \| confidence= \| updated_at= …` |
+| "Tags" | **No free-form tag array.** A single normalized `topic=` slug (LLM-suggested, *often overridden by the folder name*), plus **which file/folder the LLM writes to** as the real organizing axis. Strong "prefer fewer, broader files" bias. |
+| "Title" | Per-**file** `oneLiner` = **mechanical** concat of the first ≤4 active fact texts, truncated to 120 chars. *No LLM.* No per-memory title or abstractive summary anywhere. |
+| Retrieval | **LLM agent navigates the markdown tree** + literal substring search; mechanical fallback score fuses keyword overlap + tier + status + source-trust + confidence. |
+| Write | **Every write is an LLM call** — extract facts, then decide create / append / corroborate (boost confidence) / supersede (decay confidence). |
+| Decomposition | **One input → many memories.** A conversation/document is split by the LLM into atomic bullets across files; long inputs are chunked. |
+
+The thing to internalize: in nanomem the topic slug + folder placement + oneLiner **are the retrieval index** — there's nothing else. They are forced to be good because there are no embeddings.
+
+### Our `@provos/memory-mcp-server`
+
+| Dimension | Ours |
+|---|---|
+| Storage | **SQLite** + `sqlite-vec` (768-dim BGE embeddings, cosine) + **FTS5** (`content`, `tags`) + cross-encoder reranker (ms-marco-MiniLM). |
+| Record | `id` (opaque hex), `namespace`, `content`, `tags[]`, `importance`, timestamps, `access_count`, `is_compacted`, `compacted_from`, `source`, `metadata`. **No `title`/`name`/`slug`/`description`.** (`types.ts:6-20`) |
+| Tags | **User/agent-supplied only**, optional, free-form, no controlled vocabulary, capped at 50/100-char (`validation.ts:8-9`). Used as: FTS signal (weighted 1.5 vs content 3.0), **AND/intersection post-filter** on recall (`pipeline.ts:74-79`), and stats (`computeTopTags`). **No inference anywhere.** |
+| Title | **None.** `content` is the only human-readable label; `id` is opaque hex. |
+| Retrieval | 11-step pipeline: embed query → hybrid vector+FTS candidate gen → relative-score fusion → tag filter → composite score (recency/importance/access) → relevance gate → cross-encoder rerank → embedding dedup → token-budget pack → format. |
+| Write | **Synchronous path makes zero LLM calls** — embed + exact-dedup (cosine > 0.95 merge). Heavier dedup/contradiction is **deferred to consolidation** (batched LLM call every ~50 stores; degrades to "mark all distinct" with no LLM). Compaction does LLM cluster-summarization. |
+| Decomposition | **None server-side.** `store` takes a single pre-formed fact; splitting raw input into atomic facts is left entirely to the calling agent. |
+
+The thing to internalize: **our recall is already semantic.** Vector + FTS + reranker find relevant memories without help from tags or titles. So inferred metadata in our system is *not* needed for recall — its value is filtering, browsing/inspection, and dedup. That changes the cost/benefit versus nanomem entirely.
+
+---
+
+## 2. Question 1 — should tags be automatically inferred?
+
+### The reframe
+
+Borrowing "infer tags" from nanomem without borrowing its constraints is a trap. nanomem doesn't even *have* a free-form tag array — it has one normalized `topic` slug that is frequently overwritten by the folder name. Its consistency comes from **(a) normalization** (`normalizeTopic`: lowercase/slugify/collapse) and **(b) a tiny vocabulary** (folder names, with a "few broad files" rule). That discipline is the whole point.
+
+Our tags are free-form strings supplied ad hoc by whatever agent is writing. If we bolt naive LLM inference on top — "read content, emit tags" — we get **vocabulary drift / tag explosion**: `preference`, `preferences`, `user-preference`, `pref`, `prefs` all coexisting. That actively degrades the two things tags are actually for in our system:
+
+- the **AND-filter** on recall (callers can't predict which spelling to filter on), and
+- **stats / browsing** (`memory_inspect view=tags` becomes noise).
+
+So the question is not "infer or not" — it's **"how do we keep inferred tags self-consistent."**
+
+### Recommendation
+
+**Infer tags during consolidation, against a converging vocabulary, never overwriting caller tags.**
+
+Three design choices, in priority order:
+
+1. **Closed-loop vocabulary (the load-bearing decision).** When inferring, hand the LLM the namespace's existing top-N tags as a *preferred* vocabulary: "reuse one of these unless none fit; only mint a new tag when genuinely novel." The tag space then **converges** instead of exploding. This is the soft analogue of nanomem's "check whether an existing file can absorb this before making a new one."
+2. **Canonicalization.** Slugify (lowercase, dash, dedupe) on the way in; optionally an **embedding-based near-duplicate merge** at consolidation time (we already have the embedder) so `user-prefs` ≈ `preferences` collapses.
+3. **Run it in deferred consolidation, not synchronous write.** Consolidation (`storage/consolidation.ts`) already (a) fires a *batched* LLM call, (b) has the namespace's neighbors loaded for dedup, and (c) operates on exactly the `consolidated:false` rows new writes produce. Tag inference + canonicalization ride that same pass for ~no extra architecture and ~no extra latency on the hot path.
+
+**Caller tags remain ground truth.** If the storing agent supplied tags, keep them; inference *augments/fills*, it does not overwrite. (The system prompt already nudges agents to tag — that signal is higher-quality than inference and should win.)
+
+### Why this is worth doing even though recall is already semantic
+
+Because the payoff is **faceting, browsing, and forget-by-tag** — not recall. Today an agent that didn't bother to tag leaves a memory un-filterable and invisible to `view=tags`. Inference guarantees a baseline of consistent facets across the whole store, which makes `memory_recall tags=[…]`, `memory_forget tags=[…]`, and inspection reliable.
+
+---
+
+## 3. Question 2 — should memories get an inferred title?
+
+### The reframe
+
+nanomem's "title" is **mechanical** and **per-file** (`oneLiner` = concat of first 4 bullets). It has **no per-memory title at all**. Our memories are **atomic facts**, frequently a single sentence. A per-memory abstractive title over a one-sentence fact is often just a lossy restatement of `content` — pure cost, little gain.
+
+But two cases break that symmetry:
+
+- **Compacted memories** are LLM-summarized clusters; `content` can be long, and the compaction LLM call *already runs* — emitting a one-line headline alongside the summary is essentially free and genuinely useful.
+- **Long `content`** (the schema permits up to 10k chars) is hard to scan in `memory_inspect`, the daemon UI, and `view=export`. A headline is the difference between a browsable store and a wall of text.
+
+### Recommendation
+
+**Add an optional, lazily-inferred `title` (short headline, ≤ ~80 chars). Never required, never blocks a write.** Inference strategy by case:
+
+- **Compacted / consolidated memories:** emit `title` from the same LLM call that already produces the summary (free).
+- **Long `content`:** infer a headline during the consolidation pass (alongside tag inference — one call).
+- **Short atomic facts:** derive mechanically (first clause / truncate, nanomem-style) **or leave null.** Don't spend an LLM call to paraphrase one sentence.
+
+Surface `title` in `memory_inspect` (all views), the web UI lists, and `export`; add it as an FTS column weighted between content (3.0) and tags (1.5) — say ~2.0 — so a good headline gives a modest keyword-recall boost as a side effect.
+
+### Bonus consideration — a human-readable handle
+
+Our `id` is opaque hex. The user's *own* auto-memory system (the `MEMORY.md` + per-file `name:` slug convention) shows the value of a stable, human-readable name. A normalized `title` could double as a **slug/handle** for reference and `forget`. Worth deciding explicitly; for v1, a display-only `title` is the minimum, and slug-as-handle is an easy follow-on.
+
+---
+
+## 4. Question 3 — expanding one request into many (fact extraction)
+
+> Highest-value of the three. Unlike tags and titles, this one materially improves *recall*, and it's the one feature that cannot be deferred to consolidation.
+
+### What nanomem does
+
+nanomem's ingestion is not "store this string." You hand it a **conversation or document**, and an agentic loop **extracts the durable facts** and fans them out into many bullets across (potentially) many files — `create_new_file` / `append_memory` / `update_bullets` / `corroborate_bullet`, once per fact, with long inputs chunked. One ingestion request → N writes, and each extracted fact is independently routed to create / append / corroborate / supersede.
+
+### Where we stand
+
+Our `memory_store` takes a single `content` documented as "a single fact," and does **zero** extraction — decomposition is pushed entirely onto the calling agent. So:
+
+- We already have nanomem's **per-fact routing**: exact-dedup at write (`engine-impl.ts:87-98`) + merge/contradiction in consolidation (`storage/consolidation.ts`).
+- We lack nanomem's **per-input fact extraction**: splitting one raw input into atomic facts.
+
+### Why this matters *more* for us than for nanomem
+
+Our recall is **embedding-based**. A compound `content` — *"prefers dark mode, lives in Portland, manager is Alice"* — embeds to one muddy centroid vector; recall for any single fact inside it is degraded, and exact-dedup, `importance`, and decay all operate at the wrong granularity. nanomem's substring + tree-navigation retrieval tolerates fat bullets; **our vector index does not.** Clean atomic facts are a *retrieval-quality requirement* for us, not merely tidiness — which is why this ranks above tags and titles.
+
+### The architectural twist — this one can't be deferred
+
+Tags and titles ride the deferred consolidation pass because they *annotate* an already-stored row. Decomposition is different: **splitting has to happen before embedding**, so each fact gets its own clean vector. Deferring it would let a compound row pollute recall until it's split, then re-embed the pieces — backwards. So decomposition belongs at **ingestion** — not in consolidation, and not bolted onto the synchronous `store` (which stays LLM-free).
+
+### Recommendation — a two-tier ingestion surface
+
+Mirror nanomem's own conversation-vs-document split with two distinct tools:
+
+1. **Fast path — `store` stays LLM-free; the caller pre-decomposes.** The in-loop agent is already an LLM with full conversational context, so it's the best-placed splitter and it's free to us. Strengthen the system prompt ("one atomic fact per `store`") and let `store` accept `content: string | string[]` so the agent can submit a pre-split batch in a single call.
+2. **Heavy path — a new, explicitly-LLM `memory_ingest` / `remember` tool.** Input: a raw blob (conversation transcript, document, or the session-close summary produced by `src/memory/auto-save.ts`). Behavior: one LLM call extracts atomic facts, then each is written through the *normal* `store` → dedup → consolidation machinery — extraction is the only new step; embedding, routing, dedup, tagging, and titling all reuse what already exists (and what §2/§3 add). Long inputs chunk like nanomem. Kept clearly separate from `store` so the hot-path LLM-free guarantee survives, and so external/non-agent MCP clients (this is a standalone published server) still get good atomicity when they hand over a blob.
+
+`src/memory/auto-save.ts` is the natural first consumer: today it asks the agent to store a session summary; it should instead route that summary through `ingest`, so a session becomes a set of atomic facts rather than one blob.
+
+#### `memory_ingest` tool sketch
+
+```ts
+// Heavy, LLM-backed; distinct from the fast memory_store.
+{
+  content: string;                     // raw blob: conversation, document, or summary
+  source?: string;                     // e.g. 'session:abc', 'document', 'conversation'
+  mode?: 'conversation' | 'document';  // strict (explicit facts only) vs. broader extraction
+  tags?: string[];                     // optional seed tags applied to every extracted fact
+  importance?: number;                 // optional default importance for extracted facts
+  dry_run?: boolean;                   // return proposed atomic facts without writing
+}
+// → { ingested: number; memory_ids: string[]; facts?: string[] }   // facts[] when dry_run
+```
+
+`mode` carries nanomem's strict-vs-broad distinction (conversation: only what was explicitly stated, no inference; document: reasonable inference allowed). `dry_run` previews the decomposition before committing — useful for the agent loop and for tests. With no LLM configured, `ingest` degrades to storing the blob as a single memory (and says so), preserving graceful degradation.
+
+---
+
+## 5. Concrete schema/flow changes (if approved)
+
+1. **New `memory_ingest` tool (`tools/ingest.ts` + registration in `server.ts`):** LLM-backed fact extraction → writes each atomic fact through the existing `store` → dedup → consolidation path. Params: `mode` (conversation|document), `dry_run`, optional seed `tags`/`importance`. Chunks long inputs. Degrades to a single-blob store when no LLM is configured.
+2. **`memory_store` accepts `content: string | string[]`:** lets a capable caller submit a pre-split batch in one call without invoking the LLM path.
+3. **Route `src/memory/auto-save.ts` through `ingest`:** session-close summaries get decomposed into atomic facts instead of stored as one blob.
+4. **Schema:** add nullable `title` column + matching FTS column; bump `schema_meta` version (3 → 4) with a migration. Tags stay `string[]`.
+5. **Consolidation pass (`storage/consolidation.ts`):** extend the existing batched LLM call to *also* (a) propose canonical tags against the namespace's existing top-N vocabulary, and (b) emit a `title` for long memories. Mechanical fallback (truncate/first-clause) for short content and for the no-LLM degraded mode.
+6. **Compaction (`storage/compaction.ts`):** have `compactCluster` return `title` alongside the summarized `content` (free — same call).
+7. **Retrieval/format/inspect + web UI:** surface `title`; add the FTS weight; show it in inspect/export/UI lists.
+8. **Invariants:** caller-supplied tags are never overwritten; the `store` write path stays LLM-free; everything degrades gracefully when no LLM is configured.
+
+---
+
+## 6. Alternatives considered and discarded
+
+| # | Alternative | Why discarded |
+|---|---|---|
+| 1 | **Infer synchronously at write time** (nanomem: "every write is an LLM call"). | Destroys our deliberate LLM-free, low-latency, graceful-degradation write path; adds per-store cost/latency. nanomem can afford it because the LLM *is* its engine — we have local embeddings doing recall, and consolidation already gives inference a batched home. |
+| 2 | **Free-form inferred tags with no vocabulary control.** | Tag explosion / vocabulary drift makes the AND-filter and stats *less* reliable than no inference. The converging-vocabulary loop is the fix; without it, don't infer at all. |
+| 3 | **Adopt nanomem's folder + single-`topic` model wholesale (drop tag arrays).** | It's a workaround for *not having embeddings*. We already have hybrid semantic retrieval, so tree navigation buys nothing and we'd lose multi-label faceting. (We *do* borrow the single-normalized-topic discipline as the canonicalization rule for tags.) |
+| 4 | **Mechanical-only title (nanomem `oneLiner` style), no LLM ever.** | Kept as the *fallback* for short content / no-LLM mode, but rejected as the sole mechanism: for compacted/long memories an abstractive headline is meaningfully better and nearly free (compaction already calls the LLM). |
+| 5 | **Separate per-memory abstractive `summary` field (distinct from title) for all memories.** | Overkill for v1: atomic facts don't need it, it's redundant with `content`, and it doubles inference cost. Fold headline into `title`; revisit only if long-content memories become common. |
+| 6 | **Fixed enum tag taxonomy (predefined global categories).** | Too rigid for an open personal-memory domain; brittle as the domain grows. The soft converging-vocabulary approach gets most of the consistency benefit without a hard schema. |
+| 7 | **Title as a required field.** | Would force an LLM call (or a bad mechanical guess) on every write, re-introducing the write-path coupling from #1. Optional + lazy avoids it. |
+| 8 | **Synchronous LLM extraction inside `store`** (nanomem-style, but on our hot path). | Re-couples the fast write path to an LLM and kills its zero-LLM / low-latency guarantee. The separate `ingest` tool delivers extraction without touching `store`. |
+| 9 | **Defer decomposition to the consolidation pass** (the way we defer tags/titles). | Splitting must precede embedding — a compound row pollutes recall until it's split, and split-then-re-embed is wasteful and backwards. Decomposition belongs at ingestion. |
+| 10 | **Status quo: single-fact `store` only, all decomposition left implicit on the caller.** | Fine when the caller is a capable, well-prompted agent; fragile for blob inputs, session summaries, and external/non-agent clients. We keep caller-side splitting for the fast path but add the `string[]` affordance and `ingest` for everything else. |
+
+---
+
+## 7. Out of scope, but worth borrowing later
+
+These came out of the nanomem study and are *not* part of the tags/title decision, but are strong ideas to track:
+
+- **Confidence as a first-class, mutating field** (corroboration → gentle boost; contradiction → sharp decay). We already detect contradictions in consolidation but resolve only by supersession; a confidence signal is a softer, auditable alternative.
+- **Retrieval self-assessment metadata** (`coverage`, `missing_variables`, low-confidence flags) returned from `memory_recall`, so agent loops know when to ask the user instead of guessing.
+- **Tiered memory + automatic expiry** (working / long-term / history, with LLM-set `expires_at` and a zero-LLM prune). Our `importance` decay is the rough analogue; explicit tiers + expiry are more legible.
+
+---
+
+## 8. Open questions for the reviewer
+
+1. Should `title` double as a stable human-readable **handle/slug** (for `forget`/reference), or stay display-only for v1?
+2. What's N for the "existing top-N tags" vocabulary handed to the inference call — global top-N, or query-relevant neighbors' tags?
+3. Do we want an embedding-based tag-merge step now, or start with slug-normalization only and add merge if drift still appears?
+4. **`ingest` rollout:** ship both the `content: string[]` batch affordance on `store` *and* the heavy `ingest` tool, or start with `ingest` alone?
+5. **`ingest` model:** reuse the consolidation/compaction LLM config (`config.ts` default `claude-haiku-4-5`), or use a stronger model for extraction quality?

--- a/docs/designs/memory-corpus-and-diagnostic.md
+++ b/docs/designs/memory-corpus-and-diagnostic.md
@@ -1,0 +1,186 @@
+# Memory corpus build + representativeness diagnostic
+
+**Status:** Results doc for the `feat/memory-ingest` branch. Pairs with the
+[`memory-ingest` tool design](./memory-ingest-tool.md) and the
+[representative-eval-set proposal](./memory-eval-representative-set.md).
+
+## Why this exists
+
+The LoCoMo retrieval benchmark is **not representative** of how the memory
+server is used in production: it ingests every turn flat — `importance ≡ 0.5`,
+near-identical `created_at`, `access_count ≡ 0` — so the composite scorer's
+recency / importance / access terms carry no signal. An `evolve` run against it
+"won" only by **dropping** those dead terms, a change that would regress
+production (where those signals are live). Before evolving the composite scorer
+for real, we need a corpus whose metadata signals are genuinely alive.
+
+This branch builds that corpus from a real, private claude.ai conversation export
+using the production `memory_ingest` path, then runs a diagnostic that decides —
+explicitly, GO/NO-GO — whether the corpus is non-degenerate enough that evolving
+the scorer is meaningful.
+
+**Out of scope:** running `evolve` itself (that harness lives on
+`dogfood/memory-fusion`). This branch stops at a merged, demonstrated-representative
+corpus + the tooling to rebuild it.
+
+## Sensitive data
+
+The export (`donotcommit/claude-export/conversations.json`) and the built corpus
+DB (`donotcommit/corpus/`) are **private** and never committed (gitignored under
+`donotcommit/` plus explicit `**/conversations.json`, `*.memdb*` rules). Every
+persisted artifact the tooling produces — progress log, diagnostic fixture,
+diagnostic report — is **content-free**: ids, counts, and numeric signals only,
+never fact/conversation/query text. LLM extraction sends conversation text to
+Haiku (`claude-haiku-4-5`); this egress is the user's own Claude data and is
+consented.
+
+## The driver (`scripts/memory-corpus/build-corpus.ts`)
+
+Single Node process (run via `tsx`) that owns the DB and calls the production
+`ingestBlob` path per conversation:
+
+- **Unit = atomic fact.** Each conversation transcript (`[sender]: text` lines)
+  is decomposed by one Haiku call per chunk into atomic, self-contained facts —
+  the production ingest path, so the corpus matches how production stores memory.
+- **Faithful recency.** Each conversation's real `created_at` is passed as
+  `as_of`, so every fact carries its source date (not ingest time).
+- **Fail-loud, never contaminate.** `on_extraction_failure: 'skip'` — a fully
+  failed extraction writes nothing (no muddy single-blob fallback into the
+  corpus) and is recorded for retry, rather than silently degrading.
+- **Deterministic maintenance.** `MEMORY_MAINTENANCE_INTERVAL` is set very high
+  so the per-store `maybeRunMaintenance` (which runs a DECAY phase) never fires
+  mid-bulk — critical, because `computeVitality` uses `now - created_at` and would
+  mark backdated facts decayed, destroying the recency spread we are building. A
+  single `runConsolidation` (never full `runMaintenance`) runs at the very end.
+- Resumable (`--resume`), content-free logging, gitignored output.
+
+### Prompt evolution: atomic *and* complete
+
+Initial extraction produced correctly atomic facts, but a minority resolved the
+*subject* while dropping the *referent* — "The user has 5 business days to cancel
+**the contract**" (which contract?), "…before winning **the game**" (which game?).
+The self-containment rule was strengthened to also require naming the specific
+project / product / document / entity the fact is about. Effect on a 6-conversation
+sample: minimum fact length rose 22→58 chars (the context-stripped fragments
+disappeared) while facts stayed atomic (avg ~131 chars) with well-varied
+importance. The full corpus was built with the improved prompt.
+
+## Corpus build results
+
+503 conversations → **3,962 fact rows** (3,975 created, 58 merged), built in ~47 min.
+
+| outcome | conversations |
+|---|---|
+| ingested | 305 |
+| partial (some chunks failed) | 19 |
+| skipped — failed extraction | 30 |
+| skipped — empty (no text) | 149 |
+
+- **Importance:** min 0.20 / mean 0.75 / max 0.95 — genuinely varied per fact
+  (not the flat 0.5 that killed LoCoMo).
+- **Recency:** 2024-08-29 → 2026-06-19, ~22 months.
+
+### The recency reality (honest scoping)
+
+The export *spans* 2023-07 → 2026-06, but the corpus starts 2024-08. This is a
+**data reality, not a pipeline gap**: all 40 of the 2023 conversations are empty
+husks (no message text in the export) — there is nothing to recover. Status by
+year:
+
+| year | ingested | partial | failed | empty |
+|---|---|---|---|---|
+| 2023 | 0 | 0 | 0 | 40 |
+| 2024 | 18 | 0 | 11 | 20 |
+| 2025 | 128 | 11 | 12 | 16 |
+| 2026 | 159 | 8 | 7 | 73 |
+
+So the corpus carries ~22 months of real recency spread — a solid multi-year
+signal, just not the full three years. The 30 failed extractions are spread
+across 2024–26 (not the old data); because extraction runs at temperature 0 they
+are deterministic ("no facts parsed"), so they are genuine no-durable-content /
+format cases (~8.5% of text-bearing conversations), documented here as a known
+completeness gap rather than recoverable loss.
+
+Text-only assembly (ignoring `content` blocks) is deliberate: of the 143
+all-empty-`text` conversations only 2 had any `content`, and those blocks are
+overwhelmingly `thinking` / `tool_use` / `tool_result` — internal reasoning and
+tool noise we explicitly do not want in a memory corpus.
+
+## The diagnostic (`scripts/memory-corpus/diagnose-corpus.ts`)
+
+Answers one question with a GO/NO-GO verdict: are the metadata signals alive and
+do they actively reshape rankings, so that evolving the composite scorer is
+meaningful? Three parts:
+
+- **A. Distributional liveness** (read-only): recency span / distinct months /
+  stddev; importance stddev + fraction stuck at the 0.5 seed; access (latent,
+  ~0 on a fresh corpus — expected, not a failure); content_length (atomic-sized).
+- **B. Self-supervised recall probe** (on a DB *copy* so `access_count` is never
+  mutated): sample N facts stratified by recency, generate one natural query each
+  via Haiku (gold = that fact), build a content-free candidate-pool fixture via
+  real hybrid retrieval, then compute **recall@budget** for the production
+  `composite` and `fusion-only` scorers plus single-signal control baselines
+  (recency / importance / access / bm25 / vector only). Composite and fusion are
+  the **real production functions** (`computeCompositeScore`, `hybridScoreFusion`,
+  `packToBudget`), so the numbers reflect exactly what `evolve` would tune.
+- **C. Ranking influence:** mean Kendall-τ between the composite and fusion-only
+  orderings — τ well below 1 means recency/importance actively reorder results
+  (the live-lever test, the direct antidote to the LoCoMo failure).
+
+**Verdict:** GO iff `recency_live AND importance_live AND reshapes_rankings`. The
+"composite ≥ every single-signal baseline" confound check is supporting evidence,
+not a gate. Anti-vacuity is unit-proven: a LoCoMo-shaped degenerate fixture
+yields NO-GO, a healthy one GO.
+
+## Diagnostic result
+
+Run: `diagnose-corpus.ts --seed 42 --sample 120 --budget 300` over 3,962 rows.
+
+**Verdict: GO** — `recency_live ✓  importance_live ✓  reshapes_rankings ✓`
+(plus the supporting `not_single_signal_confound ✓`).
+
+**A. Distributional liveness**
+
+- Recency: span 659.8 days (2024-08-29 → 2026-06-19), 20 distinct year-months,
+  stddev 114.2 days. Right-skewed toward recent (2024=1%, 2025=32%, 2026=67%) —
+  realistic (recent conversations carry more text), and a genuine multi-month
+  spread, not LoCoMo's single point.
+- Importance: 0.20 / 0.752 / 0.95 (min/mean/max), stddev 0.120, 13 distinct
+  values, only **3.8%** at the 0.5 seed. Alive, model-assigned, varied.
+- Access: 0 everywhere — latent on a fresh corpus, expected, not a failure.
+- Content length: p50 149 chars, p90 232 — atomic facts, not muddy blobs.
+
+**B. Recall@budget (budget = 300 tokens), by ranking variant**
+
+| variant | recall |
+|---|---|
+| composite | 0.983 |
+| fusion-only | 0.983 |
+| vector-only | 0.983 |
+| bm25-only | 0.942 |
+| access-only | 0.075 |
+| importance-only | 0.042 |
+| recency-only | 0.025 |
+
+**C. Ranking influence:** Kendall-τ(composite, fusion-only) = **0.563** (gate < 0.9).
+
+### How to read this (honest scoping)
+
+The probe is self-supervised — each query is generated *from* a fact, so it tests
+"find the source fact from a question about it." Content-based retrieval aces that
+(composite = fusion = vector = 0.983), and the single-metadata baselines are
+near-useless for it (recency/importance/access alone can't locate a content-specific
+fact) — exactly as expected. So composite does **not** beat fusion on this probe,
+and that is fine: the GO is not "metadata improves recall," it is the goal's actual
+bar — **the corpus is non-degenerate and the metadata terms are live levers.** The
+proof is τ = 0.563: at the current weights, recency/importance already reorder
+retrieval substantially (on LoCoMo τ ≈ 1.0 because the terms were constant). The
+levers `evolve` would tune are alive and have headroom, and there is no single-signal
+confound. What this probe does **not** establish — whether metadata *improves*
+relevance-ranked retrieval — is precisely the open question `evolve` exists to
+answer, now on a corpus where the question is meaningful.
+
+**Conclusion: this branch is evolve-ready.** Once merged, the
+`dogfood/memory-fusion` harness can be rebased onto master and pointed at this
+corpus (rebuild with `scripts/memory-corpus/build-corpus.ts`, dump a content-free
+fixture) instead of LoCoMo.

--- a/docs/designs/memory-eval-representative-set.md
+++ b/docs/designs/memory-eval-representative-set.md
@@ -1,0 +1,411 @@
+# A Representative Eval Set for Memory Hybrid-Fusion Retrieval — Feasibility & Proposal
+
+Status: **Proposal + feasibility assessment** (2026-06-21). NOT an implementation. Scopes whether we
+can synthesize a *production-representative* retrieval eval from Claude Code session logs to fix the
+metadata-flatness bug that broke the first ASI-Evolve dogfood. Every load-bearing claim is grounded
+in `file:line` or a measured artifact.
+
+Read-with: [`evolve-memory-fusion-dogfood.md`](./evolve-memory-fusion-dogfood.md) (the harness we
+already built — reuse it), [`evolve-target-workloads.md`](./evolve-target-workloads.md) §2 (why this
+dogfood exists).
+
+---
+
+## 0. The motivating failure (read first)
+
+We ran ASI-Evolve on the memory fusion code (`packages/memory-mcp-server/src/retrieval/scoring.ts`)
+against **LoCoMo** (`benchmark/data/locomo10.json`), with the cached-pool harness in
+`benchmark/fusion-evolve/`. The winning candidate "improved" recall by **dropping the
+recency/importance/access composite terms** from `computeCompositeScore` (`scoring.ts:129-145`).
+
+It won because **those three metadata signals are dead in LoCoMo** — and I verified this empirically
+against the *shipped* fixture (`benchmark/fixture/locomo-pool.jsonl`, 39 MB):
+
+- **`importance` is the single constant `0.5`** across the entire fixture. Ground truth:
+  `benchmark/locomo/ingest.py:40` and the TS port `build-locomo-fixture.ts:114` both call
+  `store(..., importance: 0.5)` for *every* turn. Measured: the set of distinct `importance` values
+  over the first 200 fixture records is exactly `{0.5}`. So `0.1 * memory.importance`
+  (`scoring.ts:145`) is a **constant added to every candidate** — it cannot change any ranking.
+- **`created_at` is one ingest batch.** Every turn is stored in a single tight loop
+  (`build-locomo-fixture.ts:216-221`), then `now` is frozen *once* (`:224`). Spread is sub-second
+  against a ~30-day half-life (`Math.exp(-0.001 * ageHours)`, `scoring.ts:134`), so the recency term
+  is **flat to ~5 decimal places** across candidates.
+- **`access_count` is near-zero noise.** Measured distinct values `{0..9}` — these come only from the
+  same memory being re-retrieved *during the dump itself* (`updateAccessStats`, `queries.ts:120-134`,
+  called at `pipeline.ts:172`); they carry no signal about query relevance.
+
+So the eval was **unrepresentative on exactly the axis the "improvement" exploited.** In production
+those signals are **LIVE**:
+
+- `importance` is a settable tool argument — `memory_store`'s `importance: z.number().min(0).max(1)`
+  (`server.ts:43-48`), "Higher values resist decay."
+- `access_count` / `last_accessed_at` update on **every** retrieval (`updateAccessStats`,
+  `queries.ts:120-134`; called for returned memories at `pipeline.ts:172`).
+- An **"unused memories decay over time"** maintenance pipeline reads all three:
+  `computeVitality` (`maintenance.ts:74-91`) decays a memory using `created_at`, `importance`
+  (half-life ∝ importance, `:78`), `access_count` (reinforcement, `:84`), and `last_accessed_at`
+  (`:87`). A candidate that ignores these signals at retrieval time fights the decay model that
+  *keeps the high-importance, frequently-accessed memories alive in the first place.*
+
+**Porting the LoCoMo winner to production would likely hurt.** The eval must be representative on the
+metadata axis. That is the entire reason this document exists.
+
+---
+
+## 1. What a representative eval set MUST satisfy (derived from the failure)
+
+| # | Requirement | Why (grounded) |
+|---|---|---|
+| **R1** | **Live metadata signals.** Memories accrue over real wall-clock time (`created_at` spans days), with varying `importance`, and `access_count`/`last_accessed_at` reflecting real re-use. | The LoCoMo bug: all three flat. Production reads all three at retrieval (`scoring.ts:129-145`) *and* in decay (`maintenance.ts:74-91`). |
+| **R2** | **Production content distribution.** An *agent's* accumulated memories — facts, decisions, preferences, project/code knowledge — NOT two-persona social dialogue. | A "memory" is whatever the caller stores via `store(content, opts)` (`engine.ts:25`); the server does **no** extraction (§2). LoCoMo/LongMemEval ingest raw chat turns 1:1 (`ingest.py:36-48`). That is not the production distribution. |
+| **R3** | **Relevance queries.** Given a new task/context, *which past memories are relevant* — not factual-evidence QA ("When did Caroline go to the LGBTQ support group?", a real LoCoMo query, `evolve-memory-fusion-dogfood.md:61`). | The production call is `memory_recall(query)` → "what should I remember that bears on this task," `recall.ts`. |
+| **R4** | **Ground-truth relevance labels** — the crux. See §4. | The metric is pure set-membership (`scoring-lib.mjs:26-36`); it needs a gold set per query. |
+| **R5** | **Realistic budget(s).** Score at the production default `2000` AND a ranking-stress budget. | `MEMORY_DEFAULT_TOKEN_BUDGET=2000` (memory CLAUDE.md). The harness already tightened to `300` *deliberately* — `scoring-lib.mjs:11`: "at 2000 recall is near-saturated (0.81 of a 0.91 ceiling) and ranking barely matters; 300 makes ranking the lever." |
+| **R6** | **Comprehensiveness.** Spans the agent's real memory types; large enough to be statistically meaningful. | LoCoMo gives ~1,500-2,000 scorable queries; a representative set should be comparable. |
+
+---
+
+## 2. What a "memory" actually is (confirms R2)
+
+Verified against the engine surface, because the task asked whether we can reuse a built-in
+extraction path:
+
+- **`MemoryEngine` is `store(content, opts) / recall(opts) / context / forget / inspect / close`**
+  (`engine.ts:24-31`). `store` takes **pre-formed `content`** plus `{ tags?, importance? }`
+  (`StoreOptions`, `engine.ts:19-22`). The schema row is `{ id, content, tags, importance,
+  created_at, updated_at, last_accessed_at, access_count, ... }` (`database.ts:6-20`,
+  `types.ts:6-20`).
+- **There is NO transcript→memory extraction path in the server.** The closest things are
+  `compaction.ts` (LLM clusters + summarizes *already-stored* memories) and `consolidation.ts`
+  (dedup at store time) — both operate on existing rows, neither turns a conversation into discrete
+  memories. The store tool description (`server.ts:36-38`) says content "should be a single fact,
+  observation, decision, or preference" — i.e. **the caller is expected to have already extracted.**
+
+**Conclusion for the pipeline: extraction is ours to define.** We cannot "reuse the server's ingest."
+The session-logs pipeline must (a) extract discrete memories from transcripts, (b) call
+`engine.store(content, { tags, importance })` with derived metadata, then (c) reuse the **existing**
+dump tap + evaluator (§5) verbatim. This is a feature, not a gap: it means the eval's content
+distribution is whatever *we* choose, so we can make it agent-coding-work (R2) instead of chat turns.
+
+---
+
+## 3. The Claude Code session-logs synthesis pipeline (core of the proposal)
+
+### 3.1 The raw material — VERIFIED structure
+
+Logs live at `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`. Measured on this machine:
+
+- **26 project dirs, 308 MB total** (`du -sh ~/.claude/projects` = `308M`). The IronCurtain project
+  alone has **20 session files**, largest 20 MB.
+- **Entry types** (one 20 MB session): `user`, `assistant`, `system`, `attachment`,
+  `file-history-snapshot`, `tool` results inside `user` entries, plus harness bookkeeping (`mode`,
+  `permission-mode`, `pr-link`, `ai-title`, …). The load-bearing ones are `user` and `assistant`.
+- **Per-entry ISO-8601 timestamps EXIST.** 5,494 timestamped entries in one file; across all 40
+  files, **36,755 timestamped entries spanning 2026-04-14 → 2026-06-22 (~2.3 months).**
+  *This is the single fact that makes recency real* — unlike LoCoMo's one-batch ingest, these
+  memories would carry a genuine multi-week `created_at` gradient (R1).
+- Each `user`/`assistant` entry also carries `cwd`, `gitBranch`, `sessionId`, `uuid`, `parentUuid`
+  (verified key list). `cwd` → per-project scoping; `parentUuid` → causal thread.
+- **`user` entries** carry either a string (a real prompt, e.g. `"please carefully review
+  @docs/designs/asi-evolve-native-workflow.md …"`) or a list with `tool_result` blocks.
+- **`assistant` entries** carry a list of `text` blocks and `tool_use` blocks — verified a `Bash`
+  call with `input.command`/`input.description`, and `Read`/`Edit` calls expose `file_path`. So
+  **file references and tool actions are recoverable per entry** (load-bearing for both extraction
+  and the behavioral labeling in §4).
+
+> **Feasibility verdict on the raw material: GREEN.** Per-entry timestamps, cwd, file paths, and
+> tool calls all exist. Recency (R1) is derivable from real entry timestamps, not file mtimes.
+
+### 3.2 Memory extraction (transcript → discrete memories)
+
+A new **offline** tool (NOT on the server hot path — same layering discipline the existing tap
+respects, `pipeline.ts:44-54`). Proposed name: `benchmark/session-logs/extract.ts`.
+
+Input: a set of `<session>.jsonl` files. Output: a list of `{ content, tags, created_at, importance,
+access_signals }` records ready for `engine.store`.
+
+Two extraction strategies, in increasing fidelity (recommend starting with the cheap one):
+
+- **(E1) Heuristic / structural extraction (no LLM).** Mine high-signal spans directly:
+  - **User prompts** → "task/intent" memories (the `user` string content).
+  - **Assistant decision statements** → `text` blocks containing decision language (the assistant
+    summarizing what it did / chose).
+  - **File-knowledge memories** → from `Read`/`Edit`/`Bash` `tool_use` inputs: "file `X` does `Y`"
+    keyed on `file_path` (recoverable, §3.1).
+  - **Preferences** → user corrections ("no, don't…", "always use…") — pattern-matchable.
+
+  Cheap, deterministic, no circularity risk, no API cost. Lower recall on subtle facts.
+- **(E2) LLM-assisted extraction.** Feed transcript windows to a model with the *store* tool
+  description (`server.ts:36-38`: "a single fact, observation, decision, or preference") and ask it
+  to emit discrete memories — exactly how a real agent using this server would behave. Higher
+  fidelity, mirrors production usage, but adds API cost and a **provenance** burden (each extracted
+  memory must keep a back-pointer to its source entry `uuid`(s) so §4 labeling can work).
+
+**Metadata derivation (the R1 fix — this is the whole point):**
+
+- **`created_at`** = the **source entry's real timestamp** (§3.1). A memory extracted from an
+  April session is genuinely older than one from June. Recency (`scoring.ts:134`) becomes a *live*
+  signal with a real multi-week spread, not LoCoMo's flat batch.
+- **`importance`** = derived, NOT constant. Candidate signals (pick a documented formula, freeze it):
+  decision/preference memories > incidental file reads; memories the user explicitly emphasized;
+  memories on a `gitBranch` that later merged. Crucially **`importance` must take ≥3 distinct values**
+  or we have re-created the LoCoMo bug. (Sanity-gate the fixture: assert `distinct(importance) ≥ 3`.)
+- **`access_count` / `last_accessed_at`** = derived from **cross-session re-reference**: how often a
+  fact/file/decision reappears in *later* sessions (a file re-Read, a decision restated, a term
+  recurring). This is real re-use, and it is the *same* signal §4(a) uses for labeling — so we get
+  both metadata and labels from one provenance pass. To stay representative, simulate the production
+  feedback loop: replay queries in timestamp order and let `updateAccessStats` (`queries.ts:120-134`)
+  fire naturally, so `access_count` at query *t* reflects only accesses *before* t (no leakage).
+
+> **Design note (avoid a subtle leak):** if `access_count` is derived from the *same* future
+> re-references that define the gold label (§4a), then a candidate could "cheat" by ranking on
+> `access_count` to predict the label. Mitigation: derive `access_count` only from re-references in
+> the window `[memory.created_at, query.created_at)` (strictly past), never from the post-query
+> window the label is drawn from. This keeps the metadata causal and the label honest. **Flag this as
+> an open risk for the adversarial reviewer** — it is the most likely place a representative-looking
+> eval silently re-introduces circularity.
+
+### 3.3 Query construction (transcript → "which past memories are relevant")
+
+A **query** is a later-session task/context; the **gold set** is the earlier memories relevant to it.
+
+- **Query text** = a real later user prompt (`user` string content) or a synthesized "task context"
+  (the first N tokens of a session's opening prompt + cwd + branch). Using the *actual* prompt keeps
+  the query distribution real (R3).
+- **Temporal split is mandatory:** a query at time *t* may only be answered by memories with
+  `created_at < t`. Enforced by processing sessions in timestamp order. This is what makes recency
+  meaningful and prevents "retrieving the future."
+
+### 3.4 Fixture shape — REUSE the existing schema
+
+The extracted memories are stored via `engine.store`, then the **existing dump tap fires unchanged**:
+`pipeline.ts:98-101` already dumps `{ id, dia_id, vector_distance, bm25_score, created_at,
+last_accessed_at, access_count, importance, content_length }` per candidate (`FixtureCandidate`,
+`dump.ts:18-33`). The only change is the **gold key**: replace `gold_dia_ids` with
+`gold_memory_ids` and tag each stored memory with a stable `mem_id:<uuid>` (mirroring LoCoMo's
+`dia_id:<id>` tag, `ingest.py:79`). The evaluator (`scoring-lib.mjs`) is then a one-field rename.
+
+**This is the big payoff of the session-logs path: we built the dump + rescore loop for LoCoMo
+already (`evolve-memory-fusion-dogfood.md`), and it is content-agnostic. We are swapping the
+*ingest+label* front-end, not the harness.**
+
+---
+
+## 4. LABELING — the make-or-break (be rigorous about circularity)
+
+The trap: if the gold set is produced by the **same fusion/embedding the eval is meant to test**,
+the eval just rewards the current ranker — circular. Honest evaluation of the three options:
+
+### (a) Behavioral / implicit — "the agent actually re-referenced it" — RECOMMEND as primary
+
+A past memory is **relevant to a later query** iff, in the transcript, the agent *actually used that
+fact* while serving that task: it re-opened the same `file_path`, restated the same decision, or the
+distinctive fact/term reappears in the later session's `tool_use`/`text`.
+
+- **Why it is NOT circular:** the label comes from **observed human+agent behavior recorded in the
+  logs**, computed from `tool_use` inputs and entry text — it never calls `embedQuery`,
+  `hybridScoreFusion`, or the reranker. It is ground truth from *actual usage*, the gold standard
+  LoCoMo's hand-annotated `evidence` only approximates. This is the same provenance signal that feeds
+  `access_count` (§3.2) — one pass, two products.
+- **Honest weaknesses:** (i) **sparse** — most past memories are never re-referenced, so positives
+  are few; (ii) **noisy** — a file re-Read for an unrelated reason is a false positive; a relevant
+  memory the agent *re-derived from scratch* instead of recalling is a false negative; (iii) it
+  measures "what the agent did re-use," which is a *lower bound* on "what was relevant." Mitigate with
+  a per-query positive floor (drop queries with <1 behavioral positive) and string/AST-level matching
+  for file and decision re-use rather than fuzzy similarity.
+
+### (b) LLM-judged relevance — scalable but circular-risk
+
+Ask a model "is memory M relevant to query Q?" for each candidate pair.
+
+- **Scalable** and gives dense labels. **But two failure modes:** (i) **circularity** — an LLM judge
+  ranks on semantic similarity, the *same* signal the vector arm of the fusion uses, so it rewards
+  the embedding the eval should test independently; (ii) **cost** — O(queries × candidates) judge
+  calls. Acceptable only as a *secondary* signal or spot-check, never the sole gold.
+
+### (c) Hybrid + human spot-check — RECOMMEND as the actual strategy
+
+- **Gold = (a) behavioral.** It is non-circular by construction.
+- **Use (b) LLM-judge ONLY to triage**, never as gold: surface candidates the behavioral pass missed
+  for *human* review (catches false negatives in (a) cheaply), and flag behavioral positives that look
+  like coincidental file touches for removal. The human (not the LLM, not the ranker) is the final
+  arbiter on the spot-checked subset.
+- **Human spot-check a sample** (e.g. 50 queries) to estimate the precision/recall of the behavioral
+  labels themselves, and report it as the eval's *own* error bar.
+
+> **Why this is defensible to an adversarial reviewer:** the primary label is *behavioral re-use
+> recorded in logs* — it cannot reward the ranker because it never invokes the ranker. The LLM only
+> *surfaces candidates for human review*; it does not assign gold. The single residual circularity
+> risk is the `access_count`/label coupling (§3.2 design note), which the strict-past window closes.
+
+---
+
+## 5. Reuse the cached-fixture pattern (don't rebuild the harness)
+
+The whole point of the existing dogfood is that **the per-round eval is pure / fast / zero-model-call /
+no-network** via a cached candidate-pool fixture + a Node rescore loop. That pattern transfers
+unchanged:
+
+1. **Dump once, offline.** Ingest the extracted session-log memories (with LIVE metadata) into a temp
+   DB, run `engine.recall(query)` per constructed query with `MEMORY_FIXTURE_DUMP_DIR` set; the tap
+   at `pipeline.ts:98-101` writes the raw vector+FTS pool (which already carries all five composite
+   fields, `dump.ts:18-33`). The real BGE embedder + sqlite-vec + FTS5 run **only here**
+   (`build-locomo-fixture.ts:27,204` use the production `MemoryEngine` directly — reuse this driver,
+   swap the ingest + gold-join).
+2. **Rescore loop = the evaluator we already have.** `benchmark/fusion-evolve/evaluator.mjs` +
+   `scoring-lib.mjs` rescore a candidate's `rankPool(pool, budget)` against the gold set by
+   set-membership — **deterministic, sub-second, zero model calls** (`evaluator.mjs:10`). Rename
+   `gold_dia_ids → gold_memory_ids` and it works as-is.
+3. **Constant-tuning baseline stays the honest bar.** `tune-constants.mjs` already sweeps the 8
+   constants; on a *live-metadata* fixture this sweep will now find non-trivial recency/importance/
+   access weights (they're no longer dead), which is itself the proof the new set is representative.
+
+---
+
+## 6. PII / privacy handling (mandatory)
+
+Session logs contain the user's **real code, prompts, file contents, and possibly secrets**. This is
+the hardest *non-technical* constraint and a likely blocker for anything that leaves the machine.
+
+Precedent already in the repo: the fixture `.gitignore` (`benchmark/fixture/.gitignore`) ignores
+`*.jsonl` — "Generated fixtures are large derived artifacts … Commit only the GENERATORS." Verified
+`git check-ignore` reports `locomo-pool.jsonl` is ignored. Extend that discipline:
+
+- **Local-only, gitignored, never committed.** The extracted memories, the DB, and the fixture stay
+  under `benchmark/session-logs/` (or `donotcommit/`), all `*.jsonl`/`*.db` gitignored. Only the
+  *extractor/builder/evaluator code* is committed.
+- **Content never enters the fixture.** The existing fixture already stores `content_length`, **not
+  `content`** (`dump.ts:31`: "no conversation text leaks into the fixture") — the evolved surface
+  reads only the length via `estimateTokens` (`scoring.ts:151,205`). Keep this: the candidate pool
+  carries embeddings-derived scores + metadata + length + an opaque `mem_id`, **zero raw text.** This
+  means the *fixture itself* is largely PII-free even though the intermediate DB is not.
+- **Redaction pass on extracted content** *before* it touches the DB: strip obvious secrets
+  (API-key/token regexes — the repo already has credential-handling discipline, CLAUDE.md "Safe
+  Coding"), file paths under `$HOME`, and email/PII. The redaction runs on the embedded text, which
+  never leaves the fixture anyway, but it protects the intermediate DB and any debug dumps.
+- **No LLM extraction (E2) without an explicit local-model / consent gate.** Sending raw transcript
+  windows to a hosted model is a data-egress event. Default to heuristic extraction (E1); gate E2
+  behind a local model (Ollama, as the benchmarks already assume — `locomo/config.py:67`) or explicit
+  opt-in.
+- **Single-user distribution caveat (not privacy, but representativeness):** one developer's logs are
+  one distribution. Document it; do not over-claim generality from a single user's corpus.
+
+---
+
+## 7. Alternatives — honest comparison
+
+| Path | Representativeness | Labeling | PII | Effort | When it's right |
+|---|---|---|---|---|---|
+| **(1) Claude Code session logs** | **Highest** — real agent-coding memories, **live multi-week metadata** (R1✓, R2✓, R3✓). Verified: 36,755 timestamped entries over 2.3 months. | **Hardest** — must build behavioral labeling (§4); circularity + sparsity risk. | **High** — real code/secrets; mitigated by content-free fixture + redaction (§6). | **Largest** — extractor + labeler + redaction are all new; harness reused. | When we need the gold-standard representative set and can absorb the labeling build. |
+| **(2) LongMemEval (`benchmark/longmemeval/`)** | **Partial.** Labeled (500 Q, 6 types), independent held-out. **BUT:** (i) chat-history QA, not agent-coding-work (R2✗, R3✗); (ii) **same flatness bug** — `ingest.py:48` stores every turn with `importance_default=0.5` (`config.py:94`) in one batch (R1✗). | **Ready** — `answer_session_ids` gold (`evolve-memory-fusion-dogfood.md:261`). | Low — public dataset. | **Medium** — **not in-repo, downloads from HF** `xiaowu0162/longmemeval-cleaned` (`dataset.py:20,47`); needs Ollama + a reader/judge LLM to run the full benchmark (`config.py:59,67`). | As a **held-out overfit guard** and a quick "representative-enough" baseline — but it does **NOT** fix the metadata-flatness bug, so it cannot be the *primary* fix. |
+| **(3) Curated synthetic agent-memory set** | **Medium-high, controllable** — hand-design memories with *deliberately varied* importance/recency/access and known-relevant queries. R1 satisfied by construction. | **Easiest** — gold is authored, fully non-circular. | None. | **Medium** — authoring effort; risk of baking in our own assumptions (a designed set may not match real usage). | As the **walking skeleton** and a fast unit-level guard: smallest thing that proves the harness rewards live-metadata candidates. Weakest on *real* distribution. |
+
+### The honest call
+
+**LongMemEval does NOT solve the stated problem.** It is labeled and in-pipeline, but it ingests one
+batch with constant importance (`ingest.py:48`, `config.py:94`) — the *exact* flatness that caused
+the LoCoMo failure. Using it as the primary representative set would re-run the same bug on different
+data. It remains valuable as the **held-out guard** (already its role in
+`evolve-memory-fusion-dogfood.md:255-266`).
+
+So the real choice is **session-logs (gold standard, big build)** vs **curated synthetic (fast, less
+real)**. They are complementary: synthetic is the walking skeleton that *proves the harness
+discriminates on live metadata*; session-logs is the representative set that *proves it on real data.*
+
+---
+
+## 8. Recommendation
+
+**Phased, synthetic-first, session-logs as the gold-standard payoff.**
+
+1. **Fix the harness's metadata-flatness blindness with a curated synthetic slice FIRST** (the
+   walking skeleton, §9). It is fast, PII-free, fully non-circular, and directly proves the central
+   claim: *a candidate that drops the metadata terms must score WORSE on a live-metadata set.* If the
+   synthetic set does not punish the LoCoMo winner, the whole premise is wrong — find that out in a
+   day, not a month.
+2. **Then build the session-logs set as the representative gold standard**, with **behavioral
+   labeling** (§4c) as the primary, LLM-judge as triage-only, human spot-check for the error bar.
+   This is the larger, higher-value build; do it once the skeleton has de-risked the metric.
+3. **Keep LongMemEval as the held-out overfit guard**, exactly as the existing design already
+   positions it — not as the representativeness fix.
+
+**Do NOT** make session-logs a prerequisite for re-running evolve. The synthetic skeleton is enough to
+stop the metadata-flatness regression *today*; session-logs raises the realism ceiling afterward.
+
+---
+
+## 9. THE WALKING SKELETON (smallest slice that fixes the LoCoMo bug end-to-end)
+
+**Goal:** a fixture with **live metadata** on which the LoCoMo-winning candidate (drop metadata terms)
+scores **measurably worse** than a metadata-respecting candidate — using the **existing** evaluator
+unchanged. This is the minimal proof the new axis is representative.
+
+Steps (all host-side, no container, no LLM, hours not days):
+
+1. **Author a tiny curated fixture** `session-pool.mini.jsonl` (~20 query records) in the **existing
+   schema** (`dump.ts:18-39`) but with **deliberately varied metadata**: importance ∈ {0.1, 0.5, 0.9},
+   `created_at` spread over weeks, `access_count` ∈ {0..20}. Construct it so that for some queries the
+   **fusion score ties but the metadata breaks the tie toward the gold memory** — i.e. metadata is
+   load-bearing for the correct answer. (This is exactly the structure LoCoMo cannot have.)
+2. **Reuse `evaluator.mjs` + `scoring-lib.mjs` unchanged** (rename `gold_dia_ids → gold_memory_ids`).
+   Score the **baseline** (`initial_program.mjs`, keeps metadata terms) and the **LoCoMo winner**
+   (a candidate that zeroes the 0.15/0.1/0.1 weights) against the mini fixture.
+3. **Milestone (the de-risk gate):** the baseline scores **higher** than the metadata-dropping
+   candidate. *If it does not, the fixture isn't exercising metadata — fix the fixture before
+   anything else.* This single inversion is the entire thesis: it demonstrates the representative set
+   discriminates exactly where LoCoMo was blind.
+4. **(Then) tiny real slice:** run the §3 extractor (E1 heuristic) over **one** IronCurtain session
+   file, store via `engine.store` with derived `created_at`/`importance`, dump via the existing tap,
+   behavioral-label ~10 queries (§4a) by hand-verified file re-reference. Confirm the harness runs on
+   *real* extracted memories end-to-end. Small, PII-stays-local, proves the extraction+label join.
+
+Deliverable: `node evaluator.mjs <candidate> session-pool.mini.jsonl out.json` prints a **lower** score
+for the metadata-dropping candidate than the baseline — the LoCoMo bug, fixed, in the smallest
+possible artifact, reusing the harness we already validated.
+
+---
+
+## 10. Effort & risk
+
+| Phase | Effort | Risk |
+|---|---|---|
+| 9. Curated synthetic skeleton | **Low** (~1 day) — hand-authored fixture + rename one field in the existing evaluator | **Low** — pure host code, the harness exists |
+| 3. Session-logs extractor (E1 heuristic) + metadata derivation | **Medium** (~2-4 days) | **Med** — extraction quality; `access_count`/label leak (§3.2 design note) |
+| 4. Behavioral labeling + human spot-check | **High** (the crux) | **High** — sparsity, noise, the circularity argument must hold |
+| 6. Redaction + PII discipline | **Low-med** (reuses gitignore precedent + regex redaction) | **Med** — must be airtight before any non-local step |
+| 2 (LLM-assisted extraction E2) | optional | data-egress; gate on local model |
+
+---
+
+## 11. The single biggest risk
+
+**Labeling circularity, with PII a close second.**
+
+- **Circularity (primary).** The eval is worthless if the gold labels are produced by the ranker
+  under test. The defense is §4c: **behavioral re-use as gold** (never invokes embed/fusion/reranker)
+  + LLM-judge as *triage only* + human as final arbiter. The one residual leak is the
+  `access_count`↔label coupling, closed by the strict-past derivation window (§3.2 design note). An
+  adversarial reviewer should attack exactly this seam.
+- **PII (close second).** Real code and secrets in the source logs. Defense: content-free fixture
+  (`dump.ts:31` already stores only `content_length`), redaction before the DB, local-only +
+  gitignored (the `benchmark/fixture/.gitignore` precedent), and no hosted-LLM extraction without a
+  consent/local-model gate.
+
+---
+
+## 12. Grounding index (for the adversarial reviewer)
+
+- LoCoMo flatness, measured: `importance` ≡ `0.5` over the shipped fixture; ingest at
+  `benchmark/locomo/ingest.py:40`, `build-locomo-fixture.ts:114`; frozen `now` at `:224`.
+- Live metadata in production: `server.ts:43-48` (importance settable), `queries.ts:120-134` +
+  `pipeline.ts:172` (access stats update on recall), `maintenance.ts:74-91` (decay reads all three).
+- Evolved surface reads exactly 5 metadata fields: `scoring.ts:129-145`.
+- Memory = caller-formed content, no server extraction: `engine.ts:19-31`, `server.ts:36-38`.
+- Session logs structure (measured): 26 projects / 308 MB; per-entry timestamps (36,755 entries,
+  2026-04-14→2026-06-22); `cwd`/`gitBranch`/`tool_use`/`file_path` per entry.
+- Reusable harness: `benchmark/fixture/dump.ts:18-39` (tap + schema), `build-locomo-fixture.ts`
+  (offline driver, production `MemoryEngine`), `benchmark/fusion-evolve/evaluator.mjs` +
+  `scoring-lib.mjs` (pure rescore, `:11` the 300-vs-2000 budget rationale).
+- LongMemEval same-flatness + HF-download + Ollama: `benchmark/longmemeval/ingest.py:48`,
+  `config.py:94`, `dataset.py:20,47`, `locomo/config.py:67`.
+- PII precedent: `benchmark/fixture/.gitignore` (commit generators, ignore `*.jsonl`).

--- a/docs/designs/memory-ingest-tool.md
+++ b/docs/designs/memory-ingest-tool.md
@@ -1,0 +1,832 @@
+# Design: `memory_ingest` — LLM-backed fact decomposition tool
+
+**Status:** Design v2 (review-amended) — no implementation
+**Scope:** Builds **only** Question 3 / decomposition from
+[`docs/brainstorm/memory-inferred-metadata-proposal.md`](../brainstorm/memory-inferred-metadata-proposal.md).
+Question 1 (auto-inferred tags) and Question 2 (titles) are **explicitly deferred** — this doc does not design them.
+**Package:** `packages/memory-mcp-server/`
+
+> **v2 amendments.** This tool is dual-purpose: a product feature (decompose blobs into
+> atomic-fact memories) **and** the substrate for building a representative eval corpus from a
+> multi-year claude.ai conversation export (each conversation ingested with its real date via
+> `as_of`). An adversarial review found the v1 design pushed **recency and importance fidelity**
+> onto an out-of-scope "eval driver" — but those are **insert-time** decisions only this tool
+> can make. v2 moves them in: **per-fact importance from extraction** (A2), **order-independent
+> merge timestamps** (A1), a **controllable extraction-failure mode** with observable partial
+> extraction (A3), **durability-focused prompts** (A4), **window overlap** in chunking (A5),
+> **PII-safe logging/errors** (A6), and **honest result stats** (A7). The driver itself (a
+> separate script) is still out of scope; see §13.
+
+---
+
+## 1. Overview
+
+`memory_ingest` is the heavy, explicitly-LLM ingestion path. It takes a raw blob
+(conversation transcript, document, or session summary), makes **one LLM call per chunk**
+(`model = claude-haiku-4-5`, reusing the existing consolidation/compaction LLM config — no
+new model config path) to extract **atomic facts**, and writes each fact through the
+**existing** `store → exact-dedup → deferred-consolidation` machinery. Each fact becomes its
+own clean memory row with its own clean vector, which is the entire point: a compound blob
+embeds to a muddy centroid and degrades recall, importance, and dedup granularity.
+
+The normal `memory_store` write path stays **LLM-free**. `memory_ingest` is the only tool
+that calls an LLM **directly** on the write side (extraction). Deferred consolidation also uses
+the LLM, but **indirectly** via `batchJudgeMemoryRelations`/`parseBatchJudgments` — neither path
+adds a new model config. Both `memory_store` and `memory_ingest` share the same `store`
+insert/dedup pipeline, so we add exactly one new step (extraction) and reuse everything
+downstream.
+
+Because extraction is the **only** point in the pipeline that reads every individual fact before
+it is written, it is also the only place where two insert-time fidelity decisions can be made:
+**per-fact importance** (A2) and the **durability filter** that keeps stable preferences /
+identity / project facts / decisions and drops ephemeral session-local task chatter (A4). These
+are baked into extraction here rather than deferred, because nothing downstream ever sees the
+facts pre-write.
+
+---
+
+## 2. Key design decisions
+
+1. **`ingest` is a new method on the `MemoryEngine` interface, not a tool-handler-local
+   function.** Tool handlers in this codebase receive **only** the `MemoryEngine`
+   (`server.ts` → `handleStore(engine, args)`), never `MemoryConfig`. The `config` (which
+   holds `llmModel`/`llmBaseUrl`/`llmApiKey` and is needed for the LLM call + embedding) is
+   captured in the engine closure in `engine-impl.ts`. Extraction therefore belongs on the
+   engine, parallel to `store`/`recall`. This preserves the existing handler signature
+   convention and keeps the LLM/config dependency inside the one place that already owns it.
+   *Rationale: handlers are config-free by construction; the engine closure is the only seam
+   that already holds both `db` and `config`.*
+
+2. **Reuse `llmComplete()` from `llm/client.js`** — the same OpenAI-compatible client used
+   **directly** by `compaction.ts` and **indirectly** by `consolidation.ts` (which calls it via
+   `batchJudgeMemoryRelations` → `parseBatchJudgments`). No new client, no new model field.
+   `config.llmModel` already defaults to `claude-haiku-4-5-20251001`. *Rationale: §5/§8
+   open-question 5 in the proposal is resolved in favor of "reuse the consolidation/compaction
+   config" per the task brief.*
+
+3. **Each extracted fact flows through the existing `store` path**, not a bespoke insert. The
+   only change `store` needs is an **optional `createdAt`** on `StoreOptions` (for `as_of`
+   backdating). We do **not** widen `store` to accept `string | string[]` for this feature —
+   that batch affordance is a separate, deferrable proposal item and is not required for
+   `memory_ingest`. *Rationale: minimal surface; one new optional field, contract preserved.*
+
+4. **`as_of` is threaded as a `createdAt` insert parameter, not a post-insert UPDATE.**
+   Stamping at insert time is atomic and avoids a second write + a window where the row carries
+   a wrong timestamp. See §5.
+
+5. **Graceful degradation is first-class — but now *controllable*.** No LLM configured →
+   default behavior stores the blob as a **single** memory (truncated to `MAX_CONTENT_LENGTH`)
+   and reports `degraded: true`, mirroring `consolidation`/`compaction` (which degrade when
+   `getLLMClient()` returns null). **(A3)** A new `on_extraction_failure` option lets a caller
+   override this: `'degrade'` (default, product behavior), `'skip'` (write nothing, report
+   `skipped`), or `'error'` (throw, so a corpus driver can retry). Default preserves v1 product
+   behavior exactly.
+
+6. **Malformed model output never throws (by default).** Parsing follows the
+   `parseBatchJudgments`-style defensive approach already in `llm/client.ts`: extract a JSON
+   array, validate each item, drop junk. If parsing yields **zero** facts, the default
+   (`on_extraction_failure='degrade'`) falls back to the single-blob store (same as the no-LLM
+   path) so the tool never returns "ingested 0" silently on a parse failure. `'error'` mode
+   surfaces the failure instead.
+
+7. **(A2) Per-fact importance is assigned at extraction.** The extraction schema is an array of
+   `{ fact, importance? }`, not bare strings. The extraction LLM already reads every fact, so
+   emitting a per-fact salience in 0–1 is nearly free, and extraction is the **only** place per-
+   fact importance can be set. When the model omits importance for a fact, it falls back to the
+   call-level seed `importance` (default 0.5). *Rationale: this is the most important amendment —
+   it is the only insert-time decision that recovers importance fidelity for a bulk corpus.*
+
+8. **(A1) Merge timestamps are order-independent for backdated ingests.** Dedup is content-
+   similarity, **not** time-aware, and a multi-year export may be ingested in any order. When a
+   backdated (`as_of`) fact merges into an existing row, the surviving row's timestamps are
+   reconciled with `min`/`max` (true first-seen / true last-touched), not left to whichever
+   insert happened to land first. v1's "skip the existing row's `created_at` on merge" rule let
+   ingest **order** decide the surviving timestamp, flattening recency precisely for the most-
+   repeated (hence most-important) facts. Normal non-`as_of` stores are unchanged. See §5.4.
+
+9. **(A3) Partial extraction is observable, never silent.** If any chunk of a multi-chunk call
+   returns null/`[]`, the result reports `degraded: true` and a `failed_chunks` count. v1's
+   silent "that chunk contributes nothing, the call still looks fully successful" path is a
+   corpus-contamination hazard; v2 eliminates the silence.
+
+10. **(A4) Extraction targets durable facts.** Both mode prompts instruct the model to keep
+    facts worth remembering beyond the conversation (stable preferences, identity, project
+    facts, decisions) and to skip ephemeral session-local state (transient errors, one-off
+    debugging steps, "let's try X"). The two modes still differ only on the explicit-vs-inference
+    axis; durability applies to both. See §4.2.
+
+11. **(A6) PII-safe logging is a hard rule.** This tool handles sensitive content. We **never**
+    log raw content/chunk/blob or the model's raw response to stderr or into error messages —
+    only lengths, token estimates, chunk indices, and content-free failure shapes. See §4.4 and
+    the testing section.
+
+12. **(A7) Result stats are honest.** `IngestResult` reports `created` and `merged` separately
+    (we already compute `action` per fact), so a bulk run's numbers are interpretable and the
+    merge count — a corroboration signal — is visible. See §3.2.
+
+---
+
+## 3. Tool surface
+
+### 3.1 Input schema (Zod, registered in `server.ts`)
+
+```ts
+server.tool(
+  'memory_ingest',
+  TOOL_DESCRIPTIONS.memory_ingest,
+  {
+    content: z
+      .string()
+      .describe('Raw blob to decompose: a conversation transcript, document, or session summary.'),
+    source: z
+      .string()
+      .optional()
+      .describe("Provenance, e.g. 'session:abc', 'document', 'conversation'. Stored on each fact."),
+    mode: z
+      .enum(['conversation', 'document'])
+      .optional()
+      .describe(
+        "'conversation' (default): STRICT — only DURABLE facts explicitly stated, no inference. " +
+          "'document': broader — DURABLE facts with reasonable inference allowed. " +
+          'Both modes keep stable preferences/identity/project facts/decisions and skip ' +
+          'ephemeral task chatter. Use document for conversation transcripts.',
+      ),
+    tags: z
+      .array(z.string())
+      .optional()
+      .describe('Optional seed tags applied to EVERY extracted fact.'),
+    importance: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe(
+        'SEED importance 0-1, used as the fallback when the extraction model does not emit a ' +
+          'per-fact importance. Default: 0.5. Per-fact importance (when the model provides it) wins.',
+      ),
+    dry_run: z
+      .boolean()
+      .optional()
+      .describe('If true, run extraction and RETURN the facts WITHOUT writing anything. Default: false.'),
+    on_extraction_failure: z
+      .enum(['degrade', 'skip', 'error'])
+      .optional()
+      .describe(
+        "How to handle a chunk/call that yields no facts (no LLM, LLM error, or unparseable). " +
+          "'degrade' (default): store the blob as a single memory (product behavior). " +
+          "'skip': write nothing, return { ingested: 0, skipped: true }. " +
+          "'error': throw, so a bulk driver can retry. Default: 'degrade'.",
+      ),
+    as_of: z
+      .union([z.number(), z.string()])
+      .optional()
+      .describe(
+        'Backdate: stamp created_at/last_accessed_at of every extracted fact to this time ' +
+          '(epoch ms or ISO 8601) instead of now. For ingesting historical exports.',
+      ),
+  },
+  async (args) => {
+    try {
+      const text = await handleIngest(engine, args);
+      return { content: [{ type: 'text' as const, text }] };
+    } catch (err) {
+      return { content: [{ type: 'text' as const, text: formatError(err) }], isError: true };
+    }
+  },
+);
+```
+
+This sits alongside the existing five tools under the same
+`/* eslint-disable @typescript-eslint/no-deprecated */` block (the package still uses the
+deprecated `server.tool()` API; match it — do not introduce `registerTool` for one tool).
+
+`TOOL_DESCRIPTIONS.memory_ingest` is added to `prompts.ts` (one new entry; keep style
+consistent), e.g.:
+
+> "Ingest a raw blob (conversation, document, or session summary) and decompose it into atomic,
+> DURABLE memories via an LLM (extracts stable preferences/identity/project facts/decisions; skips
+> ephemeral task chatter). Unlike `memory_store` (one pre-formed fact), this extracts many facts
+> from one input, each with its own importance. Use `mode='conversation'` for strict
+> explicit-only extraction or `mode='document'` to allow reasonable inference (better for
+> conversation transcripts); `dry_run=true` to preview the decomposition (note: dry_run still
+> sends the blob to the configured LLM — it only skips local persistence). By default falls back
+> to a single store if no LLM is configured; set `on_extraction_failure` to `skip` or `error` to
+> change that."
+
+### 3.2 Output shape
+
+The MCP tool surface returns text (matching every other handler), but the handler builds it
+from a structured result. The engine method returns the structured object; the handler
+formats it.
+
+```ts
+// types.ts
+export interface IngestResult {
+  // ---- honest write stats (A7) ----
+  created: number;         // rows newly created (action === 'created')
+  merged: number;          // facts that hit an existing row (merged_duplicate / contradiction)
+  ingested: number;        // ALIAS for `created`, kept for back-compat of the v1 field name
+  memory_ids: string[];    // ids of all touched rows (created + merged); empty when dry_run
+
+  // ---- substance ----
+  facts: ExtractedFact[];  // the extracted atomic facts + their importance (always populated)
+
+  // ---- diagnostics (A3) ----
+  chunks?: number;         // number of LLM windows used (omitted when 1)
+  failed_chunks?: number;  // chunks that returned null/[] (omitted when 0)
+  degraded?: boolean;      // true when we fell back to single-blob store, OR a partial failure
+  partial?: boolean;       // true when SOME (not all) chunks failed but others produced facts
+  skipped?: boolean;       // true when on_extraction_failure='skip' wrote nothing
+}
+```
+
+`ExtractedFact` is `{ fact: string; importance?: number }` (see §4) — `facts` carries the
+per-fact importance so a `dry_run` preview shows the salience the model assigned, not just text.
+
+**Stat semantics (A7).** We already compute `action` per fact in the write loop (§5.1), so
+`created` and `merged` are free. `created` counts `action === 'created'`; `merged` counts
+`merged_duplicate` **and** `contradiction_resolved`. `ingested` is retained as an alias of
+`created` so v1 callers reading `ingested` still see the new-row count; new callers should read
+`created`/`merged` to interpret a bulk run (a high `merged` is corroboration, not failure).
+
+**Diagnostics (A3).** `failed_chunks` and `partial` make per-chunk failures visible instead of
+silent. `degraded` is set when we fell back to a single-blob store **or** when any chunk failed
+(`partial` distinguishes "some chunks failed but we still got facts" from "full degrade").
+`skipped` is only set under `on_extraction_failure='skip'`.
+
+`facts` is **always present** (it is the substance of a `dry_run` and cheap otherwise); all
+diagnostics are optional. The handler renders, e.g.:
+
+- normal: `Ingested 7 atomic facts: 6 new memories, 1 merged into existing (ids: a1b2…, …).`
+- dry_run: a numbered list of the proposed facts with their importance, plus `Dry run — nothing written.`
+- partial: `Ingested 4 facts (3 new, 1 merged); 1 of 3 chunks failed extraction — partial result.`
+- degraded: `No LLM configured — stored the blob as a single memory <id>.`
+- skipped: `Extraction failed and on_extraction_failure=skip — nothing written.`
+
+### 3.3 Engine interface change
+
+```ts
+// engine.ts
+export interface IngestOptions {
+  source?: string;
+  mode?: 'conversation' | 'document';
+  tags?: string[];
+  importance?: number; // SEED importance; per-fact importance from extraction overrides it
+  dry_run?: boolean;
+  as_of?: number; // normalized to epoch ms by the handler before reaching the engine
+  on_extraction_failure?: 'degrade' | 'skip' | 'error'; // default 'degrade' (A3)
+}
+
+export interface MemoryEngine {
+  store(content: string, opts: StoreOptions): Promise<StoreResult>;
+  ingest(content: string, opts: IngestOptions): Promise<IngestResult>; // NEW
+  recall(opts: RecallOptions): Promise<RecallResult>;
+  // …unchanged…
+}
+```
+
+`createMemoryEngine(modules)` (the test factory in `engine-impl.ts`) and `EngineModules`
+gain the `ingest` passthrough, exactly like the other methods.
+
+---
+
+## 4. Extraction
+
+### 4.1 LLM call
+
+New module: `src/storage/extraction.ts` (sits next to `consolidation.ts`/`compaction.ts`,
+which are the other LLM-on-write modules). It exports:
+
+```ts
+export interface ExtractedFact {
+  fact: string;
+  importance?: number; // 0–1, OPTIONAL; absent ⇒ caller falls back to the seed importance
+}
+
+export async function extractFacts(
+  config: MemoryConfig,
+  blob: string,
+  mode: 'conversation' | 'document',
+): Promise<ExtractedFact[] | null>; // null ⇒ no LLM or hard failure ⇒ caller handles per on_extraction_failure
+```
+
+`ExtractedFact` is the unit threaded everywhere downstream (it also appears in `IngestResult.facts`,
+§3.2). The return type is `ExtractedFact[] | null`, **not** `string[] | null` (A2): each fact
+carries its own optional importance.
+
+Internals reuse `llmComplete(config, systemPrompt, userPrompt, { maxTokens })` — the same plain
+chat-completions wrapper used (directly) by `compaction.ts` and (indirectly, via
+`batchJudgeMemoryRelations`) by `consolidation.ts`. We do **not** add structured-output /
+function-calling — the rest of the package parses JSON out of text content. Match that.
+`maxTokens` scales with chunk size (e.g. `Math.min(1500, ~blob_tokens)`), bounded. The per-fact
+`importance` field adds only a few tokens per element, so it does not meaningfully raise the
+output budget.
+
+### 4.2 Prompts (two mode variants)
+
+Both share an envelope: input wrapped in `<input>` tags (so the model can't confuse
+instructions with content), output **only** a JSON array of **objects** `{ "fact": "...",
+"importance": 0.0-1.0 }`. The two modes differ **only** on the explicit-vs-inference axis; the
+**durability filter (A4)** and the **per-fact importance instruction (A2)** apply to **both**.
+There is no third mode.
+
+**Shared rules (in both prompts):**
+
+> - Output ONLY a JSON array of objects, each `{ "fact": "<self-contained fact>", "importance":
+>   <0.0–1.0> }`. One atomic fact per element — never combine two facts with "and".
+> - Each fact must be self-contained: resolve pronouns to names, include the subject
+>   ("The user prefers dark mode", not "prefers dark mode").
+> - **Extract only DURABLE facts** worth remembering beyond this conversation: stable
+>   preferences, identity, project facts, decisions, learned constraints.
+> - **SKIP ephemeral / session-local state**: transient errors, one-off debugging steps,
+>   "let's try X", task chatter, pleasantries, meta-talk.
+> - **`importance`** reflects how durable/identity-defining the fact is: durable identity,
+>   standing preferences, and decisions → high (≈0.7–1.0); useful-but-replaceable project facts
+>   → mid (≈0.4–0.7); marginal/ephemeral facts you still chose to keep → low (≈0.1–0.4). When
+>   unsure, omit `importance` and the caller will use the seed default.
+> - If nothing durable is stated, output `[]`. Reply with ONLY the JSON array, no prose.
+
+**`conversation` (STRICT) — additional rule:**
+
+> - Extract ONLY facts that are **explicitly stated**. Do NOT infer, summarize, or editorialize.
+
+**`document` (BROADER) — additional rule:**
+
+> - **Reasonable inference is allowed** where the text clearly implies a durable fact, but do
+>   not fabricate. Prefer atomic facts; split compound statements.
+
+The user prompt is `<input>\n{chunk}\n</input>`. Keep the two system prompts as named
+constants in `extraction.ts` so the difference is one prompt, not branching code.
+
+> **Driver note (A4).** For multi-turn conversation transcripts, the eval driver should pass
+> `mode='document'`, not `'conversation'`. Durable facts in a transcript are frequently
+> synthesized **across** turns (a preference stated once, then relied on later) rather than
+> uttered as a single explicit sentence; STRICT explicit-only extraction loses them. `document`
+> permits the cross-turn synthesis while the durability filter keeps the flood of task chatter
+> out. (The driver chooses this per conversation; the tool does not hard-code it.)
+
+### 4.3 Structured-output / parsing
+
+The model returns text. Parse defensively, mirroring `parseBatchJudgments`, into
+`ExtractedFact[]`:
+
+```
+export function parseExtractedFacts(raw: string): ExtractedFact[] {
+  // 1. Find the first JSON array via /\[[\s\S]*\]/.
+  // 2. JSON.parse; if not an array → return [].
+  // 3. For each item, accept EITHER:
+  //      - an object { fact: string, importance?: number }  → preferred (A2), OR
+  //      - a bare string                                     → treat as { fact, importance: undefined }
+  //    (tolerating the plain-string form keeps us robust to a model that ignored the schema).
+  // 4. Drop junk: require a non-empty trimmed `fact`; cap `fact` length at MAX_CONTENT_LENGTH.
+  //    If `importance` is present but not a finite number, drop it (→ undefined); otherwise
+  //    CLAMP it to [0, 1].
+  // 5. Cap count at MAX_FACTS_PER_INGEST (e.g. 200) to bound a runaway response.
+  // 6. De-dupe exact-`fact`-string repeats within the batch (keep the first occurrence's importance).
+  // catch → return [].
+}
+```
+
+`parseExtractedFacts` is pure and exported → directly unit-testable with canned strings. **(A6)**
+On a parse miss it must not echo `raw` — return `[]` and let the caller log a content-free shape
+(e.g. `"no JSON array found in N-char response"`); see §4.4.
+
+### 4.4 Retry / error handling (A3 + A6)
+
+- `llmComplete` already swallows API errors and returns `null`. `extractFacts` treats `null` →
+  returns `null`. **No new retry loop** — the package has no retry anywhere and a single Haiku
+  call is cheap; adding retries would be inconsistent over-engineering. Retry, when wanted, is
+  the **driver's** job via `on_extraction_failure='error'`.
+- A malformed-but-non-null response → `parseExtractedFacts` returns `[]`. Both `null` and `[]`
+  count as a **chunk failure** for diagnostics.
+- **Per-chunk failures are tracked, not swallowed (A3).** The engine counts failed chunks. After
+  all chunks run:
+  - If **every** chunk failed (or no LLM) → the union is empty → apply `on_extraction_failure`:
+    `'degrade'` → single-blob store (`degraded: true`); `'skip'` → write nothing
+    (`skipped: true`, `ingested/created: 0`); `'error'` → throw.
+  - If **some** chunks failed but others produced facts → ingest the facts we have, and set
+    `partial: true`, `degraded: true`, `failed_chunks: <n>`. v1's silent partial path (the call
+    "looked fully successful" while a chunk's facts were dropped) is gone — this is a
+    corpus-contamination hazard the eval driver must be able to see and act on.
+- **PII-safe logging/errors (A6, hard rule).** `extractFacts`, `parseExtractedFacts`, the engine
+  loop, and `formatError`/the handler **must never** write raw content, a chunk, the blob, or the
+  model's raw response to stderr or into a thrown/returned error message. Log only **content-free
+  shapes**: blob/chunk **lengths**, token estimates, chunk **indices**, fact **counts**, and
+  failure descriptors like `"no JSON array found in {raw.length}-char response"` or
+  `"chunk 3/7 returned 0 facts"`. The `'error'`-mode exception message likewise carries counts
+  and indices only, never substrings of the input or output.
+
+---
+
+## 5. Write path
+
+### 5.1 Flow per ingest call (engine `ingest`)
+
+1. Normalize seed `importance` (default 0.5), `mode` (default `'conversation'`),
+   `on_extraction_failure` (default `'degrade'`), `as_of` → epoch ms.
+2. Chunk the blob (§6, with overlap per §7). For each chunk, `extractFacts(config, chunk, mode)`.
+   - Count `failedChunks` = chunks returning `null` **or** `[]` (A3). Track `totalChunks`.
+3. Union the `ExtractedFact[]` across chunks (preserve order; drop exact-`fact`-string dups
+   across chunks — the first occurrence keeps its `importance`).
+4. **If the union is empty** (no LLM, all chunks failed) → apply `on_extraction_failure` (A3):
+   - `'error'` → throw a content-free error (A6) so the driver can retry.
+   - `'skip'` → return `{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts: [],
+     skipped: true }` (when `dry_run`, same but the lone preview "fact" may be omitted).
+   - `'degrade'` (default) → **single-blob store**: `store(blobTruncatedToMax, { tags,
+     importance: seedImportance, source, createdAt })` and return `{ created: 1, merged: 0,
+     ingested: 1, memory_ids: [id], facts: [{ fact: blob…, importance: seedImportance }],
+     degraded: true }`. (When `dry_run`, `created: 0`, no write, `degraded: true` — the preview
+     shows there was no decomposition.)
+5. **If `dry_run`** → return `{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts }`
+   **without writing** (carry `chunks`/`failed_chunks`/`partial` diagnostics through).
+6. Otherwise, for **each** `ExtractedFact f`, call the **existing** `store(f.fact, { tags,
+   importance: f.importance ?? seedImportance, source, createdAt })` (A2 — per-fact importance
+   wins, seed is the fallback). Collect `result.id` into `memory_ids`. Tally by `result.action`:
+   `created` += `action === 'created'`; `merged` += `merged_duplicate` **or**
+   `contradiction_resolved` (A7). Set `ingested = created` (alias). Return `{ created, merged,
+   ingested, memory_ids, facts, chunks, ...(failedChunks ? { failed_chunks: failedChunks,
+   degraded: true, partial: true } : {}) }`.
+
+`store` is called in a loop in-process; `better-sqlite3` is synchronous and each `store` is its
+own transaction (as today). No batching transaction is added — keeps the change minimal and
+each fact independently dedups. `maybeRunMaintenance` already fires inside `storeImmediate`
+every `maintenanceInterval` stores, so a large ingest naturally triggers a consolidation pass;
+no extra orchestration needed.
+
+> **Bulk-driver note (out of scope for tool code).** For a reproducible eval corpus the driver
+> may want a single, deterministic consolidation pass at the **end** of the bulk load instead of
+> the `maintenanceInterval`-triggered passes interleaving mid-ingest. That is a driver concern:
+> the driver can raise `maintenanceInterval` (via `MEMORY_*` config) during the bulk run and run
+> one consolidation at the end. We deliberately add **no** tool code for this — `ingest` keeps
+> the existing `maybeRunMaintenance` behavior.
+
+### 5.2 `store` signature change — `createdAt`, not `string[]`
+
+```ts
+// engine.ts
+export interface StoreOptions {
+  tags?: string[];
+  importance?: number;
+  source?: string;     // NEW — ingest stamps provenance; insert path already supports `source`
+  createdAt?: number;  // NEW — epoch ms; when set, stamp created_at/updated_at/last_accessed_at
+}
+```
+
+- `source` is added because `insertMemory` **already** accepts `source` (`queries.ts`
+  `InsertMemoryParams.source`) but `storeImmediate` never forwards it. Threading it is a
+  one-line change and gives ingested facts real provenance.
+- `createdAt` is the `as_of` mechanism (§5.4).
+- **We do NOT add `content: string | string[]`.** The proposal lists it as a separate
+  affordance; `memory_ingest` does not need it (it loops over facts itself), and widening the
+  hot-path tool's input type is out of scope here.
+
+**Contract preservation:** both new fields are optional. Existing callers of `store` and the
+`memory_store` tool are unaffected. `StoreResult` is unchanged.
+
+### 5.3 Dedup interaction — rely on what exists, add nothing
+
+Extracted facts may duplicate existing memories or each other. We rely entirely on the existing
+two-tier dedup:
+
+- **Within the same ingest:** two near-identical facts → the second hits exact-dedup
+  (`EXACT_DEDUP_DISTANCE`) in `storeImmediate` and is `merged_duplicate`, or lands in the
+  consolidation band and is resolved on the next maintenance pass.
+- **Against prior memories:** identical — `storeImmediate`'s `vectorSearch` + consolidation
+  catch it.
+
+No new dedup logic. We count `created` vs `merged` (`merged_duplicate` + `contradiction_resolved`)
+so the result honestly reports both how many *new* rows landed and how many facts corroborated an
+existing memory (A7).
+
+**Per-fact importance on merge.** When a fact merges, the surviving row's importance is already
+reconciled by the existing `updateMemoryContent` SQL (`importance = MAX(importance, ?)`), so a
+high-importance corroborating fact correctly raises the survivor's importance and a low-importance
+one never lowers it. No change needed — per-fact importance (A2) composes with the existing merge
+rule for free.
+
+### 5.4 `createdAt` / `as_of` mechanism in `store`
+
+`storeImmediate`, `insertMemory`, and `updateMemoryContent` currently hard-code
+`now = Date.now()`. The change has two parts — the **created** path (singleton backdate) and the
+**merge** path (order-independent reconciliation, A1).
+
+**Created path (singleton, unchanged intent from v1):**
+
+- `insertMemory` gains an optional `createdAt` in `InsertMemoryParams`. When present, it is used
+  for `created_at`, `updated_at`, **and** `last_accessed_at` (all three). When absent, behavior
+  is byte-for-byte unchanged (`Date.now()`).
+- `storeImmediate` forwards `opts.createdAt` into `insertMemory`.
+- **Singleton `last_accessed_at = as_of` is intentional (documented decision).** A backdated fact
+  that creates a *new* row is faithful to its source date in every column: a 2023 fact **is**
+  cold, and stamping `last_accessed_at = as_of` lets recency/decay scoring treat it as old. We do
+  **not** stamp `last_accessed_at = now` for created backdated rows.
+
+**Merge path (A1 — REPLACES v1's "do not rewrite `created_at`" rule):**
+
+v1 said: on merge, leave the existing row's `created_at` alone, backdate applies to new rows only.
+That let ingest **order** decide the surviving timestamp — the merge target keeps whatever
+timestamp the first-landed insert happened to give it, regardless of which fact is actually older.
+For a multi-year export ingested in arbitrary order, this flattens recency precisely for the
+most-repeated (most-important) facts. **New rule:** when a backdated fact merges into an existing
+row, reconcile timestamps **order-independently**:
+
+```
+created_at        = min(existing.created_at,        incoming as_of)   // true first-seen
+last_accessed_at  = max(existing.last_accessed_at,  incoming as_of)   // true last-touched
+updated_at        = max(existing.updated_at,        incoming as_of)   // true last-touched
+```
+
+Implementation:
+
+- The exact-dedup merge branch in `storeImmediate` calls `updateMemoryContent` (content/embedding/
+  tags/importance) **and then**, only when `opts.createdAt` is set, a small new query
+  `updateMemoryTimestampsOnMerge(db, namespace, id, asOf)` that runs:
+  ```sql
+  UPDATE memories
+     SET created_at       = MIN(created_at, ?),
+         last_accessed_at = MAX(last_accessed_at, ?),
+         updated_at       = MAX(updated_at, ?)
+   WHERE id = ? AND namespace = ?
+  ```
+  (Three `?`-bindings of `asOf`.) This is additive — `updateMemoryContent` is unchanged, so the
+  consolidation-path caller of `updateMemoryContent` is unaffected. The min/max are computed in
+  SQL so the merge is atomic and order-independent regardless of which insert wins the race.
+- **Non-`as_of` merges are unchanged.** When `opts.createdAt` is absent, the new query is **not**
+  called; `updateMemoryContent`'s existing `updated_at = now` behavior stands, byte-for-byte.
+
+This is the only place v1 made an **order-dependent** timestamp decision; A1 removes it.
+
+---
+
+## 6. `as_of` backdating — schema impact
+
+**None.** `created_at`, `updated_at`, `last_accessed_at` are existing `INTEGER` columns. We are
+only choosing the value written — at insert (created path) and, for the A1 order-independent
+merge, in the new `updateMemoryTimestampsOnMerge` UPDATE (§5.4). Both reuse the same three
+existing columns. **No migration, no `SCHEMA_VERSION` bump.** (Contrast with the deferred title
+feature, which *would* need a migration; we are not doing it.)
+
+Handler-side normalization: `as_of` may be epoch ms (number) or ISO 8601 (string).
+`validateIngestInput` resolves it to epoch ms via `Date.parse` for strings, rejects
+non-finite/negative results with a clear error, and passes a `number` to the engine. The engine
+never sees the string form (keeps the engine contract numeric and simple).
+
+---
+
+## 7. Chunking
+
+Conversations can exceed the model context. Strategy:
+
+- **Token estimate:** reuse `estimateTokens` from `retrieval/scoring.ts` (already exported, used
+  by the budget packer) — no new estimator.
+- **Threshold:** a `MAX_INGEST_CHUNK_TOKENS` constant (≈ 6000 tokens, comfortably inside
+  Haiku's window with room for the prompt + output). If `estimateTokens(blob) <= threshold`,
+  one chunk, one LLM call.
+- **Splitting:** greedy line-oriented windows. Split on newlines (transcripts and documents are
+  line-structured), accumulate lines until the next line would exceed the threshold, emit the
+  window, continue. A single pathological line longer than the threshold is hard-split on
+  whitespace as a fallback. This keeps speaker turns / paragraphs intact at window boundaries far
+  more often than a blind character cut.
+- **Window overlap (A5):** prepend the last **~10–15% of window N's lines** to the front of
+  window N+1, so a fact whose supporting evidence straddles a window boundary is recoverable from
+  at least one window (it appears whole in the overlap region of the next window). The overlap is
+  bounded by line count, not characters, so it never pushes a window over the token threshold by
+  more than a small constant. The duplicate facts this naturally produces in the overlap region
+  are already collapsed by the union step's exact-`fact`-string drop (below), so overlap costs a
+  little extra extraction work, not duplicate rows.
+- **Residual lossiness (A5):** overlap recovers boundary-straddling evidence **between adjacent**
+  windows only. Evidence spread across *non-adjacent* windows, or a single fact synthesized from
+  more context than one window holds, is still not reconstructable from a single extraction call —
+  that is inherent to per-window extraction and is left to the normal dedup/consolidation pipeline,
+  not solved here. We document it rather than over-engineer a global pass.
+- **Union semantics:** extract per window, concatenate the `ExtractedFact` lists in order, drop
+  exact-`fact`-string duplicates across windows (first occurrence keeps its `importance`).
+  Cross-window *semantic* duplicates are left to the normal dedup pipeline (§5.3) — we do not embed
+  during extraction.
+- **Bound:** cap total chunks (e.g. `MAX_INGEST_CHUNKS = 50`) and total facts
+  (`MAX_FACTS_PER_INGEST`) to keep a hostile or enormous blob from fanning out unboundedly.
+
+Chunking lives in `extraction.ts` (`chunkBlob(blob): string[]`, with the ~10–15% overlap of
+A5 baked in) — pure, unit-testable.
+
+---
+
+## 8. `dry_run` control flow
+
+`dry_run` short-circuits **after** extraction, **before** any write (§5.1 step 5). It runs the
+full LLM extraction + chunking so the preview is faithful, then returns
+`{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts }` (where `facts` is
+`ExtractedFact[]`, carrying the model's per-fact importance for inspection). No `store`, no
+embedding, no dedup, no maintenance.
+
+This is the safe-preview path for sensitive content: extraction reads the blob but nothing is
+persisted to SQLite. (Note: the blob is still sent to the configured LLM endpoint — that is
+inherent to extraction; `dry_run` controls *local persistence*, not whether the model sees the
+text. Call this out in the tool description so a user previewing sensitive content understands
+the model still receives it.) We deliberately **do not** add a separate no-egress / local-only
+preview mode: the eval-corpus user has **consented** to Haiku egress, and a non-egressing preview
+would not exercise the real extraction. The honest framing — `dry_run` egresses content to the
+configured LLM but persists nothing locally — is the contract. (PII-safe *logging* per A6 is
+orthogonal and always applies, including under `dry_run`.)
+
+---
+
+## 9. Degradation — no-LLM fallback
+
+`getLLMClient(config)` returns `null` when neither `llmApiKey` nor `llmBaseUrl` is set. In that
+case `extractFacts` returns `null` for every chunk and the union is empty. The behavior then
+follows `on_extraction_failure` (§5.1 step 4):
+
+- **`'degrade'` (default), `dry_run=false`:** stores the blob as a single memory
+  (`store(blobTruncated, { tags, importance: seedImportance, source, createdAt })`) and returns
+  `{ created: 1, merged: 0, ingested: 1, memory_ids: [id], facts: [{ fact: blob, importance:
+  seedImportance }], degraded: true }`. The blob is truncated to `MAX_CONTENT_LENGTH` so the
+  existing `store` content cap is respected.
+- **`'degrade'`, `dry_run=true`:** returns `{ created: 0, merged: 0, ingested: 0, memory_ids: [],
+  facts: [{ fact: blob }], degraded: true }` with no write.
+- **`'skip'`:** writes nothing, returns `{ created: 0, merged: 0, ingested: 0, memory_ids: [],
+  facts: [], skipped: true }`.
+- **`'error'`:** throws a content-free error (A6).
+
+With the default `'degrade'`, `memory_ingest` **never hard-fails** on a missing model — identical
+philosophy to consolidation/compaction "skip when no LLM" degradation. `'skip'`/`'error'` are
+opt-in for the corpus driver, which prefers a clean failure over a contaminating single-blob row.
+The handler's rendered text states the outcome explicitly so the caller knows decomposition did
+not happen.
+
+---
+
+## 10. Auto-save seam (note only — no change now)
+
+Proposal §5 wants `src/memory/auto-save.ts` (in the **IronCurtain runtime**, not this package)
+to eventually route session summaries through `ingest` instead of asking the agent to call
+`memory_store` once. That module builds a prompt instructing the agent to call `memory_store`;
+switching it to instruct `memory_ingest` (docker name) / `memory.ingest` (in-process) is a
+**one-line `toolName` change in `buildAutoSavePrompt`** plus the prompt body asking for a raw
+summary rather than a pre-condensed one. **We do not change it in this work** — we only note the
+seam. The MCP tool must exist and be registered first; the runtime switch is a follow-up so it
+can be tested end-to-end against the daemon.
+
+---
+
+## 11. Testing strategy
+
+Follow the existing harness exactly. Two layers:
+
+### 11.1 Pure-function unit tests (no DB, no LLM)
+File: `test/extraction.test.ts`. Mirrors `parseBatchJudgments` coverage in
+`test/llm-client.test.ts` style.
+- `parseExtractedFacts`: valid array of objects → `ExtractedFact[]` with trimmed `fact` and
+  preserved `importance`; **bare-string items tolerated** → `{ fact, importance: undefined }`
+  (A2); non-array JSON → `[]`; prose-wrapped array → extracted; empty/junk → `[]`; over-long
+  `fact` truncated; count capped; intra-batch exact-`fact` dups dropped (first keeps importance).
+- **Per-fact importance parsing (A2):** `importance` out of `[0,1]` → **clamped**; non-finite /
+  non-number `importance` → **dropped to undefined**; missing `importance` → undefined (caller
+  falls back to seed).
+- **PII-safe parse (A6):** `parseExtractedFacts` on a non-JSON response containing a known
+  sensitive substring returns `[]` and the function/caller log does not contain that substring —
+  only a content-free shape (`"no JSON array found in N-char response"`).
+- `chunkBlob`: short blob → 1 chunk; long blob → N chunks split on newlines; **adjacent chunks
+  overlap by ~10–15% of lines (A5)** — assert the tail lines of chunk N reappear at the head of
+  chunk N+1; pathological long line → hard-split; chunk count bounded.
+
+### 11.2 Engine `ingest` tests (real in-memory SQLite, mocked LLM)
+File: `test/ingest.test.ts`. Use the `mkdtempSync` + `initDatabase(TEST_MODEL)` pattern from
+`test/database.test.ts`. Two mocking choices, pick per the package's existing seams:
+- **Mock the LLM** by `vi.mock('../src/llm/client.js', …)` so `llmComplete` returns a canned
+  JSON array of `{ fact, importance }` objects (and `getLLMClient` returns a truthy stub) — lets
+  the *real* `store`/dedup/insert run. This is the highest-value path: it proves decomposition →
+  N rows end to end.
+- The **embedder** loads a real (small) model in these tests as it does in `database.test.ts`;
+  if model-load time is a concern, follow `maintenance.test.ts`'s approach. (The package already
+  tolerates real embedding in unit tests with the 30s timeout.)
+
+Assertions:
+- **Decomposition → N rows:** mock returns 3 facts → `getNamespaceStats().total_memories === 3`,
+  result `created === 3`, `ingested === 3` (alias), `merged === 0`, `memory_ids.length === 3`,
+  three distinct contents.
+- **Per-fact importance (A2):** mock returns facts with explicit `importance` (e.g. 0.9 / 0.2)
+  and one with importance **omitted** → assert each written row's `importance` equals the model's
+  value, and the omitted one equals the **seed** `importance` passed to the call (default 0.5).
+- **`dry_run` writes nothing:** same mock, `dry_run: true` → `total_memories === 0`,
+  `created === 0`, `facts.length === 3`, and `facts[i].importance` carries the model's value.
+- **`as_of` stamps dates (created path):** `as_of` = a fixed past epoch (and an ISO string
+  variant) → every newly-created row's `created_at`/`updated_at`/`last_accessed_at` equals it
+  (including `last_accessed_at = as_of`, the documented singleton decision); assert via
+  `getMemoriesByIds`. Also assert that omitting `as_of` yields `created_at ≈ Date.now()`.
+- **Order-independent merge timestamps (A1):** store a fact at `as_of = T_old`, then ingest a
+  duplicate fact (same content → exact-dedup merge) at `as_of = T_new > T_old`; assert the
+  surviving row has `created_at === T_old` (`min`), `last_accessed_at === T_new` and
+  `updated_at === T_new` (`max`). Then run the **reverse order** (ingest `T_new` first, merge
+  `T_old` second) and assert the **same** surviving timestamps — proving order-independence.
+  Also assert a non-`as_of` merge leaves `created_at` untouched and only bumps `updated_at`
+  (the new query is not called).
+- **Merge importance composes (A1/A2):** merging a higher-importance duplicate raises the
+  survivor's importance (existing `MAX(importance, ?)`), a lower one does not lower it.
+- **Honest stats (A7):** a call where 1 of 3 facts duplicates an existing row → `created === 2`,
+  `merged === 1`, `ingested === 2`, `memory_ids.length === 3`.
+- **Degradation, default (`'degrade'`, no LLM):** config with `llmApiKey: null, llmBaseUrl: null`
+  (the `configWithoutLLM()` helper from `llm-client.test.ts`) → one row, content === blob
+  (truncated), `created === 1`, `degraded === true`.
+- **`on_extraction_failure='skip'` (A3):** no/failed LLM + `skip` → `total_memories === 0`,
+  `created === 0`, `skipped === true`, no throw.
+- **`on_extraction_failure='error'` (A3):** no/failed LLM + `error` → `ingest` **rejects**; assert
+  it throws and that the **error message contains no input substring** (A6).
+- **Malformed response (default degrade):** mock `llmComplete` → `'not json at all'` → union
+  empty → degraded single-blob store (not a throw); `degraded === true`, one row.
+- **Partial extraction is observable (A3):** multi-chunk blob where the mock returns facts for
+  chunk 1 and `null` (or non-JSON) for chunk 2 → facts from chunk 1 are ingested AND
+  `partial === true`, `degraded === true`, `failed_chunks === 1`, `chunks === 2`.
+- **PII-safe on failure (A6):** spy on `console.error`/stderr; trigger a parse failure and an
+  LLM-error with a blob containing a known sensitive marker → assert **neither** stderr **nor**
+  the returned/thrown text contains that marker (only content-free shapes).
+- **Seed tags / source propagate** to every written fact; durability/importance come from the
+  model (per above), seed `importance` is the fallback only.
+- **Chunking integration (with overlap, A5):** a blob over the token threshold with a mock that
+  returns distinct facts per call → assert `llmComplete` called >1 time and facts unioned,
+  `chunks > 1`; a fact placed on the boundary line is recovered (appears once after the
+  exact-`fact` union dedups the overlap duplicate).
+
+### 11.3 Tool/registration tests
+File: extend `test/server.test.ts` and add `test/ingest-tool.test.ts` (mirrors `tools.test.ts`):
+- `listTools` now returns **6** tools including `memory_ingest` (update the existing
+  `lists all 5 memory tools` assertion in `test/server.test.ts` to 6 — note this is an
+  intentional, expected test change).
+- Schema has `content` required; `mode`/`dry_run`/`as_of`/`on_extraction_failure`/`tags`/
+  `importance`/`source` optional.
+- `validateIngestInput`: rejects empty content; rejects bad `as_of` (non-numeric string,
+  negative); normalizes ISO `as_of` → epoch ms; defaults `mode` to `'conversation'`; defaults
+  `on_extraction_failure` to `'degrade'`; rejects an `on_extraction_failure` outside the enum.
+- Handler routes to `engine.ingest` with a mock engine (à la `server.test.ts`
+  `createMockEngine`, extended with an `ingest` mock) and renders the expected text for the
+  normal / dry_run / **partial** / degraded / **skipped** results — including that the normal
+  render reports `created` and `merged` separately (A7).
+
+---
+
+## 12. Migration / back-compat
+
+- **DB schema:** **no change, no `SCHEMA_VERSION` bump.** `as_of` reuses existing timestamp
+  columns; facts are ordinary rows.
+- **`store` public contract:** **preserved.** `StoreOptions` gains two *optional* fields
+  (`source`, `createdAt`); `store(content, opts)` and `memory_store` behavior is identical when
+  they are absent. `StoreResult` unchanged.
+- **`MemoryEngine` interface:** gains one method (`ingest`). All implementers in this package
+  (`createMemoryEngineFromConfig`, `createMemoryEngine`/`EngineModules`) and every test mock
+  engine must add it — this is a compile-time-enforced, mechanical addition. (The `server.test.ts`
+  / `tools.test.ts` `createMockEngine` helpers get an `ingest: vi.fn()…`.)
+- **Published API:** additive. External MCP clients gain a new tool; nothing they used changes.
+
+---
+
+## 13. Explicit non-goals
+
+- **Auto-inferred tags (Question 1):** not designed here. Seed `tags` are applied verbatim to
+  every fact; no inference, no vocabulary convergence.
+- **Inferred titles (Question 2):** not designed here. No `title` column, no migration.
+- **`store` accepting `content: string | string[]`:** out of scope; a separate proposal item.
+- **Routing `auto-save.ts` through ingest:** noted as a seam (§10); not changed in this work.
+- **The historical-export / eval-corpus driver is a SEPARATE script**, not part of this tool.
+  `memory_ingest` provides the **insert-time** primitives the driver needs — per-fact importance
+  (A2), order-independent merge timestamps (A1), `on_extraction_failure` (A3), durability prompts
+  (A4), overlap (A5), PII-safe logging (A6), honest stats (A7), plus `as_of`/`dry_run`. The driver
+  keeps the **per-run policy** decisions that are genuinely its own and that this tool deliberately
+  does **not** absorb:
+  - Choosing `mode` / `as_of` / `on_extraction_failure` **per conversation** (e.g. `document` for
+    transcripts, real conversation date as `as_of`, `error` to force a retry).
+  - Controlling **maintenance cadence** for a reproducible corpus — e.g. raising
+    `maintenanceInterval` during the bulk load and running one consolidation at the end. The tool
+    keeps the existing `maybeRunMaintenance` behavior and adds **no** code for this (noted in §5.1).
+  - Choosing **Haiku-vs-local** extraction model via the existing `MEMORY_LLM_*` config; the tool
+    reuses whatever is configured and adds no model path.
+  The driver (reading a multi-year export, chunking by source conversation) lives outside the
+  server package and is not designed here.
+- **No third extraction mode (A4):** modes stay `conversation` / `document` on the explicit-vs-
+  inference axis; the durability filter is added to **both**, not as a separate mode.
+- **No no-egress / local-only preview mode:** the eval-corpus user has consented to Haiku egress;
+  `dry_run` previews without local persistence but still egresses content to the configured LLM
+  (§8). PII-safe *logging* (A6) is the orthogonal protection that always applies.
+- **No retry loop / no structured-output API:** intentionally consistent with the package's
+  existing single-call, parse-defensively LLM idiom. Retry is the driver's job via
+  `on_extraction_failure='error'`.
+- **No `SCHEMA_VERSION` bump:** timestamps (created path **and** the A1 merge reconciliation)
+  reuse existing `INTEGER` columns; no migration.
+
+---
+
+## 14. File-change summary
+
+| File | Change |
+|---|---|
+| `src/engine.ts` | Add `IngestOptions` (incl. `on_extraction_failure?`, A3), `ingest()` to `MemoryEngine`; add `source?`/`createdAt?` to `StoreOptions`. |
+| `src/types.ts` | Add `IngestResult` with `created`/`merged`/`ingested` (alias) + `failed_chunks`/`degraded`/`partial`/`skipped` diagnostics (A7/A3). |
+| `src/storage/extraction.ts` | **New.** `ExtractedFact` type (A2); `extractFacts` (returns `ExtractedFact[]\|null`), `parseExtractedFacts` (object-form + clamp + bare-string tolerance, A2; PII-safe failure shapes, A6), `chunkBlob` (with ~10–15% overlap, A5), two durability-filtered + importance-instructed mode prompts (A4/A2), constants. |
+| `src/storage/queries.ts` | `InsertMemoryParams.createdAt?`; `insertMemory` uses it (else `Date.now()`). **New** `updateMemoryTimestampsOnMerge(db, ns, id, asOf)` doing `created_at=MIN(.,?)`, `last_accessed_at=MAX(.,?)`, `updated_at=MAX(.,?)` (A1). `updateMemoryContent` unchanged. |
+| `src/engine-impl.ts` | `storeImmediate` forwards `source`/`createdAt` and, on an `as_of` exact-dedup merge, calls `updateMemoryTimestampsOnMerge` (A1); add `ingest` impl (per-fact importance threading A2, `on_extraction_failure` branching + partial-failure tracking A3, honest `created`/`merged` tally A7, PII-safe logging A6); add `ingest` to `EngineModules` + `createMemoryEngine`. |
+| `src/tools/ingest.ts` | **New.** `validateIngestInput` (validate/normalize `on_extraction_failure`, default `'degrade'`), `handleIngest`, `formatIngestResult` (render normal/dry_run/partial/degraded/skipped, A7/A3; content-free, A6), `as_of` normalization. |
+| `src/tools/validation.ts` | (Optional) `MAX_FACTS_PER_INGEST`, chunk/token/overlap constants if shared. |
+| `src/server.ts` | Register `memory_ingest` (in the existing eslint-disable block); schema gains `on_extraction_failure`. |
+| `src/prompts.ts` | Add `TOOL_DESCRIPTIONS.memory_ingest`. |
+| `test/extraction.test.ts`, `test/ingest.test.ts`, `test/ingest-tool.test.ts` | **New.** Cover per-fact importance (A2), order-independent merge (A1), failure modes (A3), overlap (A5), PII leak (A6), honest stats (A7). |
+| `test/server.test.ts` | Update tool-count assertion 5 → 6; add `ingest` to mock engine. |
+| `test/tools.test.ts` | Add `ingest` to `createMockEngine`. |

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -166,7 +166,7 @@ async function extractAllFacts(
  * Decompose a blob into atomic-fact memories via the LLM, writing each fact
  * through the existing `store` pipeline. PII-safe: never logs raw content.
  */
-async function ingestBlob(
+export async function ingestBlob(
   db: Database.Database,
   config: MemoryConfig,
   content: string,

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -2,9 +2,10 @@
  * MemoryEngine implementation that wires together the engine modules.
  */
 
-import type { MemoryEngine, StoreOptions } from './engine.js';
+import type { MemoryEngine, StoreOptions, IngestOptions } from './engine.js';
 import type {
   StoreResult,
+  IngestResult,
   RecallOptions,
   RecallResult,
   ContextOptions,
@@ -21,6 +22,7 @@ import {
   generateId,
   insertMemory,
   updateMemoryContent,
+  updateMemoryTimestampsOnMerge,
   vectorSearch,
   deleteMemories,
   findMemoriesByTags,
@@ -36,6 +38,9 @@ import { embed, embedQuery } from './embedding/embedder.js';
 import { recall as retrievalRecall } from './retrieval/pipeline.js';
 import { estimateTokens } from './retrieval/scoring.js';
 import { EXACT_DEDUP_DISTANCE } from './storage/constants.js';
+import { MAX_CONTENT_LENGTH } from './tools/validation.js';
+import { chunkBlob, extractFacts } from './storage/extraction.js';
+import type { ExtractedFact, IngestMode } from './storage/extraction.js';
 import { parseTags } from './utils/tags.js';
 import type Database from 'better-sqlite3';
 
@@ -94,6 +99,11 @@ async function storeImmediate(
     const mergedTags = [...new Set([...existingTags, ...newTags])];
 
     updateMemoryContent(db, namespace, exactMatch.id, content, embedding, importance, exactMatch.content, mergedTags);
+    // Order-independent timestamp reconciliation for backdated (`as_of`) merges (A1).
+    // Only runs when createdAt is set; non-`as_of` merges are byte-for-byte unchanged.
+    if (opts.createdAt !== undefined) {
+      updateMemoryTimestampsOnMerge(db, namespace, exactMatch.id, opts.createdAt);
+    }
     return { id: exactMatch.id, action: 'merged_duplicate' };
   }
 
@@ -107,13 +117,136 @@ async function storeImmediate(
       content,
       tags: opts.tags,
       importance,
+      source: opts.source,
       consolidated: false,
+      createdAt: opts.createdAt,
     },
     embedding,
   );
 
   await maybeRunMaintenance(db, config);
   return { id, action: 'created' };
+}
+
+// ---------- Ingest (LLM-backed fact decomposition) ----------
+
+const DEFAULT_SEED_IMPORTANCE = 0.5;
+
+/**
+ * Extract facts from each chunk and union them, dropping exact-`fact`-string
+ * duplicates across windows (first occurrence keeps its importance). Tracks how
+ * many chunks returned null/[] for diagnostics (A3).
+ */
+async function extractAllFacts(
+  config: MemoryConfig,
+  chunks: string[],
+  mode: IngestMode,
+): Promise<{ facts: ExtractedFact[]; totalChunks: number; failedChunks: number }> {
+  const seen = new Set<string>();
+  const facts: ExtractedFact[] = [];
+  let failedChunks = 0;
+
+  for (const chunk of chunks) {
+    const chunkFacts = await extractFacts(config, chunk, mode);
+    if (chunkFacts === null || chunkFacts.length === 0) {
+      failedChunks += 1;
+      continue;
+    }
+    for (const fact of chunkFacts) {
+      if (seen.has(fact.fact)) continue;
+      seen.add(fact.fact);
+      facts.push(fact);
+    }
+  }
+
+  return { facts, totalChunks: chunks.length, failedChunks };
+}
+
+/**
+ * Decompose a blob into atomic-fact memories via the LLM, writing each fact
+ * through the existing `store` pipeline. PII-safe: never logs raw content.
+ */
+async function ingestBlob(
+  db: Database.Database,
+  config: MemoryConfig,
+  content: string,
+  opts: IngestOptions,
+): Promise<IngestResult> {
+  const seedImportance = opts.importance ?? DEFAULT_SEED_IMPORTANCE;
+  const mode: IngestMode = opts.mode ?? 'conversation';
+  const onFailure = opts.on_extraction_failure ?? 'degrade';
+  const createdAt = opts.as_of;
+  const dryRun = opts.dry_run ?? false;
+
+  const store = (factContent: string, importance: number): Promise<StoreResult> =>
+    storeImmediate(db, config, factContent, {
+      tags: opts.tags,
+      importance,
+      source: opts.source,
+      createdAt,
+    });
+
+  const chunks = chunkBlob(content);
+  const { facts, totalChunks, failedChunks } = await extractAllFacts(config, chunks, mode);
+  const multiChunk = totalChunks > 1;
+
+  // ---- All chunks failed (no LLM / hard failure / unparseable everywhere) ----
+  if (facts.length === 0) {
+    if (onFailure === 'error') {
+      throw new Error(`memory_ingest: extraction produced no facts (${failedChunks}/${totalChunks} chunks failed)`);
+    }
+    if (onFailure === 'skip') {
+      return { created: 0, merged: 0, ingested: 0, memory_ids: [], facts: [], skipped: true };
+    }
+    // 'degrade': store the blob as a single memory (product behavior).
+    const truncated = content.length > MAX_CONTENT_LENGTH ? content.slice(0, MAX_CONTENT_LENGTH) : content;
+    if (dryRun) {
+      return {
+        created: 0,
+        merged: 0,
+        ingested: 0,
+        memory_ids: [],
+        facts: [{ fact: truncated, importance: seedImportance }],
+        degraded: true,
+      };
+    }
+    const result = await store(truncated, seedImportance);
+    return {
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: [result.id],
+      facts: [{ fact: truncated, importance: seedImportance }],
+      degraded: true,
+    };
+  }
+
+  const partial = failedChunks > 0;
+  const diagnostics: Pick<IngestResult, 'chunks' | 'failed_chunks' | 'degraded' | 'partial'> = {
+    ...(multiChunk ? { chunks: totalChunks } : {}),
+    ...(partial ? { failed_chunks: failedChunks, degraded: true, partial: true } : {}),
+  };
+
+  // ---- Dry run: preview without writing ----
+  if (dryRun) {
+    return { created: 0, merged: 0, ingested: 0, memory_ids: [], facts, ...diagnostics };
+  }
+
+  // ---- Write each fact through the existing store pipeline ----
+  let created = 0;
+  let merged = 0;
+  const memoryIds: string[] = [];
+  for (const fact of facts) {
+    const result = await store(fact.fact, fact.importance ?? seedImportance);
+    memoryIds.push(result.id);
+    if (result.action === 'created') {
+      created += 1;
+    } else {
+      merged += 1;
+    }
+  }
+
+  return { created, merged, ingested: created, memory_ids: memoryIds, facts, ...diagnostics };
 }
 
 // ---------- Context ----------
@@ -298,6 +431,10 @@ export function createMemoryEngineFromConfig(config: MemoryConfig): MemoryEngine
       return storeImmediate(db, config, content, opts);
     },
 
+    async ingest(content: string, opts: IngestOptions): Promise<IngestResult> {
+      return ingestBlob(db, config, content, opts);
+    },
+
     async recall(opts: RecallOptions): Promise<RecallResult> {
       const result = await retrievalRecall(db, config, {
         query: opts.query,
@@ -336,6 +473,7 @@ export function createMemoryEngineFromConfig(config: MemoryConfig): MemoryEngine
  */
 export interface EngineModules {
   store(content: string, opts: StoreOptions): Promise<StoreResult>;
+  ingest(content: string, opts: IngestOptions): Promise<IngestResult>;
   recall(opts: RecallOptions): Promise<RecallResult>;
   context(opts: ContextOptions): Promise<string>;
   forget(opts: ForgetOptions): Promise<ForgetResult>;
@@ -346,6 +484,7 @@ export interface EngineModules {
 export function createMemoryEngine(modules: EngineModules): MemoryEngine {
   return {
     store: (...args) => modules.store(...args),
+    ingest: (...args) => modules.ingest(...args),
     recall: (...args) => modules.recall(...args),
     context: (...args) => modules.context(...args),
     forget: (...args) => modules.forget(...args),

--- a/packages/memory-mcp-server/src/engine.ts
+++ b/packages/memory-mcp-server/src/engine.ts
@@ -6,6 +6,7 @@
 
 import type {
   StoreResult,
+  IngestResult,
   RecallOptions,
   RecallResult,
   ContextOptions,
@@ -19,10 +20,31 @@ import type {
 export interface StoreOptions {
   tags?: string[];
   importance?: number;
+  /** Provenance stamped on the row. The insert path already supports `source`. */
+  source?: string;
+  /**
+   * Epoch ms. When set, stamps created_at/updated_at/last_accessed_at to this
+   * value at insert time (the `as_of` backdate mechanism). Absent ⇒ Date.now().
+   */
+  createdAt?: number;
+}
+
+export interface IngestOptions {
+  source?: string;
+  mode?: 'conversation' | 'document';
+  tags?: string[];
+  /** SEED importance; per-fact importance from extraction overrides it. */
+  importance?: number;
+  dry_run?: boolean;
+  /** Normalized to epoch ms by the handler before reaching the engine. */
+  as_of?: number;
+  /** How to handle a chunk/call that yields no facts. Default 'degrade'. */
+  on_extraction_failure?: 'degrade' | 'skip' | 'error';
 }
 
 export interface MemoryEngine {
   store(content: string, opts: StoreOptions): Promise<StoreResult>;
+  ingest(content: string, opts: IngestOptions): Promise<IngestResult>;
   recall(opts: RecallOptions): Promise<RecallResult>;
   context(opts: ContextOptions): Promise<string>;
   forget(opts: ForgetOptions): Promise<ForgetResult>;

--- a/packages/memory-mcp-server/src/llm/client.ts
+++ b/packages/memory-mcp-server/src/llm/client.ts
@@ -1,6 +1,27 @@
 import OpenAI from 'openai';
 import type { MemoryConfig } from '../config.js';
 
+/**
+ * Describe an LLM error as a CONTENT-FREE shape for logging.
+ *
+ * The OpenAI SDK error embeds the request body (= the prompt, which for
+ * `memory_ingest` is raw sensitive content) and/or the response body in its
+ * `.message`, so we log ONLY the error name plus any numeric status/code — never
+ * the message, the request, or the response. Used by every llmComplete caller
+ * (extraction, compaction, consolidation), so the guarantee holds package-wide.
+ */
+function describeLlmError(err: unknown): string {
+  if (err instanceof Error) {
+    const parts = [err.name];
+    const withFields = err as { status?: unknown; code?: unknown };
+    if (typeof withFields.status === 'number') parts.push(`status=${withFields.status}`);
+    if (typeof withFields.code === 'number') parts.push(`code=${withFields.code}`);
+    return parts.join(' ');
+  }
+  // Non-Error throw: report only its primitive type, never its serialized value.
+  return `non-error throw (${typeof err})`;
+}
+
 let llmClient: OpenAI | null = null;
 let clientConfig: { baseUrl: string | null; apiKey: string | null } | null = null;
 
@@ -54,7 +75,9 @@ export async function llmComplete(
     });
     return response.choices[0]?.message?.content ?? null;
   } catch (err) {
-    console.error('[memory-server] LLM call failed:', err);
+    // PII-safe: log a content-free error shape only — the SDK error can embed the
+    // prompt/response body, which for memory_ingest is raw sensitive content.
+    console.error('[memory-server] LLM call failed:', describeLlmError(err));
     return null;
   }
 }

--- a/packages/memory-mcp-server/src/prompts.ts
+++ b/packages/memory-mcp-server/src/prompts.ts
@@ -145,6 +145,16 @@ export const TOOL_DESCRIPTIONS = {
     'and deduplicated. Use this PROACTIVELY whenever the user shares facts, preferences, ' +
     'decisions, or anything worth remembering across sessions. Store atomic facts — one idea per memory.',
 
+  memory_ingest:
+    'Ingest a raw blob (conversation, document, or session summary) and decompose it into atomic, ' +
+    'DURABLE memories via an LLM (extracts stable preferences/identity/project facts/decisions; skips ' +
+    'ephemeral task chatter). Unlike memory_store (one pre-formed fact), this extracts many facts from ' +
+    "one input, each with its own importance. Use mode='conversation' for strict explicit-only " +
+    "extraction or mode='document' to allow reasonable inference (better for conversation transcripts); " +
+    'dry_run=true to preview the decomposition (note: dry_run still sends the blob to the configured LLM ' +
+    '— it only skips local persistence). By default falls back to a single store if no LLM is configured; ' +
+    'set on_extraction_failure to skip or error to change that.',
+
   memory_recall:
     'Recall memories relevant to a query. Returns a pre-summarized context block optimized ' +
     'for your context window. Uses hybrid semantic + keyword search. Use format="answer" to get ' +

--- a/packages/memory-mcp-server/src/server.ts
+++ b/packages/memory-mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { MemoryEngine } from './engine.js';
 import { FORMAT_MODES } from './retrieval/formatting.js';
 import { handleStore } from './tools/store.js';
+import { handleIngest } from './tools/ingest.js';
 import { handleRecall } from './tools/recall.js';
 import { handleContext } from './tools/context.js';
 import { handleForget } from './tools/forget.js';
@@ -50,6 +51,67 @@ function registerTools(server: McpServer, engine: MemoryEngine): void {
     async (args) => {
       try {
         const text = await handleStore(engine, args);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: formatError(err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'memory_ingest',
+    TOOL_DESCRIPTIONS.memory_ingest,
+    {
+      content: z.string().describe('Raw blob to decompose: a conversation transcript, document, or session summary.'),
+      source: z
+        .string()
+        .optional()
+        .describe("Provenance, e.g. 'session:abc', 'document', 'conversation'. Stored on each fact."),
+      mode: z
+        .enum(['conversation', 'document'])
+        .optional()
+        .describe(
+          "'conversation' (default): STRICT — only DURABLE facts explicitly stated, no inference. " +
+            "'document': broader — DURABLE facts with reasonable inference allowed. " +
+            'Both modes keep stable preferences/identity/project facts/decisions and skip ' +
+            'ephemeral task chatter. Use document for conversation transcripts.',
+        ),
+      tags: z.array(z.string()).optional().describe('Optional seed tags applied to EVERY extracted fact.'),
+      importance: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe(
+          'SEED importance 0-1, used as the fallback when the extraction model does not emit a ' +
+            'per-fact importance. Default: 0.5. Per-fact importance (when the model provides it) wins.',
+        ),
+      dry_run: z
+        .boolean()
+        .optional()
+        .describe('If true, run extraction and RETURN the facts WITHOUT writing anything. Default: false.'),
+      on_extraction_failure: z
+        .enum(['degrade', 'skip', 'error'])
+        .optional()
+        .describe(
+          'How to handle a chunk/call that yields no facts (no LLM, LLM error, or unparseable). ' +
+            "'degrade' (default): store the blob as a single memory (product behavior). " +
+            "'skip': write nothing, return ingested 0. 'error': throw, so a bulk driver can retry.",
+        ),
+      as_of: z
+        .union([z.number(), z.string()])
+        .optional()
+        .describe(
+          'Backdate: stamp created_at/last_accessed_at of every extracted fact to this time ' +
+            '(epoch ms or ISO 8601) instead of now. For ingesting historical exports.',
+        ),
+    },
+    async (args) => {
+      try {
+        const text = await handleIngest(engine, args);
         return { content: [{ type: 'text' as const, text }] };
       } catch (err) {
         return {

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -48,8 +48,11 @@ const CHUNK_OVERLAP_FRACTION = 0.12;
 const SHARED_RULES =
   '- Output ONLY a JSON array of objects, each { "fact": "<self-contained fact>", ' +
   '"importance": <0.0-1.0> }. One atomic fact per element — never combine two facts with "and".\n' +
-  '- Each fact must be self-contained: resolve pronouns to names, include the subject ' +
-  '("The user prefers dark mode", not "prefers dark mode").\n' +
+  '- Each fact must be self-contained: resolve pronouns to names and include the subject ' +
+  '("The user prefers dark mode", not "prefers dark mode"), AND name the specific thing the ' +
+  'fact is about — the project, product, document, game, or entity ("The user wants players to ' +
+  'pay off all loans before winning Debt Quest", not "...before winning the game"). If a fact ' +
+  'would be ambiguous out of context, name its referent.\n' +
   '- Extract only DURABLE facts worth remembering beyond this conversation: stable ' +
   'preferences, identity, project facts, decisions, learned constraints.\n' +
   '- SKIP ephemeral / session-local state: transient errors, one-off debugging steps, ' +

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -1,0 +1,273 @@
+/**
+ * LLM-backed fact extraction for `memory_ingest`.
+ *
+ * Sits next to consolidation.ts / compaction.ts (the other LLM-on-write modules).
+ * Reuses `llmComplete` from llm/client.js and `estimateTokens` from retrieval/scoring.js.
+ *
+ * PII-safe rule (hard): this module NEVER logs raw content/chunk/blob or the model's
+ * raw response. Only lengths, token estimates, chunk indices, and content-free failure
+ * shapes are ever emitted.
+ */
+
+import type { MemoryConfig } from '../config.js';
+import { llmComplete } from '../llm/client.js';
+import { estimateTokens } from '../retrieval/scoring.js';
+import { MAX_CONTENT_LENGTH } from '../tools/validation.js';
+
+export interface ExtractedFact {
+  fact: string;
+  /** 0–1, OPTIONAL; absent ⇒ caller falls back to the seed importance. */
+  importance?: number;
+}
+
+export type IngestMode = 'conversation' | 'document';
+
+// ---------- Constants ----------
+
+/** Per-chunk token budget; comfortably inside Haiku's window with room for prompt + output. */
+export const MAX_INGEST_CHUNK_TOKENS = 6000;
+
+/** Cap total extracted facts per ingest to bound a runaway response. */
+export const MAX_FACTS_PER_INGEST = 200;
+
+/** Cap total chunks so a hostile/enormous blob can't fan out unboundedly. */
+export const MAX_INGEST_CHUNKS = 50;
+
+/**
+ * Char-based hard cap per piece, derived from the per-chunk token budget via the
+ * package's ~4-chars/token heuristic (`estimateTokens`). Used as a last-resort cut
+ * for whitespace-free input so no emitted piece can exceed MAX_INGEST_CHUNK_TOKENS.
+ */
+const MAX_INGEST_CHUNK_CHARS = MAX_INGEST_CHUNK_TOKENS * 4;
+
+/** Fraction of a window's lines re-fed at the head of the next window (A5). */
+const CHUNK_OVERLAP_FRACTION = 0.12;
+
+// ---------- Prompts ----------
+
+const SHARED_RULES =
+  '- Output ONLY a JSON array of objects, each { "fact": "<self-contained fact>", ' +
+  '"importance": <0.0-1.0> }. One atomic fact per element — never combine two facts with "and".\n' +
+  '- Each fact must be self-contained: resolve pronouns to names, include the subject ' +
+  '("The user prefers dark mode", not "prefers dark mode").\n' +
+  '- Extract only DURABLE facts worth remembering beyond this conversation: stable ' +
+  'preferences, identity, project facts, decisions, learned constraints.\n' +
+  '- SKIP ephemeral / session-local state: transient errors, one-off debugging steps, ' +
+  '"let\'s try X", task chatter, pleasantries, meta-talk.\n' +
+  '- "importance" reflects how durable/identity-defining the fact is: durable identity, ' +
+  'standing preferences, and decisions → high (~0.7-1.0); useful-but-replaceable project ' +
+  'facts → mid (~0.4-0.7); marginal/ephemeral facts you still chose to keep → low ' +
+  '(~0.1-0.4). When unsure, omit "importance" and the caller will use the seed default.\n' +
+  '- If nothing durable is stated, output []. Reply with ONLY the JSON array, no prose.';
+
+export const CONVERSATION_EXTRACTION_PROMPT =
+  'You extract atomic, durable facts from a conversation transcript for long-term memory.\n' +
+  SHARED_RULES +
+  '\n- Extract ONLY facts that are explicitly stated. Do NOT infer, summarize, or editorialize.';
+
+export const DOCUMENT_EXTRACTION_PROMPT =
+  'You extract atomic, durable facts from a document or session summary for long-term memory.\n' +
+  SHARED_RULES +
+  '\n- Reasonable inference is allowed where the text clearly implies a durable fact, but do ' +
+  'not fabricate. Prefer atomic facts; split compound statements.';
+
+function systemPromptFor(mode: IngestMode): string {
+  return mode === 'document' ? DOCUMENT_EXTRACTION_PROMPT : CONVERSATION_EXTRACTION_PROMPT;
+}
+
+// ---------- Parsing ----------
+
+interface RawFactObject {
+  fact?: unknown;
+  importance?: unknown;
+}
+
+function coerceFact(item: unknown): ExtractedFact | null {
+  // Accept a bare string OR an object { fact, importance? }.
+  if (typeof item === 'string') {
+    const fact = item.trim();
+    return fact.length > 0 ? { fact } : null;
+  }
+  if (item === null || typeof item !== 'object') return null;
+
+  const obj = item as RawFactObject;
+  if (typeof obj.fact !== 'string') return null;
+  const fact = obj.fact.trim();
+  if (fact.length === 0) return null;
+
+  const capped = fact.length > MAX_CONTENT_LENGTH ? fact.slice(0, MAX_CONTENT_LENGTH) : fact;
+
+  let importance: number | undefined;
+  if (typeof obj.importance === 'number' && Number.isFinite(obj.importance)) {
+    importance = Math.min(1, Math.max(0, obj.importance));
+  }
+
+  return importance === undefined ? { fact: capped } : { fact: capped, importance };
+}
+
+/**
+ * Parse the model's text response into ExtractedFact[]. Pure & defensive,
+ * mirroring `parseBatchJudgments`.
+ *
+ * On a parse miss it returns [] and NEVER echoes `raw` (A6) — the caller logs a
+ * content-free shape.
+ */
+export function parseExtractedFacts(raw: string): ExtractedFact[] {
+  try {
+    const jsonMatch = raw.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) return [];
+
+    const parsed = JSON.parse(jsonMatch[0]) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    const facts: ExtractedFact[] = [];
+    const seen = new Set<string>();
+    for (const item of parsed) {
+      const coerced = coerceFact(item);
+      if (!coerced) continue;
+      if (seen.has(coerced.fact)) continue;
+      seen.add(coerced.fact);
+      facts.push(coerced);
+      if (facts.length >= MAX_FACTS_PER_INGEST) break;
+    }
+    return facts;
+  } catch {
+    return [];
+  }
+}
+
+// ---------- Chunking ----------
+
+/**
+ * Cut a single string into char-bounded pieces of at most MAX_INGEST_CHUNK_CHARS
+ * (≈ MAX_INGEST_CHUNK_TOKENS at ~4 chars/token). Last-resort fallback for content
+ * with no usable whitespace (base64, minified JSON, one giant token) so that no
+ * emitted piece can exceed the token cap.
+ */
+function hardCutChars(text: string): string[] {
+  const pieces: string[] = [];
+  for (let i = 0; i < text.length; i += MAX_INGEST_CHUNK_CHARS) {
+    pieces.push(text.slice(i, i + MAX_INGEST_CHUNK_CHARS));
+  }
+  return pieces;
+}
+
+/**
+ * Hard-split a single pathological line (longer than the threshold) on whitespace
+ * into sub-lines that each fit under MAX_INGEST_CHUNK_TOKENS. Any resulting piece
+ * that still exceeds the budget — e.g. a single whitespace-free giant token —
+ * falls back to a char-based hard cut, so the token cap is a HARD bound regardless
+ * of input.
+ */
+function hardSplitLine(line: string): string[] {
+  const words = line.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 0) return capPieces([line]);
+
+  const pieces: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current.length === 0 ? word : `${current} ${word}`;
+    if (estimateTokens(candidate) > MAX_INGEST_CHUNK_TOKENS && current.length > 0) {
+      pieces.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) pieces.push(current);
+  return capPieces(pieces);
+}
+
+/** Replace any piece still over the token budget with char-bounded sub-pieces. */
+function capPieces(pieces: string[]): string[] {
+  const capped: string[] = [];
+  for (const piece of pieces) {
+    if (estimateTokens(piece) > MAX_INGEST_CHUNK_TOKENS) {
+      capped.push(...hardCutChars(piece));
+    } else {
+      capped.push(piece);
+    }
+  }
+  return capped;
+}
+
+/**
+ * Split a blob into line-oriented windows of ~MAX_INGEST_CHUNK_TOKENS, with a
+ * ~10-15% line overlap between adjacent windows (A5). Pathological long lines are
+ * hard-split on whitespace. Total chunk count is bounded by MAX_INGEST_CHUNKS.
+ */
+export function chunkBlob(blob: string): string[] {
+  if (estimateTokens(blob) <= MAX_INGEST_CHUNK_TOKENS) {
+    return [blob];
+  }
+
+  // Normalize lines, hard-splitting any single line that exceeds the threshold.
+  const rawLines = blob.split('\n');
+  const lines: string[] = [];
+  for (const line of rawLines) {
+    if (estimateTokens(line) > MAX_INGEST_CHUNK_TOKENS) {
+      lines.push(...hardSplitLine(line));
+    } else {
+      lines.push(line);
+    }
+  }
+
+  const chunks: string[] = [];
+  let window: string[] = [];
+  let windowTokens = 0;
+
+  const flush = (): void => {
+    if (window.length === 0) return;
+    chunks.push(window.join('\n'));
+    // Carry the tail ~CHUNK_OVERLAP_FRACTION of lines into the next window (A5).
+    const overlapCount = Math.min(window.length - 1, Math.max(1, Math.floor(window.length * CHUNK_OVERLAP_FRACTION)));
+    const overlap = overlapCount > 0 ? window.slice(window.length - overlapCount) : [];
+    window = [...overlap];
+    windowTokens = overlap.reduce((sum, l) => sum + estimateTokens(l) + 1, 0);
+  };
+
+  for (const line of lines) {
+    const lineTokens = estimateTokens(line) + 1; // +1 for the newline
+    if (windowTokens + lineTokens > MAX_INGEST_CHUNK_TOKENS && window.length > 0) {
+      flush();
+      if (chunks.length >= MAX_INGEST_CHUNKS) break;
+    }
+    window.push(line);
+    windowTokens += lineTokens;
+  }
+
+  if (chunks.length < MAX_INGEST_CHUNKS && window.length > 0) {
+    chunks.push(window.join('\n'));
+  }
+
+  return chunks.slice(0, MAX_INGEST_CHUNKS);
+}
+
+// ---------- LLM call ----------
+
+/**
+ * Extract atomic durable facts from a single chunk via one LLM call.
+ *
+ * Returns:
+ *   - ExtractedFact[]  on success (may be [] if the model found nothing durable),
+ *   - null             when no LLM is configured or the call hard-failed.
+ *
+ * The caller treats both `null` and `[]` as a chunk failure for diagnostics.
+ * PII-safe: never logs the chunk or the raw response.
+ */
+export async function extractFacts(
+  config: MemoryConfig,
+  blob: string,
+  mode: IngestMode,
+): Promise<ExtractedFact[] | null> {
+  const maxTokens = Math.min(1500, Math.max(300, estimateTokens(blob)));
+  const raw = await llmComplete(config, systemPromptFor(mode), `<input>\n${blob}\n</input>`, { maxTokens });
+  if (raw === null) return null;
+
+  const facts = parseExtractedFacts(raw);
+  if (facts.length === 0) {
+    // Content-free failure shape only (A6).
+    console.error(`[memory-server] extraction: no facts parsed from ${raw.length}-char response`);
+  }
+  return facts;
+}

--- a/packages/memory-mcp-server/src/storage/queries.ts
+++ b/packages/memory-mcp-server/src/storage/queries.ts
@@ -17,10 +17,15 @@ export interface InsertMemoryParams {
   source?: string;
   metadata?: Record<string, unknown>;
   consolidated?: boolean;
+  /**
+   * Epoch ms backdate. When present, stamps created_at/updated_at/last_accessed_at
+   * to this value (the `as_of` mechanism). Absent ⇒ Date.now() (unchanged behavior).
+   */
+  createdAt?: number;
 }
 
 export function insertMemory(db: Database.Database, params: InsertMemoryParams, embedding: Float32Array): void {
-  const now = Date.now();
+  const now = params.createdAt ?? Date.now();
   const txn = db.transaction(() => {
     db.prepare(
       `INSERT INTO memories (id, namespace, content, tags, importance,
@@ -115,6 +120,33 @@ export function updateMemoryContent(
     ).run(Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength), id, namespace);
   });
   txn();
+}
+
+/**
+ * Reconcile a merged row's timestamps order-independently against a backdated
+ * `as_of` (A1). Additive — does NOT touch `updateMemoryContent`, which is shared
+ * with the consolidation contradiction path.
+ *
+ *   created_at       = MIN(created_at, asOf)   // true first-seen
+ *   last_accessed_at = MAX(last_accessed_at, asOf)
+ *   updated_at       = MAX(updated_at, asOf)
+ *
+ * Computed in SQL so the merge is atomic and order-independent regardless of
+ * which insert wins the race.
+ */
+export function updateMemoryTimestampsOnMerge(
+  db: Database.Database,
+  namespace: string,
+  id: string,
+  asOf: number,
+): void {
+  db.prepare(
+    `UPDATE memories
+        SET created_at       = MIN(created_at, ?),
+            last_accessed_at = MAX(last_accessed_at, ?),
+            updated_at       = MAX(updated_at, ?)
+      WHERE id = ? AND namespace = ?`,
+  ).run(asOf, asOf, asOf, id, namespace);
 }
 
 export function updateAccessStats(db: Database.Database, namespace: string, ids: string[]): void {

--- a/packages/memory-mcp-server/src/tools/ingest.ts
+++ b/packages/memory-mcp-server/src/tools/ingest.ts
@@ -1,0 +1,177 @@
+/**
+ * memory_ingest tool handler.
+ * Validates/normalizes input, delegates to the engine, and renders a content-free
+ * result string. PII-safe: NEVER echoes raw content or model output.
+ */
+
+import type { MemoryEngine, IngestOptions } from '../engine.js';
+import type { IngestResult } from '../types.js';
+import { validateTags } from './validation.js';
+
+export type IngestMode = 'conversation' | 'document';
+export type OnExtractionFailure = 'degrade' | 'skip' | 'error';
+
+const INGEST_MODES: readonly IngestMode[] = ['conversation', 'document'];
+const ON_EXTRACTION_FAILURES: readonly OnExtractionFailure[] = ['degrade', 'skip', 'error'];
+
+export interface IngestInput {
+  content: string;
+  source?: string;
+  mode: IngestMode;
+  tags?: string[];
+  importance?: number;
+  dry_run: boolean;
+  on_extraction_failure: OnExtractionFailure;
+  as_of?: number;
+}
+
+/**
+ * Normalize `as_of` (epoch ms number, numeric string, OR ISO 8601 string) to epoch ms.
+ * Rejects non-finite / negative results.
+ */
+function normalizeAsOf(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+
+  let ms: number;
+  if (typeof value === 'number') {
+    ms = value;
+  } else if (typeof value === 'string') {
+    // A bare numeric string (e.g. "1700000000000") is epoch ms; otherwise parse as ISO.
+    // Guard empty/whitespace-only: Number('') is 0 (would slip through as epoch 0),
+    // but it was unparseable before — keep rejecting it via Date.parse → NaN.
+    const asNumber = value.trim().length === 0 ? NaN : Number(value);
+    ms = Number.isFinite(asNumber) ? asNumber : Date.parse(value);
+  } else {
+    throw new Error('as_of must be an epoch-ms number or an ISO 8601 string');
+  }
+
+  if (!Number.isFinite(ms) || ms < 0) {
+    throw new Error('as_of must resolve to a non-negative epoch-ms timestamp');
+  }
+  return ms;
+}
+
+export function validateIngestInput(args: Record<string, unknown>): IngestInput {
+  const content = args.content;
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new Error('content is required and must be a non-empty string');
+  }
+
+  const source = args.source;
+  if (source !== undefined && typeof source !== 'string') {
+    throw new Error('source must be a string');
+  }
+
+  let mode: IngestMode = 'conversation';
+  if (args.mode !== undefined) {
+    if (typeof args.mode !== 'string' || !INGEST_MODES.includes(args.mode as IngestMode)) {
+      throw new Error("mode must be 'conversation' or 'document'");
+    }
+    mode = args.mode as IngestMode;
+  }
+
+  const tags = validateTags(args.tags);
+
+  const importance = args.importance;
+  if (importance !== undefined) {
+    if (typeof importance !== 'number' || !Number.isFinite(importance) || importance < 0 || importance > 1) {
+      throw new Error('importance must be a number between 0 and 1');
+    }
+  }
+
+  const dryRun = args.dry_run;
+  if (dryRun !== undefined && typeof dryRun !== 'boolean') {
+    throw new Error('dry_run must be a boolean');
+  }
+
+  let onExtractionFailure: OnExtractionFailure = 'degrade';
+  if (args.on_extraction_failure !== undefined) {
+    if (
+      typeof args.on_extraction_failure !== 'string' ||
+      !ON_EXTRACTION_FAILURES.includes(args.on_extraction_failure as OnExtractionFailure)
+    ) {
+      throw new Error("on_extraction_failure must be 'degrade', 'skip', or 'error'");
+    }
+    onExtractionFailure = args.on_extraction_failure as OnExtractionFailure;
+  }
+
+  const asOf = normalizeAsOf(args.as_of);
+
+  return {
+    content: content.trim(),
+    source,
+    mode,
+    tags,
+    importance,
+    dry_run: dryRun ?? false,
+    on_extraction_failure: onExtractionFailure,
+    as_of: asOf,
+  };
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? `${id.slice(0, 8)}…` : id;
+}
+
+/**
+ * Render the result as a content-free human-readable string. NEVER echoes raw
+ * content or model output beyond the extracted facts the caller already provided.
+ */
+function renderDryRunPreview(result: IngestResult): string {
+  const lines = result.facts.map((f, i) => {
+    const imp = f.importance !== undefined ? ` (importance: ${f.importance})` : '';
+    return `${i + 1}. ${f.fact}${imp}`;
+  });
+  return [`Dry run — nothing written. ${result.facts.length} fact(s) proposed:`, ...lines].join('\n');
+}
+
+export function formatIngestResult(result: IngestResult): string {
+  if (result.skipped) {
+    return 'Extraction failed and on_extraction_failure=skip — nothing written.';
+  }
+
+  // Full degrade (no decomposition): set by the engine only when the fact union
+  // was empty. `partial` distinguishes this from "some chunks failed but we got facts".
+  if (result.degraded && !result.partial) {
+    if (result.created === 0) {
+      return 'No LLM configured or extraction failed — dry run, nothing written (no decomposition).';
+    }
+    const id = result.memory_ids[0] ?? '?';
+    return `No LLM configured or extraction failed — stored the blob as a single memory ${truncateId(id)}.`;
+  }
+
+  // Dry run preview (facts extracted, nothing written).
+  if (result.created === 0 && result.merged === 0 && result.memory_ids.length === 0) {
+    return renderDryRunPreview(result);
+  }
+
+  const idList = result.memory_ids.map(truncateId).join(', ');
+  const base =
+    `Ingested ${result.facts.length} atomic fact(s): ` +
+    `${result.created} new memor${result.created === 1 ? 'y' : 'ies'}, ${result.merged} merged into existing` +
+    (idList.length > 0 ? ` (ids: ${idList})` : '') +
+    '.';
+
+  if (result.partial) {
+    const failed = result.failed_chunks ?? 0;
+    const total = result.chunks ?? 0;
+    return `${base} ${failed} of ${total} chunks failed extraction — partial result.`;
+  }
+
+  return base;
+}
+
+export async function handleIngest(engine: MemoryEngine, args: Record<string, unknown>): Promise<string> {
+  const input = validateIngestInput(args);
+  const opts: IngestOptions = {
+    source: input.source,
+    mode: input.mode,
+    tags: input.tags,
+    importance: input.importance,
+    dry_run: input.dry_run,
+    as_of: input.as_of,
+    on_extraction_failure: input.on_extraction_failure,
+  };
+  const result = await engine.ingest(input.content, opts);
+  return formatIngestResult(result);
+}

--- a/packages/memory-mcp-server/src/types.ts
+++ b/packages/memory-mcp-server/src/types.ts
@@ -24,6 +24,34 @@ export interface StoreResult {
   action: 'created' | 'merged_duplicate' | 'contradiction_resolved';
 }
 
+export interface IngestResult {
+  // ---- honest write stats ----
+  /** Rows newly created (action === 'created'). */
+  created: number;
+  /** Facts that hit an existing row (merged_duplicate / contradiction_resolved). */
+  merged: number;
+  /** ALIAS for `created`, kept for back-compat of the v1 field name. */
+  ingested: number;
+  /** Ids of all touched rows (created + merged); empty when dry_run. */
+  memory_ids: string[];
+
+  // ---- substance ----
+  /** The extracted atomic facts + their importance (always populated). */
+  facts: import('./storage/extraction.js').ExtractedFact[];
+
+  // ---- diagnostics ----
+  /** Number of LLM windows used (omitted when 1). */
+  chunks?: number;
+  /** Chunks that returned null/[] (omitted when 0). */
+  failed_chunks?: number;
+  /** True when we fell back to single-blob store, OR a partial failure occurred. */
+  degraded?: boolean;
+  /** True when SOME (not all) chunks failed but others produced facts. */
+  partial?: boolean;
+  /** True when on_extraction_failure='skip' wrote nothing. */
+  skipped?: boolean;
+}
+
 export interface RecallOptions {
   query: string;
   token_budget?: number;

--- a/packages/memory-mcp-server/test/extraction.test.ts
+++ b/packages/memory-mcp-server/test/extraction.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  parseExtractedFacts,
+  chunkBlob,
+  MAX_INGEST_CHUNK_TOKENS,
+  MAX_FACTS_PER_INGEST,
+  MAX_INGEST_CHUNKS,
+} from '../src/storage/extraction.js';
+import { MAX_CONTENT_LENGTH } from '../src/tools/validation.js';
+import { estimateTokens } from '../src/retrieval/scoring.js';
+
+describe('parseExtractedFacts', () => {
+  it('parses an array of {fact, importance} objects', () => {
+    const raw =
+      '[{"fact": "The user prefers dark mode", "importance": 0.8}, {"fact": "User uses Vim", "importance": 0.6}]';
+    const facts = parseExtractedFacts(raw);
+    expect(facts).toEqual([
+      { fact: 'The user prefers dark mode', importance: 0.8 },
+      { fact: 'User uses Vim', importance: 0.6 },
+    ]);
+  });
+
+  it('trims whitespace from the fact string', () => {
+    const facts = parseExtractedFacts('[{"fact": "  spaced fact  ", "importance": 0.5}]');
+    expect(facts[0].fact).toBe('spaced fact');
+  });
+
+  it('tolerates bare-string items → importance undefined', () => {
+    const facts = parseExtractedFacts('["A bare fact", "Another bare fact"]');
+    expect(facts).toEqual([{ fact: 'A bare fact' }, { fact: 'Another bare fact' }]);
+    expect(facts[0].importance).toBeUndefined();
+  });
+
+  it('treats missing importance as undefined', () => {
+    const facts = parseExtractedFacts('[{"fact": "No importance here"}]');
+    expect(facts).toEqual([{ fact: 'No importance here' }]);
+    expect(facts[0].importance).toBeUndefined();
+  });
+
+  it('extracts a prose-wrapped JSON array', () => {
+    const raw = 'Here are the facts:\n[{"fact": "Extracted from prose", "importance": 0.4}]\nThat is all.';
+    const facts = parseExtractedFacts(raw);
+    expect(facts).toEqual([{ fact: 'Extracted from prose', importance: 0.4 }]);
+  });
+
+  it('returns [] for non-array JSON', () => {
+    expect(parseExtractedFacts('{"fact": "not an array"}')).toEqual([]);
+  });
+
+  it('returns [] for empty/junk input', () => {
+    expect(parseExtractedFacts('')).toEqual([]);
+    expect(parseExtractedFacts('not json at all')).toEqual([]);
+    expect(parseExtractedFacts('[]')).toEqual([]);
+  });
+
+  it('drops items with empty or whitespace-only facts', () => {
+    const facts = parseExtractedFacts('[{"fact": ""}, {"fact": "   "}, {"fact": "real"}]');
+    expect(facts).toEqual([{ fact: 'real' }]);
+  });
+
+  it('drops items missing a string fact', () => {
+    const facts = parseExtractedFacts('[{"importance": 0.5}, {"fact": 42}, {"fact": "ok"}]');
+    expect(facts).toEqual([{ fact: 'ok' }]);
+  });
+
+  describe('importance clamping (A2)', () => {
+    it('clamps importance above 1 to 1', () => {
+      const facts = parseExtractedFacts('[{"fact": "too high", "importance": 5}]');
+      expect(facts[0].importance).toBe(1);
+    });
+
+    it('clamps importance below 0 to 0', () => {
+      const facts = parseExtractedFacts('[{"fact": "too low", "importance": -3}]');
+      expect(facts[0].importance).toBe(0);
+    });
+
+    it('drops non-finite importance to undefined', () => {
+      const facts = parseExtractedFacts('[{"fact": "infinite", "importance": 1e999}]');
+      expect(facts[0].importance).toBeUndefined();
+    });
+
+    it('drops non-number importance to undefined', () => {
+      const facts = parseExtractedFacts('[{"fact": "stringy", "importance": "high"}]');
+      expect(facts[0].importance).toBeUndefined();
+    });
+  });
+
+  it('caps an over-long fact at MAX_CONTENT_LENGTH', () => {
+    const longFact = 'x'.repeat(MAX_CONTENT_LENGTH + 500);
+    const facts = parseExtractedFacts(JSON.stringify([{ fact: longFact, importance: 0.5 }]));
+    expect(facts).toHaveLength(1);
+    expect(facts[0].fact.length).toBe(MAX_CONTENT_LENGTH);
+  });
+
+  it('caps the number of facts at MAX_FACTS_PER_INGEST', () => {
+    const many = Array.from({ length: MAX_FACTS_PER_INGEST + 50 }, (_, i) => ({ fact: `fact ${i}` }));
+    const facts = parseExtractedFacts(JSON.stringify(many));
+    expect(facts.length).toBe(MAX_FACTS_PER_INGEST);
+  });
+
+  it('drops intra-batch exact-fact duplicates, keeping the first importance', () => {
+    const raw = '[{"fact": "dup", "importance": 0.9}, {"fact": "dup", "importance": 0.1}, {"fact": "unique"}]';
+    const facts = parseExtractedFacts(raw);
+    expect(facts).toEqual([{ fact: 'dup', importance: 0.9 }, { fact: 'unique' }]);
+  });
+
+  describe('PII-safe parse (A6)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns [] on a non-JSON response and never echoes the sensitive substring on ANY channel', () => {
+      // Widened beyond console.error to also cover process.stderr.write and
+      // console.warn — future-proofs the guarantee against a regression that emits
+      // via a different channel (T3).
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const sensitive = 'SSN-123-45-6789-SECRET';
+      const raw = `Sorry, I cannot comply. ${sensitive} appears in the input.`;
+
+      const facts = parseExtractedFacts(raw);
+
+      expect(facts).toEqual([]);
+      // parseExtractedFacts itself logs nothing, but assert defensively that nothing
+      // it might emit on any stderr channel carries the substring.
+      const allLogs = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...stderrSpy.mock.calls]
+        .map((c) => JSON.stringify(c))
+        .join('\n');
+      expect(allLogs).not.toContain(sensitive);
+    });
+  });
+});
+
+describe('chunkBlob', () => {
+  it('returns a single chunk for a short blob', () => {
+    const blob = 'line one\nline two\nline three';
+    const chunks = chunkBlob(blob);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(blob);
+  });
+
+  function bigBlob(lineCount: number): string {
+    // Each line ~ 200 chars (~50 tokens); lineCount lines comfortably exceeds the threshold.
+    const line = 'word '.repeat(40).trim();
+    return Array.from({ length: lineCount }, (_, i) => `${i}: ${line}`).join('\n');
+  }
+
+  it('splits a long blob into multiple newline-oriented chunks', () => {
+    const blob = bigBlob(600);
+    expect(estimateTokens(blob)).toBeGreaterThan(MAX_INGEST_CHUNK_TOKENS);
+
+    const chunks = chunkBlob(blob);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should stay within (roughly) the token threshold.
+    for (const chunk of chunks) {
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(MAX_INGEST_CHUNK_TOKENS + 200);
+    }
+  });
+
+  it('overlaps adjacent chunks by ~10–15% of lines (A5)', () => {
+    const blob = bigBlob(600);
+    const chunks = chunkBlob(blob);
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // The tail lines of chunk N must reappear as a contiguous prefix at the head
+    // of chunk N+1 (the ~10–15% line overlap, A5).
+    const firstLines = chunks[0].split('\n');
+    const secondLines = chunks[1].split('\n');
+
+    // The single last line of chunk 0 must reappear inside chunk 1's overlap region.
+    const lastLine = firstLines[firstLines.length - 1];
+    expect(secondLines).toContain(lastLine);
+
+    // Find how long the shared prefix is, then assert it is a real tail of chunk 0.
+    const overlapLen = secondLines.indexOf(lastLine) + 1;
+    expect(overlapLen).toBeGreaterThan(0);
+    const chunk0Tail = firstLines.slice(firstLines.length - overlapLen);
+    expect(secondLines.slice(0, overlapLen)).toEqual(chunk0Tail);
+  });
+
+  it('hard-splits a single pathological line longer than the threshold', () => {
+    const hugeLine = 'token '.repeat(MAX_INGEST_CHUNK_TOKENS * 2).trim();
+    expect(estimateTokens(hugeLine)).toBeGreaterThan(MAX_INGEST_CHUNK_TOKENS);
+
+    const chunks = chunkBlob(hugeLine);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(MAX_INGEST_CHUNK_TOKENS + 200);
+    }
+  });
+
+  it('enforces the token cap as a HARD bound on a whitespace-free giant line (P1)', () => {
+    // A 100k-char line with NO whitespace (e.g. base64 / minified JSON / one giant
+    // token). Whitespace-splitting alone would return it whole and blow the cap;
+    // the char-based hard cut must keep every emitted piece at or under the budget.
+    const hugeToken = 'A'.repeat(100_000);
+    expect(estimateTokens(hugeToken)).toBeGreaterThan(MAX_INGEST_CHUNK_TOKENS);
+
+    const chunks = chunkBlob(hugeToken);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      // HARD bound: no slack — each piece is ≤ the cap, not cap + epsilon.
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(MAX_INGEST_CHUNK_TOKENS);
+    }
+    // Round-trips losslessly (the cut only partitions, never drops characters).
+    expect(chunks.join('')).toBe(hugeToken);
+  });
+
+  it('bounds the total chunk count at MAX_INGEST_CHUNKS', () => {
+    const blob = bigBlob(20000);
+    const chunks = chunkBlob(blob);
+    expect(chunks.length).toBeLessThanOrEqual(MAX_INGEST_CHUNKS);
+  });
+});

--- a/packages/memory-mcp-server/test/ingest-tool.test.ts
+++ b/packages/memory-mcp-server/test/ingest-tool.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { MemoryEngine } from '../src/engine.js';
+import type { IngestResult } from '../src/types.js';
+import { validateIngestInput, handleIngest, formatIngestResult } from '../src/tools/ingest.js';
+
+function createMockEngine(ingestResult: IngestResult): MemoryEngine {
+  return {
+    store: vi.fn().mockResolvedValue({ id: 'x', action: 'created' }),
+    ingest: vi.fn().mockResolvedValue(ingestResult),
+    recall: vi.fn(),
+    context: vi.fn(),
+    forget: vi.fn(),
+    inspect: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+describe('validateIngestInput', () => {
+  it('rejects missing content', () => {
+    expect(() => validateIngestInput({})).toThrow('content is required');
+  });
+
+  it('rejects empty / whitespace-only content', () => {
+    expect(() => validateIngestInput({ content: '   ' })).toThrow('content is required');
+  });
+
+  it('rejects non-string content', () => {
+    expect(() => validateIngestInput({ content: 42 })).toThrow('content is required');
+  });
+
+  it('trims content', () => {
+    const input = validateIngestInput({ content: '  hello  ' });
+    expect(input.content).toBe('hello');
+  });
+
+  it('defaults mode to conversation', () => {
+    const input = validateIngestInput({ content: 'x' });
+    expect(input.mode).toBe('conversation');
+  });
+
+  it('accepts mode=document', () => {
+    const input = validateIngestInput({ content: 'x', mode: 'document' });
+    expect(input.mode).toBe('document');
+  });
+
+  it('rejects an invalid mode', () => {
+    expect(() => validateIngestInput({ content: 'x', mode: 'summary' })).toThrow('mode must be');
+  });
+
+  it('defaults on_extraction_failure to degrade', () => {
+    const input = validateIngestInput({ content: 'x' });
+    expect(input.on_extraction_failure).toBe('degrade');
+  });
+
+  it('accepts skip and error for on_extraction_failure', () => {
+    expect(validateIngestInput({ content: 'x', on_extraction_failure: 'skip' }).on_extraction_failure).toBe('skip');
+    expect(validateIngestInput({ content: 'x', on_extraction_failure: 'error' }).on_extraction_failure).toBe('error');
+  });
+
+  it('rejects an on_extraction_failure outside the enum', () => {
+    expect(() => validateIngestInput({ content: 'x', on_extraction_failure: 'retry' })).toThrow(
+      'on_extraction_failure must be',
+    );
+  });
+
+  it('defaults dry_run to false', () => {
+    expect(validateIngestInput({ content: 'x' }).dry_run).toBe(false);
+  });
+
+  it('rejects a non-boolean dry_run', () => {
+    expect(() => validateIngestInput({ content: 'x', dry_run: 'yes' })).toThrow('dry_run must be a boolean');
+  });
+
+  describe('as_of normalization', () => {
+    it('passes through an epoch-ms number', () => {
+      const input = validateIngestInput({ content: 'x', as_of: 1_700_000_000_000 });
+      expect(input.as_of).toBe(1_700_000_000_000);
+    });
+
+    it('normalizes an ISO 8601 string to epoch ms', () => {
+      const iso = '2023-01-15T00:00:00.000Z';
+      const input = validateIngestInput({ content: 'x', as_of: iso });
+      expect(input.as_of).toBe(Date.parse(iso));
+    });
+
+    it('accepts a numeric STRING as epoch ms (P2)', () => {
+      const input = validateIngestInput({ content: 'x', as_of: '1700000000000' });
+      expect(input.as_of).toBe(1_700_000_000_000);
+      // The engine contract is numeric — never a string.
+      expect(typeof input.as_of).toBe('number');
+    });
+
+    it('rejects an empty / whitespace-only as_of string (P2 — Number("") is 0, must stay unparseable)', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: '' })).toThrow('as_of');
+      expect(() => validateIngestInput({ content: 'x', as_of: '   ' })).toThrow('as_of');
+    });
+
+    it('rejects a negative numeric as_of string (P2)', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: '-1700000000000' })).toThrow('as_of');
+    });
+
+    it('rejects a non-parseable as_of string', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: 'not a date' })).toThrow('as_of');
+    });
+
+    it('rejects a negative as_of number', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: -5 })).toThrow('as_of');
+    });
+
+    it('rejects a non-finite as_of number', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: Number.POSITIVE_INFINITY })).toThrow('as_of');
+    });
+
+    it('leaves as_of undefined when omitted', () => {
+      expect(validateIngestInput({ content: 'x' }).as_of).toBeUndefined();
+    });
+  });
+
+  it('validates tags and importance', () => {
+    const input = validateIngestInput({ content: 'x', tags: ['a', 'b'], importance: 0.7 });
+    expect(input.tags).toEqual(['a', 'b']);
+    expect(input.importance).toBe(0.7);
+  });
+
+  it('rejects importance out of [0,1]', () => {
+    expect(() => validateIngestInput({ content: 'x', importance: 1.5 })).toThrow('importance must be');
+  });
+});
+
+describe('handleIngest routing', () => {
+  it('routes to engine.ingest with normalized options', async () => {
+    const result: IngestResult = {
+      created: 2,
+      merged: 1,
+      ingested: 2,
+      memory_ids: ['a1b2c3d4e5', 'f6g7h8i9j0', 'k1l2m3n4o5'],
+      facts: [{ fact: 'f1' }, { fact: 'f2' }, { fact: 'f3' }],
+    };
+    const engine = createMockEngine(result);
+    const text = await handleIngest(engine, {
+      content: '  blob  ',
+      mode: 'document',
+      tags: ['seed'],
+      importance: 0.6,
+      as_of: '2023-01-15T00:00:00.000Z',
+    });
+
+    expect(engine.ingest).toHaveBeenCalledWith('blob', {
+      source: undefined,
+      mode: 'document',
+      tags: ['seed'],
+      importance: 0.6,
+      dry_run: false,
+      as_of: Date.parse('2023-01-15T00:00:00.000Z'),
+      on_extraction_failure: 'degrade',
+    });
+    expect(text).toContain('Ingested 3 atomic fact');
+    expect(text).toContain('2 new memories, 1 merged');
+  });
+});
+
+describe('formatIngestResult', () => {
+  it('renders a normal result reporting created and merged separately (A7)', () => {
+    const text = formatIngestResult({
+      created: 6,
+      merged: 1,
+      ingested: 6,
+      memory_ids: ['aaaaaaaa11', 'bbbbbbbb22'],
+      facts: Array.from({ length: 7 }, (_, i) => ({ fact: `f${i}` })),
+    });
+    expect(text).toContain('Ingested 7 atomic fact');
+    expect(text).toContain('6 new memories');
+    expect(text).toContain('1 merged into existing');
+    expect(text).toContain('aaaaaaaa…');
+  });
+
+  it('renders a dry_run preview with per-fact importance', () => {
+    const text = formatIngestResult({
+      created: 0,
+      merged: 0,
+      ingested: 0,
+      memory_ids: [],
+      facts: [{ fact: 'First fact', importance: 0.9 }, { fact: 'Second fact' }],
+    });
+    expect(text).toContain('Dry run — nothing written.');
+    expect(text).toContain('1. First fact (importance: 0.9)');
+    expect(text).toContain('2. Second fact');
+  });
+
+  it('renders a partial result', () => {
+    const text = formatIngestResult({
+      created: 3,
+      merged: 1,
+      ingested: 3,
+      memory_ids: ['id1', 'id2', 'id3', 'id4'],
+      facts: Array.from({ length: 4 }, (_, i) => ({ fact: `f${i}` })),
+      chunks: 3,
+      failed_chunks: 1,
+      degraded: true,
+      partial: true,
+    });
+    expect(text).toContain('Ingested 4 atomic fact');
+    expect(text).toContain('1 of 3 chunks failed extraction — partial result.');
+  });
+
+  it('renders a full degrade (single-blob store)', () => {
+    const text = formatIngestResult({
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: ['deadbeef99'],
+      facts: [{ fact: 'the whole blob', importance: 0.5 }],
+      degraded: true,
+    });
+    expect(text).toContain('stored the blob as a single memory deadbeef…');
+  });
+
+  it('renders a skipped result', () => {
+    const text = formatIngestResult({
+      created: 0,
+      merged: 0,
+      ingested: 0,
+      memory_ids: [],
+      facts: [],
+      skipped: true,
+    });
+    expect(text).toContain('nothing written');
+    expect(text).toContain('skip');
+  });
+});

--- a/packages/memory-mcp-server/test/ingest.test.ts
+++ b/packages/memory-mcp-server/test/ingest.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type Database from 'better-sqlite3';
+
+// ---- Mock the LLM client so extraction returns canned JSON, but the REAL ----
+// ---- embedder + store/dedup/insert pipeline run end-to-end. ----
+const llmMock = vi.hoisted(() => ({
+  // A queue of responses; each llmComplete call shifts one. A non-array value
+  // (null) simulates a hard LLM failure for that call.
+  responses: [] as Array<string | null>,
+  hasLLM: true,
+  calls: 0,
+}));
+
+vi.mock('../src/llm/client.js', () => ({
+  getLLMClient: vi.fn(() => (llmMock.hasLLM ? {} : null)),
+  llmComplete: vi.fn(async () => {
+    llmMock.calls += 1;
+    if (!llmMock.hasLLM) return null;
+    const next = llmMock.responses.shift();
+    return next === undefined ? null : next;
+  }),
+}));
+
+import { initDatabase } from '../src/storage/database.js';
+import { getNamespaceStats, getMemoriesByIds } from '../src/storage/queries.js';
+import { createMemoryEngineFromConfig } from '../src/engine-impl.js';
+import type { MemoryEngine } from '../src/engine.js';
+import type { MemoryConfig } from '../src/config.js';
+import { loadConfig } from '../src/config.js';
+
+const NAMESPACE = 'test';
+
+function setResponses(...responses: Array<string | null>): void {
+  llmMock.responses = responses;
+  llmMock.hasLLM = true;
+  llmMock.calls = 0;
+}
+
+function disableLLM(): void {
+  llmMock.responses = [];
+  llmMock.hasLLM = false;
+  llmMock.calls = 0;
+}
+
+function factsJson(facts: Array<{ fact: string; importance?: number }>): string {
+  return JSON.stringify(facts);
+}
+
+function testConfig(dbPath: string): MemoryConfig {
+  return {
+    ...loadConfig({}),
+    dbPath,
+    namespace: NAMESPACE,
+    // The mock controls LLM availability; set non-null so the engine path is "LLM on".
+    llmApiKey: 'test-key',
+    llmBaseUrl: 'http://localhost:1234/v1',
+    // Avoid maintenance noise interleaving in small tests.
+    maintenanceInterval: 10000,
+  };
+}
+
+describe('engine.ingest', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let engine: MemoryEngine;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'memory-ingest-test-'));
+    dbPath = join(tmpDir, 'test.db');
+    const config = testConfig(dbPath);
+    engine = createMemoryEngineFromConfig(config);
+    db = initDatabase(dbPath, config.embeddingModel);
+  });
+
+  afterEach(() => {
+    engine.close();
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('decomposes a blob into N rows', async () => {
+    setResponses(
+      factsJson([
+        { fact: 'The user is named Alice', importance: 0.9 },
+        { fact: 'Alice prefers dark mode', importance: 0.6 },
+        { fact: 'Alice works on the Iron project', importance: 0.5 },
+      ]),
+    );
+
+    const result = await engine.ingest('conversation blob', { mode: 'document' });
+
+    expect(result.created).toBe(3);
+    expect(result.ingested).toBe(3);
+    expect(result.merged).toBe(0);
+    expect(result.memory_ids).toHaveLength(3);
+
+    const stats = getNamespaceStats(db, NAMESPACE);
+    expect(stats.total_memories).toBe(3);
+
+    const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+    const contents = rows.map((r) => r.content).sort();
+    expect(contents).toEqual(['Alice prefers dark mode', 'Alice works on the Iron project', 'The user is named Alice']);
+  });
+
+  it('lands per-fact importance on rows, falling back to the seed when omitted', async () => {
+    setResponses(
+      factsJson([
+        { fact: 'High salience fact', importance: 0.9 },
+        { fact: 'Low salience fact', importance: 0.2 },
+        { fact: 'No importance fact' }, // falls back to seed
+      ]),
+    );
+
+    const result = await engine.ingest('blob', { importance: 0.5 });
+    const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+    const byContent = new Map(rows.map((r) => [r.content, r.importance]));
+
+    expect(byContent.get('High salience fact')).toBeCloseTo(0.9, 5);
+    expect(byContent.get('Low salience fact')).toBeCloseTo(0.2, 5);
+    expect(byContent.get('No importance fact')).toBeCloseTo(0.5, 5);
+  });
+
+  it('dry_run writes nothing but returns the facts', async () => {
+    setResponses(
+      factsJson([{ fact: 'Fact one', importance: 0.7 }, { fact: 'Fact two', importance: 0.3 }, { fact: 'Fact three' }]),
+    );
+
+    const result = await engine.ingest('blob', { dry_run: true });
+
+    expect(result.created).toBe(0);
+    expect(result.facts).toHaveLength(3);
+    expect(result.facts[0].importance).toBe(0.7);
+    expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(0);
+  });
+
+  describe('as_of stamping (created path)', () => {
+    const T_OLD = Date.parse('2023-03-01T00:00:00.000Z');
+
+    it('stamps created/updated/last_accessed to a numeric as_of', async () => {
+      setResponses(factsJson([{ fact: 'Backdated fact', importance: 0.5 }]));
+      const result = await engine.ingest('blob', { as_of: T_OLD });
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.created_at).toBe(T_OLD);
+      expect(row.updated_at).toBe(T_OLD);
+      expect(row.last_accessed_at).toBe(T_OLD);
+    });
+
+    it('omitting as_of yields created_at ≈ Date.now()', async () => {
+      setResponses(factsJson([{ fact: 'Current fact', importance: 0.5 }]));
+      const before = Date.now();
+      const result = await engine.ingest('blob', {});
+      const after = Date.now();
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.created_at).toBeGreaterThanOrEqual(before);
+      expect(row.created_at).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('order-independent merge timestamps (A1)', () => {
+    const T_OLD = Date.parse('2022-01-01T00:00:00.000Z');
+    const T_NEW = Date.parse('2024-06-01T00:00:00.000Z');
+    const FACT = 'Alice prefers dark mode';
+
+    // NOTE on updated_at: the merge calls updateMemoryContent (which stamps
+    // updated_at = now) BEFORE updateMemoryTimestampsOnMerge runs MAX(updated_at, asOf).
+    // With asOf in the past, MAX(now, asOf) === now, so updated_at lands at ~now
+    // (the true "last touched" time — the merge just happened). created_at (MIN) and
+    // last_accessed_at (MAX, untouched by updateMemoryContent) are the clean reconciled
+    // values. This is the design's §5.4 SQL composed faithfully; see the report.
+    it('reconciles min(created)/max(last_accessed) when newer merges into older', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob A', { as_of: T_OLD });
+
+      const before = Date.now();
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob B', { as_of: T_NEW });
+      const after = Date.now();
+
+      expect(second.created).toBe(0);
+      expect(second.merged).toBe(1);
+      expect(second.memory_ids[0]).toBe(first.memory_ids[0]);
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.created_at).toBe(T_OLD); // MIN(T_OLD, T_NEW)
+      expect(row.last_accessed_at).toBe(T_NEW); // MAX(T_OLD, T_NEW)
+      expect(row.updated_at).toBeGreaterThanOrEqual(before); // MAX(now, T_NEW) === now
+      expect(row.updated_at).toBeLessThanOrEqual(after);
+    });
+
+    it('is order-independent: same survivor created/last_accessed in reverse ingest order', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob B', { as_of: T_NEW });
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob A', { as_of: T_OLD });
+
+      expect(second.merged).toBe(1);
+      expect(second.memory_ids[0]).toBe(first.memory_ids[0]);
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      // Same reconciled values regardless of which order the two as_ofs arrived.
+      expect(row.created_at).toBe(T_OLD); // MIN
+      expect(row.last_accessed_at).toBe(T_NEW); // MAX
+    });
+
+    it('a non-as_of merge leaves created_at untouched and bumps updated_at', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob A', { as_of: T_OLD });
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob B', {}); // no as_of
+
+      expect(second.merged).toBe(1);
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.created_at).toBe(T_OLD); // untouched (min not invoked)
+      expect(row.updated_at).toBeGreaterThan(T_OLD); // bumped to ~now by updateMemoryContent
+    });
+
+    // Proves the MAX(updated_at, ?) clause is LIVE rather than dead. Every other A1
+    // test uses a PAST as_of, where updateMemoryContent already stamped updated_at=now
+    // and MAX(now, past)=now — so the clause never moves the value. Only a FUTURE
+    // as_of (> the existing updated_at, i.e. > now) makes MAX pick the as_of, which is
+    // the assertion below. For the realistic backfill case (a PAST as_of, e.g. a
+    // multi-year export) updated_at correctly stays ≈ now — the merge just happened —
+    // which is exactly what the two reconcile tests above already verify.
+    it('moves updated_at to a FUTURE as_of greater than the existing updated_at (A1 — MAX clause is live)', async () => {
+      const T_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000; // ~1 year ahead, > now
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob A', {}); // created at ~now
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob B', { as_of: T_FUTURE });
+
+      expect(second.merged).toBe(1);
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      // MAX(updated_at≈now, T_FUTURE) === T_FUTURE — the clause actually moved it.
+      expect(row.updated_at).toBe(T_FUTURE);
+      // last_accessed_at = MAX(≈now, T_FUTURE) likewise advances.
+      expect(row.last_accessed_at).toBe(T_FUTURE);
+      // created_at = MIN(≈now, T_FUTURE) stays at the original (~now), not the future.
+      expect(row.created_at).toBeLessThan(T_FUTURE);
+    });
+  });
+
+  describe('merge importance composes (A1/A2)', () => {
+    const FACT = 'Bob lives in Berlin';
+
+    it('a higher-importance duplicate raises the survivor importance', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.3 }]));
+      const first = await engine.ingest('blob', {});
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.9 }]));
+      await engine.ingest('blob', {});
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.importance).toBeCloseTo(0.9, 5);
+    });
+
+    it('a lower-importance duplicate does not lower the survivor importance', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.8 }]));
+      const first = await engine.ingest('blob', {});
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.1 }]));
+      await engine.ingest('blob', {});
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.importance).toBeCloseTo(0.8, 5);
+    });
+  });
+
+  it('reports honest stats when a fact duplicates an existing row (A7)', async () => {
+    setResponses(factsJson([{ fact: 'Existing fact', importance: 0.5 }]));
+    await engine.ingest('blob', {});
+
+    setResponses(
+      factsJson([
+        { fact: 'Existing fact', importance: 0.5 }, // duplicate → merged
+        { fact: 'Brand new fact one', importance: 0.5 },
+        { fact: 'Brand new fact two', importance: 0.5 },
+      ]),
+    );
+    const result = await engine.ingest('blob', {});
+
+    expect(result.created).toBe(2);
+    expect(result.merged).toBe(1);
+    expect(result.ingested).toBe(2);
+    expect(result.memory_ids).toHaveLength(3);
+  });
+
+  describe('extraction failure handling (A3)', () => {
+    it("default 'degrade' with no LLM stores the blob as a single memory", async () => {
+      disableLLM();
+      const blob = 'unstructured content with no LLM available';
+      const result = await engine.ingest(blob, {});
+
+      expect(result.created).toBe(1);
+      expect(result.degraded).toBe(true);
+      const stats = getNamespaceStats(db, NAMESPACE);
+      expect(stats.total_memories).toBe(1);
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.content).toBe(blob);
+    });
+
+    it("'skip' writes nothing and reports skipped without throwing", async () => {
+      disableLLM();
+      const result = await engine.ingest('blob', { on_extraction_failure: 'skip' });
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(true);
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(0);
+    });
+
+    it("'error' rejects, with no input substring in the message (A6)", async () => {
+      disableLLM();
+      const sensitive = 'CREDIT-CARD-4111-1111-1111-1111';
+      await expect(engine.ingest(`secret blob ${sensitive}`, { on_extraction_failure: 'error' })).rejects.toThrow();
+
+      try {
+        await engine.ingest(`secret blob ${sensitive}`, { on_extraction_failure: 'error' });
+        throw new Error('expected ingest to reject');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).not.toContain(sensitive);
+      }
+    });
+
+    it('malformed (non-JSON) response degrades to a single-blob store (does not throw)', async () => {
+      setResponses('not json at all');
+      const result = await engine.ingest('blob to degrade', {});
+
+      expect(result.degraded).toBe(true);
+      expect(result.created).toBe(1);
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(1);
+    });
+  });
+
+  it('propagates seed tags and source to every written fact', async () => {
+    setResponses(
+      factsJson([
+        { fact: 'Tagged fact one', importance: 0.5 },
+        { fact: 'Tagged fact two', importance: 0.5 },
+      ]),
+    );
+    const result = await engine.ingest('blob', { tags: ['seed-tag'], source: 'session:abc' });
+
+    const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.source).toBe('session:abc');
+      expect(row.tags).toContain('seed-tag');
+    }
+  });
+
+  describe('chunking integration (A5)', () => {
+    function bigBlob(): string {
+      // ~150 chars/line × 250 lines ≈ 9400 tokens → ~2-3 chunks (keeps embeds cheap).
+      const line = 'sentence words here '.repeat(8).trim();
+      return Array.from({ length: 250 }, (_, i) => `${i}: ${line}`).join('\n');
+    }
+
+    it('makes >1 LLM call, unions facts, and reports chunks>1', async () => {
+      // Two distinct facts per chunk; enough responses for however many chunks form.
+      const perChunk = (n: number): string => factsJson([{ fact: `chunk ${n} fact A` }, { fact: `chunk ${n} fact B` }]);
+      setResponses(...Array.from({ length: 50 }, (_, i) => perChunk(i)));
+
+      const result = await engine.ingest(bigBlob(), { mode: 'document' });
+
+      expect(llmMock.calls).toBeGreaterThan(1);
+      expect(result.chunks).toBeGreaterThan(1);
+      expect(result.created).toBeGreaterThan(2); // facts from multiple chunks unioned
+    });
+  });
+
+  describe('partial extraction is observable (A3)', () => {
+    function bigBlob(): string {
+      // ~150 chars/line × 250 lines ≈ 9400 tokens → ~2-3 chunks (keeps embeds cheap).
+      const line = 'sentence words here '.repeat(8).trim();
+      return Array.from({ length: 250 }, (_, i) => `${i}: ${line}`).join('\n');
+    }
+
+    it('ingests good chunks and flags partial/degraded/failed_chunks when one chunk fails', async () => {
+      // First chunk → facts; all subsequent chunks → null (hard LLM failure).
+      const responses: Array<string | null> = [
+        factsJson([{ fact: 'good chunk fact A' }, { fact: 'good chunk fact B' }]),
+      ];
+      for (let i = 0; i < 49; i++) responses.push(null);
+      setResponses(...responses);
+
+      const result = await engine.ingest(bigBlob(), { mode: 'document' });
+
+      expect(result.created).toBeGreaterThanOrEqual(2);
+      expect(result.partial).toBe(true);
+      expect(result.degraded).toBe(true);
+      expect(result.failed_chunks).toBeGreaterThanOrEqual(1);
+      expect(result.chunks).toBeGreaterThan(1);
+    });
+  });
+
+  describe('PII-safe logging on failure (A6)', () => {
+    it('does not leak a sensitive marker to ANY stderr channel on parse failure or LLM error', async () => {
+      // Widened beyond console.error to also cover process.stderr.write and
+      // console.warn — future-proofs the guarantee against a regression that emits
+      // via a different channel (T3).
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const sensitive = 'PASSPORT-X9988776655';
+
+      // Parse failure: non-JSON response containing the marker would only be in `raw`.
+      setResponses(`I refuse. The input mentioned ${sensitive}.`);
+      const r1 = await engine.ingest(`blob with ${sensitive}`, {});
+      expect(r1.degraded).toBe(true);
+
+      // LLM error path.
+      disableLLM();
+      const r2 = await engine.ingest(`another blob ${sensitive}`, { on_extraction_failure: 'skip' });
+      expect(r2.skipped).toBe(true);
+
+      const allLogs = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...stderrSpy.mock.calls]
+        .map((c) => JSON.stringify(c))
+        .join('\n');
+      expect(allLogs).not.toContain(sensitive);
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      stderrSpy.mockRestore();
+    });
+  });
+});

--- a/packages/memory-mcp-server/test/server.test.ts
+++ b/packages/memory-mcp-server/test/server.test.ts
@@ -7,6 +7,13 @@ import { createServer } from '../src/server.js';
 function createMockEngine(): MemoryEngine {
   return {
     store: vi.fn().mockResolvedValue({ id: 'test-id', action: 'created' }),
+    ingest: vi.fn().mockResolvedValue({
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: ['test-id'],
+      facts: [{ fact: 'A fact', importance: 0.5 }],
+    }),
     recall: vi.fn().mockResolvedValue({
       content: 'test recall',
       memories_used: 1,
@@ -40,14 +47,21 @@ async function createConnectedClient(engine: MemoryEngine) {
 }
 
 describe('MCP server', () => {
-  it('lists all 5 memory tools', async () => {
+  it('lists all 6 memory tools', async () => {
     const engine = createMockEngine();
     const { client } = await createConnectedClient(engine);
 
     const { tools } = await client.listTools();
     const toolNames = tools.map((t) => t.name).sort();
 
-    expect(toolNames).toEqual(['memory_context', 'memory_forget', 'memory_inspect', 'memory_recall', 'memory_store']);
+    expect(toolNames).toEqual([
+      'memory_context',
+      'memory_forget',
+      'memory_ingest',
+      'memory_inspect',
+      'memory_recall',
+      'memory_store',
+    ]);
   });
 
   it('memory_store tool has correct schema', async () => {
@@ -72,6 +86,25 @@ describe('MCP server', () => {
     expect(recallTool).toBeDefined();
     expect(recallTool!.description).toContain('Recall memories');
     expect(recallTool!.inputSchema.required).toContain('query');
+  });
+
+  it('memory_ingest tool has correct schema', async () => {
+    const engine = createMockEngine();
+    const { client } = await createConnectedClient(engine);
+
+    const { tools } = await client.listTools();
+    const ingestTool = tools.find((t) => t.name === 'memory_ingest');
+
+    expect(ingestTool).toBeDefined();
+    expect(ingestTool!.inputSchema.required).toContain('content');
+
+    // Everything except `content` is optional.
+    const required = ingestTool!.inputSchema.required ?? [];
+    const properties = ingestTool!.inputSchema.properties ?? {};
+    for (const optional of ['mode', 'dry_run', 'as_of', 'on_extraction_failure', 'tags', 'importance', 'source']) {
+      expect(properties).toHaveProperty(optional);
+      expect(required).not.toContain(optional);
+    }
   });
 
   it('memory_context tool has no required params', async () => {

--- a/packages/memory-mcp-server/test/tools.test.ts
+++ b/packages/memory-mcp-server/test/tools.test.ts
@@ -9,6 +9,13 @@ import { validateInspectInput, handleInspect } from '../src/tools/inspect.js';
 function createMockEngine(overrides: Partial<MemoryEngine> = {}): MemoryEngine {
   return {
     store: vi.fn().mockResolvedValue({ id: 'abc123', action: 'created' }),
+    ingest: vi.fn().mockResolvedValue({
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: ['abc123'],
+      facts: [{ fact: 'A fact', importance: 0.5 }],
+    }),
     recall: vi.fn().mockResolvedValue({
       content: 'Recalled content',
       memories_used: 3,

--- a/scripts/memory-corpus/README.md
+++ b/scripts/memory-corpus/README.md
@@ -1,0 +1,260 @@
+# memory-corpus — claude.ai export → memory corpus builder
+
+`build-corpus.ts` ingests a claude.ai conversation export into a memory DB via
+the `memory_ingest` path (`ingestBlob`), one conversation at a time, backdated to
+each conversation's real date. It produces a representative, recency- and
+importance-spread eval corpus for the memory-mcp-server.
+
+It drives a single Node process (run via `tsx`) that owns the DB and imports the
+engine internals directly — the same pattern as the LoCoMo fixture builder.
+
+## ⚠️ SENSITIVE DATA — read first
+
+- The export (`conversations.json`) and the resulting DB contain **private
+  conversation content and PII**. Both live under the **gitignored
+  `donotcommit/`** directory and **must never be committed**.
+- Conversation `name`/`summary`/message `text`/`content` are **sensitive**. This
+  driver **never** writes any of them to logs or to the progress file. The
+  progress file (`progress.jsonl`) and the stderr progress lines carry **counts
+  and opaque uuids only** — no fact text, no transcript.
+- The SUMMARY printed at the end is content-free: it reports counts, importance
+  min/max/mean, and created_at min/max (epoch-derived ISO timestamps) — never
+  any conversation content.
+- Ingestion **egresses each conversation transcript to the configured LLM**
+  (Haiku) for fact extraction. `--dry-run` skips local persistence but **still
+  egresses** to Haiku — it is not a no-network mode. Run the real ingestion
+  yourself, with consent to that egress.
+
+## Environment
+
+- **`ANTHROPIC_API_KEY`** — **required**. The corpus needs the LLM; the driver
+  exits with an error if the key is missing (no silent degrade). Load it via
+  `--import dotenv/config` from your `.env`, or export it.
+
+The driver sets these `MEMORY_*` vars in-process before `loadConfig()`:
+
+| var                           | value                                     | why                                              |
+| ----------------------------- | ----------------------------------------- | ------------------------------------------------ |
+| `MEMORY_LLM_BASE_URL`         | `https://api.anthropic.com/v1/`           | OpenAI-compatible Haiku endpoint                 |
+| `MEMORY_LLM_API_KEY`          | `$ANTHROPIC_API_KEY`                      | extraction auth                                  |
+| `MEMORY_LLM_MODEL`            | `claude-haiku-4-5-20251001` (overridable) | extraction model                                 |
+| `MEMORY_DB_PATH`              | resolved `--db`                           | output DB                                        |
+| `MEMORY_NAMESPACE`            | `--namespace`                             | corpus isolation                                 |
+| `MEMORY_MAINTENANCE_INTERVAL` | `100000000`                               | suppress per-store maintenance (see determinism) |
+| `MEMORY_DECAY_THRESHOLD`      | `0`                                       | belt-and-suspenders: never decay                 |
+| `MEMORY_RERANKER_ENABLED`     | `false`                                   | no cross-encoder download during ingest          |
+
+## Run commands
+
+All paths default under `donotcommit/`; the driver `mkdirSync`s the DB directory.
+
+```bash
+# Validation: first 3 non-empty conversations (writes a small corpus)
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --limit 3
+
+# Dry-run: extract + preview only, write nothing (STILL egresses to Haiku)
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --limit 3 --dry-run
+
+# Single conversation by uuid
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --conversation <uuid>
+
+# Full run (all 503 conversations; 6 empty ones are skipped)
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts
+
+# Resume: skip conversations already recorded done; retry recorded failures
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --resume
+
+# Help
+npx tsx scripts/memory-corpus/build-corpus.ts --help
+```
+
+### Flags
+
+| flag                    | default                                        | meaning                                                  |
+| ----------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `--export <path>`       | `donotcommit/claude-export/conversations.json` | export JSON (top-level array)                            |
+| `--db <path>`           | `donotcommit/corpus/memories.memdb`            | output memdb                                             |
+| `--namespace <name>`    | `claude-export`                                | memory namespace                                         |
+| `--limit <N>`           | (all)                                          | process only first N **non-empty** conversations         |
+| `--conversation <uuid>` | (all)                                          | process only that conversation                           |
+| `--dry-run`             | off                                            | extract but write nothing (still egresses to Haiku)      |
+| `--resume`              | off                                            | skip conversations recorded done; retry `skipped-failed` |
+| `-h, --help`            | —                                              | show help                                                |
+
+## Per-conversation behavior
+
+- The 6 empty conversations (and any with no non-empty messages) are skipped and
+  recorded as `skipped-empty`.
+- The transcript is assembled as one `${sender}: ${text}` line per message with
+  non-empty `text` (we use `text`, not `content`), joined by newlines.
+- Ingest is called with `mode: 'document'` (durable facts across turns;
+  transcripts rarely state facts in one explicit sentence), `as_of` = the
+  conversation `created_at`, `source` = `claude-export:<uuid>`, `tags:
+['claude-export']`, and `on_extraction_failure: 'skip'`. Per-fact importance
+  comes from extraction (no call-level importance is passed).
+- `on_extraction_failure: 'skip'` means a fully-failed extraction writes nothing
+  and is recorded as `skipped-failed` — no single-blob contamination, and the
+  conversation is retried on `--resume`.
+
+### `progress.jsonl` (content-free)
+
+One line per conversation in the DB directory:
+
+```json
+{
+  "uuid": "...",
+  "status": "ingested|partial|skipped-empty|skipped-failed",
+  "created": 7,
+  "merged": 1,
+  "facts": 8,
+  "failed_chunks": 0,
+  "chunks": 2
+}
+```
+
+- `skipped-failed` when the ingest result is `skipped`.
+- `partial` when some (not all) chunks failed but others produced facts.
+- otherwise `ingested`.
+
+## Resumability
+
+On start the driver loads `progress.jsonl`. With `--resume`, it skips every uuid
+that has any record with status `ingested`, `partial`, or `skipped-empty`, and
+**retries** uuids whose only record is `skipped-failed`. Without `--resume`, an
+existing DB/progress emits a warning and the run **appends** (it does not reset).
+
+## Determinism rationale (why decay is off + consolidation-only)
+
+`maybeRunMaintenance` (called per-store inside `ingestBlob → store →
+storeImmediate`) runs the **full** `runMaintenance`, which includes a **DECAY**
+phase. `computeVitality` uses `now - created_at`; our backdated 2023–2024 facts
+have an age of ~1000 days against a ~90-day half-life, so a mid-bulk decay pass
+would mark them DECAYED (importance → 0) and **destroy the recency/importance
+spread that is the entire point of the corpus**.
+
+So the driver:
+
+1. Sets `MEMORY_MAINTENANCE_INTERVAL` very high (100,000,000) so per-store
+   maintenance **never fires mid-bulk**.
+2. Sets `MEMORY_DECAY_THRESHOLD=0` as belt-and-suspenders.
+3. At the very end runs **`runConsolidation(db, config)` ONLY** (deferred dedup /
+   contradiction resolution) — **never** `runMaintenance` (which would decay).
+
+The end-of-run SUMMARY queries the DB directly for importance min/max/mean and
+created_at min/max — these prove the corpus is **non-flat** (a spread of
+salience and a multi-year recency range).
+
+## Content-free guarantee
+
+Every artifact and log line this driver emits is content-free: opaque uuids
+(prefix only on stderr), integer counts, importance statistics, and
+epoch-derived timestamps. No conversation `name`/`summary`/`text`/`content`, no
+extracted fact text, and no model output is ever logged or written to
+`progress.jsonl` or the SUMMARY.
+
+---
+
+# diagnose-corpus — representativeness diagnostic (GO/NO-GO)
+
+`diagnose-corpus.ts` answers ONE question with a GO/NO-GO verdict: **is this
+corpus non-degenerate enough that evolving the composite retrieval scorer is
+meaningful** — i.e. are the metadata signals (recency, importance) ALIVE and do
+they actively reshape rankings, unlike the LoCoMo benchmark where flat metadata
+(importance ≡ 0.5, identical `created_at`) made those terms dead weight?
+
+The pure analysis logic lives in `diagnose-lib.ts` and is unit tested in
+isolation with SYNTHETIC fixtures (`test/diagnose-corpus.test.ts`) — including a
+degenerate LoCoMo-shaped fixture that must yield NO-GO and a healthy one that
+must yield GO (the anti-vacuity proof).
+
+## Three analyses, then a verdict
+
+**A. Distributional liveness** (real db, READ-ONLY SQL — no LLM, no retrieval):
+
+- **Recency**: min/max `created_at`, span days, distinct year-months, stddev,
+  fraction of rows per calendar year, histogram by quarter.
+- **Importance**: min/max/mean/stddev, distinct values, histogram (0.1 buckets),
+  fraction sitting **exactly** at the 0.5 seed.
+- **Access**: `access_count` distribution. On a fresh corpus this is ~0 — access
+  is a **LATENT, usage-driven** signal that stays zero until the corpus is
+  queried. This is reported honestly and does **not** fail the verdict.
+- **content_length**: min/max/mean/percentiles — a sanity check that facts are
+  ATOMIC-sized (tens–low-hundreds of chars), proving decomposition worked.
+
+**B. Self-supervised recall probe** (needs Haiku + retrieval; runs on a db
+**COPY** so the real corpus stays pristine — retrieval mutates access stats):
+
+- Sample `--sample N` facts (default 120) **stratified across recency buckets**
+  (seeded PRNG via `--seed`, so re-runs match) so older years are represented.
+- One Haiku call per sampled fact generates a natural question it answers; the
+  fact's id is the gold.
+- For each question, the REAL hybrid candidate pool (vector KNN + FTS5 +
+  production fusion) is retrieved and a **content-free** fixture row is written
+  to `donotcommit/corpus/diagnostic-fixture.jsonl`:
+  `{ query_id, gold_id, candidates: [{ id, is_gold, vector_distance, bm25_score,
+created_at, last_accessed_at, access_count, importance, content_length }] }`.
+  **No content/fact/query text** is ever in the fixture.
+- Purely on the fixture, `recall@token-budget` (default `--budget 300`, matching
+  the evolve dogfood) is computed for `composite` (full production),
+  `fusion-only`, `recency-only`, `importance-only`, `access-only`, `bm25-only`,
+  `vector-only`. The `composite`/`fusion-only` variants **reuse the production
+  scoring functions** (`computeCompositeScore`, `hybridScoreFusion`,
+  `packToBudget`, `estimateTokens`) so the diagnostic reflects what `evolve`
+  would actually tune; the single-signal variants are trivial reference rankers.
+- **Ranking influence**: mean Kendall-tau between the `composite` and
+  `fusion-only` per-query orderings. Tau well below 1.0 ⇒ the recency/importance
+  terms actively reshape rankings (the LIVE-lever test).
+
+**C. Verdict (GO/NO-GO)** with the numbers, the thresholds, and the reasoning:
+
+| condition                    | rule (default threshold)                                           |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `recency_live`               | span > 365 days AND ≥ 12 distinct year-months AND stddev ≥ 30 days |
+| `importance_live`            | importance stddev ≥ 0.05 AND fraction-at-0.5 < 0.5                 |
+| `reshapes_rankings`          | mean Kendall-tau(composite, fusion-only) < 0.9                     |
+| `not_single_signal_confound` | composite recall ≥ every single-signal baseline (supporting only)  |
+
+**GO** iff `recency_live AND importance_live AND reshapes_rankings` (the core
+anti-LoCoMo conditions). `not_single_signal_confound` is reported as supporting
+evidence but does **not** gate the verdict. **NO-GO** names which condition(s)
+failed. The process exits `0` on GO, `1` on NO-GO, `2` on error.
+
+## Run commands
+
+```bash
+# Full diagnostic (Part A read-only + Part B probe on a db copy)
+npx tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts
+
+# Smaller, faster probe with a fixed seed and tighter budget
+npx tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts --sample 40 --budget 200 --seed 7
+
+# Help (no API key needed)
+npx tsx scripts/memory-corpus/diagnose-corpus.ts --help
+
+# Pure-logic unit tests (no db, no LLM) — includes the LoCoMo-degenerate→NO-GO
+# and healthy→GO anti-vacuity cases
+npm test -- test/diagnose-corpus.test.ts
+```
+
+### Flags
+
+| flag                 | default                             | meaning                                           |
+| -------------------- | ----------------------------------- | ------------------------------------------------- |
+| `--db <path>`        | `donotcommit/corpus/memories.memdb` | corpus memdb (read-only for Part A, copied for B) |
+| `--namespace <name>` | `claude-export`                     | memory namespace                                  |
+| `--sample <N>`       | `120`                               | probe sample size, stratified by recency          |
+| `--budget <tokens>`  | `300`                               | recall@token-budget (matches evolve dogfood)      |
+| `--seed <int>`       | `1`                                 | deterministic sampling seed                       |
+
+## Pristineness + content-free guarantee
+
+- Part A opens the db **read-only** (`{ readonly: true }`) and only runs
+  `SELECT` — it never mutates the real corpus.
+- Part B copies the `.memdb` (+ WAL/SHM sidecars) to a temp dir and runs the
+  probe on the **copy**, then deletes the temp dir. The candidate pool is built
+  by calling `vectorSearch`/`ftsSearch`/`hybridScoreFusion` directly (NOT
+  `recall()`), so even the copy's access stats are never bumped and **no content
+  leaves the retrieval layer** — only numeric signals.
+- Every artifact (`diagnostic-fixture.jsonl`, `diagnostic-report.json`) and every
+  stdout/stderr line is content-free: opaque ids, numeric signals, and verdict
+  aggregates only. Both artifacts live under the gitignored `donotcommit/`.

--- a/scripts/memory-corpus/build-corpus.ts
+++ b/scripts/memory-corpus/build-corpus.ts
@@ -1,0 +1,334 @@
+/**
+ * Corpus-build driver: ingest a claude.ai conversation export into a memory DB
+ * via the `memory_ingest` (ingestBlob) path.
+ *
+ * Run with tsx, loading .env for ANTHROPIC_API_KEY:
+ *   npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --limit 3
+ *
+ * Pattern: a single Node process that owns the DB and imports the engine
+ * internals directly (mirrors the LoCoMo fixture builder). One LLM call per
+ * chunk goes to Haiku; nothing else egresses.
+ *
+ * SENSITIVE DATA: the export and the DB hold private conversation content. This
+ * driver NEVER writes conversation/fact text to logs or to the progress file —
+ * only counts and opaque uuids. See scripts/memory-corpus/README.md.
+ *
+ * DETERMINISM: per-store maintenance (which runs DECAY) is suppressed by a very
+ * high MEMORY_MAINTENANCE_INTERVAL and MEMORY_DECAY_THRESHOLD=0, so backdated
+ * 2023–2024 facts are not pruned mid-bulk. A single runConsolidation runs at the
+ * very end (never runMaintenance). See the README for the rationale.
+ */
+
+import { mkdirSync, readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type Database from 'better-sqlite3';
+
+import { loadConfig } from '../../packages/memory-mcp-server/src/config.js';
+import type { MemoryConfig } from '../../packages/memory-mcp-server/src/config.js';
+import { initDatabase } from '../../packages/memory-mcp-server/src/storage/database.js';
+import { ingestBlob } from '../../packages/memory-mcp-server/src/engine-impl.js';
+import { runConsolidation } from '../../packages/memory-mcp-server/src/storage/consolidation.js';
+import { getNamespaceStats } from '../../packages/memory-mcp-server/src/storage/queries.js';
+
+import {
+  parseArgs,
+  assembleTranscript,
+  isEmptyConversation,
+  buildSource,
+  resolveAsOf,
+  buildProgressRecord,
+  buildEmptyProgressRecord,
+  computeResumeSet,
+  type CliArgs,
+  type ExportConversation,
+  type ProgressRecord,
+} from './corpus-lib.js';
+
+// ---------- Config setup ----------
+
+/**
+ * Set the MEMORY_* env vars the engine reads, then load config. Requires
+ * ANTHROPIC_API_KEY (we REQUIRE the LLM for the corpus — no silent degrade).
+ */
+function buildConfig(args: CliArgs): MemoryConfig {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required (the corpus needs the LLM). ' +
+        'Run with `--import dotenv/config` or export it in the environment.',
+    );
+  }
+
+  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
+  process.env.MEMORY_LLM_API_KEY = apiKey;
+  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
+  process.env.MEMORY_DB_PATH = resolve(args.dbPath);
+  process.env.MEMORY_NAMESPACE = args.namespace;
+  // Determinism: never let per-store maintenance (which runs DECAY) fire mid-bulk.
+  process.env.MEMORY_MAINTENANCE_INTERVAL = '100000000';
+  process.env.MEMORY_DECAY_THRESHOLD = '0';
+  process.env.MEMORY_RERANKER_ENABLED = 'false';
+
+  return loadConfig();
+}
+
+// ---------- Export loading ----------
+
+function loadExport(exportPath: string): ExportConversation[] {
+  const raw = readFileSync(resolve(exportPath), 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Export is not a top-level JSON array of conversations.');
+  }
+  return parsed as ExportConversation[];
+}
+
+/**
+ * Apply the --conversation / --limit selection. --conversation wins and selects
+ * exactly one conversation; --limit caps the count of NON-EMPTY conversations.
+ */
+function selectConversations(conversations: ExportConversation[], args: CliArgs): ExportConversation[] {
+  if (args.conversation !== undefined) {
+    return conversations.filter((conv) => conv.uuid === args.conversation);
+  }
+  if (args.limit === undefined) {
+    return conversations;
+  }
+  const selected: ExportConversation[] = [];
+  for (const conv of conversations) {
+    if (selected.filter((c) => !isEmptyConversation(c)).length >= args.limit) break;
+    selected.push(conv);
+  }
+  return selected;
+}
+
+// ---------- Progress file (content-free) ----------
+
+function loadProgressRecords(progressPath: string): ProgressRecord[] {
+  if (!existsSync(progressPath)) return [];
+  const lines = readFileSync(progressPath, 'utf-8').split('\n');
+  const records: ProgressRecord[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    records.push(JSON.parse(trimmed) as ProgressRecord);
+  }
+  return records;
+}
+
+function appendProgress(progressPath: string, record: ProgressRecord): void {
+  appendFileSync(progressPath, `${JSON.stringify(record)}\n`);
+}
+
+// ---------- Direct-DB stats (content-free) ----------
+
+interface CorpusStats {
+  importanceMin: number | null;
+  importanceMax: number | null;
+  importanceMean: number | null;
+  createdAtMin: number | null;
+  createdAtMax: number | null;
+}
+
+/** Query importance + created_at spread directly — proves the corpus is non-flat. */
+function queryCorpusStats(db: Database.Database, namespace: string): CorpusStats {
+  const row = db
+    .prepare(
+      `SELECT MIN(importance) AS impMin, MAX(importance) AS impMax, AVG(importance) AS impMean,
+              MIN(created_at) AS createdMin, MAX(created_at) AS createdMax
+         FROM memories WHERE namespace = ?`,
+    )
+    .get(namespace) as {
+    impMin: number | null;
+    impMax: number | null;
+    impMean: number | null;
+    createdMin: number | null;
+    createdMax: number | null;
+  };
+  return {
+    importanceMin: row.impMin,
+    importanceMax: row.impMax,
+    importanceMean: row.impMean,
+    createdAtMin: row.createdMin,
+    createdAtMax: row.createdMax,
+  };
+}
+
+// ---------- Per-conversation ingest ----------
+
+interface RunTotals {
+  processed: number;
+  skippedEmpty: number;
+  skippedFailed: number;
+  partial: number;
+  created: number;
+  merged: number;
+}
+
+async function ingestConversation(
+  db: Database.Database,
+  config: MemoryConfig,
+  conv: ExportConversation,
+  dryRun: boolean,
+  progressPath: string,
+  totals: RunTotals,
+  position: string,
+): Promise<void> {
+  const transcript = assembleTranscript(conv);
+  const asOf = resolveAsOf(conv.created_at);
+  if (asOf === undefined) {
+    process.stderr.write(`${position} ${conv.uuid.slice(0, 8)} → WARNING: unparseable created_at, using now()\n`);
+  }
+  const result = await ingestBlob(db, config, transcript, {
+    mode: 'document',
+    as_of: asOf,
+    source: buildSource(conv.uuid),
+    tags: ['claude-export'],
+    on_extraction_failure: 'skip',
+    dry_run: dryRun,
+  });
+
+  const record = buildProgressRecord(conv.uuid, result);
+  appendProgress(progressPath, record);
+
+  totals.processed += 1;
+  totals.created += result.created;
+  totals.merged += result.merged;
+  if (record.status === 'skipped-failed') totals.skippedFailed += 1;
+  if (record.status === 'partial') totals.partial += 1;
+
+  logProgress(position, conv.uuid, result.created, result.merged);
+}
+
+function logProgress(position: string, uuid: string, created: number, merged: number): void {
+  // Content-free: uuid PREFIX only, no names/text.
+  process.stderr.write(`${position} ${uuid.slice(0, 8)} → created=${created} merged=${merged}\n`);
+}
+
+// ---------- Main ----------
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const config = buildConfig(args);
+  mkdirSync(dirname(config.dbPath), { recursive: true });
+  const progressPath = resolve(dirname(config.dbPath), 'progress.jsonl');
+
+  const priorRecords = loadProgressRecords(progressPath);
+  const dbExists = existsSync(config.dbPath);
+  if (!args.resume && dbExists && priorRecords.length > 0) {
+    process.stderr.write('WARNING: db/progress already exist and --resume not set; appending to existing corpus.\n');
+  }
+  const resumeSkip = args.resume ? computeResumeSet(priorRecords) : new Set<string>();
+
+  const allConversations = loadExport(args.exportPath);
+  const selected = selectConversations(allConversations, args);
+
+  const db = initDatabase(config.dbPath, config.embeddingModel);
+  const startMs = Date.now();
+  const totals: RunTotals = { processed: 0, skippedEmpty: 0, skippedFailed: 0, partial: 0, created: 0, merged: 0 };
+
+  try {
+    for (let i = 0; i < selected.length; i += 1) {
+      const conv = selected[i];
+      const position = `[${i + 1}/${selected.length}]`;
+
+      if (args.resume && resumeSkip.has(conv.uuid)) {
+        process.stderr.write(`${position} ${conv.uuid.slice(0, 8)} → skip (already done)\n`);
+        continue;
+      }
+
+      if (isEmptyConversation(conv)) {
+        appendProgress(progressPath, buildEmptyProgressRecord(conv.uuid));
+        totals.skippedEmpty += 1;
+        process.stderr.write(`${position} ${conv.uuid.slice(0, 8)} → skip (empty)\n`);
+        continue;
+      }
+
+      await ingestConversation(db, config, conv, args.dryRun, progressPath, totals, position);
+    }
+
+    if (!args.dryRun) {
+      const summary = await runConsolidation(db, config);
+      process.stderr.write(
+        `consolidation: consolidated=${summary.consolidated} merged=${summary.merged} superseded=${summary.superseded}\n`,
+      );
+    }
+
+    printSummary(db, config, selected.length, totals, startMs, args.dryRun);
+  } finally {
+    db.close();
+  }
+}
+
+function printSummary(
+  db: Database.Database,
+  config: MemoryConfig,
+  total: number,
+  totals: RunTotals,
+  startMs: number,
+  dryRun: boolean,
+): void {
+  const stats = queryCorpusStats(db, config.namespace);
+  const namespaceTotal = getNamespaceStats(db, config.namespace).total_memories;
+  const elapsedSec = ((Date.now() - startMs) / 1000).toFixed(1);
+
+  const lines = [
+    '',
+    '===== CORPUS BUILD SUMMARY =====',
+    `dry_run:              ${dryRun}`,
+    `conversations total:  ${total}`,
+    `  processed:          ${totals.processed}`,
+    `  skipped-empty:      ${totals.skippedEmpty}`,
+    `  skipped-failed:     ${totals.skippedFailed}`,
+    `  partial:            ${totals.partial}`,
+    `memories created:     ${totals.created}`,
+    `memories merged:      ${totals.merged}`,
+    `namespace total rows: ${namespaceTotal}`,
+    `importance min/max/mean: ${fmt(stats.importanceMin)} / ${fmt(stats.importanceMax)} / ${fmt(stats.importanceMean)}`,
+    `created_at min/max:   ${fmtTime(stats.createdAtMin)} / ${fmtTime(stats.createdAtMax)}`,
+    `elapsed seconds:      ${elapsedSec}`,
+    '================================',
+  ];
+  process.stderr.write(`${lines.join('\n')}\n`);
+}
+
+function fmt(value: number | null): string {
+  return value === null ? 'n/a' : value.toFixed(3);
+}
+
+function fmtTime(epochMs: number | null): string {
+  return epochMs === null ? 'n/a' : new Date(epochMs).toISOString();
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'build-corpus — ingest a claude.ai conversation export into a memory DB',
+      '',
+      'Usage: tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts [flags]',
+      '',
+      'Flags:',
+      '  --export <path>        export JSON (default donotcommit/claude-export/conversations.json)',
+      '  --db <path>            output memdb (default donotcommit/corpus/memories.memdb)',
+      '  --namespace <name>     memory namespace (default claude-export)',
+      '  --limit <N>            process only first N non-empty conversations',
+      '  --conversation <uuid>  process only that conversation',
+      '  --dry-run              extract but write nothing (still egresses to Haiku)',
+      '  --resume               skip conversations already recorded done; retry failed',
+      '  -h, --help             show this help',
+      '',
+      'Requires ANTHROPIC_API_KEY (load via --import dotenv/config).',
+      '',
+    ].join('\n'),
+  );
+}
+
+run().catch((err: unknown) => {
+  process.stderr.write(`build-corpus failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/memory-corpus/corpus-lib.ts
+++ b/scripts/memory-corpus/corpus-lib.ts
@@ -1,0 +1,248 @@
+/**
+ * Pure logic for the claude.ai conversation-export corpus builder.
+ *
+ * Everything here is side-effect free and content-free in its outputs (no fact
+ * text, no transcript text leaks into logs or progress artifacts). It is unit
+ * tested in isolation with synthetic fixtures — no DB, no LLM, no filesystem.
+ *
+ * The I/O driver that wires these helpers to the memory engine lives in
+ * `build-corpus.ts`.
+ */
+
+// ---------- Export shapes (subset of the claude.ai export schema) ----------
+
+/** A single message inside a conversation export. Only the fields we read. */
+export interface ExportMessage {
+  uuid: string;
+  /** SENSITIVE content. Never logged or written to an artifact. */
+  text: string;
+  sender: string;
+}
+
+/** A single conversation in the export array. Only the fields we read. */
+export interface ExportConversation {
+  uuid: string;
+  /** SENSITIVE content. Never logged or written to an artifact. */
+  created_at: string;
+  /** Optional because it comes from untrusted JSON; absent ⇒ treated as empty. */
+  chat_messages?: ExportMessage[];
+}
+
+// ---------- Transcript assembly ----------
+
+/**
+ * Build a transcript from a conversation's messages: one `${sender}: ${text}`
+ * line per message with non-empty `text`, joined by newlines. Messages whose
+ * `text` is empty/whitespace are dropped (some messages carry only structured
+ * `content`/attachments). We deliberately use `text`, never `content`.
+ */
+export function assembleTranscript(conversation: ExportConversation): string {
+  return nonEmptyMessages(conversation)
+    .map((msg) => `${msg.sender}: ${msg.text}`)
+    .join('\n');
+}
+
+function nonEmptyMessages(conversation: ExportConversation): ExportMessage[] {
+  const messages = conversation.chat_messages ?? [];
+  return messages.filter((msg) => typeof msg.text === 'string' && msg.text.trim().length > 0);
+}
+
+/**
+ * A conversation is empty for our purposes when it has no messages with
+ * non-empty `text`. These are skipped (recorded as `skipped-empty`).
+ */
+export function isEmptyConversation(conversation: ExportConversation): boolean {
+  return nonEmptyMessages(conversation).length === 0;
+}
+
+/**
+ * Provenance string stamped on every fact extracted from a conversation, e.g.
+ * `claude-export:3f2a...`. The uuid is an opaque identifier, not content.
+ */
+export function buildSource(uuid: string): string {
+  return `claude-export:${uuid}`;
+}
+
+/**
+ * Resolve a conversation's `created_at` (ISO 8601) to an epoch-ms `as_of`.
+ * Returns `undefined` for a missing/unparseable timestamp so the engine falls
+ * back to `Date.now()` instead of stamping `NaN` into the INTEGER column (which
+ * would corrupt the recency spread the corpus depends on). The timestamp is not
+ * sensitive content, so the caller may warn with the uuid.
+ */
+export function resolveAsOf(createdAt: string | undefined): number | undefined {
+  if (typeof createdAt !== 'string') return undefined;
+  const epoch = Date.parse(createdAt);
+  return Number.isFinite(epoch) ? epoch : undefined;
+}
+
+// ---------- Progress records (content-free) ----------
+
+/**
+ * Terminal status for one conversation. Every value is content-free.
+ * - `ingested`  — facts written (no chunk failures)
+ * - `partial`   — some chunks failed but others produced facts
+ * - `skipped-empty`  — the conversation had no non-empty messages
+ * - `skipped-failed` — extraction yielded nothing (on_extraction_failure='skip')
+ */
+export type ConversationStatus = 'ingested' | 'partial' | 'skipped-empty' | 'skipped-failed';
+
+/** One line in `progress.jsonl`. COUNTS ONLY — never fact text or transcript. */
+export interface ProgressRecord {
+  uuid: string;
+  status: ConversationStatus;
+  created: number;
+  merged: number;
+  facts: number;
+  failed_chunks: number;
+  chunks: number;
+}
+
+/** The subset of an `IngestResult` the progress builder reads. */
+export interface IngestResultLike {
+  created: number;
+  merged: number;
+  facts: { length: number };
+  chunks?: number;
+  failed_chunks?: number;
+  partial?: boolean;
+  skipped?: boolean;
+}
+
+/**
+ * Map an ingest result to a content-free progress record. `status` is
+ * skipped-failed when the result is `skipped`, partial when `partial`, else
+ * ingested. The fact count comes from `facts.length` (a count, never text).
+ */
+export function buildProgressRecord(uuid: string, result: IngestResultLike): ProgressRecord {
+  const status: ConversationStatus = result.skipped ? 'skipped-failed' : result.partial ? 'partial' : 'ingested';
+  return {
+    uuid,
+    status,
+    created: result.created,
+    merged: result.merged,
+    facts: result.facts.length,
+    failed_chunks: result.failed_chunks ?? 0,
+    chunks: result.chunks ?? 1,
+  };
+}
+
+/** Progress record for a conversation skipped because it had no content. */
+export function buildEmptyProgressRecord(uuid: string): ProgressRecord {
+  return { uuid, status: 'skipped-empty', created: 0, merged: 0, facts: 0, failed_chunks: 0, chunks: 0 };
+}
+
+// ---------- Resume-set computation ----------
+
+/** Statuses that count as "done" for resume — only `skipped-failed` is retried. */
+const RESUME_DONE_STATUSES: ReadonlySet<ConversationStatus> = new Set<ConversationStatus>([
+  'ingested',
+  'partial',
+  'skipped-empty',
+]);
+
+/**
+ * Given the records already in the progress file, compute the set of conversation
+ * uuids to skip on `--resume`. A uuid is skipped if any of its records has a
+ * "done" status; `skipped-failed`-only uuids are retried (not in the set).
+ */
+export function computeResumeSet(records: readonly ProgressRecord[]): Set<string> {
+  const skip = new Set<string>();
+  for (const record of records) {
+    if (RESUME_DONE_STATUSES.has(record.status)) {
+      skip.add(record.uuid);
+    }
+  }
+  return skip;
+}
+
+// ---------- Argument parsing ----------
+
+export interface CliArgs {
+  exportPath: string;
+  dbPath: string;
+  namespace: string;
+  /** Process only the first N non-empty conversations; undefined ⇒ all. */
+  limit?: number;
+  /** Process only this conversation uuid; undefined ⇒ all. */
+  conversation?: string;
+  dryRun: boolean;
+  resume: boolean;
+  help: boolean;
+}
+
+export const DEFAULT_ARGS: Readonly<Pick<CliArgs, 'exportPath' | 'dbPath' | 'namespace'>> = {
+  exportPath: 'donotcommit/claude-export/conversations.json',
+  dbPath: 'donotcommit/corpus/memories.memdb',
+  namespace: 'claude-export',
+};
+
+/**
+ * Parse the driver's CLI flags. Throws on a missing value for a flag that needs
+ * one, or on an unrecognized flag, so a typo fails loudly instead of silently
+ * running against the wrong target.
+ */
+export function parseArgs(argv: readonly string[]): CliArgs {
+  const args: CliArgs = {
+    exportPath: DEFAULT_ARGS.exportPath,
+    dbPath: DEFAULT_ARGS.dbPath,
+    namespace: DEFAULT_ARGS.namespace,
+    dryRun: false,
+    resume: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--export':
+        args.exportPath = requireValue(argv, (i += 1), flag);
+        break;
+      case '--db':
+        args.dbPath = requireValue(argv, (i += 1), flag);
+        break;
+      case '--namespace':
+        args.namespace = requireValue(argv, (i += 1), flag);
+        break;
+      case '--limit':
+        args.limit = parsePositiveInt(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '--conversation':
+        args.conversation = requireValue(argv, (i += 1), flag);
+        break;
+      case '--dry-run':
+        args.dryRun = true;
+        break;
+      case '--resume':
+        args.resume = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  return args;
+}
+
+function requireValue(argv: readonly string[], index: number, flag: string): string {
+  if (index >= argv.length) {
+    throw new Error(`Flag ${flag} requires a value`);
+  }
+  const value = argv[index];
+  if (value.startsWith('--')) {
+    throw new Error(`Flag ${flag} requires a value`);
+  }
+  return value;
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Flag ${flag} requires a positive integer, got: ${raw}`);
+  }
+  return parsed;
+}

--- a/scripts/memory-corpus/diagnose-corpus.ts
+++ b/scripts/memory-corpus/diagnose-corpus.ts
@@ -1,0 +1,611 @@
+/**
+ * Corpus representativeness diagnostic.
+ *
+ * Answers ONE question with a GO/NO-GO verdict: is this corpus non-degenerate
+ * enough that evolving the composite retrieval scorer is meaningful — i.e. are
+ * the metadata signals (recency, importance) ALIVE and do they actively reshape
+ * rankings, unlike the LoCoMo benchmark where flat metadata (importance ≡ 0.5,
+ * identical created_at) made those terms dead weight?
+ *
+ * Three analyses, then a verdict:
+ *   A. Distributional liveness — real db, READ-ONLY SQL. No LLM, no retrieval.
+ *   B. Self-supervised recall probe — Haiku question generation + the REAL
+ *      hybrid candidate pool, run on a COPY of the db so the real corpus stays
+ *      pristine (retrieval mutates access stats). Emits a CONTENT-FREE fixture.
+ *   C. Verdict — GO iff recency_live AND importance_live AND reshapes_rankings.
+ *
+ * Run with tsx, loading .env for ANTHROPIC_API_KEY:
+ *   npx tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts
+ *
+ * SENSITIVE DATA: the corpus DB holds private conversation facts. This driver
+ * NEVER writes fact/query text to stdout, logs, the fixture, or the report —
+ * only opaque ids and numeric signals. The fixture and report live under the
+ * gitignored `donotcommit/`. See scripts/memory-corpus/README.md.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import Database from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
+
+import { loadConfig } from '../../packages/memory-mcp-server/src/config.js';
+import type { MemoryConfig } from '../../packages/memory-mcp-server/src/config.js';
+import { initDatabase } from '../../packages/memory-mcp-server/src/storage/database.js';
+import type { MemoryRow } from '../../packages/memory-mcp-server/src/storage/database.js';
+import { vectorSearch, ftsSearch } from '../../packages/memory-mcp-server/src/storage/queries.js';
+import { hybridScoreFusion } from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
+import { embedQuery } from '../../packages/memory-mcp-server/src/embedding/embedder.js';
+import { getLLMClient } from '../../packages/memory-mcp-server/src/llm/client.js';
+
+import {
+  summarizeRecency,
+  summarizeImportance,
+  summarizeNumeric,
+  percentiles,
+  histogram,
+  recallTable,
+  meanCompositeVsFusionTau,
+  stratifiedSample,
+  mulberry32,
+  evaluateVerdict,
+  SINGLE_SIGNAL_VARIANTS,
+  type FixtureQuery,
+  type FixtureCandidate,
+  type SampleRow,
+  type RecencySummary,
+  type ImportanceSummary,
+  type NumericSummary,
+  type VerdictResult,
+} from './diagnose-lib.js';
+
+// ---------- CLI ----------
+
+interface DiagnoseArgs {
+  dbPath: string;
+  namespace: string;
+  sample: number;
+  budget: number;
+  seed: number;
+  help: boolean;
+}
+
+const DEFAULTS = {
+  dbPath: 'donotcommit/corpus/memories.memdb',
+  namespace: 'claude-export',
+  sample: 120,
+  budget: 300,
+  seed: 1,
+};
+
+function parseArgs(argv: readonly string[]): DiagnoseArgs {
+  const args: DiagnoseArgs = { ...DEFAULTS, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--db':
+        args.dbPath = requireValue(argv, (i += 1), flag);
+        break;
+      case '--namespace':
+        args.namespace = requireValue(argv, (i += 1), flag);
+        break;
+      case '--sample':
+        args.sample = parsePositiveInt(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '--budget':
+        args.budget = parsePositiveInt(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '--seed':
+        args.seed = parseIntFlag(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '-h':
+      case '--help':
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+  return args;
+}
+
+function requireValue(argv: readonly string[], index: number, flag: string): string {
+  if (index >= argv.length) throw new Error(`Flag ${flag} requires a value`);
+  const value = argv[index];
+  if (value.startsWith('--')) throw new Error(`Flag ${flag} requires a value`);
+  return value;
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`Flag ${flag} requires a positive integer, got: ${raw}`);
+  return n;
+}
+
+function parseIntFlag(raw: string, flag: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n)) throw new Error(`Flag ${flag} requires an integer, got: ${raw}`);
+  return n;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'diagnose-corpus — representativeness diagnostic for a memory corpus (GO/NO-GO)',
+      '',
+      'Answers: are the metadata signals (recency, importance) ALIVE and do they',
+      'reshape rankings — i.e. is evolving the composite scorer meaningful on this',
+      'corpus, unlike the flat-metadata LoCoMo benchmark?',
+      '',
+      'Usage: tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts [flags]',
+      '',
+      'Flags:',
+      `  --db <path>          corpus memdb (default ${DEFAULTS.dbPath})`,
+      `  --namespace <name>   memory namespace (default ${DEFAULTS.namespace})`,
+      `  --sample <N>         probe sample size, stratified by recency (default ${DEFAULTS.sample})`,
+      `  --budget <tokens>    recall@token-budget (default ${DEFAULTS.budget}, matches evolve dogfood)`,
+      `  --seed <int>         deterministic sampling seed (default ${DEFAULTS.seed})`,
+      '  -h, --help           show this help',
+      '',
+      'Part A (distributional stats) reads the real db READ-ONLY and needs no LLM.',
+      'Part B (recall probe) copies the db to a temp path, embeds Haiku-generated',
+      'questions, and needs ANTHROPIC_API_KEY (load via --import dotenv/config).',
+      '',
+      'Artifacts (content-free, under gitignored donotcommit/):',
+      '  donotcommit/corpus/diagnostic-fixture.jsonl   per-query candidate signals',
+      '  donotcommit/corpus/diagnostic-report.json     aggregate verdict numbers',
+      '',
+    ].join('\n'),
+  );
+}
+
+// ---------- Config ----------
+
+/** Wire MEMORY_* env so the engine helpers (embedder, LLM client) load Haiku. */
+function buildConfig(args: DiagnoseArgs): MemoryConfig {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required for the recall probe (Haiku question generation). ' +
+        'Run with `--import dotenv/config` or export it.',
+    );
+  }
+  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
+  process.env.MEMORY_LLM_API_KEY = apiKey;
+  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
+  process.env.MEMORY_NAMESPACE = args.namespace;
+  process.env.MEMORY_RERANKER_ENABLED = 'false';
+  return loadConfig();
+}
+
+// ---------- Part A: distributional stats (real db, READ-ONLY) ----------
+
+interface RawSignals {
+  ids: string[];
+  createdAt: number[];
+  importance: number[];
+  accessCount: number[];
+  contentLength: number[];
+}
+
+/** Pull the raw per-row signal arrays. READ-ONLY: only SELECT, never mutates. */
+function readRawSignals(db: Database.Database, namespace: string): RawSignals {
+  const rows = db
+    .prepare(
+      `SELECT id, created_at, importance, access_count, length(content) AS content_length
+         FROM memories WHERE namespace = ?`,
+    )
+    .all(namespace) as Array<{
+    id: string;
+    created_at: number;
+    importance: number;
+    access_count: number;
+    content_length: number;
+  }>;
+  return {
+    ids: rows.map((r) => r.id),
+    createdAt: rows.map((r) => r.created_at),
+    importance: rows.map((r) => r.importance),
+    accessCount: rows.map((r) => r.access_count),
+    contentLength: rows.map((r) => r.content_length),
+  };
+}
+
+interface DistributionalReport {
+  rowCount: number;
+  recency: RecencySummary;
+  importance: ImportanceSummary;
+  access: { numeric: NumericSummary; histogram: Record<string, number>; allZero: boolean };
+  contentLength: { numeric: NumericSummary; percentiles: Record<string, number | null> };
+}
+
+function summarizeDistribution(raw: RawSignals): DistributionalReport {
+  const accessNumeric = summarizeNumeric(raw.accessCount);
+  return {
+    rowCount: raw.ids.length,
+    recency: summarizeRecency(raw.createdAt),
+    importance: summarizeImportance(raw.importance),
+    access: {
+      numeric: accessNumeric,
+      histogram: histogram(raw.accessCount, 1, 0, 0),
+      allZero: accessNumeric.max === 0 || accessNumeric.max === null,
+    },
+    contentLength: {
+      numeric: summarizeNumeric(raw.contentLength),
+      percentiles: percentiles(raw.contentLength, [0, 0.25, 0.5, 0.75, 0.9, 1]),
+    },
+  };
+}
+
+// ---------- Part B: recall probe (db COPY) ----------
+
+const DEFAULT_CANDIDATE_LIMIT = 50;
+const MAX_VECTOR_DISTANCE = 0.9;
+
+/** Copy the memdb (+ WAL/SHM sidecars if present) into a temp dir; return the copy path. */
+function copyDbToTemp(dbPath: string): { copyPath: string; tempDir: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), 'corpus-diag-'));
+  const copyPath = join(tempDir, 'corpus-copy.memdb');
+  copyFileSync(dbPath, copyPath);
+  for (const suffix of ['-wal', '-shm']) {
+    if (existsSync(dbPath + suffix)) copyFileSync(dbPath + suffix, copyPath + suffix);
+  }
+  return { copyPath, tempDir };
+}
+
+/** Open a db read-only with the sqlite-vec extension loaded (for vector_distance_cosine). */
+function openReadOnly(dbPath: string): Database.Database {
+  const db = new Database(dbPath, { readonly: true });
+  sqliteVec.load(db);
+  return db;
+}
+
+const QUESTION_SYSTEM_PROMPT =
+  'Given a single fact, output ONLY a short, natural question that a user might ask ' +
+  'which this fact answers. No preamble, no quotes, no explanation — just the question.';
+
+/** One Haiku call: fact text in, a natural question out. Returns null on failure. */
+async function generateQuestion(config: MemoryConfig, factContent: string): Promise<string | null> {
+  const client = getLLMClient(config);
+  if (!client) return null;
+  try {
+    const response = await client.chat.completions.create({
+      model: config.llmModel,
+      messages: [
+        { role: 'system', content: QUESTION_SYSTEM_PROMPT },
+        { role: 'user', content: factContent },
+      ],
+      max_tokens: 60,
+      temperature: 0,
+    });
+    const text = response.choices[0]?.message?.content?.trim();
+    return text && text.length > 0 ? text : null;
+  } catch {
+    // Content-free: never log the prompt (the fact) or the SDK error body.
+    process.stderr.write('  question generation failed for one fact (skipping)\n');
+    return null;
+  }
+}
+
+/**
+ * Build the CONTENT-FREE candidate pool for a query by running the REAL hybrid
+ * retrieval (vector KNN + FTS5 + production fusion). We call the search/fusion
+ * helpers directly rather than `recall()` so that (a) nothing mutates access
+ * stats and (b) only numeric signals — never content — leave this function.
+ */
+function buildCandidatePool(
+  db: Database.Database,
+  namespace: string,
+  queryEmbedding: Float32Array,
+  queryText: string,
+  goldId: string,
+): FixtureCandidate[] {
+  const vectorResults = vectorSearch(db, namespace, queryEmbedding, DEFAULT_CANDIDATE_LIMIT).filter(
+    (r) => r.distance < MAX_VECTOR_DISTANCE,
+  );
+  const ftsResults = ftsSearch(db, namespace, queryText, DEFAULT_CANDIDATE_LIMIT);
+
+  const all = new Map<string, MemoryRow>();
+  for (const m of vectorResults) all.set(m.id, m);
+  for (const m of ftsResults) all.set(m.id, m);
+
+  const distanceById = new Map(vectorResults.map((r) => [r.id, r.distance]));
+  const bm25ById = new Map(ftsResults.map((r) => [r.id, r.bm25_score]));
+
+  // Fuse only to confirm the pool is well-formed; the fixture stores raw signals,
+  // and the pure lib re-derives fusion from them at analysis time.
+  hybridScoreFusion(vectorResults, ftsResults, all);
+
+  const candidates: FixtureCandidate[] = [];
+  for (const [id, m] of all) {
+    candidates.push({
+      id,
+      is_gold: id === goldId,
+      vector_distance: distanceById.get(id),
+      bm25_score: bm25ById.get(id),
+      created_at: m.created_at,
+      last_accessed_at: m.last_accessed_at,
+      access_count: m.access_count,
+      importance: m.importance,
+      content_length: m.content.length,
+    });
+  }
+  return candidates;
+}
+
+/** Read a sampled fact's content from the COPY db (content stays local, never persisted). */
+function readContent(db: Database.Database, namespace: string, id: string): string | null {
+  const row = db.prepare(`SELECT content FROM memories WHERE namespace = ? AND id = ?`).get(namespace, id) as
+    | { content: string }
+    | undefined;
+  return row?.content ?? null;
+}
+
+interface ProbeResult {
+  queries: FixtureQuery[];
+  generated: number;
+  skipped: number;
+}
+
+/**
+ * Run the self-supervised probe on the db COPY: for each sampled fact, generate
+ * a question (Haiku), retrieve the candidate pool, and record a content-free
+ * fixture row. Appends each row to the fixture file as it goes.
+ */
+async function runRecallProbe(
+  db: Database.Database,
+  config: MemoryConfig,
+  sampleIds: readonly string[],
+  fixturePath: string,
+): Promise<ProbeResult> {
+  writeFileSync(fixturePath, '');
+  const queries: FixtureQuery[] = [];
+  let generated = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < sampleIds.length; i += 1) {
+    const goldId = sampleIds[i];
+    const content = readContent(db, config.namespace, goldId);
+    if (content === null) {
+      skipped += 1;
+      continue;
+    }
+
+    const question = await generateQuestion(config, content);
+    if (question === null) {
+      skipped += 1;
+      continue;
+    }
+
+    const queryEmbedding = await embedQuery(question, config);
+    const candidates = buildCandidatePool(db, config.namespace, queryEmbedding, question, goldId);
+
+    const query: FixtureQuery = { query_id: `probe-${i}`, gold_id: goldId, candidates };
+    queries.push(query);
+    appendFileSync(fixturePath, `${JSON.stringify(query)}\n`);
+    generated += 1;
+
+    if ((i + 1) % 20 === 0) {
+      process.stderr.write(`  probe ${i + 1}/${sampleIds.length} (generated=${generated} skipped=${skipped})\n`);
+    }
+  }
+
+  return { queries, generated, skipped };
+}
+
+// ---------- Report assembly + printing ----------
+
+interface FullReport {
+  meta: {
+    namespace: string;
+    sample_requested: number;
+    sample_probed: number;
+    budget: number;
+    seed: number;
+    generated_at: string;
+  };
+  distributional: DistributionalReport;
+  probe: {
+    recall_at_budget: Record<string, number>;
+    composite_vs_fusion_tau: number;
+    not_single_signal_confound: boolean;
+    single_signal_variants: readonly string[];
+  };
+  verdict: VerdictResult;
+}
+
+function fmt(n: number | null, digits = 3): string {
+  return n === null ? 'n/a' : n.toFixed(digits);
+}
+
+function fmtTime(epochMs: number | null): string {
+  return epochMs === null ? 'n/a' : new Date(epochMs).toISOString();
+}
+
+function printReport(report: FullReport): void {
+  const { distributional: d, probe: p, verdict: v } = report;
+  const out: string[] = [];
+  out.push('');
+  out.push('===== CORPUS REPRESENTATIVENESS DIAGNOSTIC =====');
+  out.push(`namespace:            ${report.meta.namespace}`);
+  out.push(`rows:                 ${d.rowCount}`);
+  out.push(`sample probed:        ${report.meta.sample_probed} / ${report.meta.sample_requested} requested`);
+  out.push(`budget:               ${report.meta.budget} tokens   seed: ${report.meta.seed}`);
+  out.push('');
+
+  out.push('--- A. Recency ---');
+  out.push(`  span:               ${fmtTime(d.recency.numeric.min)} → ${fmtTime(d.recency.numeric.max)}`);
+  out.push(`  span days:          ${fmt(d.recency.spanDays, 1)}`);
+  out.push(`  distinct yr-months: ${d.recency.distinctYearMonths}`);
+  out.push(
+    `  stddev (days):      ${fmt(d.recency.numeric.stddev === null ? null : d.recency.numeric.stddev / 86400000, 1)}`,
+  );
+  out.push(`  fraction by year:   ${formatFractionMap(d.recency.fractionByYear)}`);
+  out.push(`  histogram (quarter):${formatCountMap(d.recency.histogramByQuarter)}`);
+
+  out.push('--- A. Importance ---');
+  out.push(
+    `  min/max/mean:       ${fmt(d.importance.numeric.min)} / ${fmt(d.importance.numeric.max)} / ${fmt(d.importance.numeric.mean)}`,
+  );
+  out.push(`  stddev:             ${fmt(d.importance.numeric.stddev)}`);
+  out.push(`  distinct values:    ${d.importance.distinctValues}`);
+  out.push(`  fraction at 0.5:    ${fmt(d.importance.fractionAtSeed)}`);
+  out.push(`  histogram (0.1):    ${formatCountMap(d.importance.histogram)}`);
+
+  out.push('--- A. Access (LATENT — zero until the corpus is queried) ---');
+  out.push(
+    `  min/max/mean:       ${fmt(d.access.numeric.min)} / ${fmt(d.access.numeric.max)} / ${fmt(d.access.numeric.mean)}`,
+  );
+  out.push(
+    `  all zero:           ${d.access.allZero} ${d.access.allZero ? '(expected on a fresh corpus — not a failure)' : ''}`,
+  );
+
+  out.push('--- A. Content length (atomicity sanity) ---');
+  out.push(
+    `  min/max/mean:       ${fmt(d.contentLength.numeric.min, 0)} / ${fmt(d.contentLength.numeric.max, 0)} / ${fmt(d.contentLength.numeric.mean, 0)}`,
+  );
+  out.push(`  percentiles:        ${formatPercentiles(d.contentLength.percentiles)}`);
+
+  out.push('');
+  out.push('--- B. Recall@budget by ranking variant ---');
+  for (const [variant, recall] of Object.entries(p.recall_at_budget)) {
+    out.push(`  ${variant.padEnd(18)}${fmt(recall)}`);
+  }
+  out.push(`  composite vs fusion Kendall-tau: ${fmt(p.composite_vs_fusion_tau)}`);
+  out.push(`  composite ≥ every single-signal baseline (confound check): ${p.not_single_signal_confound}`);
+
+  out.push('');
+  out.push('--- Thresholds ---');
+  out.push(`  distinct year-months ≥ ${v.thresholds.minDistinctYearMonths}`);
+  out.push(`  recency stddev (days) ≥ ${v.thresholds.minRecencyStddevDays}`);
+  out.push(`  importance stddev ≥ ${v.thresholds.minImportanceStddev}`);
+  out.push(`  fraction at 0.5 < ${v.thresholds.maxFractionAtSeed}`);
+  out.push(`  composite-vs-fusion tau < ${v.thresholds.maxReshapeTau}`);
+
+  out.push('');
+  out.push('--- C. Verdict ---');
+  out.push(`  recency_live:               ${v.recencyLive}`);
+  out.push(`  importance_live:            ${v.importanceLive}`);
+  out.push(`  reshapes_rankings:          ${v.reshapesRankings}`);
+  out.push(`  not_single_signal_confound: ${v.notSingleSignalConfound} (supporting evidence)`);
+  if (!v.go) out.push(`  failed conditions:          ${v.failedConditions.join(', ')}`);
+  out.push('');
+  out.push(`  >>> ${v.go ? 'GO' : 'NO-GO'} <<<`);
+  out.push('================================================');
+  out.push('');
+  process.stdout.write(out.join('\n'));
+}
+
+function formatFractionMap(m: Record<string, number>): string {
+  return Object.entries(m)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v.toFixed(2)}`)
+    .join(' ');
+}
+
+function formatCountMap(m: Record<string, number>): string {
+  return Object.entries(m)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+}
+
+function formatPercentiles(m: Record<string, number | null>): string {
+  return Object.entries(m)
+    .map(([k, v]) => `${k}=${v === null ? 'n/a' : Math.round(v)}`)
+    .join(' ');
+}
+
+// ---------- Main ----------
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const config = buildConfig(args);
+  const dbPath = resolve(args.dbPath);
+  if (!existsSync(dbPath)) {
+    throw new Error(`Corpus db not found: ${dbPath} (build it first with build-corpus.ts)`);
+  }
+  config.dbPath = dbPath;
+
+  const outDir = dirname(dbPath);
+  mkdirSync(outDir, { recursive: true });
+  const fixturePath = join(outDir, 'diagnostic-fixture.jsonl');
+  const reportPath = join(outDir, 'diagnostic-report.json');
+
+  // ---- Part A: distributional stats on the REAL db, READ-ONLY ----
+  process.stderr.write('Part A: distributional stats (read-only)…\n');
+  const roDb = openReadOnly(dbPath);
+  let raw: RawSignals;
+  try {
+    raw = readRawSignals(roDb, config.namespace);
+  } finally {
+    roDb.close();
+  }
+  if (raw.ids.length === 0) {
+    throw new Error(`Namespace '${config.namespace}' has no memories in ${dbPath}.`);
+  }
+  const distributional = summarizeDistribution(raw);
+
+  // ---- Part B: recall probe on a COPY of the db ----
+  process.stderr.write('Part B: recall probe (on a db copy)…\n');
+  const sampleRows: SampleRow[] = raw.ids.map((id, i) => ({ id, created_at: raw.createdAt[i] }));
+  const sampleIds = stratifiedSample(sampleRows, args.sample, mulberry32(args.seed));
+
+  const { copyPath, tempDir } = copyDbToTemp(dbPath);
+  let probe: ProbeResult;
+  const copyDb = initDatabase(copyPath, config.embeddingModel);
+  try {
+    probe = await runRecallProbe(copyDb, config, sampleIds, fixturePath);
+  } finally {
+    copyDb.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+  if (probe.queries.length === 0) {
+    throw new Error('Recall probe produced no queries (all questions failed). Cannot evaluate the verdict.');
+  }
+
+  // ---- Part C: verdict (pure logic on the fixture + distributional stats) ----
+  const now = Date.now();
+  const table = recallTable(probe.queries, args.budget, now);
+  const tau = meanCompositeVsFusionTau(probe.queries, now);
+  const verdict = evaluateVerdict({
+    recency: distributional.recency,
+    importance: distributional.importance,
+    reshapeTau: tau,
+    recallTable: table,
+  });
+
+  const report: FullReport = {
+    meta: {
+      namespace: config.namespace,
+      sample_requested: args.sample,
+      sample_probed: probe.generated,
+      budget: args.budget,
+      seed: args.seed,
+      generated_at: new Date().toISOString(),
+    },
+    distributional,
+    probe: {
+      recall_at_budget: table,
+      composite_vs_fusion_tau: tau,
+      not_single_signal_confound: verdict.notSingleSignalConfound,
+      single_signal_variants: SINGLE_SIGNAL_VARIANTS,
+    },
+    verdict,
+  };
+
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  printReport(report);
+  process.stderr.write(`\nfixture: ${fixturePath}\nreport:  ${reportPath}\n`);
+  process.exitCode = verdict.go ? 0 : 1;
+}
+
+run().catch((err: unknown) => {
+  process.stderr.write(`diagnose-corpus failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(2);
+});

--- a/scripts/memory-corpus/diagnose-lib.ts
+++ b/scripts/memory-corpus/diagnose-lib.ts
@@ -1,0 +1,599 @@
+/**
+ * Pure logic for the corpus representativeness diagnostic.
+ *
+ * The diagnostic answers ONE question: is the corpus non-degenerate enough that
+ * evolving the composite retrieval scorer is meaningful — i.e. are the metadata
+ * signals (recency, importance) ALIVE and do they actively reshape rankings,
+ * unlike the LoCoMo benchmark where flat metadata (importance ≡ 0.5, identical
+ * created_at) made those terms dead weight?
+ *
+ * Everything here is side-effect free and content-free: it operates on the
+ * content-free fixture rows produced by the recall probe (vector_distance,
+ * bm25_score, created_at, importance, ...) and on raw numeric arrays read from
+ * the db. NO fact/query/content text ever flows through this module. It is unit
+ * tested in isolation with SYNTHETIC fixtures — no DB, no LLM, no filesystem.
+ *
+ * The composite/fusion variants REUSE the production scoring functions
+ * (`computeCompositeScore`, `hybridScoreFusion`, `estimateTokens`,
+ * `packToBudget`) so the diagnostic reflects exactly what `evolve` would tune.
+ * The single-signal baselines (recency-only, importance-only, ...) are
+ * deliberately NOT production code — they are trivial reference rankers whose
+ * only job is to be a confound floor.
+ *
+ * The I/O driver that wires these helpers to the real db and Haiku lives in
+ * `diagnose-corpus.ts`.
+ */
+
+import type { MemoryRow } from '../../packages/memory-mcp-server/src/storage/database.js';
+import type { ScoredMemory } from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
+import {
+  hybridScoreFusion,
+  computeCompositeScore,
+  packToBudget,
+} from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
+
+// ---------- Fixture row shapes (content-free) ----------
+
+/**
+ * One candidate retrieved for a probe query. Carries ONLY the signals the
+ * scorers consume — never any content/fact/query text. `vector_distance` is
+ * absent when the candidate came only from FTS; `bm25_score` is absent when it
+ * came only from vector search.
+ */
+export interface FixtureCandidate {
+  id: string;
+  is_gold: boolean;
+  /** Cosine distance from the query embedding (lower = closer). FTS-only ⇒ undefined. */
+  vector_distance?: number;
+  /** Raw FTS5 bm25() score (negative; more negative = better). Vector-only ⇒ undefined. */
+  bm25_score?: number;
+  created_at: number;
+  last_accessed_at: number;
+  access_count: number;
+  importance: number;
+  /** Character length of the fact's content — drives the token-budget pack. */
+  content_length: number;
+}
+
+/** One probe query: a sampled fact's id (gold) and the candidate pool it drew. */
+export interface FixtureQuery {
+  query_id: string;
+  gold_id: string;
+  candidates: FixtureCandidate[];
+}
+
+// ---------- Ranking variants ----------
+
+/** The ranking variants the recall@budget table is computed for. */
+export const RANKING_VARIANTS = [
+  'composite',
+  'fusion-only',
+  'recency-only',
+  'importance-only',
+  'access-only',
+  'bm25-only',
+  'vector-only',
+] as const;
+
+export type RankingVariant = (typeof RANKING_VARIANTS)[number];
+
+/** The single-signal baselines — used for the confound check. */
+export const SINGLE_SIGNAL_VARIANTS: readonly RankingVariant[] = [
+  'recency-only',
+  'importance-only',
+  'access-only',
+  'bm25-only',
+  'vector-only',
+];
+
+// ---------- Fixture → ScoredMemory reconstruction ----------
+
+/**
+ * Rebuild the minimal `MemoryRow` shape the production scorers read from a
+ * content-free fixture candidate. `content` is a synthetic placeholder of the
+ * recorded length so `estimateTokens(content)` reproduces the real token cost
+ * WITHOUT carrying any real text — token estimation is length-only (~4 chars).
+ */
+function candidateToRow(c: FixtureCandidate): MemoryRow {
+  return {
+    id: c.id,
+    namespace: 'diagnostic',
+    content: 'x'.repeat(Math.max(0, Math.round(c.content_length))),
+    tags: null,
+    importance: c.importance,
+    created_at: c.created_at,
+    updated_at: c.created_at,
+    last_accessed_at: c.last_accessed_at,
+    access_count: c.access_count,
+    is_compacted: 0,
+    consolidated: 1,
+    source: null,
+    metadata: null,
+  };
+}
+
+/**
+ * Recompute the production fusion + composite scores for a query's candidate
+ * pool by feeding the recorded vector distances and bm25 scores back through
+ * the REAL `hybridScoreFusion` and `computeCompositeScore`. This is the heart
+ * of fidelity: the `composite`/`fusion-only` orderings are exactly what the
+ * live pipeline would produce for this pool.
+ *
+ * `now` is the reference time for recency/access decay (caller-supplied so it is
+ * deterministic in tests). Returns the scored candidates in production-fusion
+ * order alongside the fusionMax used for normalization.
+ */
+export function scoreFixtureQuery(query: FixtureQuery, now: number): ScoredMemory[] {
+  const allMemories = new Map<string, MemoryRow>();
+  const vectorResults = [];
+  const ftsResults = [];
+
+  for (const c of query.candidates) {
+    const row = candidateToRow(c);
+    allMemories.set(c.id, row);
+    if (c.vector_distance !== undefined) {
+      vectorResults.push({ ...row, distance: c.vector_distance });
+    }
+    if (c.bm25_score !== undefined) {
+      ftsResults.push({ ...row, bm25_score: c.bm25_score });
+    }
+  }
+
+  const { scored, fusionMax } = hybridScoreFusion(vectorResults, ftsResults, allMemories);
+  for (const mem of scored) {
+    mem.compositeScore = computeCompositeScore(mem, now, fusionMax || 1);
+  }
+  return scored;
+}
+
+// ---------- Single-signal rankers ----------
+
+/**
+ * The key each single-signal ranker sorts by — higher = ranked first. These are
+ * intentionally trivial: they exist so the confound check can prove the
+ * composite isn't reducible to any one signal. Candidates missing a vector/bm25
+ * signal sort last for that variant (worst possible key).
+ */
+function signalKey(c: FixtureCandidate, variant: RankingVariant): number {
+  switch (variant) {
+    case 'recency-only':
+      return c.created_at;
+    case 'importance-only':
+      return c.importance;
+    case 'access-only':
+      return c.access_count;
+    case 'bm25-only':
+      // bm25 is negative (more negative = better) ⇒ negate so higher = better.
+      return c.bm25_score === undefined ? -Infinity : -c.bm25_score;
+    case 'vector-only':
+      // distance: lower = better ⇒ negate so higher = better.
+      return c.vector_distance === undefined ? -Infinity : -c.vector_distance;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Produce the ordered candidate list for a ranking variant. `composite` and
+ * `fusion-only` go through the production scorers; the single-signal variants
+ * sort by their trivial key. Ties break by `id` so the order is deterministic.
+ */
+export function rankCandidates(query: FixtureQuery, variant: RankingVariant, now: number): FixtureCandidate[] {
+  const byId = new Map(query.candidates.map((c) => [c.id, c]));
+
+  if (variant === 'composite' || variant === 'fusion-only') {
+    const scored = scoreFixtureQuery(query, now);
+    const key = variant === 'composite' ? (m: ScoredMemory) => m.compositeScore : (m: ScoredMemory) => m.fusionScore;
+    return [...scored]
+      .sort((a, b) => key(b) - key(a) || a.id.localeCompare(b.id))
+      .flatMap((m) => {
+        const c = byId.get(m.id);
+        return c ? [c] : [];
+      });
+  }
+
+  return [...query.candidates].sort(
+    (a, b) => signalKey(b, variant) - signalKey(a, variant) || a.id.localeCompare(b.id),
+  );
+}
+
+// ---------- recall@token-budget ----------
+
+/**
+ * Greedily pack the ranked candidates to the token budget (reusing the
+ * production `estimateTokens` + `packToBudget` skip-not-break semantics) and
+ * report whether the gold candidate landed in the packed set.
+ */
+export function recallAtBudget(query: FixtureQuery, ranked: FixtureCandidate[], budget: number): boolean {
+  const scored: ScoredMemory[] = ranked.map((c) => ({
+    ...candidateToRow(c),
+    fusionScore: 0,
+    compositeScore: 0,
+  }));
+  const packed = packToBudget(scored, budget);
+  return packed.some((m) => m.id === query.gold_id);
+}
+
+/** Mean recall@budget over all queries for one ranking variant. */
+export function meanRecallForVariant(
+  queries: readonly FixtureQuery[],
+  variant: RankingVariant,
+  budget: number,
+  now: number,
+): number {
+  if (queries.length === 0) return 0;
+  let hits = 0;
+  for (const query of queries) {
+    const ranked = rankCandidates(query, variant, now);
+    if (recallAtBudget(query, ranked, budget)) hits += 1;
+  }
+  return hits / queries.length;
+}
+
+/** recall@budget for every ranking variant. */
+export function recallTable(
+  queries: readonly FixtureQuery[],
+  budget: number,
+  now: number,
+): Record<RankingVariant, number> {
+  const table = {} as Record<RankingVariant, number>;
+  for (const variant of RANKING_VARIANTS) {
+    table[variant] = meanRecallForVariant(queries, variant, budget, now);
+  }
+  return table;
+}
+
+// ---------- Kendall-tau (ranking influence) ----------
+
+/**
+ * Kendall-tau rank correlation between two orderings of the same id set.
+ * +1 = identical order, -1 = reversed, 0 = uncorrelated. Tau well below 1.0
+ * between `composite` and `fusion-only` means the recency/importance terms are
+ * actively reshaping the ranking (the LIVE-lever test).
+ *
+ * Ids present in one ordering but not the other are dropped (we only compare the
+ * shared set). Returns 1.0 for sets of size < 2 (no pairs ⇒ trivially agreeing).
+ */
+export function kendallTau(orderA: readonly string[], orderB: readonly string[]): number {
+  const setB = new Set(orderB);
+  const common = orderA.filter((id) => setB.has(id));
+  const rankB = new Map<string, number>();
+  orderB.forEach((id, i) => rankB.set(id, i));
+
+  const n = common.length;
+  if (n < 2) return 1.0;
+
+  let concordant = 0;
+  let discordant = 0;
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      // In orderA, common[i] precedes common[j] by construction.
+      const bi = rankB.get(common[i]);
+      const bj = rankB.get(common[j]);
+      if (bi === undefined || bj === undefined) continue;
+      if (bi < bj) concordant += 1;
+      else discordant += 1;
+    }
+  }
+  const totalPairs = (n * (n - 1)) / 2;
+  if (totalPairs === 0) return 1.0;
+  return (concordant - discordant) / totalPairs;
+}
+
+/**
+ * Mean Kendall-tau between the `composite` and `fusion-only` per-query
+ * orderings across all queries. The anti-LoCoMo "reshapes rankings" signal.
+ */
+export function meanCompositeVsFusionTau(queries: readonly FixtureQuery[], now: number): number {
+  if (queries.length === 0) return 1.0;
+  let sum = 0;
+  for (const query of queries) {
+    const composite = rankCandidates(query, 'composite', now).map((c) => c.id);
+    const fusion = rankCandidates(query, 'fusion-only', now).map((c) => c.id);
+    sum += kendallTau(composite, fusion);
+  }
+  return sum / queries.length;
+}
+
+// ---------- Distributional summarizers ----------
+
+export interface NumericSummary {
+  count: number;
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  stddev: number | null;
+}
+
+/** min/max/mean/stddev (population) of a numeric array. Empty ⇒ all null. */
+export function summarizeNumeric(values: readonly number[]): NumericSummary {
+  if (values.length === 0) {
+    return { count: 0, min: null, max: null, mean: null, stddev: null };
+  }
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+  }
+  const mean = sum / values.length;
+  let sqDiff = 0;
+  for (const v of values) sqDiff += (v - mean) ** 2;
+  const stddev = Math.sqrt(sqDiff / values.length);
+  return { count: values.length, min, max, mean, stddev };
+}
+
+/** Percentiles (linear interpolation) of a numeric array at the given fractions [0,1]. */
+export function percentiles(values: readonly number[], fractions: readonly number[]): Record<string, number | null> {
+  const result: Record<string, number | null> = {};
+  if (values.length === 0) {
+    for (const f of fractions) result[`p${Math.round(f * 100)}`] = null;
+    return result;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  for (const f of fractions) {
+    const key = `p${Math.round(f * 100)}`;
+    const rank = f * (sorted.length - 1);
+    const lo = Math.floor(rank);
+    const hi = Math.ceil(rank);
+    result[key] = lo === hi ? sorted[lo] : sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+  }
+  return result;
+}
+
+/**
+ * Histogram of a numeric array into fixed-width buckets. Returns a label→count
+ * map; labels are the bucket's lower bound formatted to `decimals`. Values are
+ * assigned to `floor((v - origin) / width)`.
+ */
+export function histogram(values: readonly number[], width: number, origin = 0, decimals = 1): Record<string, number> {
+  const buckets: Record<string, number> = {};
+  for (const v of values) {
+    const idx = Math.floor((v - origin) / width);
+    const lower = origin + idx * width;
+    const label = lower.toFixed(decimals);
+    buckets[label] = (buckets[label] ?? 0) + 1;
+  }
+  return buckets;
+}
+
+// ---------- Recency-specific summaries ----------
+
+/** Convert an epoch-ms timestamp to a `YYYY-MM` (UTC) bucket label. */
+export function yearMonth(epochMs: number): string {
+  const d = new Date(epochMs);
+  const y = d.getUTCFullYear();
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+/** Convert an epoch-ms timestamp to a `YYYY-Qn` (UTC) quarter label. */
+export function yearQuarter(epochMs: number): string {
+  const d = new Date(epochMs);
+  const q = Math.floor(d.getUTCMonth() / 3) + 1;
+  return `${d.getUTCFullYear()}-Q${q}`;
+}
+
+export interface RecencySummary {
+  numeric: NumericSummary;
+  distinctYearMonths: number;
+  spanDays: number | null;
+  fractionByYear: Record<string, number>;
+  histogramByQuarter: Record<string, number>;
+}
+
+/** Recency distribution over an array of created_at epoch-ms timestamps. */
+export function summarizeRecency(createdAt: readonly number[]): RecencySummary {
+  const numeric = summarizeNumeric(createdAt);
+  const months = new Set(createdAt.map(yearMonth));
+  const byYear: Record<string, number> = {};
+  for (const ts of createdAt) {
+    const y = String(new Date(ts).getUTCFullYear());
+    byYear[y] = (byYear[y] ?? 0) + 1;
+  }
+  const fractionByYear: Record<string, number> = {};
+  for (const [y, n] of Object.entries(byYear)) {
+    fractionByYear[y] = createdAt.length === 0 ? 0 : n / createdAt.length;
+  }
+  const histogramByQuarter: Record<string, number> = {};
+  for (const ts of createdAt) {
+    const q = yearQuarter(ts);
+    histogramByQuarter[q] = (histogramByQuarter[q] ?? 0) + 1;
+  }
+  const spanDays =
+    numeric.min !== null && numeric.max !== null ? (numeric.max - numeric.min) / (1000 * 60 * 60 * 24) : null;
+  return { numeric, distinctYearMonths: months.size, spanDays, fractionByYear, histogramByQuarter };
+}
+
+export interface ImportanceSummary {
+  numeric: NumericSummary;
+  distinctValues: number;
+  fractionAtSeed: number;
+  histogram: Record<string, number>;
+}
+
+/** The seed importance value the engine stamps before extraction overrides it. */
+export const IMPORTANCE_SEED = 0.5;
+
+/** Importance distribution, including the fraction sitting EXACTLY at the seed. */
+export function summarizeImportance(importance: readonly number[]): ImportanceSummary {
+  const numeric = summarizeNumeric(importance);
+  const distinct = new Set(importance).size;
+  const atSeed = importance.filter((v) => v === IMPORTANCE_SEED).length;
+  return {
+    numeric,
+    distinctValues: distinct,
+    fractionAtSeed: importance.length === 0 ? 0 : atSeed / importance.length,
+    histogram: histogram(importance, 0.1, 0, 1),
+  };
+}
+
+// ---------- Stratified sampler ----------
+
+/**
+ * Small deterministic PRNG (mulberry32) so sampling is reproducible across runs
+ * given a `--seed`. Math.random is fine in a script, but the diagnostic must be
+ * re-runnable to the same sample for comparison.
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** A row eligible for sampling — only the bucketing key matters here. */
+export interface SampleRow {
+  id: string;
+  created_at: number;
+}
+
+/**
+ * Stratified sample of `total` ids across recency buckets so older years are
+ * represented, not just recent ones. Rows are bucketed by `bucketOf` (default:
+ * calendar year). The target per bucket is `total / numBuckets`; under-filled
+ * buckets donate their slack to the others via a second pass. Sampling within a
+ * bucket and bucket-fill order are driven by the seeded PRNG, so re-runs with
+ * the same seed produce the same sample.
+ */
+export function stratifiedSample(
+  rows: readonly SampleRow[],
+  total: number,
+  rng: () => number,
+  bucketOf: (row: SampleRow) => string = (r) => String(new Date(r.created_at).getUTCFullYear()),
+): string[] {
+  if (total <= 0 || rows.length === 0) return [];
+
+  const byBucket = new Map<string, SampleRow[]>();
+  for (const row of rows) {
+    const key = bucketOf(row);
+    const list = byBucket.get(key) ?? [];
+    list.push(row);
+    byBucket.set(key, list);
+  }
+
+  // Shuffle within each bucket deterministically.
+  const buckets = [...byBucket.entries()].sort(([a], [b]) => a.localeCompare(b));
+  for (const [, list] of buckets) shuffleInPlace(list, rng);
+
+  const cap = Math.min(total, rows.length);
+  const perBucket = Math.max(1, Math.floor(cap / buckets.length));
+
+  // First pass: take up to perBucket from each bucket.
+  const selected: string[] = [];
+  const remaining = new Map<string, SampleRow[]>();
+  for (const [key, list] of buckets) {
+    const take = Math.min(perBucket, list.length);
+    for (let i = 0; i < take; i += 1) selected.push(list[i].id);
+    remaining.set(key, list.slice(take));
+  }
+
+  // Second pass: round-robin the leftover slots from buckets that still have rows.
+  const leftover = buckets.flatMap(([key]) => remaining.get(key) ?? []);
+  shuffleInPlace(leftover, rng);
+  for (const row of leftover) {
+    if (selected.length >= cap) break;
+    selected.push(row.id);
+  }
+
+  return selected.slice(0, cap);
+}
+
+function shuffleInPlace(arr: SampleRow[], rng: () => number): void {
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+// ---------- Verdict ----------
+
+/** Thresholds for the GO/NO-GO verdict — printed alongside the result. */
+export interface VerdictThresholds {
+  minDistinctYearMonths: number;
+  minRecencyStddevDays: number;
+  minImportanceStddev: number;
+  maxFractionAtSeed: number;
+  maxReshapeTau: number;
+}
+
+export const DEFAULT_THRESHOLDS: VerdictThresholds = {
+  minDistinctYearMonths: 12,
+  minRecencyStddevDays: 30,
+  minImportanceStddev: 0.05,
+  maxFractionAtSeed: 0.5,
+  maxReshapeTau: 0.9,
+};
+
+export interface VerdictInputs {
+  recency: RecencySummary;
+  importance: ImportanceSummary;
+  reshapeTau: number;
+  recallTable: Record<RankingVariant, number>;
+}
+
+export interface VerdictResult {
+  go: boolean;
+  recencyLive: boolean;
+  importanceLive: boolean;
+  reshapesRankings: boolean;
+  notSingleSignalConfound: boolean;
+  /** Names of the conditions that FAILED — empty on GO. */
+  failedConditions: string[];
+  thresholds: VerdictThresholds;
+}
+
+/**
+ * The GO/NO-GO verdict. GO iff the three core anti-LoCoMo conditions hold:
+ *   recency_live AND importance_live AND reshapes_rankings.
+ *
+ * `not_single_signal_confound` (composite ≥ every single-signal baseline) is
+ * SUPPORTING evidence reported in the result but does NOT gate the verdict —
+ * the core question is whether the metadata signals are alive and move order,
+ * not whether composite beats every trivial ranker on a tiny probe. Access being
+ * dead (zero on a fresh corpus) is EXPECTED and does not fail the verdict.
+ */
+export function evaluateVerdict(
+  inputs: VerdictInputs,
+  thresholds: VerdictThresholds = DEFAULT_THRESHOLDS,
+): VerdictResult {
+  const { recency, importance, reshapeTau } = inputs;
+
+  const recencyStddevDays = recency.numeric.stddev === null ? 0 : recency.numeric.stddev / (1000 * 60 * 60 * 24);
+  const recencyLive =
+    (recency.spanDays ?? 0) > 365 &&
+    recency.distinctYearMonths >= thresholds.minDistinctYearMonths &&
+    recencyStddevDays >= thresholds.minRecencyStddevDays;
+
+  const importanceStddev = importance.numeric.stddev ?? 0;
+  const importanceLive =
+    importanceStddev >= thresholds.minImportanceStddev && importance.fractionAtSeed < thresholds.maxFractionAtSeed;
+
+  const reshapesRankings = reshapeTau < thresholds.maxReshapeTau;
+
+  const composite = inputs.recallTable.composite;
+  const notSingleSignalConfound = SINGLE_SIGNAL_VARIANTS.every((v) => composite >= inputs.recallTable[v]);
+
+  const failedConditions: string[] = [];
+  if (!recencyLive) failedConditions.push('recency_live');
+  if (!importanceLive) failedConditions.push('importance_live');
+  if (!reshapesRankings) failedConditions.push('reshapes_rankings');
+
+  const go = recencyLive && importanceLive && reshapesRankings;
+
+  return {
+    go,
+    recencyLive,
+    importanceLive,
+    reshapesRankings,
+    notSingleSignalConfound,
+    failedConditions,
+    thresholds,
+  };
+}

--- a/test/build-corpus.test.ts
+++ b/test/build-corpus.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  assembleTranscript,
+  isEmptyConversation,
+  buildSource,
+  resolveAsOf,
+  buildProgressRecord,
+  buildEmptyProgressRecord,
+  computeResumeSet,
+  parseArgs,
+  DEFAULT_ARGS,
+  type ExportConversation,
+  type ProgressRecord,
+  type IngestResultLike,
+} from '../scripts/memory-corpus/corpus-lib.js';
+
+// ---------- Synthetic fixtures (NOT real export data) ----------
+
+function conv(overrides: Partial<ExportConversation> = {}): ExportConversation {
+  return {
+    uuid: 'conv-1',
+    created_at: '2023-05-01T12:00:00.000Z',
+    chat_messages: [
+      { uuid: 'm1', sender: 'human', text: 'I prefer dark mode.' },
+      { uuid: 'm2', sender: 'assistant', text: 'Noted, dark mode it is.' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('assembleTranscript', () => {
+  it('labels each line with the sender and joins with newlines', () => {
+    expect(assembleTranscript(conv())).toBe('human: I prefer dark mode.\nassistant: Noted, dark mode it is.');
+  });
+
+  it('drops messages whose text is empty or whitespace-only', () => {
+    const c = conv({
+      chat_messages: [
+        { uuid: 'm1', sender: 'human', text: 'keep me' },
+        { uuid: 'm2', sender: 'assistant', text: '' },
+        { uuid: 'm3', sender: 'human', text: '   ' },
+        { uuid: 'm4', sender: 'assistant', text: 'keep me too' },
+      ],
+    });
+    expect(assembleTranscript(c)).toBe('human: keep me\nassistant: keep me too');
+  });
+
+  it('uses `text`, never `content`', () => {
+    // A message carrying only structured `content` (no usable text) is dropped.
+    const c = conv({
+      chat_messages: [
+        { uuid: 'm1', sender: 'human', text: '', content: [{ type: 'text', text: 'from content' }] } as never,
+        { uuid: 'm2', sender: 'assistant', text: 'from text' },
+      ],
+    });
+    const transcript = assembleTranscript(c);
+    expect(transcript).toBe('assistant: from text');
+    expect(transcript).not.toContain('from content');
+  });
+});
+
+describe('isEmptyConversation', () => {
+  it('is false when at least one message has non-empty text', () => {
+    expect(isEmptyConversation(conv())).toBe(false);
+  });
+
+  it('is true when there are no messages', () => {
+    expect(isEmptyConversation(conv({ chat_messages: [] }))).toBe(true);
+  });
+
+  it('is true when all messages have empty/whitespace text', () => {
+    const c = conv({
+      chat_messages: [
+        { uuid: 'm1', sender: 'human', text: '' },
+        { uuid: 'm2', sender: 'assistant', text: '  ' },
+      ],
+    });
+    expect(isEmptyConversation(c)).toBe(true);
+  });
+});
+
+describe('buildSource', () => {
+  it('formats the provenance string as claude-export:<uuid>', () => {
+    expect(buildSource('3f2a-abc')).toBe('claude-export:3f2a-abc');
+  });
+});
+
+describe('resolveAsOf (created_at is the backdate source)', () => {
+  it('resolves an ISO 8601 created_at to its epoch-ms (not now)', () => {
+    // The driver passes resolveAsOf(conv.created_at) as as_of; this asserts the
+    // contract that created_at is the source-of-truth timestamp, not now.
+    const c = conv({ created_at: '2024-02-29T08:30:00.000Z' });
+    expect(resolveAsOf(c.created_at)).toBe(Date.UTC(2024, 1, 29, 8, 30, 0));
+  });
+
+  it('returns undefined for an unparseable or missing created_at (engine falls back to now)', () => {
+    expect(resolveAsOf('not a date')).toBeUndefined();
+    expect(resolveAsOf('')).toBeUndefined();
+    expect(resolveAsOf(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildProgressRecord', () => {
+  function result(overrides: Partial<IngestResultLike> = {}): IngestResultLike {
+    return { created: 5, merged: 2, facts: { length: 7 }, ...overrides };
+  }
+
+  it('records counts only (no fact text)', () => {
+    const record = buildProgressRecord('conv-9', result({ chunks: 3, failed_chunks: 0 }));
+    expect(record).toEqual({
+      uuid: 'conv-9',
+      status: 'ingested',
+      created: 5,
+      merged: 2,
+      facts: 7,
+      failed_chunks: 0,
+      chunks: 3,
+    });
+  });
+
+  it('marks status=partial when partial is set', () => {
+    const record = buildProgressRecord('c', result({ partial: true, failed_chunks: 1, chunks: 2 }));
+    expect(record.status).toBe('partial');
+    expect(record.failed_chunks).toBe(1);
+  });
+
+  it('marks status=skipped-failed when skipped is set', () => {
+    const record = buildProgressRecord('c', result({ skipped: true, created: 0, merged: 0, facts: { length: 0 } }));
+    expect(record.status).toBe('skipped-failed');
+  });
+
+  it('defaults chunks to 1 and failed_chunks to 0 when omitted', () => {
+    const record = buildProgressRecord('c', result());
+    expect(record.chunks).toBe(1);
+    expect(record.failed_chunks).toBe(0);
+  });
+
+  it('buildEmptyProgressRecord produces a zeroed skipped-empty record', () => {
+    expect(buildEmptyProgressRecord('e')).toEqual({
+      uuid: 'e',
+      status: 'skipped-empty',
+      created: 0,
+      merged: 0,
+      facts: 0,
+      failed_chunks: 0,
+      chunks: 0,
+    });
+  });
+});
+
+describe('computeResumeSet', () => {
+  const records: ProgressRecord[] = [
+    { uuid: 'done-ingested', status: 'ingested', created: 3, merged: 0, facts: 3, failed_chunks: 0, chunks: 1 },
+    { uuid: 'done-partial', status: 'partial', created: 1, merged: 0, facts: 1, failed_chunks: 1, chunks: 2 },
+    { uuid: 'done-empty', status: 'skipped-empty', created: 0, merged: 0, facts: 0, failed_chunks: 0, chunks: 0 },
+    { uuid: 'retry-failed', status: 'skipped-failed', created: 0, merged: 0, facts: 0, failed_chunks: 1, chunks: 1 },
+  ];
+
+  it('skips ingested, partial, and skipped-empty; retries skipped-failed', () => {
+    const skip = computeResumeSet(records);
+    expect(skip.has('done-ingested')).toBe(true);
+    expect(skip.has('done-partial')).toBe(true);
+    expect(skip.has('done-empty')).toBe(true);
+    expect(skip.has('retry-failed')).toBe(false);
+  });
+
+  it('treats a uuid as done if any of its records is done, even if a prior attempt failed', () => {
+    const withRetry: ProgressRecord[] = [
+      { uuid: 'x', status: 'skipped-failed', created: 0, merged: 0, facts: 0, failed_chunks: 1, chunks: 1 },
+      { uuid: 'x', status: 'ingested', created: 2, merged: 0, facts: 2, failed_chunks: 0, chunks: 1 },
+    ];
+    expect(computeResumeSet(withRetry).has('x')).toBe(true);
+  });
+
+  it('returns an empty set for no records', () => {
+    expect(computeResumeSet([]).size).toBe(0);
+  });
+});
+
+describe('parseArgs', () => {
+  it('applies defaults when no flags are given', () => {
+    const args = parseArgs([]);
+    expect(args.exportPath).toBe(DEFAULT_ARGS.exportPath);
+    expect(args.dbPath).toBe(DEFAULT_ARGS.dbPath);
+    expect(args.namespace).toBe(DEFAULT_ARGS.namespace);
+    expect(args.dryRun).toBe(false);
+    expect(args.resume).toBe(false);
+    expect(args.limit).toBeUndefined();
+    expect(args.conversation).toBeUndefined();
+  });
+
+  it('parses value flags', () => {
+    const args = parseArgs([
+      '--export',
+      '/tmp/e.json',
+      '--db',
+      '/tmp/m.memdb',
+      '--namespace',
+      'ns',
+      '--conversation',
+      'abc-123',
+    ]);
+    expect(args.exportPath).toBe('/tmp/e.json');
+    expect(args.dbPath).toBe('/tmp/m.memdb');
+    expect(args.namespace).toBe('ns');
+    expect(args.conversation).toBe('abc-123');
+  });
+
+  it('parses boolean flags', () => {
+    const args = parseArgs(['--dry-run', '--resume']);
+    expect(args.dryRun).toBe(true);
+    expect(args.resume).toBe(true);
+  });
+
+  it('parses --limit as a positive integer', () => {
+    expect(parseArgs(['--limit', '3']).limit).toBe(3);
+  });
+
+  it('rejects a non-positive or non-integer --limit', () => {
+    expect(() => parseArgs(['--limit', '0'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--limit', '-1'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--limit', 'abc'])).toThrow(/positive integer/);
+  });
+
+  it('throws when a value flag is missing its value', () => {
+    expect(() => parseArgs(['--db'])).toThrow(/requires a value/);
+    expect(() => parseArgs(['--db', '--resume'])).toThrow(/requires a value/);
+  });
+
+  it('throws on an unknown flag', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/Unknown flag/);
+  });
+
+  it('sets help for --help and -h', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+});

--- a/test/diagnose-corpus.test.ts
+++ b/test/diagnose-corpus.test.ts
@@ -1,0 +1,549 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  summarizeNumeric,
+  percentiles,
+  histogram,
+  summarizeRecency,
+  summarizeImportance,
+  yearMonth,
+  yearQuarter,
+  rankCandidates,
+  recallAtBudget,
+  recallTable,
+  meanRecallForVariant,
+  kendallTau,
+  meanCompositeVsFusionTau,
+  stratifiedSample,
+  mulberry32,
+  evaluateVerdict,
+  DEFAULT_THRESHOLDS,
+  type FixtureCandidate,
+  type FixtureQuery,
+  type SampleRow,
+} from '../scripts/memory-corpus/diagnose-lib.js';
+
+// ---------- Synthetic fixture helpers (NOT real corpus data) ----------
+
+const NOW = Date.UTC(2026, 0, 1); // fixed reference time for deterministic decay
+const DAY = 24 * 60 * 60 * 1000;
+const YEAR = 365 * DAY;
+
+function candidate(overrides: Partial<FixtureCandidate> = {}): FixtureCandidate {
+  return {
+    id: 'c0',
+    is_gold: false,
+    vector_distance: 0.4,
+    bm25_score: -3,
+    created_at: NOW - YEAR,
+    last_accessed_at: NOW - YEAR,
+    access_count: 0,
+    importance: 0.5,
+    content_length: 80,
+    ...overrides,
+  };
+}
+
+/**
+ * A LoCoMo-shaped degenerate query: all importance ≡ 0.5, all created_at
+ * identical, access ≡ 0. The only thing that differs between candidates is the
+ * retrieval signal (vector/bm25) — so composite and fusion-only MUST produce the
+ * same order (tau = 1, reshapes_rankings = false).
+ */
+function degenerateQuery(idx: number): FixtureQuery {
+  const created = Date.UTC(2024, 5, 15); // identical for every candidate
+  const candidates: FixtureCandidate[] = [0, 1, 2, 3, 4].map((i) => ({
+    id: `q${idx}-c${i}`,
+    is_gold: i === 0,
+    vector_distance: 0.2 + i * 0.1,
+    bm25_score: -10 + i * 2,
+    created_at: created,
+    last_accessed_at: created,
+    access_count: 0,
+    importance: 0.5,
+    content_length: 60,
+  }));
+  return { query_id: `q${idx}`, gold_id: `q${idx}-c0`, candidates };
+}
+
+/**
+ * A healthy query: importance and recency VARY in a way that should reorder the
+ * pool versus fusion-only. The gold candidate has a mediocre retrieval signal
+ * but high importance + strong recency, so composite should lift it above
+ * fusion-only neighbours — reshaping the ranking (tau < 1).
+ */
+function healthyQuery(idx: number): FixtureQuery {
+  const candidates: FixtureCandidate[] = [
+    // gold: near-top retrieval AND very recent + very important
+    {
+      id: `q${idx}-gold`,
+      is_gold: true,
+      vector_distance: 0.22,
+      bm25_score: -11,
+      created_at: NOW - 10 * DAY,
+      last_accessed_at: NOW - 10 * DAY,
+      access_count: 0,
+      importance: 0.95,
+      content_length: 70,
+    },
+    // BEST fusion but OLD + LOW importance — composite's metadata terms should
+    // drop it below gold, reshaping the order (the LIVE-lever signal).
+    {
+      id: `q${idx}-a`,
+      is_gold: false,
+      vector_distance: 0.2,
+      bm25_score: -12,
+      created_at: NOW - 4 * YEAR,
+      last_accessed_at: NOW - 4 * YEAR,
+      access_count: 0,
+      importance: 0.3,
+      content_length: 70,
+    },
+    {
+      id: `q${idx}-b`,
+      is_gold: false,
+      vector_distance: 0.5,
+      bm25_score: -6,
+      created_at: NOW - 2 * YEAR,
+      last_accessed_at: NOW - 2 * YEAR,
+      access_count: 0,
+      importance: 0.4,
+      content_length: 70,
+    },
+    {
+      id: `q${idx}-c`,
+      is_gold: false,
+      vector_distance: 0.6,
+      bm25_score: -3,
+      created_at: NOW - 3 * YEAR,
+      last_accessed_at: NOW - 3 * YEAR,
+      access_count: 0,
+      importance: 0.6,
+      content_length: 70,
+    },
+  ];
+  return { query_id: `q${idx}`, gold_id: `q${idx}-gold`, candidates };
+}
+
+// ---------- summarizeNumeric ----------
+
+describe('summarizeNumeric', () => {
+  it('returns all-null for an empty array', () => {
+    expect(summarizeNumeric([])).toEqual({ count: 0, min: null, max: null, mean: null, stddev: null });
+  });
+
+  it('computes min/max/mean/population-stddev', () => {
+    const s = summarizeNumeric([2, 4, 4, 4, 5, 5, 7, 9]);
+    expect(s.min).toBe(2);
+    expect(s.max).toBe(9);
+    expect(s.mean).toBe(5);
+    expect(s.stddev).toBeCloseTo(2, 6); // textbook population stddev = 2
+  });
+
+  it('reports zero stddev for constant input', () => {
+    expect(summarizeNumeric([0.5, 0.5, 0.5]).stddev).toBe(0);
+  });
+});
+
+describe('percentiles', () => {
+  it('interpolates linearly between ranks', () => {
+    const p = percentiles([0, 10, 20, 30, 40], [0, 0.5, 1]);
+    expect(p.p0).toBe(0);
+    expect(p.p50).toBe(20);
+    expect(p.p100).toBe(40);
+  });
+
+  it('returns null per fraction for empty input', () => {
+    expect(percentiles([], [0.5, 0.9])).toEqual({ p50: null, p90: null });
+  });
+});
+
+describe('histogram', () => {
+  it('buckets values into fixed-width bins', () => {
+    const h = histogram([0.0, 0.05, 0.12, 0.55, 0.95], 0.1, 0, 1);
+    expect(h['0.0']).toBe(2); // 0.0 and 0.05
+    expect(h['0.1']).toBe(1); // 0.12
+    expect(h['0.5']).toBe(1); // 0.55
+    expect(h['0.9']).toBe(1); // 0.95
+  });
+});
+
+// ---------- recency / importance summarizers ----------
+
+describe('yearMonth / yearQuarter', () => {
+  it('formats UTC year-month and quarter labels', () => {
+    const ts = Date.UTC(2024, 7, 9); // August 2024 ⇒ Q3
+    expect(yearMonth(ts)).toBe('2024-08');
+    expect(yearQuarter(ts)).toBe('2024-Q3');
+  });
+});
+
+describe('summarizeRecency', () => {
+  it('counts distinct year-months and computes a multi-year span', () => {
+    const ts = [Date.UTC(2023, 0, 1), Date.UTC(2023, 5, 1), Date.UTC(2024, 0, 1), Date.UTC(2025, 11, 1)];
+    const s = summarizeRecency(ts);
+    expect(s.distinctYearMonths).toBe(4);
+    expect(s.spanDays).not.toBeNull();
+    expect(s.spanDays as number).toBeGreaterThan(365 * 2);
+    expect(Object.keys(s.fractionByYear).sort()).toEqual(['2023', '2024', '2025']);
+    expect(s.fractionByYear['2023']).toBeCloseTo(0.5, 6);
+  });
+
+  it('collapses to a single year-month for identical timestamps (LoCoMo-shaped)', () => {
+    const same = Date.UTC(2024, 5, 15);
+    const s = summarizeRecency([same, same, same, same]);
+    expect(s.distinctYearMonths).toBe(1);
+    expect(s.spanDays).toBe(0);
+    expect(s.numeric.stddev).toBe(0);
+  });
+});
+
+describe('summarizeImportance', () => {
+  it('reports distinct values and the fraction exactly at the 0.5 seed', () => {
+    const s = summarizeImportance([0.5, 0.5, 0.7, 0.9]);
+    expect(s.distinctValues).toBe(3);
+    expect(s.fractionAtSeed).toBeCloseTo(0.5, 6);
+    expect(s.numeric.stddev as number).toBeGreaterThan(0);
+  });
+
+  it('flags a fully-flat (all-0.5) distribution', () => {
+    const s = summarizeImportance([0.5, 0.5, 0.5, 0.5]);
+    expect(s.distinctValues).toBe(1);
+    expect(s.fractionAtSeed).toBe(1);
+    expect(s.numeric.stddev).toBe(0);
+  });
+});
+
+// ---------- single-signal rankers ----------
+
+describe('rankCandidates single-signal variants', () => {
+  const q: FixtureQuery = {
+    query_id: 'q',
+    gold_id: 'hi-imp',
+    candidates: [
+      candidate({
+        id: 'old-recent',
+        created_at: NOW - 2 * YEAR,
+        importance: 0.3,
+        access_count: 1,
+        vector_distance: 0.5,
+        bm25_score: -2,
+      }),
+      candidate({
+        id: 'new-recent',
+        created_at: NOW - 1 * DAY,
+        importance: 0.4,
+        access_count: 0,
+        vector_distance: 0.6,
+        bm25_score: -1,
+      }),
+      candidate({
+        id: 'hi-imp',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.9,
+        access_count: 0,
+        vector_distance: 0.55,
+        bm25_score: -3,
+      }),
+      candidate({
+        id: 'hi-access',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.5,
+        access_count: 9,
+        vector_distance: 0.7,
+        bm25_score: -1,
+      }),
+      candidate({
+        id: 'close-vec',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.5,
+        access_count: 0,
+        vector_distance: 0.1,
+        bm25_score: -0.5,
+      }),
+      candidate({
+        id: 'top-bm25',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.5,
+        access_count: 0,
+        vector_distance: 0.8,
+        bm25_score: -20,
+      }),
+    ],
+  };
+
+  it('recency-only ranks the newest first', () => {
+    expect(rankCandidates(q, 'recency-only', NOW)[0].id).toBe('new-recent');
+  });
+
+  it('importance-only ranks the most important first', () => {
+    expect(rankCandidates(q, 'importance-only', NOW)[0].id).toBe('hi-imp');
+  });
+
+  it('access-only ranks the most accessed first', () => {
+    expect(rankCandidates(q, 'access-only', NOW)[0].id).toBe('hi-access');
+  });
+
+  it('vector-only ranks the closest (smallest distance) first', () => {
+    expect(rankCandidates(q, 'vector-only', NOW)[0].id).toBe('close-vec');
+  });
+
+  it('bm25-only ranks the most-negative bm25 first', () => {
+    expect(rankCandidates(q, 'bm25-only', NOW)[0].id).toBe('top-bm25');
+  });
+
+  it('is deterministic (ties break by id)', () => {
+    const a = rankCandidates(q, 'importance-only', NOW).map((c) => c.id);
+    const b = rankCandidates(q, 'importance-only', NOW).map((c) => c.id);
+    expect(a).toEqual(b);
+  });
+});
+
+// ---------- recall@budget ----------
+
+describe('recallAtBudget', () => {
+  const q = healthyQuery(0);
+
+  it('reports gold present when the budget fits the gold-containing top set', () => {
+    const ranked = rankCandidates(q, 'composite', NOW);
+    // Budget large enough to pack everything ⇒ gold is present.
+    expect(recallAtBudget(q, ranked, 1000)).toBe(true);
+  });
+
+  it('reports gold absent when the budget is too small to reach gold', () => {
+    // Rank gold last, then a budget that fits only the first candidate ⇒ gold absent.
+    const ranked = [...q.candidates].sort((a, b) => (a.is_gold ? 1 : 0) - (b.is_gold ? 1 : 0));
+    // First candidate is 70 chars ≈ 18 tokens; budget 20 fits only one ⇒ gold (last) excluded.
+    expect(recallAtBudget(q, ranked, 20)).toBe(false);
+  });
+
+  it('packs with skip-not-break: a small later item still fits', () => {
+    const q2: FixtureQuery = {
+      query_id: 'q2',
+      gold_id: 'small-gold',
+      candidates: [
+        candidate({ id: 'big', is_gold: false, content_length: 400 }),
+        candidate({ id: 'small-gold', is_gold: true, content_length: 8 }),
+      ],
+    };
+    // budget 20 tokens: 'big' is ~100 tokens (skip), 'small-gold' is ~2 tokens (fits).
+    expect(recallAtBudget(q2, q2.candidates, 20)).toBe(true);
+  });
+});
+
+// ---------- Kendall-tau ----------
+
+describe('kendallTau', () => {
+  it('is +1 for identical orderings', () => {
+    expect(kendallTau(['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'd'])).toBe(1);
+  });
+
+  it('is -1 for fully reversed orderings', () => {
+    expect(kendallTau(['a', 'b', 'c', 'd'], ['d', 'c', 'b', 'a'])).toBe(-1);
+  });
+
+  it('is between -1 and 1 for a partial swap', () => {
+    const tau = kendallTau(['a', 'b', 'c', 'd'], ['a', 'c', 'b', 'd']);
+    expect(tau).toBeGreaterThan(-1);
+    expect(tau).toBeLessThan(1);
+  });
+
+  it('returns 1 for sets with fewer than two shared elements', () => {
+    expect(kendallTau(['a'], ['a'])).toBe(1);
+    expect(kendallTau([], [])).toBe(1);
+  });
+});
+
+describe('meanCompositeVsFusionTau', () => {
+  it('is exactly 1 for degenerate queries (metadata is flat, no reshaping)', () => {
+    const queries = [degenerateQuery(0), degenerateQuery(1), degenerateQuery(2)];
+    expect(meanCompositeVsFusionTau(queries, NOW)).toBeCloseTo(1, 6);
+  });
+
+  it('is below 1 for healthy queries (recency/importance reshape order)', () => {
+    const queries = [healthyQuery(0), healthyQuery(1), healthyQuery(2)];
+    expect(meanCompositeVsFusionTau(queries, NOW)).toBeLessThan(1);
+  });
+});
+
+// ---------- recall table ----------
+
+describe('recallTable', () => {
+  it('produces a recall value for every ranking variant', () => {
+    const queries = [healthyQuery(0), healthyQuery(1)];
+    const table = recallTable(queries, 300, NOW);
+    for (const v of [
+      'composite',
+      'fusion-only',
+      'recency-only',
+      'importance-only',
+      'access-only',
+      'bm25-only',
+      'vector-only',
+    ] as const) {
+      expect(table[v]).toBeGreaterThanOrEqual(0);
+      expect(table[v]).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('composite recalls the recency/importance-favored gold the single retrieval signals miss at tight budget', () => {
+    // At a tight budget the gold (weak vector/bm25) is only recalled when the
+    // metadata terms lift it — composite should beat fusion/vector/bm25-only.
+    const queries = [healthyQuery(0), healthyQuery(1), healthyQuery(2)];
+    const budget = 20; // ~18 tokens per 70-char fact ⇒ only one candidate fits
+    expect(meanRecallForVariant(queries, 'composite', budget, NOW)).toBe(1);
+    expect(meanRecallForVariant(queries, 'fusion-only', budget, NOW)).toBeLessThan(1);
+  });
+});
+
+// ---------- stratified sampler ----------
+
+describe('stratifiedSample', () => {
+  function rowsAcrossYears(): SampleRow[] {
+    const rows: SampleRow[] = [];
+    for (const year of [2023, 2024, 2025, 2026]) {
+      for (let i = 0; i < 20; i += 1) {
+        rows.push({ id: `${year}-${i}`, created_at: Date.UTC(year, i % 12, 1) });
+      }
+    }
+    return rows;
+  }
+
+  it('covers every recency bucket (no year left unrepresented)', () => {
+    const rows = rowsAcrossYears();
+    const sample = stratifiedSample(rows, 12, mulberry32(42));
+    const years = new Set(sample.map((id) => id.split('-')[0]));
+    expect(years).toEqual(new Set(['2023', '2024', '2025', '2026']));
+  });
+
+  it('is deterministic for a fixed seed', () => {
+    const rows = rowsAcrossYears();
+    const a = stratifiedSample(rows, 12, mulberry32(7));
+    const b = stratifiedSample(rows, 12, mulberry32(7));
+    expect(a).toEqual(b);
+  });
+
+  it('produces a different sample for a different seed', () => {
+    const rows = rowsAcrossYears();
+    const a = stratifiedSample(rows, 12, mulberry32(7));
+    const b = stratifiedSample(rows, 12, mulberry32(99));
+    expect(a).not.toEqual(b);
+  });
+
+  it('never exceeds the requested total or the available rows', () => {
+    const rows = rowsAcrossYears();
+    expect(stratifiedSample(rows, 12, mulberry32(1)).length).toBe(12);
+    expect(stratifiedSample(rows, 10000, mulberry32(1)).length).toBe(rows.length);
+  });
+
+  it('returns empty for total <= 0 or no rows', () => {
+    expect(stratifiedSample(rowsAcrossYears(), 0, mulberry32(1))).toEqual([]);
+    expect(stratifiedSample([], 5, mulberry32(1))).toEqual([]);
+  });
+});
+
+// ---------- VERDICT: the anti-vacuity proof ----------
+
+describe('evaluateVerdict — degenerate (LoCoMo-like) corpus → NO-GO', () => {
+  // All importance 0.5, all created_at identical, access 0. The diagnostic must
+  // FAIL this — it is exactly the corpus shape that made the metadata terms dead
+  // weight in the LoCoMo benchmark.
+  const sameTs = Date.UTC(2024, 5, 15);
+  const flatCreatedAt = Array.from({ length: 200 }, () => sameTs);
+  const flatImportance = Array.from({ length: 200 }, () => 0.5);
+  const queries = [degenerateQuery(0), degenerateQuery(1), degenerateQuery(2)];
+
+  const verdict = evaluateVerdict({
+    recency: summarizeRecency(flatCreatedAt),
+    importance: summarizeImportance(flatImportance),
+    reshapeTau: meanCompositeVsFusionTau(queries, NOW),
+    recallTable: recallTable(queries, 300, NOW),
+  });
+
+  it('returns NO-GO', () => {
+    expect(verdict.go).toBe(false);
+  });
+
+  it('fails importance_live (flat importance ≡ 0.5)', () => {
+    expect(verdict.importanceLive).toBe(false);
+    expect(verdict.failedConditions).toContain('importance_live');
+  });
+
+  it('fails reshapes_rankings (tau ≈ 1: metadata moves nothing)', () => {
+    expect(verdict.reshapesRankings).toBe(false);
+    expect(verdict.failedConditions).toContain('reshapes_rankings');
+  });
+
+  it('fails recency_live (identical created_at ⇒ no span, one year-month)', () => {
+    expect(verdict.recencyLive).toBe(false);
+    expect(verdict.failedConditions).toContain('recency_live');
+  });
+});
+
+describe('evaluateVerdict — healthy corpus → GO', () => {
+  // Multi-year recency + varied importance that reshapes rankings.
+  function healthyCreatedAt(): number[] {
+    const ts: number[] = [];
+    for (let year = 2023; year <= 2026; year += 1) {
+      for (let month = 0; month < 12; month += 1) {
+        ts.push(Date.UTC(year, month, 10));
+        ts.push(Date.UTC(year, month, 20));
+      }
+    }
+    return ts;
+  }
+  function variedImportance(): number[] {
+    const vals: number[] = [];
+    const levels = [0.6, 0.7, 0.8, 0.9, 0.55, 0.65];
+    for (let i = 0; i < 200; i += 1) vals.push(levels[i % levels.length]);
+    return vals;
+  }
+  const queries = [healthyQuery(0), healthyQuery(1), healthyQuery(2)];
+
+  const verdict = evaluateVerdict({
+    recency: summarizeRecency(healthyCreatedAt()),
+    importance: summarizeImportance(variedImportance()),
+    reshapeTau: meanCompositeVsFusionTau(queries, NOW),
+    recallTable: recallTable(queries, 300, NOW),
+  });
+
+  it('returns GO', () => {
+    expect(verdict.go).toBe(true);
+    expect(verdict.failedConditions).toEqual([]);
+  });
+
+  it('marks all three core conditions live', () => {
+    expect(verdict.recencyLive).toBe(true);
+    expect(verdict.importanceLive).toBe(true);
+    expect(verdict.reshapesRankings).toBe(true);
+  });
+
+  it('prints the thresholds it used', () => {
+    expect(verdict.thresholds).toEqual(DEFAULT_THRESHOLDS);
+  });
+});
+
+describe('evaluateVerdict — dead access alone does NOT fail the verdict', () => {
+  // A healthy corpus where access is zero everywhere (fresh, never queried).
+  // access is a LATENT signal; the verdict must still be GO.
+  function healthyCreatedAt(): number[] {
+    const ts: number[] = [];
+    for (let year = 2023; year <= 2026; year += 1) {
+      for (let month = 0; month < 12; month += 1) ts.push(Date.UTC(year, month, 15));
+    }
+    return ts;
+  }
+  const importance = Array.from({ length: 48 }, (_, i) => 0.5 + (i % 5) * 0.1);
+  const queries = [healthyQuery(0), healthyQuery(1)]; // access_count is 0 in all healthy candidates
+
+  const verdict = evaluateVerdict({
+    recency: summarizeRecency(healthyCreatedAt()),
+    importance: summarizeImportance(importance),
+    reshapeTau: meanCompositeVsFusionTau(queries, NOW),
+    recallTable: recallTable(queries, 300, NOW),
+  });
+
+  it('is still GO even though access-only recall is the floor', () => {
+    expect(verdict.go).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Builds the `memory_ingest` MCP tool (LLM decomposition of raw blobs into atomic-fact memories) and the tooling to build + validate a **representative** memory corpus from a real conversation export — so the composite retrieval scorer can later be evolved against a corpus where the metadata signals are actually alive.

Motivation: the LoCoMo benchmark is **not representative** — it ingests flat (`importance ≡ 0.5`, near-identical `created_at`, `access ≡ 0`), so the scorer's recency/importance/access terms are dead weight and an `evolve` run "wins" only by dropping them (which would regress production). This branch produces a corpus whose metadata signals are demonstrably live.

**Out of scope:** running `evolve` itself (that harness lives on `dogfood/memory-fusion`). This branch stops at a merged, demonstrated-representative corpus + the tooling to rebuild it.

## Contents

**1. `memory_ingest` tool** (`packages/memory-mcp-server`) — one Haiku call per chunk decomposes a blob into atomic facts, each written through the existing store→dedup→consolidation path. Recency/importance fidelity are insert-time decisions the tool owns:
- order-independent merge timestamps (`created_at = MIN`, `last_accessed = MAX`) so a repeated fact keeps its true first-seen date regardless of ingest order;
- per-fact importance emitted by extraction (not flat 0.5);
- `on_extraction_failure: degrade|skip|error` + observable partial-chunk (no silent blob contamination);
- `as_of` backdating, `dry_run`, durability-filtered prompts, PII-safe logging (incl. scrubbing the shared `llm/client` error log).

Extraction prompts also require naming the fact's **referent** (which project/product/document), so facts are atomic *and* complete.

**2. Corpus-build driver** (`scripts/memory-corpus/build-corpus.ts`) — ingests an export per-conversation with the conversation's real date as `as_of`, fail-loud, resumable, deterministic maintenance (suspend the per-store decay pass mid-bulk — it uses `now - created_at` and would prune backdated facts — and run one consolidation at the end), content-free logging.

**3. Representativeness diagnostic** (`scripts/memory-corpus/diagnose-corpus.ts`) — distributional liveness + a self-supervised recall probe (on a db copy) reusing the **production** scorers, single-signal control baselines, and Kendall-τ ranking influence → explicit **GO/NO-GO**. Anti-vacuity unit-proven (a LoCoMo-shaped degenerate fixture yields NO-GO).

## Result on a real corpus (3,962 facts)

**Verdict: GO** — `recency_live ✓  importance_live ✓  reshapes_rankings ✓`:
- importance stddev **0.120**, 13 distinct values, only **3.8%** at the 0.5 seed (vs LoCoMo's ~100% flat);
- ~22-month recency spread (2024-08 → 2026-06);
- composite-vs-fusion Kendall-τ = **0.563** — the recency/importance terms actively reshape rankings (on LoCoMo τ≈1.0, dead);
- no single-signal confound (composite recall ≥ every trivial baseline).

See [`docs/designs/memory-corpus-and-diagnostic.md`](docs/designs/memory-corpus-and-diagnostic.md) for the full methodology, the honest scoping (the probe proves non-degeneracy + live levers, not that metadata *improves* recall — that's what `evolve` will answer), and the recency-gap accounting.

## Privacy

The export, corpus DB, fixtures, and reports are private and **gitignored**; every persisted artifact is content-free (ids + numeric signals only). LLM extraction egresses conversation text to Haiku (the user's own Claude data, consented).

## Tests

Package suite **223 passed**; script-logic suites **66 passed** (driver 25, diagnostic 41, incl. the degenerate→NO-GO anti-vacuity proof). tsc/lint/prettier clean.

## Evolve-ready handoff

Once merged, the `dogfood/memory-fusion` harness can be rebased onto master and pointed at this corpus instead of LoCoMo.