### PR TITLE
feat(memory): atomic-fact ingest + parent-context retrieval for the memory server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ docs/vuln-discovery-onboarding/*.pdf
 
 # Local scratch / staged experiments — never committed
 donotcommit/
+
+# Claude conversation exports + ingested memory DBs (SENSITIVE — never commit)
+**/claude-export/
+**/conversations.json
+**/memories.json
+*.memdb
+*.memdb-*

--- a/docs/brainstorm/memory-inferred-metadata-proposal.md
+++ b/docs/brainstorm/memory-inferred-metadata-proposal.md
@@ -1,0 +1,208 @@
+# Proposal: Auto-inferred metadata for `memory-mcp-server`
+
+**Status:** Brainstorm / proposal for discussion
+**Scope:** Should memories get (1) automatically inferred **tags**, (2) an inferred **title**, and (3) be decomposed from raw input into atomic memories via an **`ingest`/`remember` tool**?
+**Origin:** Cross-study of [`OpenAnonymity/nanomem`](https://github.com/OpenAnonymity/nanomem) vs. our `@provos/memory-mcp-server`.
+**Note:** Nothing outside this project depends on the memory interface, so schema changes are on the table.
+
+---
+
+## TL;DR — recommendation
+
+1. **Decomposition — yes, and the highest-value of the three (Question 3).** Add a separate, explicitly-LLM **`ingest`/`remember` tool** that takes a raw blob (conversation, document, session summary) and fans it out into atomic memories. Keep the existing `store` fast and LLM-free; unlike tags/titles, decomposition must happen **at ingestion, before embedding**, so it cannot be deferred to consolidation.
+2. **Tags — yes, infer them, but the inference must converge on an existing vocabulary, not invent free-form labels.** Run it in the **deferred consolidation pass** (which already makes a batched LLM call and already has the namespace loaded), never on the synchronous write path. Caller-supplied tags stay authoritative; inference only fills the gap and canonicalizes.
+3. **Titles — yes, but lazily and conditionally, not for every memory.** A title earns its keep for **compacted/long** memories (where it's nearly free and genuinely aids scanning); for short atomic facts it's mostly a restatement of `content`, so derive it mechanically or skip it.
+4. The single most important *tag-consistency* decision is **vocabulary convergence**. Naive LLM tagging produces "preference" / "preferences" / "user-pref" sprawl that makes our AND-filter and stats *worse*, not better.
+
+The reasoning below explains why these are the right calls given that **our retrieval is already semantic** (so metadata doesn't have to carry recall the way it does in nanomem) and our **write path is deliberately LLM-free**.
+
+---
+
+## 1. What the two systems actually do
+
+### nanomem (the source of the ideas)
+
+| Dimension | nanomem |
+|---|---|
+| Storage | Plain **markdown files**. No embeddings, no vector store, no ANN anywhere. |
+| Record | A markdown **bullet** with pipe-delimited metadata: `text \| topic= \| tier= \| status= \| source= \| confidence= \| updated_at= …` |
+| "Tags" | **No free-form tag array.** A single normalized `topic=` slug (LLM-suggested, *often overridden by the folder name*), plus **which file/folder the LLM writes to** as the real organizing axis. Strong "prefer fewer, broader files" bias. |
+| "Title" | Per-**file** `oneLiner` = **mechanical** concat of the first ≤4 active fact texts, truncated to 120 chars. *No LLM.* No per-memory title or abstractive summary anywhere. |
+| Retrieval | **LLM agent navigates the markdown tree** + literal substring search; mechanical fallback score fuses keyword overlap + tier + status + source-trust + confidence. |
+| Write | **Every write is an LLM call** — extract facts, then decide create / append / corroborate (boost confidence) / supersede (decay confidence). |
+| Decomposition | **One input → many memories.** A conversation/document is split by the LLM into atomic bullets across files; long inputs are chunked. |
+
+The thing to internalize: in nanomem the topic slug + folder placement + oneLiner **are the retrieval index** — there's nothing else. They are forced to be good because there are no embeddings.
+
+### Our `@provos/memory-mcp-server`
+
+| Dimension | Ours |
+|---|---|
+| Storage | **SQLite** + `sqlite-vec` (768-dim BGE embeddings, cosine) + **FTS5** (`content`, `tags`) + cross-encoder reranker (ms-marco-MiniLM). |
+| Record | `id` (opaque hex), `namespace`, `content`, `tags[]`, `importance`, timestamps, `access_count`, `is_compacted`, `compacted_from`, `source`, `metadata`. **No `title`/`name`/`slug`/`description`.** (`types.ts:6-20`) |
+| Tags | **User/agent-supplied only**, optional, free-form, no controlled vocabulary, capped at 50/100-char (`validation.ts:8-9`). Used as: FTS signal (weighted 1.5 vs content 3.0), **AND/intersection post-filter** on recall (`pipeline.ts:74-79`), and stats (`computeTopTags`). **No inference anywhere.** |
+| Title | **None.** `content` is the only human-readable label; `id` is opaque hex. |
+| Retrieval | 11-step pipeline: embed query → hybrid vector+FTS candidate gen → relative-score fusion → tag filter → composite score (recency/importance/access) → relevance gate → cross-encoder rerank → embedding dedup → token-budget pack → format. |
+| Write | **Synchronous path makes zero LLM calls** — embed + exact-dedup (cosine > 0.95 merge). Heavier dedup/contradiction is **deferred to consolidation** (batched LLM call every ~50 stores; degrades to "mark all distinct" with no LLM). Compaction does LLM cluster-summarization. |
+| Decomposition | **None server-side.** `store` takes a single pre-formed fact; splitting raw input into atomic facts is left entirely to the calling agent. |
+
+The thing to internalize: **our recall is already semantic.** Vector + FTS + reranker find relevant memories without help from tags or titles. So inferred metadata in our system is *not* needed for recall — its value is filtering, browsing/inspection, and dedup. That changes the cost/benefit versus nanomem entirely.
+
+---
+
+## 2. Question 1 — should tags be automatically inferred?
+
+### The reframe
+
+Borrowing "infer tags" from nanomem without borrowing its constraints is a trap. nanomem doesn't even *have* a free-form tag array — it has one normalized `topic` slug that is frequently overwritten by the folder name. Its consistency comes from **(a) normalization** (`normalizeTopic`: lowercase/slugify/collapse) and **(b) a tiny vocabulary** (folder names, with a "few broad files" rule). That discipline is the whole point.
+
+Our tags are free-form strings supplied ad hoc by whatever agent is writing. If we bolt naive LLM inference on top — "read content, emit tags" — we get **vocabulary drift / tag explosion**: `preference`, `preferences`, `user-preference`, `pref`, `prefs` all coexisting. That actively degrades the two things tags are actually for in our system:
+
+- the **AND-filter** on recall (callers can't predict which spelling to filter on), and
+- **stats / browsing** (`memory_inspect view=tags` becomes noise).
+
+So the question is not "infer or not" — it's **"how do we keep inferred tags self-consistent."**
+
+### Recommendation
+
+**Infer tags during consolidation, against a converging vocabulary, never overwriting caller tags.**
+
+Three design choices, in priority order:
+
+1. **Closed-loop vocabulary (the load-bearing decision).** When inferring, hand the LLM the namespace's existing top-N tags as a *preferred* vocabulary: "reuse one of these unless none fit; only mint a new tag when genuinely novel." The tag space then **converges** instead of exploding. This is the soft analogue of nanomem's "check whether an existing file can absorb this before making a new one."
+2. **Canonicalization.** Slugify (lowercase, dash, dedupe) on the way in; optionally an **embedding-based near-duplicate merge** at consolidation time (we already have the embedder) so `user-prefs` ≈ `preferences` collapses.
+3. **Run it in deferred consolidation, not synchronous write.** Consolidation (`storage/consolidation.ts`) already (a) fires a *batched* LLM call, (b) has the namespace's neighbors loaded for dedup, and (c) operates on exactly the `consolidated:false` rows new writes produce. Tag inference + canonicalization ride that same pass for ~no extra architecture and ~no extra latency on the hot path.
+
+**Caller tags remain ground truth.** If the storing agent supplied tags, keep them; inference *augments/fills*, it does not overwrite. (The system prompt already nudges agents to tag — that signal is higher-quality than inference and should win.)
+
+### Why this is worth doing even though recall is already semantic
+
+Because the payoff is **faceting, browsing, and forget-by-tag** — not recall. Today an agent that didn't bother to tag leaves a memory un-filterable and invisible to `view=tags`. Inference guarantees a baseline of consistent facets across the whole store, which makes `memory_recall tags=[…]`, `memory_forget tags=[…]`, and inspection reliable.
+
+---
+
+## 3. Question 2 — should memories get an inferred title?
+
+### The reframe
+
+nanomem's "title" is **mechanical** and **per-file** (`oneLiner` = concat of first 4 bullets). It has **no per-memory title at all**. Our memories are **atomic facts**, frequently a single sentence. A per-memory abstractive title over a one-sentence fact is often just a lossy restatement of `content` — pure cost, little gain.
+
+But two cases break that symmetry:
+
+- **Compacted memories** are LLM-summarized clusters; `content` can be long, and the compaction LLM call *already runs* — emitting a one-line headline alongside the summary is essentially free and genuinely useful.
+- **Long `content`** (the schema permits up to 10k chars) is hard to scan in `memory_inspect`, the daemon UI, and `view=export`. A headline is the difference between a browsable store and a wall of text.
+
+### Recommendation
+
+**Add an optional, lazily-inferred `title` (short headline, ≤ ~80 chars). Never required, never blocks a write.** Inference strategy by case:
+
+- **Compacted / consolidated memories:** emit `title` from the same LLM call that already produces the summary (free).
+- **Long `content`:** infer a headline during the consolidation pass (alongside tag inference — one call).
+- **Short atomic facts:** derive mechanically (first clause / truncate, nanomem-style) **or leave null.** Don't spend an LLM call to paraphrase one sentence.
+
+Surface `title` in `memory_inspect` (all views), the web UI lists, and `export`; add it as an FTS column weighted between content (3.0) and tags (1.5) — say ~2.0 — so a good headline gives a modest keyword-recall boost as a side effect.
+
+### Bonus consideration — a human-readable handle
+
+Our `id` is opaque hex. The user's *own* auto-memory system (the `MEMORY.md` + per-file `name:` slug convention) shows the value of a stable, human-readable name. A normalized `title` could double as a **slug/handle** for reference and `forget`. Worth deciding explicitly; for v1, a display-only `title` is the minimum, and slug-as-handle is an easy follow-on.
+
+---
+
+## 4. Question 3 — expanding one request into many (fact extraction)
+
+> Highest-value of the three. Unlike tags and titles, this one materially improves *recall*, and it's the one feature that cannot be deferred to consolidation.
+
+### What nanomem does
+
+nanomem's ingestion is not "store this string." You hand it a **conversation or document**, and an agentic loop **extracts the durable facts** and fans them out into many bullets across (potentially) many files — `create_new_file` / `append_memory` / `update_bullets` / `corroborate_bullet`, once per fact, with long inputs chunked. One ingestion request → N writes, and each extracted fact is independently routed to create / append / corroborate / supersede.
+
+### Where we stand
+
+Our `memory_store` takes a single `content` documented as "a single fact," and does **zero** extraction — decomposition is pushed entirely onto the calling agent. So:
+
+- We already have nanomem's **per-fact routing**: exact-dedup at write (`engine-impl.ts:87-98`) + merge/contradiction in consolidation (`storage/consolidation.ts`).
+- We lack nanomem's **per-input fact extraction**: splitting one raw input into atomic facts.
+
+### Why this matters *more* for us than for nanomem
+
+Our recall is **embedding-based**. A compound `content` — *"prefers dark mode, lives in Portland, manager is Alice"* — embeds to one muddy centroid vector; recall for any single fact inside it is degraded, and exact-dedup, `importance`, and decay all operate at the wrong granularity. nanomem's substring + tree-navigation retrieval tolerates fat bullets; **our vector index does not.** Clean atomic facts are a *retrieval-quality requirement* for us, not merely tidiness — which is why this ranks above tags and titles.
+
+### The architectural twist — this one can't be deferred
+
+Tags and titles ride the deferred consolidation pass because they *annotate* an already-stored row. Decomposition is different: **splitting has to happen before embedding**, so each fact gets its own clean vector. Deferring it would let a compound row pollute recall until it's split, then re-embed the pieces — backwards. So decomposition belongs at **ingestion** — not in consolidation, and not bolted onto the synchronous `store` (which stays LLM-free).
+
+### Recommendation — a two-tier ingestion surface
+
+Mirror nanomem's own conversation-vs-document split with two distinct tools:
+
+1. **Fast path — `store` stays LLM-free; the caller pre-decomposes.** The in-loop agent is already an LLM with full conversational context, so it's the best-placed splitter and it's free to us. Strengthen the system prompt ("one atomic fact per `store`") and let `store` accept `content: string | string[]` so the agent can submit a pre-split batch in a single call.
+2. **Heavy path — a new, explicitly-LLM `memory_ingest` / `remember` tool.** Input: a raw blob (conversation transcript, document, or the session-close summary produced by `src/memory/auto-save.ts`). Behavior: one LLM call extracts atomic facts, then each is written through the *normal* `store` → dedup → consolidation machinery — extraction is the only new step; embedding, routing, dedup, tagging, and titling all reuse what already exists (and what §2/§3 add). Long inputs chunk like nanomem. Kept clearly separate from `store` so the hot-path LLM-free guarantee survives, and so external/non-agent MCP clients (this is a standalone published server) still get good atomicity when they hand over a blob.
+
+`src/memory/auto-save.ts` is the natural first consumer: today it asks the agent to store a session summary; it should instead route that summary through `ingest`, so a session becomes a set of atomic facts rather than one blob.
+
+#### `memory_ingest` tool sketch
+
+```ts
+// Heavy, LLM-backed; distinct from the fast memory_store.
+{
+  content: string;                     // raw blob: conversation, document, or summary
+  source?: string;                     // e.g. 'session:abc', 'document', 'conversation'
+  mode?: 'conversation' | 'document';  // strict (explicit facts only) vs. broader extraction
+  tags?: string[];                     // optional seed tags applied to every extracted fact
+  importance?: number;                 // optional default importance for extracted facts
+  dry_run?: boolean;                   // return proposed atomic facts without writing
+}
+// → { ingested: number; memory_ids: string[]; facts?: string[] }   // facts[] when dry_run
+```
+
+`mode` carries nanomem's strict-vs-broad distinction (conversation: only what was explicitly stated, no inference; document: reasonable inference allowed). `dry_run` previews the decomposition before committing — useful for the agent loop and for tests. With no LLM configured, `ingest` degrades to storing the blob as a single memory (and says so), preserving graceful degradation.
+
+---
+
+## 5. Concrete schema/flow changes (if approved)
+
+1. **New `memory_ingest` tool (`tools/ingest.ts` + registration in `server.ts`):** LLM-backed fact extraction → writes each atomic fact through the existing `store` → dedup → consolidation path. Params: `mode` (conversation|document), `dry_run`, optional seed `tags`/`importance`. Chunks long inputs. Degrades to a single-blob store when no LLM is configured.
+2. **`memory_store` accepts `content: string | string[]`:** lets a capable caller submit a pre-split batch in one call without invoking the LLM path.
+3. **Route `src/memory/auto-save.ts` through `ingest`:** session-close summaries get decomposed into atomic facts instead of stored as one blob.
+4. **Schema:** add nullable `title` column + matching FTS column; bump `schema_meta` version (3 → 4) with a migration. Tags stay `string[]`.
+5. **Consolidation pass (`storage/consolidation.ts`):** extend the existing batched LLM call to *also* (a) propose canonical tags against the namespace's existing top-N vocabulary, and (b) emit a `title` for long memories. Mechanical fallback (truncate/first-clause) for short content and for the no-LLM degraded mode.
+6. **Compaction (`storage/compaction.ts`):** have `compactCluster` return `title` alongside the summarized `content` (free — same call).
+7. **Retrieval/format/inspect + web UI:** surface `title`; add the FTS weight; show it in inspect/export/UI lists.
+8. **Invariants:** caller-supplied tags are never overwritten; the `store` write path stays LLM-free; everything degrades gracefully when no LLM is configured.
+
+---
+
+## 6. Alternatives considered and discarded
+
+| # | Alternative | Why discarded |
+|---|---|---|
+| 1 | **Infer synchronously at write time** (nanomem: "every write is an LLM call"). | Destroys our deliberate LLM-free, low-latency, graceful-degradation write path; adds per-store cost/latency. nanomem can afford it because the LLM *is* its engine — we have local embeddings doing recall, and consolidation already gives inference a batched home. |
+| 2 | **Free-form inferred tags with no vocabulary control.** | Tag explosion / vocabulary drift makes the AND-filter and stats *less* reliable than no inference. The converging-vocabulary loop is the fix; without it, don't infer at all. |
+| 3 | **Adopt nanomem's folder + single-`topic` model wholesale (drop tag arrays).** | It's a workaround for *not having embeddings*. We already have hybrid semantic retrieval, so tree navigation buys nothing and we'd lose multi-label faceting. (We *do* borrow the single-normalized-topic discipline as the canonicalization rule for tags.) |
+| 4 | **Mechanical-only title (nanomem `oneLiner` style), no LLM ever.** | Kept as the *fallback* for short content / no-LLM mode, but rejected as the sole mechanism: for compacted/long memories an abstractive headline is meaningfully better and nearly free (compaction already calls the LLM). |
+| 5 | **Separate per-memory abstractive `summary` field (distinct from title) for all memories.** | Overkill for v1: atomic facts don't need it, it's redundant with `content`, and it doubles inference cost. Fold headline into `title`; revisit only if long-content memories become common. |
+| 6 | **Fixed enum tag taxonomy (predefined global categories).** | Too rigid for an open personal-memory domain; brittle as the domain grows. The soft converging-vocabulary approach gets most of the consistency benefit without a hard schema. |
+| 7 | **Title as a required field.** | Would force an LLM call (or a bad mechanical guess) on every write, re-introducing the write-path coupling from #1. Optional + lazy avoids it. |
+| 8 | **Synchronous LLM extraction inside `store`** (nanomem-style, but on our hot path). | Re-couples the fast write path to an LLM and kills its zero-LLM / low-latency guarantee. The separate `ingest` tool delivers extraction without touching `store`. |
+| 9 | **Defer decomposition to the consolidation pass** (the way we defer tags/titles). | Splitting must precede embedding — a compound row pollutes recall until it's split, and split-then-re-embed is wasteful and backwards. Decomposition belongs at ingestion. |
+| 10 | **Status quo: single-fact `store` only, all decomposition left implicit on the caller.** | Fine when the caller is a capable, well-prompted agent; fragile for blob inputs, session summaries, and external/non-agent clients. We keep caller-side splitting for the fast path but add the `string[]` affordance and `ingest` for everything else. |
+
+---
+
+## 7. Out of scope, but worth borrowing later
+
+These came out of the nanomem study and are *not* part of the tags/title decision, but are strong ideas to track:
+
+- **Confidence as a first-class, mutating field** (corroboration → gentle boost; contradiction → sharp decay). We already detect contradictions in consolidation but resolve only by supersession; a confidence signal is a softer, auditable alternative.
+- **Retrieval self-assessment metadata** (`coverage`, `missing_variables`, low-confidence flags) returned from `memory_recall`, so agent loops know when to ask the user instead of guessing.
+- **Tiered memory + automatic expiry** (working / long-term / history, with LLM-set `expires_at` and a zero-LLM prune). Our `importance` decay is the rough analogue; explicit tiers + expiry are more legible.
+
+---
+
+## 8. Open questions for the reviewer
+
+1. Should `title` double as a stable human-readable **handle/slug** (for `forget`/reference), or stay display-only for v1?
+2. What's N for the "existing top-N tags" vocabulary handed to the inference call — global top-N, or query-relevant neighbors' tags?
+3. Do we want an embedding-based tag-merge step now, or start with slug-normalization only and add merge if drift still appears?
+4. **`ingest` rollout:** ship both the `content: string[]` batch affordance on `store` *and* the heavy `ingest` tool, or start with `ingest` alone?
+5. **`ingest` model:** reuse the consolidation/compaction LLM config (`config.ts` default `claude-haiku-4-5`), or use a stronger model for extraction quality?

--- a/docs/designs/memory-corpus-and-diagnostic.md
+++ b/docs/designs/memory-corpus-and-diagnostic.md
@@ -1,0 +1,186 @@
+# Memory corpus build + representativeness diagnostic
+
+**Status:** Results doc for the `feat/memory-ingest` branch. Pairs with the
+[`memory-ingest` tool design](./memory-ingest-tool.md) and the
+[representative-eval-set proposal](./memory-eval-representative-set.md).
+
+## Why this exists
+
+The LoCoMo retrieval benchmark is **not representative** of how the memory
+server is used in production: it ingests every turn flat — `importance ≡ 0.5`,
+near-identical `created_at`, `access_count ≡ 0` — so the composite scorer's
+recency / importance / access terms carry no signal. An `evolve` run against it
+"won" only by **dropping** those dead terms, a change that would regress
+production (where those signals are live). Before evolving the composite scorer
+for real, we need a corpus whose metadata signals are genuinely alive.
+
+This branch builds that corpus from a real, private claude.ai conversation export
+using the production `memory_ingest` path, then runs a diagnostic that decides —
+explicitly, GO/NO-GO — whether the corpus is non-degenerate enough that evolving
+the scorer is meaningful.
+
+**Out of scope:** running `evolve` itself (that harness lives on
+`dogfood/memory-fusion`). This branch stops at a merged, demonstrated-representative
+corpus + the tooling to rebuild it.
+
+## Sensitive data
+
+The export (`donotcommit/claude-export/conversations.json`) and the built corpus
+DB (`donotcommit/corpus/`) are **private** and never committed (gitignored under
+`donotcommit/` plus explicit `**/conversations.json`, `*.memdb*` rules). Every
+persisted artifact the tooling produces — progress log, diagnostic fixture,
+diagnostic report — is **content-free**: ids, counts, and numeric signals only,
+never fact/conversation/query text. LLM extraction sends conversation text to
+Haiku (`claude-haiku-4-5`); this egress is the user's own Claude data and is
+consented.
+
+## The driver (`scripts/memory-corpus/build-corpus.ts`)
+
+Single Node process (run via `tsx`) that owns the DB and calls the production
+`ingestBlob` path per conversation:
+
+- **Unit = atomic fact.** Each conversation transcript (`[sender]: text` lines)
+  is decomposed by one Haiku call per chunk into atomic, self-contained facts —
+  the production ingest path, so the corpus matches how production stores memory.
+- **Faithful recency.** Each conversation's real `created_at` is passed as
+  `as_of`, so every fact carries its source date (not ingest time).
+- **Fail-loud, never contaminate.** `on_extraction_failure: 'skip'` — a fully
+  failed extraction writes nothing (no muddy single-blob fallback into the
+  corpus) and is recorded for retry, rather than silently degrading.
+- **Deterministic maintenance.** `MEMORY_MAINTENANCE_INTERVAL` is set very high
+  so the per-store `maybeRunMaintenance` (which runs a DECAY phase) never fires
+  mid-bulk — critical, because `computeVitality` uses `now - created_at` and would
+  mark backdated facts decayed, destroying the recency spread we are building. A
+  single `runConsolidation` (never full `runMaintenance`) runs at the very end.
+- Resumable (`--resume`), content-free logging, gitignored output.
+
+### Prompt evolution: atomic *and* complete
+
+Initial extraction produced correctly atomic facts, but a minority resolved the
+*subject* while dropping the *referent* — "The user has 5 business days to cancel
+**the contract**" (which contract?), "…before winning **the game**" (which game?).
+The self-containment rule was strengthened to also require naming the specific
+project / product / document / entity the fact is about. Effect on a 6-conversation
+sample: minimum fact length rose 22→58 chars (the context-stripped fragments
+disappeared) while facts stayed atomic (avg ~131 chars) with well-varied
+importance. The full corpus was built with the improved prompt.
+
+## Corpus build results
+
+503 conversations → **3,962 fact rows** (3,975 created, 58 merged), built in ~47 min.
+
+| outcome | conversations |
+|---|---|
+| ingested | 305 |
+| partial (some chunks failed) | 19 |
+| skipped — failed extraction | 30 |
+| skipped — empty (no text) | 149 |
+
+- **Importance:** min 0.20 / mean 0.75 / max 0.95 — genuinely varied per fact
+  (not the flat 0.5 that killed LoCoMo).
+- **Recency:** 2024-08-29 → 2026-06-19, ~22 months.
+
+### The recency reality (honest scoping)
+
+The export *spans* 2023-07 → 2026-06, but the corpus starts 2024-08. This is a
+**data reality, not a pipeline gap**: all 40 of the 2023 conversations are empty
+husks (no message text in the export) — there is nothing to recover. Status by
+year:
+
+| year | ingested | partial | failed | empty |
+|---|---|---|---|---|
+| 2023 | 0 | 0 | 0 | 40 |
+| 2024 | 18 | 0 | 11 | 20 |
+| 2025 | 128 | 11 | 12 | 16 |
+| 2026 | 159 | 8 | 7 | 73 |
+
+So the corpus carries ~22 months of real recency spread — a solid multi-year
+signal, just not the full three years. The 30 failed extractions are spread
+across 2024–26 (not the old data); because extraction runs at temperature 0 they
+are deterministic ("no facts parsed"), so they are genuine no-durable-content /
+format cases (~8.5% of text-bearing conversations), documented here as a known
+completeness gap rather than recoverable loss.
+
+Text-only assembly (ignoring `content` blocks) is deliberate: of the 143
+all-empty-`text` conversations only 2 had any `content`, and those blocks are
+overwhelmingly `thinking` / `tool_use` / `tool_result` — internal reasoning and
+tool noise we explicitly do not want in a memory corpus.
+
+## The diagnostic (`scripts/memory-corpus/diagnose-corpus.ts`)
+
+Answers one question with a GO/NO-GO verdict: are the metadata signals alive and
+do they actively reshape rankings, so that evolving the composite scorer is
+meaningful? Three parts:
+
+- **A. Distributional liveness** (read-only): recency span / distinct months /
+  stddev; importance stddev + fraction stuck at the 0.5 seed; access (latent,
+  ~0 on a fresh corpus — expected, not a failure); content_length (atomic-sized).
+- **B. Self-supervised recall probe** (on a DB *copy* so `access_count` is never
+  mutated): sample N facts stratified by recency, generate one natural query each
+  via Haiku (gold = that fact), build a content-free candidate-pool fixture via
+  real hybrid retrieval, then compute **recall@budget** for the production
+  `composite` and `fusion-only` scorers plus single-signal control baselines
+  (recency / importance / access / bm25 / vector only). Composite and fusion are
+  the **real production functions** (`computeCompositeScore`, `hybridScoreFusion`,
+  `packToBudget`), so the numbers reflect exactly what `evolve` would tune.
+- **C. Ranking influence:** mean Kendall-τ between the composite and fusion-only
+  orderings — τ well below 1 means recency/importance actively reorder results
+  (the live-lever test, the direct antidote to the LoCoMo failure).
+
+**Verdict:** GO iff `recency_live AND importance_live AND reshapes_rankings`. The
+"composite ≥ every single-signal baseline" confound check is supporting evidence,
+not a gate. Anti-vacuity is unit-proven: a LoCoMo-shaped degenerate fixture
+yields NO-GO, a healthy one GO.
+
+## Diagnostic result
+
+Run: `diagnose-corpus.ts --seed 42 --sample 120 --budget 300` over 3,962 rows.
+
+**Verdict: GO** — `recency_live ✓  importance_live ✓  reshapes_rankings ✓`
+(plus the supporting `not_single_signal_confound ✓`).
+
+**A. Distributional liveness**
+
+- Recency: span 659.8 days (2024-08-29 → 2026-06-19), 20 distinct year-months,
+  stddev 114.2 days. Right-skewed toward recent (2024=1%, 2025=32%, 2026=67%) —
+  realistic (recent conversations carry more text), and a genuine multi-month
+  spread, not LoCoMo's single point.
+- Importance: 0.20 / 0.752 / 0.95 (min/mean/max), stddev 0.120, 13 distinct
+  values, only **3.8%** at the 0.5 seed. Alive, model-assigned, varied.
+- Access: 0 everywhere — latent on a fresh corpus, expected, not a failure.
+- Content length: p50 149 chars, p90 232 — atomic facts, not muddy blobs.
+
+**B. Recall@budget (budget = 300 tokens), by ranking variant**
+
+| variant | recall |
+|---|---|
+| composite | 0.983 |
+| fusion-only | 0.983 |
+| vector-only | 0.983 |
+| bm25-only | 0.942 |
+| access-only | 0.075 |
+| importance-only | 0.042 |
+| recency-only | 0.025 |
+
+**C. Ranking influence:** Kendall-τ(composite, fusion-only) = **0.563** (gate < 0.9).
+
+### How to read this (honest scoping)
+
+The probe is self-supervised — each query is generated *from* a fact, so it tests
+"find the source fact from a question about it." Content-based retrieval aces that
+(composite = fusion = vector = 0.983), and the single-metadata baselines are
+near-useless for it (recency/importance/access alone can't locate a content-specific
+fact) — exactly as expected. So composite does **not** beat fusion on this probe,
+and that is fine: the GO is not "metadata improves recall," it is the goal's actual
+bar — **the corpus is non-degenerate and the metadata terms are live levers.** The
+proof is τ = 0.563: at the current weights, recency/importance already reorder
+retrieval substantially (on LoCoMo τ ≈ 1.0 because the terms were constant). The
+levers `evolve` would tune are alive and have headroom, and there is no single-signal
+confound. What this probe does **not** establish — whether metadata *improves*
+relevance-ranked retrieval — is precisely the open question `evolve` exists to
+answer, now on a corpus where the question is meaningful.
+
+**Conclusion: this branch is evolve-ready.** Once merged, the
+`dogfood/memory-fusion` harness can be rebased onto master and pointed at this
+corpus (rebuild with `scripts/memory-corpus/build-corpus.ts`, dump a content-free
+fixture) instead of LoCoMo.

--- a/docs/designs/memory-eval-representative-set.md
+++ b/docs/designs/memory-eval-representative-set.md
@@ -1,0 +1,411 @@
+# A Representative Eval Set for Memory Hybrid-Fusion Retrieval — Feasibility & Proposal
+
+Status: **Proposal + feasibility assessment** (2026-06-21). NOT an implementation. Scopes whether we
+can synthesize a *production-representative* retrieval eval from Claude Code session logs to fix the
+metadata-flatness bug that broke the first ASI-Evolve dogfood. Every load-bearing claim is grounded
+in `file:line` or a measured artifact.
+
+Read-with: [`evolve-memory-fusion-dogfood.md`](./evolve-memory-fusion-dogfood.md) (the harness we
+already built — reuse it), [`evolve-target-workloads.md`](./evolve-target-workloads.md) §2 (why this
+dogfood exists).
+
+---
+
+## 0. The motivating failure (read first)
+
+We ran ASI-Evolve on the memory fusion code (`packages/memory-mcp-server/src/retrieval/scoring.ts`)
+against **LoCoMo** (`benchmark/data/locomo10.json`), with the cached-pool harness in
+`benchmark/fusion-evolve/`. The winning candidate "improved" recall by **dropping the
+recency/importance/access composite terms** from `computeCompositeScore` (`scoring.ts:129-145`).
+
+It won because **those three metadata signals are dead in LoCoMo** — and I verified this empirically
+against the *shipped* fixture (`benchmark/fixture/locomo-pool.jsonl`, 39 MB):
+
+- **`importance` is the single constant `0.5`** across the entire fixture. Ground truth:
+  `benchmark/locomo/ingest.py:40` and the TS port `build-locomo-fixture.ts:114` both call
+  `store(..., importance: 0.5)` for *every* turn. Measured: the set of distinct `importance` values
+  over the first 200 fixture records is exactly `{0.5}`. So `0.1 * memory.importance`
+  (`scoring.ts:145`) is a **constant added to every candidate** — it cannot change any ranking.
+- **`created_at` is one ingest batch.** Every turn is stored in a single tight loop
+  (`build-locomo-fixture.ts:216-221`), then `now` is frozen *once* (`:224`). Spread is sub-second
+  against a ~30-day half-life (`Math.exp(-0.001 * ageHours)`, `scoring.ts:134`), so the recency term
+  is **flat to ~5 decimal places** across candidates.
+- **`access_count` is near-zero noise.** Measured distinct values `{0..9}` — these come only from the
+  same memory being re-retrieved *during the dump itself* (`updateAccessStats`, `queries.ts:120-134`,
+  called at `pipeline.ts:172`); they carry no signal about query relevance.
+
+So the eval was **unrepresentative on exactly the axis the "improvement" exploited.** In production
+those signals are **LIVE**:
+
+- `importance` is a settable tool argument — `memory_store`'s `importance: z.number().min(0).max(1)`
+  (`server.ts:43-48`), "Higher values resist decay."
+- `access_count` / `last_accessed_at` update on **every** retrieval (`updateAccessStats`,
+  `queries.ts:120-134`; called for returned memories at `pipeline.ts:172`).
+- An **"unused memories decay over time"** maintenance pipeline reads all three:
+  `computeVitality` (`maintenance.ts:74-91`) decays a memory using `created_at`, `importance`
+  (half-life ∝ importance, `:78`), `access_count` (reinforcement, `:84`), and `last_accessed_at`
+  (`:87`). A candidate that ignores these signals at retrieval time fights the decay model that
+  *keeps the high-importance, frequently-accessed memories alive in the first place.*
+
+**Porting the LoCoMo winner to production would likely hurt.** The eval must be representative on the
+metadata axis. That is the entire reason this document exists.
+
+---
+
+## 1. What a representative eval set MUST satisfy (derived from the failure)
+
+| # | Requirement | Why (grounded) |
+|---|---|---|
+| **R1** | **Live metadata signals.** Memories accrue over real wall-clock time (`created_at` spans days), with varying `importance`, and `access_count`/`last_accessed_at` reflecting real re-use. | The LoCoMo bug: all three flat. Production reads all three at retrieval (`scoring.ts:129-145`) *and* in decay (`maintenance.ts:74-91`). |
+| **R2** | **Production content distribution.** An *agent's* accumulated memories — facts, decisions, preferences, project/code knowledge — NOT two-persona social dialogue. | A "memory" is whatever the caller stores via `store(content, opts)` (`engine.ts:25`); the server does **no** extraction (§2). LoCoMo/LongMemEval ingest raw chat turns 1:1 (`ingest.py:36-48`). That is not the production distribution. |
+| **R3** | **Relevance queries.** Given a new task/context, *which past memories are relevant* — not factual-evidence QA ("When did Caroline go to the LGBTQ support group?", a real LoCoMo query, `evolve-memory-fusion-dogfood.md:61`). | The production call is `memory_recall(query)` → "what should I remember that bears on this task," `recall.ts`. |
+| **R4** | **Ground-truth relevance labels** — the crux. See §4. | The metric is pure set-membership (`scoring-lib.mjs:26-36`); it needs a gold set per query. |
+| **R5** | **Realistic budget(s).** Score at the production default `2000` AND a ranking-stress budget. | `MEMORY_DEFAULT_TOKEN_BUDGET=2000` (memory CLAUDE.md). The harness already tightened to `300` *deliberately* — `scoring-lib.mjs:11`: "at 2000 recall is near-saturated (0.81 of a 0.91 ceiling) and ranking barely matters; 300 makes ranking the lever." |
+| **R6** | **Comprehensiveness.** Spans the agent's real memory types; large enough to be statistically meaningful. | LoCoMo gives ~1,500-2,000 scorable queries; a representative set should be comparable. |
+
+---
+
+## 2. What a "memory" actually is (confirms R2)
+
+Verified against the engine surface, because the task asked whether we can reuse a built-in
+extraction path:
+
+- **`MemoryEngine` is `store(content, opts) / recall(opts) / context / forget / inspect / close`**
+  (`engine.ts:24-31`). `store` takes **pre-formed `content`** plus `{ tags?, importance? }`
+  (`StoreOptions`, `engine.ts:19-22`). The schema row is `{ id, content, tags, importance,
+  created_at, updated_at, last_accessed_at, access_count, ... }` (`database.ts:6-20`,
+  `types.ts:6-20`).
+- **There is NO transcript→memory extraction path in the server.** The closest things are
+  `compaction.ts` (LLM clusters + summarizes *already-stored* memories) and `consolidation.ts`
+  (dedup at store time) — both operate on existing rows, neither turns a conversation into discrete
+  memories. The store tool description (`server.ts:36-38`) says content "should be a single fact,
+  observation, decision, or preference" — i.e. **the caller is expected to have already extracted.**
+
+**Conclusion for the pipeline: extraction is ours to define.** We cannot "reuse the server's ingest."
+The session-logs pipeline must (a) extract discrete memories from transcripts, (b) call
+`engine.store(content, { tags, importance })` with derived metadata, then (c) reuse the **existing**
+dump tap + evaluator (§5) verbatim. This is a feature, not a gap: it means the eval's content
+distribution is whatever *we* choose, so we can make it agent-coding-work (R2) instead of chat turns.
+
+---
+
+## 3. The Claude Code session-logs synthesis pipeline (core of the proposal)
+
+### 3.1 The raw material — VERIFIED structure
+
+Logs live at `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`. Measured on this machine:
+
+- **26 project dirs, 308 MB total** (`du -sh ~/.claude/projects` = `308M`). The IronCurtain project
+  alone has **20 session files**, largest 20 MB.
+- **Entry types** (one 20 MB session): `user`, `assistant`, `system`, `attachment`,
+  `file-history-snapshot`, `tool` results inside `user` entries, plus harness bookkeeping (`mode`,
+  `permission-mode`, `pr-link`, `ai-title`, …). The load-bearing ones are `user` and `assistant`.
+- **Per-entry ISO-8601 timestamps EXIST.** 5,494 timestamped entries in one file; across all 40
+  files, **36,755 timestamped entries spanning 2026-04-14 → 2026-06-22 (~2.3 months).**
+  *This is the single fact that makes recency real* — unlike LoCoMo's one-batch ingest, these
+  memories would carry a genuine multi-week `created_at` gradient (R1).
+- Each `user`/`assistant` entry also carries `cwd`, `gitBranch`, `sessionId`, `uuid`, `parentUuid`
+  (verified key list). `cwd` → per-project scoping; `parentUuid` → causal thread.
+- **`user` entries** carry either a string (a real prompt, e.g. `"please carefully review
+  @docs/designs/asi-evolve-native-workflow.md …"`) or a list with `tool_result` blocks.
+- **`assistant` entries** carry a list of `text` blocks and `tool_use` blocks — verified a `Bash`
+  call with `input.command`/`input.description`, and `Read`/`Edit` calls expose `file_path`. So
+  **file references and tool actions are recoverable per entry** (load-bearing for both extraction
+  and the behavioral labeling in §4).
+
+> **Feasibility verdict on the raw material: GREEN.** Per-entry timestamps, cwd, file paths, and
+> tool calls all exist. Recency (R1) is derivable from real entry timestamps, not file mtimes.
+
+### 3.2 Memory extraction (transcript → discrete memories)
+
+A new **offline** tool (NOT on the server hot path — same layering discipline the existing tap
+respects, `pipeline.ts:44-54`). Proposed name: `benchmark/session-logs/extract.ts`.
+
+Input: a set of `<session>.jsonl` files. Output: a list of `{ content, tags, created_at, importance,
+access_signals }` records ready for `engine.store`.
+
+Two extraction strategies, in increasing fidelity (recommend starting with the cheap one):
+
+- **(E1) Heuristic / structural extraction (no LLM).** Mine high-signal spans directly:
+  - **User prompts** → "task/intent" memories (the `user` string content).
+  - **Assistant decision statements** → `text` blocks containing decision language (the assistant
+    summarizing what it did / chose).
+  - **File-knowledge memories** → from `Read`/`Edit`/`Bash` `tool_use` inputs: "file `X` does `Y`"
+    keyed on `file_path` (recoverable, §3.1).
+  - **Preferences** → user corrections ("no, don't…", "always use…") — pattern-matchable.
+
+  Cheap, deterministic, no circularity risk, no API cost. Lower recall on subtle facts.
+- **(E2) LLM-assisted extraction.** Feed transcript windows to a model with the *store* tool
+  description (`server.ts:36-38`: "a single fact, observation, decision, or preference") and ask it
+  to emit discrete memories — exactly how a real agent using this server would behave. Higher
+  fidelity, mirrors production usage, but adds API cost and a **provenance** burden (each extracted
+  memory must keep a back-pointer to its source entry `uuid`(s) so §4 labeling can work).
+
+**Metadata derivation (the R1 fix — this is the whole point):**
+
+- **`created_at`** = the **source entry's real timestamp** (§3.1). A memory extracted from an
+  April session is genuinely older than one from June. Recency (`scoring.ts:134`) becomes a *live*
+  signal with a real multi-week spread, not LoCoMo's flat batch.
+- **`importance`** = derived, NOT constant. Candidate signals (pick a documented formula, freeze it):
+  decision/preference memories > incidental file reads; memories the user explicitly emphasized;
+  memories on a `gitBranch` that later merged. Crucially **`importance` must take ≥3 distinct values**
+  or we have re-created the LoCoMo bug. (Sanity-gate the fixture: assert `distinct(importance) ≥ 3`.)
+- **`access_count` / `last_accessed_at`** = derived from **cross-session re-reference**: how often a
+  fact/file/decision reappears in *later* sessions (a file re-Read, a decision restated, a term
+  recurring). This is real re-use, and it is the *same* signal §4(a) uses for labeling — so we get
+  both metadata and labels from one provenance pass. To stay representative, simulate the production
+  feedback loop: replay queries in timestamp order and let `updateAccessStats` (`queries.ts:120-134`)
+  fire naturally, so `access_count` at query *t* reflects only accesses *before* t (no leakage).
+
+> **Design note (avoid a subtle leak):** if `access_count` is derived from the *same* future
+> re-references that define the gold label (§4a), then a candidate could "cheat" by ranking on
+> `access_count` to predict the label. Mitigation: derive `access_count` only from re-references in
+> the window `[memory.created_at, query.created_at)` (strictly past), never from the post-query
+> window the label is drawn from. This keeps the metadata causal and the label honest. **Flag this as
+> an open risk for the adversarial reviewer** — it is the most likely place a representative-looking
+> eval silently re-introduces circularity.
+
+### 3.3 Query construction (transcript → "which past memories are relevant")
+
+A **query** is a later-session task/context; the **gold set** is the earlier memories relevant to it.
+
+- **Query text** = a real later user prompt (`user` string content) or a synthesized "task context"
+  (the first N tokens of a session's opening prompt + cwd + branch). Using the *actual* prompt keeps
+  the query distribution real (R3).
+- **Temporal split is mandatory:** a query at time *t* may only be answered by memories with
+  `created_at < t`. Enforced by processing sessions in timestamp order. This is what makes recency
+  meaningful and prevents "retrieving the future."
+
+### 3.4 Fixture shape — REUSE the existing schema
+
+The extracted memories are stored via `engine.store`, then the **existing dump tap fires unchanged**:
+`pipeline.ts:98-101` already dumps `{ id, dia_id, vector_distance, bm25_score, created_at,
+last_accessed_at, access_count, importance, content_length }` per candidate (`FixtureCandidate`,
+`dump.ts:18-33`). The only change is the **gold key**: replace `gold_dia_ids` with
+`gold_memory_ids` and tag each stored memory with a stable `mem_id:<uuid>` (mirroring LoCoMo's
+`dia_id:<id>` tag, `ingest.py:79`). The evaluator (`scoring-lib.mjs`) is then a one-field rename.
+
+**This is the big payoff of the session-logs path: we built the dump + rescore loop for LoCoMo
+already (`evolve-memory-fusion-dogfood.md`), and it is content-agnostic. We are swapping the
+*ingest+label* front-end, not the harness.**
+
+---
+
+## 4. LABELING — the make-or-break (be rigorous about circularity)
+
+The trap: if the gold set is produced by the **same fusion/embedding the eval is meant to test**,
+the eval just rewards the current ranker — circular. Honest evaluation of the three options:
+
+### (a) Behavioral / implicit — "the agent actually re-referenced it" — RECOMMEND as primary
+
+A past memory is **relevant to a later query** iff, in the transcript, the agent *actually used that
+fact* while serving that task: it re-opened the same `file_path`, restated the same decision, or the
+distinctive fact/term reappears in the later session's `tool_use`/`text`.
+
+- **Why it is NOT circular:** the label comes from **observed human+agent behavior recorded in the
+  logs**, computed from `tool_use` inputs and entry text — it never calls `embedQuery`,
+  `hybridScoreFusion`, or the reranker. It is ground truth from *actual usage*, the gold standard
+  LoCoMo's hand-annotated `evidence` only approximates. This is the same provenance signal that feeds
+  `access_count` (§3.2) — one pass, two products.
+- **Honest weaknesses:** (i) **sparse** — most past memories are never re-referenced, so positives
+  are few; (ii) **noisy** — a file re-Read for an unrelated reason is a false positive; a relevant
+  memory the agent *re-derived from scratch* instead of recalling is a false negative; (iii) it
+  measures "what the agent did re-use," which is a *lower bound* on "what was relevant." Mitigate with
+  a per-query positive floor (drop queries with <1 behavioral positive) and string/AST-level matching
+  for file and decision re-use rather than fuzzy similarity.
+
+### (b) LLM-judged relevance — scalable but circular-risk
+
+Ask a model "is memory M relevant to query Q?" for each candidate pair.
+
+- **Scalable** and gives dense labels. **But two failure modes:** (i) **circularity** — an LLM judge
+  ranks on semantic similarity, the *same* signal the vector arm of the fusion uses, so it rewards
+  the embedding the eval should test independently; (ii) **cost** — O(queries × candidates) judge
+  calls. Acceptable only as a *secondary* signal or spot-check, never the sole gold.
+
+### (c) Hybrid + human spot-check — RECOMMEND as the actual strategy
+
+- **Gold = (a) behavioral.** It is non-circular by construction.
+- **Use (b) LLM-judge ONLY to triage**, never as gold: surface candidates the behavioral pass missed
+  for *human* review (catches false negatives in (a) cheaply), and flag behavioral positives that look
+  like coincidental file touches for removal. The human (not the LLM, not the ranker) is the final
+  arbiter on the spot-checked subset.
+- **Human spot-check a sample** (e.g. 50 queries) to estimate the precision/recall of the behavioral
+  labels themselves, and report it as the eval's *own* error bar.
+
+> **Why this is defensible to an adversarial reviewer:** the primary label is *behavioral re-use
+> recorded in logs* — it cannot reward the ranker because it never invokes the ranker. The LLM only
+> *surfaces candidates for human review*; it does not assign gold. The single residual circularity
+> risk is the `access_count`/label coupling (§3.2 design note), which the strict-past window closes.
+
+---
+
+## 5. Reuse the cached-fixture pattern (don't rebuild the harness)
+
+The whole point of the existing dogfood is that **the per-round eval is pure / fast / zero-model-call /
+no-network** via a cached candidate-pool fixture + a Node rescore loop. That pattern transfers
+unchanged:
+
+1. **Dump once, offline.** Ingest the extracted session-log memories (with LIVE metadata) into a temp
+   DB, run `engine.recall(query)` per constructed query with `MEMORY_FIXTURE_DUMP_DIR` set; the tap
+   at `pipeline.ts:98-101` writes the raw vector+FTS pool (which already carries all five composite
+   fields, `dump.ts:18-33`). The real BGE embedder + sqlite-vec + FTS5 run **only here**
+   (`build-locomo-fixture.ts:27,204` use the production `MemoryEngine` directly — reuse this driver,
+   swap the ingest + gold-join).
+2. **Rescore loop = the evaluator we already have.** `benchmark/fusion-evolve/evaluator.mjs` +
+   `scoring-lib.mjs` rescore a candidate's `rankPool(pool, budget)` against the gold set by
+   set-membership — **deterministic, sub-second, zero model calls** (`evaluator.mjs:10`). Rename
+   `gold_dia_ids → gold_memory_ids` and it works as-is.
+3. **Constant-tuning baseline stays the honest bar.** `tune-constants.mjs` already sweeps the 8
+   constants; on a *live-metadata* fixture this sweep will now find non-trivial recency/importance/
+   access weights (they're no longer dead), which is itself the proof the new set is representative.
+
+---
+
+## 6. PII / privacy handling (mandatory)
+
+Session logs contain the user's **real code, prompts, file contents, and possibly secrets**. This is
+the hardest *non-technical* constraint and a likely blocker for anything that leaves the machine.
+
+Precedent already in the repo: the fixture `.gitignore` (`benchmark/fixture/.gitignore`) ignores
+`*.jsonl` — "Generated fixtures are large derived artifacts … Commit only the GENERATORS." Verified
+`git check-ignore` reports `locomo-pool.jsonl` is ignored. Extend that discipline:
+
+- **Local-only, gitignored, never committed.** The extracted memories, the DB, and the fixture stay
+  under `benchmark/session-logs/` (or `donotcommit/`), all `*.jsonl`/`*.db` gitignored. Only the
+  *extractor/builder/evaluator code* is committed.
+- **Content never enters the fixture.** The existing fixture already stores `content_length`, **not
+  `content`** (`dump.ts:31`: "no conversation text leaks into the fixture") — the evolved surface
+  reads only the length via `estimateTokens` (`scoring.ts:151,205`). Keep this: the candidate pool
+  carries embeddings-derived scores + metadata + length + an opaque `mem_id`, **zero raw text.** This
+  means the *fixture itself* is largely PII-free even though the intermediate DB is not.
+- **Redaction pass on extracted content** *before* it touches the DB: strip obvious secrets
+  (API-key/token regexes — the repo already has credential-handling discipline, CLAUDE.md "Safe
+  Coding"), file paths under `$HOME`, and email/PII. The redaction runs on the embedded text, which
+  never leaves the fixture anyway, but it protects the intermediate DB and any debug dumps.
+- **No LLM extraction (E2) without an explicit local-model / consent gate.** Sending raw transcript
+  windows to a hosted model is a data-egress event. Default to heuristic extraction (E1); gate E2
+  behind a local model (Ollama, as the benchmarks already assume — `locomo/config.py:67`) or explicit
+  opt-in.
+- **Single-user distribution caveat (not privacy, but representativeness):** one developer's logs are
+  one distribution. Document it; do not over-claim generality from a single user's corpus.
+
+---
+
+## 7. Alternatives — honest comparison
+
+| Path | Representativeness | Labeling | PII | Effort | When it's right |
+|---|---|---|---|---|---|
+| **(1) Claude Code session logs** | **Highest** — real agent-coding memories, **live multi-week metadata** (R1✓, R2✓, R3✓). Verified: 36,755 timestamped entries over 2.3 months. | **Hardest** — must build behavioral labeling (§4); circularity + sparsity risk. | **High** — real code/secrets; mitigated by content-free fixture + redaction (§6). | **Largest** — extractor + labeler + redaction are all new; harness reused. | When we need the gold-standard representative set and can absorb the labeling build. |
+| **(2) LongMemEval (`benchmark/longmemeval/`)** | **Partial.** Labeled (500 Q, 6 types), independent held-out. **BUT:** (i) chat-history QA, not agent-coding-work (R2✗, R3✗); (ii) **same flatness bug** — `ingest.py:48` stores every turn with `importance_default=0.5` (`config.py:94`) in one batch (R1✗). | **Ready** — `answer_session_ids` gold (`evolve-memory-fusion-dogfood.md:261`). | Low — public dataset. | **Medium** — **not in-repo, downloads from HF** `xiaowu0162/longmemeval-cleaned` (`dataset.py:20,47`); needs Ollama + a reader/judge LLM to run the full benchmark (`config.py:59,67`). | As a **held-out overfit guard** and a quick "representative-enough" baseline — but it does **NOT** fix the metadata-flatness bug, so it cannot be the *primary* fix. |
+| **(3) Curated synthetic agent-memory set** | **Medium-high, controllable** — hand-design memories with *deliberately varied* importance/recency/access and known-relevant queries. R1 satisfied by construction. | **Easiest** — gold is authored, fully non-circular. | None. | **Medium** — authoring effort; risk of baking in our own assumptions (a designed set may not match real usage). | As the **walking skeleton** and a fast unit-level guard: smallest thing that proves the harness rewards live-metadata candidates. Weakest on *real* distribution. |
+
+### The honest call
+
+**LongMemEval does NOT solve the stated problem.** It is labeled and in-pipeline, but it ingests one
+batch with constant importance (`ingest.py:48`, `config.py:94`) — the *exact* flatness that caused
+the LoCoMo failure. Using it as the primary representative set would re-run the same bug on different
+data. It remains valuable as the **held-out guard** (already its role in
+`evolve-memory-fusion-dogfood.md:255-266`).
+
+So the real choice is **session-logs (gold standard, big build)** vs **curated synthetic (fast, less
+real)**. They are complementary: synthetic is the walking skeleton that *proves the harness
+discriminates on live metadata*; session-logs is the representative set that *proves it on real data.*
+
+---
+
+## 8. Recommendation
+
+**Phased, synthetic-first, session-logs as the gold-standard payoff.**
+
+1. **Fix the harness's metadata-flatness blindness with a curated synthetic slice FIRST** (the
+   walking skeleton, §9). It is fast, PII-free, fully non-circular, and directly proves the central
+   claim: *a candidate that drops the metadata terms must score WORSE on a live-metadata set.* If the
+   synthetic set does not punish the LoCoMo winner, the whole premise is wrong — find that out in a
+   day, not a month.
+2. **Then build the session-logs set as the representative gold standard**, with **behavioral
+   labeling** (§4c) as the primary, LLM-judge as triage-only, human spot-check for the error bar.
+   This is the larger, higher-value build; do it once the skeleton has de-risked the metric.
+3. **Keep LongMemEval as the held-out overfit guard**, exactly as the existing design already
+   positions it — not as the representativeness fix.
+
+**Do NOT** make session-logs a prerequisite for re-running evolve. The synthetic skeleton is enough to
+stop the metadata-flatness regression *today*; session-logs raises the realism ceiling afterward.
+
+---
+
+## 9. THE WALKING SKELETON (smallest slice that fixes the LoCoMo bug end-to-end)
+
+**Goal:** a fixture with **live metadata** on which the LoCoMo-winning candidate (drop metadata terms)
+scores **measurably worse** than a metadata-respecting candidate — using the **existing** evaluator
+unchanged. This is the minimal proof the new axis is representative.
+
+Steps (all host-side, no container, no LLM, hours not days):
+
+1. **Author a tiny curated fixture** `session-pool.mini.jsonl` (~20 query records) in the **existing
+   schema** (`dump.ts:18-39`) but with **deliberately varied metadata**: importance ∈ {0.1, 0.5, 0.9},
+   `created_at` spread over weeks, `access_count` ∈ {0..20}. Construct it so that for some queries the
+   **fusion score ties but the metadata breaks the tie toward the gold memory** — i.e. metadata is
+   load-bearing for the correct answer. (This is exactly the structure LoCoMo cannot have.)
+2. **Reuse `evaluator.mjs` + `scoring-lib.mjs` unchanged** (rename `gold_dia_ids → gold_memory_ids`).
+   Score the **baseline** (`initial_program.mjs`, keeps metadata terms) and the **LoCoMo winner**
+   (a candidate that zeroes the 0.15/0.1/0.1 weights) against the mini fixture.
+3. **Milestone (the de-risk gate):** the baseline scores **higher** than the metadata-dropping
+   candidate. *If it does not, the fixture isn't exercising metadata — fix the fixture before
+   anything else.* This single inversion is the entire thesis: it demonstrates the representative set
+   discriminates exactly where LoCoMo was blind.
+4. **(Then) tiny real slice:** run the §3 extractor (E1 heuristic) over **one** IronCurtain session
+   file, store via `engine.store` with derived `created_at`/`importance`, dump via the existing tap,
+   behavioral-label ~10 queries (§4a) by hand-verified file re-reference. Confirm the harness runs on
+   *real* extracted memories end-to-end. Small, PII-stays-local, proves the extraction+label join.
+
+Deliverable: `node evaluator.mjs <candidate> session-pool.mini.jsonl out.json` prints a **lower** score
+for the metadata-dropping candidate than the baseline — the LoCoMo bug, fixed, in the smallest
+possible artifact, reusing the harness we already validated.
+
+---
+
+## 10. Effort & risk
+
+| Phase | Effort | Risk |
+|---|---|---|
+| 9. Curated synthetic skeleton | **Low** (~1 day) — hand-authored fixture + rename one field in the existing evaluator | **Low** — pure host code, the harness exists |
+| 3. Session-logs extractor (E1 heuristic) + metadata derivation | **Medium** (~2-4 days) | **Med** — extraction quality; `access_count`/label leak (§3.2 design note) |
+| 4. Behavioral labeling + human spot-check | **High** (the crux) | **High** — sparsity, noise, the circularity argument must hold |
+| 6. Redaction + PII discipline | **Low-med** (reuses gitignore precedent + regex redaction) | **Med** — must be airtight before any non-local step |
+| 2 (LLM-assisted extraction E2) | optional | data-egress; gate on local model |
+
+---
+
+## 11. The single biggest risk
+
+**Labeling circularity, with PII a close second.**
+
+- **Circularity (primary).** The eval is worthless if the gold labels are produced by the ranker
+  under test. The defense is §4c: **behavioral re-use as gold** (never invokes embed/fusion/reranker)
+  + LLM-judge as *triage only* + human as final arbiter. The one residual leak is the
+  `access_count`↔label coupling, closed by the strict-past derivation window (§3.2 design note). An
+  adversarial reviewer should attack exactly this seam.
+- **PII (close second).** Real code and secrets in the source logs. Defense: content-free fixture
+  (`dump.ts:31` already stores only `content_length`), redaction before the DB, local-only +
+  gitignored (the `benchmark/fixture/.gitignore` precedent), and no hosted-LLM extraction without a
+  consent/local-model gate.
+
+---
+
+## 12. Grounding index (for the adversarial reviewer)
+
+- LoCoMo flatness, measured: `importance` ≡ `0.5` over the shipped fixture; ingest at
+  `benchmark/locomo/ingest.py:40`, `build-locomo-fixture.ts:114`; frozen `now` at `:224`.
+- Live metadata in production: `server.ts:43-48` (importance settable), `queries.ts:120-134` +
+  `pipeline.ts:172` (access stats update on recall), `maintenance.ts:74-91` (decay reads all three).
+- Evolved surface reads exactly 5 metadata fields: `scoring.ts:129-145`.
+- Memory = caller-formed content, no server extraction: `engine.ts:19-31`, `server.ts:36-38`.
+- Session logs structure (measured): 26 projects / 308 MB; per-entry timestamps (36,755 entries,
+  2026-04-14→2026-06-22); `cwd`/`gitBranch`/`tool_use`/`file_path` per entry.
+- Reusable harness: `benchmark/fixture/dump.ts:18-39` (tap + schema), `build-locomo-fixture.ts`
+  (offline driver, production `MemoryEngine`), `benchmark/fusion-evolve/evaluator.mjs` +
+  `scoring-lib.mjs` (pure rescore, `:11` the 300-vs-2000 budget rationale).
+- LongMemEval same-flatness + HF-download + Ollama: `benchmark/longmemeval/ingest.py:48`,
+  `config.py:94`, `dataset.py:20,47`, `locomo/config.py:67`.
+- PII precedent: `benchmark/fixture/.gitignore` (commit generators, ignore `*.jsonl`).

--- a/docs/designs/memory-ingest-tool.md
+++ b/docs/designs/memory-ingest-tool.md
@@ -84,10 +84,13 @@ facts pre-write.
 
 6. **Malformed model output never throws (by default).** Parsing follows the
    `parseBatchJudgments`-style defensive approach already in `llm/client.ts`: extract a JSON
-   array, validate each item, drop junk. If parsing yields **zero** facts, the default
+   array, validate each item, drop junk. If a chunk **fails to parse** (no JSON array / invalid
+   JSON / non-array → `null`) and no usable facts result, the default
    (`on_extraction_failure='degrade'`) falls back to the single-blob store (same as the no-LLM
    path) so the tool never returns "ingested 0" silently on a parse failure. `'error'` mode
-   surfaces the failure instead.
+   surfaces the failure instead. (A successfully parsed empty array `[]` — the model validly found
+   nothing durable — is **not** a parse failure: it writes nothing and returns a clean empty
+   result, never the degrade/error path.)
 
 7. **(A2) Per-fact importance is assigned at extraction.** The extraction schema is an array of
    `{ fact, importance? }`, not bare strings. The extraction LLM already reads every fact, so
@@ -98,14 +101,17 @@ facts pre-write.
 
 8. **(A1) Merge timestamps are order-independent for backdated ingests.** Dedup is content-
    similarity, **not** time-aware, and a multi-year export may be ingested in any order. When a
-   backdated (`as_of`) fact merges into an existing row, the surviving row's timestamps are
-   reconciled with `min`/`max` (true first-seen / true last-touched), not left to whichever
-   insert happened to land first. v1's "skip the existing row's `created_at` on merge" rule let
+   backdated (`as_of`) fact merges into an existing row, `created_at` (`min`, true first-seen) and
+   `last_accessed_at` (`max`, historical recency) are reconciled order-independently, not left to
+   whichever insert happened to land first. (`updated_at` stays at the local row-mutation time —
+   see §5.4.) v1's "skip the existing row's `created_at` on merge" rule let
    ingest **order** decide the surviving timestamp, flattening recency precisely for the most-
    repeated (hence most-important) facts. Normal non-`as_of` stores are unchanged. See §5.4.
 
 9. **(A3) Partial extraction is observable, never silent.** If any chunk of a multi-chunk call
-   returns null/`[]`, the result reports `degraded: true` and a `failed_chunks` count. v1's
+   **fails** (returns `null` — no LLM, hard error, or unparseable response; a parsed empty `[]`
+   is a clean "nothing durable" result, not a failure), the result reports `degraded: true` and a
+   `failed_chunks` count. v1's
    silent "that chunk contributes nothing, the call still looks fully successful" path is a
    corpus-contamination hazard; v2 eliminates the silence.
 
@@ -233,7 +239,8 @@ export interface IngestResult {
 
   // ---- diagnostics (A3) ----
   chunks?: number;         // number of LLM windows used (omitted when 1)
-  failed_chunks?: number;  // chunks that returned null/[] (omitted when 0)
+  failed_chunks?: number;  // chunks that returned null (no LLM / hard fail / unparseable);
+                           // a parsed [] is NOT a failure. Omitted when 0.
   degraded?: boolean;      // true when we fell back to single-blob store, OR a partial failure
   partial?: boolean;       // true when SOME (not all) chunks failed but others produced facts
   skipped?: boolean;       // true when on_extraction_failure='skip' wrote nothing
@@ -371,9 +378,9 @@ The model returns text. Parse defensively, mirroring `parseBatchJudgments`, into
 `ExtractedFact[]`:
 
 ```
-export function parseExtractedFacts(raw: string): ExtractedFact[] {
-  // 1. Find the first JSON array via /\[[\s\S]*\]/.
-  // 2. JSON.parse; if not an array → return [].
+export function parseExtractedFacts(raw: string): ExtractedFact[] | null {
+  // 1. Find the first JSON array via /\[[\s\S]*\]/; if none → return null (PARSE FAILURE).
+  // 2. JSON.parse; if it throws or the payload is not an array → return null (PARSE FAILURE).
   // 3. For each item, accept EITHER:
   //      - an object { fact: string, importance?: number }  → preferred (A2), OR
   //      - a bare string                                     → treat as { fact, importance: undefined }
@@ -383,13 +390,17 @@ export function parseExtractedFacts(raw: string): ExtractedFact[] {
   //    CLAMP it to [0, 1].
   // 5. Cap count at MAX_FACTS_PER_INGEST (e.g. 200) to bound a runaway response.
   // 6. De-dupe exact-`fact`-string repeats within the batch (keep the first occurrence's importance).
-  // catch → return [].
+  // → return the (possibly EMPTY) array. An empty `[]` is a VALID parse meaning the model
+  //   reported no durable facts (the prompt instructs `[]` in that case) — it is NOT a failure.
 }
 ```
 
-`parseExtractedFacts` is pure and exported → directly unit-testable with canned strings. **(A6)**
-On a parse miss it must not echo `raw` — return `[]` and let the caller log a content-free shape
-(e.g. `"no JSON array found in N-char response"`); see §4.4.
+`parseExtractedFacts` is pure and exported → directly unit-testable with canned strings. It returns
+`ExtractedFact[] | null`: `null` only on a genuine parse failure (no JSON array found, invalid
+JSON, or a non-array payload), and a (possibly empty) array on any successful parse — a parsed `[]`
+is a clean "nothing durable" result, not a failure. **(A6)** On a parse miss it must not echo
+`raw` — return `null` and let the caller log a content-free shape (e.g. `"no JSON array found in
+N-char response"`); see §4.4.
 
 ### 4.4 Retry / error handling (A3 + A6)
 
@@ -397,8 +408,11 @@ On a parse miss it must not echo `raw` — return `[]` and let the caller log a 
   returns `null`. **No new retry loop** — the package has no retry anywhere and a single Haiku
   call is cheap; adding retries would be inconsistent over-engineering. Retry, when wanted, is
   the **driver's** job via `on_extraction_failure='error'`.
-- A malformed-but-non-null response → `parseExtractedFacts` returns `[]`. Both `null` and `[]`
-  count as a **chunk failure** for diagnostics.
+- An **unparseable** response (no JSON array / invalid JSON / non-array) → `parseExtractedFacts`
+  returns `null`, and `extractFacts` returns `null` → counted as a **chunk failure** for
+  diagnostics. A successfully parsed **empty array** `[]` is **not** a failure: it is a clean
+  "model found nothing durable" result and is **not** counted in `failed_chunks`. Only `null` (no
+  LLM configured, a hard LLM/API failure, or an unparseable response) is a chunk failure.
 - **Per-chunk failures are tracked, not swallowed (A3).** The engine counts failed chunks. After
   all chunks run:
   - If **every** chunk failed (or no LLM) → the union is empty → apply `on_extraction_failure`:
@@ -425,10 +439,18 @@ On a parse miss it must not echo `raw` — return `[]` and let the caller log a 
 1. Normalize seed `importance` (default 0.5), `mode` (default `'conversation'`),
    `on_extraction_failure` (default `'degrade'`), `as_of` → epoch ms.
 2. Chunk the blob (§6, with overlap per §7). For each chunk, `extractFacts(config, chunk, mode)`.
-   - Count `failedChunks` = chunks returning `null` **or** `[]` (A3). Track `totalChunks`.
+   - Count `failedChunks` = chunks returning `null` (no LLM / hard fail / unparseable) (A3). A
+     chunk returning a parsed `[]` contributed no facts but **did not fail** — do not count it.
+     Track `totalChunks`.
 3. Union the `ExtractedFact[]` across chunks (preserve order; drop exact-`fact`-string dups
    across chunks — the first occurrence keeps its `importance`).
-4. **If the union is empty** (no LLM, all chunks failed) → apply `on_extraction_failure` (A3):
+4. **If the union is empty:**
+   - **No failures** (`failedChunks === 0`) → extraction **succeeded** and the model reported no
+     durable facts. Write nothing and return a clean empty result (`created: 0, merged: 0,
+     memory_ids: [], facts: []`). This is **not** a failure, so it never enters the
+     `on_extraction_failure` path.
+   - **Otherwise** (some/all chunks returned `null` so no usable facts) → apply
+     `on_extraction_failure` (A3):
    - `'error'` → throw a content-free error (A6) so the driver can retry.
    - `'skip'` → return `{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts: [],
      skipped: true }` (when `dry_run`, same but the lone preview "fact" may be omitted).
@@ -532,9 +554,18 @@ row, reconcile timestamps **order-independently**:
 
 ```
 created_at        = min(existing.created_at,        incoming as_of)   // true first-seen
-last_accessed_at  = max(existing.last_accessed_at,  incoming as_of)   // true last-touched
-updated_at        = max(existing.updated_at,        incoming as_of)   // true last-touched
+last_accessed_at  = max(existing.last_accessed_at,  incoming as_of)   // historical recency
+updated_at        = local row-mutation time (when this row was last written), NOT a historical max
 ```
+
+`created_at` (true first-seen) and `last_accessed_at` (historical recency) are the
+order-independent reconciled values. `updated_at` is **not** a historical max: it is the row's
+last-mutation time. The exact-dedup merge first calls `updateMemoryContent`, which unconditionally
+stamps `updated_at = Date.now()`; the subsequent `updateMemoryTimestampsOnMerge` then runs
+`updated_at = MAX(updated_at, as_of)`, and for a backdated (past) `as_of` that `MAX` is the
+just-written `now`. So a historical backfill leaves `updated_at` at the local mutation time — by
+design, `updated_at` tracks when the row was last written while `last_accessed_at` carries the
+recency signal.
 
 Implementation:
 
@@ -550,7 +581,10 @@ Implementation:
   ```
   (Three `?`-bindings of `asOf`.) This is additive — `updateMemoryContent` is unchanged, so the
   consolidation-path caller of `updateMemoryContent` is unaffected. The min/max are computed in
-  SQL so the merge is atomic and order-independent regardless of which insert wins the race.
+  SQL so the `created_at`/`last_accessed_at` reconciliation is atomic and order-independent
+  regardless of which insert wins the race. `updated_at` resolves to the row's last-mutation time
+  (`updateMemoryContent` set it to `now` immediately before, so `MAX(now, as_of)` is `now` for a
+  backdated `as_of`), not a historical max — see the note above.
 - **Non-`as_of` merges are unchanged.** When `opts.createdAt` is absent, the new query is **not**
   called; `updateMemoryContent`'s existing `updated_at = now` behavior stands, byte-for-byte.
 
@@ -678,13 +712,15 @@ File: `test/extraction.test.ts`. Mirrors `parseBatchJudgments` coverage in
 `test/llm-client.test.ts` style.
 - `parseExtractedFacts`: valid array of objects → `ExtractedFact[]` with trimmed `fact` and
   preserved `importance`; **bare-string items tolerated** → `{ fact, importance: undefined }`
-  (A2); non-array JSON → `[]`; prose-wrapped array → extracted; empty/junk → `[]`; over-long
-  `fact` truncated; count capped; intra-batch exact-`fact` dups dropped (first keeps importance).
+  (A2); a parsed empty array `[]` → `[]` (valid "nothing durable", **not** `null`); non-array
+  JSON → `null`; prose-wrapped array → extracted; no-JSON-array / unparseable junk → `null`;
+  over-long `fact` truncated; count capped; intra-batch exact-`fact` dups dropped (first keeps
+  importance).
 - **Per-fact importance parsing (A2):** `importance` out of `[0,1]` → **clamped**; non-finite /
   non-number `importance` → **dropped to undefined**; missing `importance` → undefined (caller
   falls back to seed).
 - **PII-safe parse (A6):** `parseExtractedFacts` on a non-JSON response containing a known
-  sensitive substring returns `[]` and the function/caller log does not contain that substring —
+  sensitive substring returns `null` and the function/caller log does not contain that substring —
   only a content-free shape (`"no JSON array found in N-char response"`).
 - `chunkBlob`: short blob → 1 chunk; long blob → N chunks split on newlines; **adjacent chunks
   overlap by ~10–15% of lines (A5)** — assert the tail lines of chunk N reappear at the head of
@@ -716,9 +752,13 @@ Assertions:
   `getMemoriesByIds`. Also assert that omitting `as_of` yields `created_at ≈ Date.now()`.
 - **Order-independent merge timestamps (A1):** store a fact at `as_of = T_old`, then ingest a
   duplicate fact (same content → exact-dedup merge) at `as_of = T_new > T_old`; assert the
-  surviving row has `created_at === T_old` (`min`), `last_accessed_at === T_new` and
-  `updated_at === T_new` (`max`). Then run the **reverse order** (ingest `T_new` first, merge
-  `T_old` second) and assert the **same** surviving timestamps — proving order-independence.
+  surviving row has `created_at === T_old` (`min`) and `last_accessed_at === T_new` (`max`).
+  `updated_at` lands at `~now` (local mutation time), **not** `T_new`: `updateMemoryContent`
+  stamps `updated_at = now` immediately before, so for these past `as_of` values
+  `MAX(now, as_of) === now`. Then run the **reverse order** (ingest `T_new` first, merge `T_old`
+  second) and assert the **same** surviving `created_at`/`last_accessed_at` — proving
+  order-independence for the reconciled values. A separate case uses a **future** `as_of`
+  (`> now`) to prove the `MAX(updated_at, ?)` clause is live and can move `updated_at` forward.
   Also assert a non-`as_of` merge leaves `created_at` untouched and only bumps `updated_at`
   (the new query is not called).
 - **Merge importance composes (A1/A2):** merging a higher-importance duplicate raises the

--- a/docs/designs/memory-ingest-tool.md
+++ b/docs/designs/memory-ingest-tool.md
@@ -1,0 +1,832 @@
+# Design: `memory_ingest` — LLM-backed fact decomposition tool
+
+**Status:** Design v2 (review-amended) — no implementation
+**Scope:** Builds **only** Question 3 / decomposition from
+[`docs/brainstorm/memory-inferred-metadata-proposal.md`](../brainstorm/memory-inferred-metadata-proposal.md).
+Question 1 (auto-inferred tags) and Question 2 (titles) are **explicitly deferred** — this doc does not design them.
+**Package:** `packages/memory-mcp-server/`
+
+> **v2 amendments.** This tool is dual-purpose: a product feature (decompose blobs into
+> atomic-fact memories) **and** the substrate for building a representative eval corpus from a
+> multi-year claude.ai conversation export (each conversation ingested with its real date via
+> `as_of`). An adversarial review found the v1 design pushed **recency and importance fidelity**
+> onto an out-of-scope "eval driver" — but those are **insert-time** decisions only this tool
+> can make. v2 moves them in: **per-fact importance from extraction** (A2), **order-independent
+> merge timestamps** (A1), a **controllable extraction-failure mode** with observable partial
+> extraction (A3), **durability-focused prompts** (A4), **window overlap** in chunking (A5),
+> **PII-safe logging/errors** (A6), and **honest result stats** (A7). The driver itself (a
+> separate script) is still out of scope; see §13.
+
+---
+
+## 1. Overview
+
+`memory_ingest` is the heavy, explicitly-LLM ingestion path. It takes a raw blob
+(conversation transcript, document, or session summary), makes **one LLM call per chunk**
+(`model = claude-haiku-4-5`, reusing the existing consolidation/compaction LLM config — no
+new model config path) to extract **atomic facts**, and writes each fact through the
+**existing** `store → exact-dedup → deferred-consolidation` machinery. Each fact becomes its
+own clean memory row with its own clean vector, which is the entire point: a compound blob
+embeds to a muddy centroid and degrades recall, importance, and dedup granularity.
+
+The normal `memory_store` write path stays **LLM-free**. `memory_ingest` is the only tool
+that calls an LLM **directly** on the write side (extraction). Deferred consolidation also uses
+the LLM, but **indirectly** via `batchJudgeMemoryRelations`/`parseBatchJudgments` — neither path
+adds a new model config. Both `memory_store` and `memory_ingest` share the same `store`
+insert/dedup pipeline, so we add exactly one new step (extraction) and reuse everything
+downstream.
+
+Because extraction is the **only** point in the pipeline that reads every individual fact before
+it is written, it is also the only place where two insert-time fidelity decisions can be made:
+**per-fact importance** (A2) and the **durability filter** that keeps stable preferences /
+identity / project facts / decisions and drops ephemeral session-local task chatter (A4). These
+are baked into extraction here rather than deferred, because nothing downstream ever sees the
+facts pre-write.
+
+---
+
+## 2. Key design decisions
+
+1. **`ingest` is a new method on the `MemoryEngine` interface, not a tool-handler-local
+   function.** Tool handlers in this codebase receive **only** the `MemoryEngine`
+   (`server.ts` → `handleStore(engine, args)`), never `MemoryConfig`. The `config` (which
+   holds `llmModel`/`llmBaseUrl`/`llmApiKey` and is needed for the LLM call + embedding) is
+   captured in the engine closure in `engine-impl.ts`. Extraction therefore belongs on the
+   engine, parallel to `store`/`recall`. This preserves the existing handler signature
+   convention and keeps the LLM/config dependency inside the one place that already owns it.
+   *Rationale: handlers are config-free by construction; the engine closure is the only seam
+   that already holds both `db` and `config`.*
+
+2. **Reuse `llmComplete()` from `llm/client.js`** — the same OpenAI-compatible client used
+   **directly** by `compaction.ts` and **indirectly** by `consolidation.ts` (which calls it via
+   `batchJudgeMemoryRelations` → `parseBatchJudgments`). No new client, no new model field.
+   `config.llmModel` already defaults to `claude-haiku-4-5-20251001`. *Rationale: §5/§8
+   open-question 5 in the proposal is resolved in favor of "reuse the consolidation/compaction
+   config" per the task brief.*
+
+3. **Each extracted fact flows through the existing `store` path**, not a bespoke insert. The
+   only change `store` needs is an **optional `createdAt`** on `StoreOptions` (for `as_of`
+   backdating). We do **not** widen `store` to accept `string | string[]` for this feature —
+   that batch affordance is a separate, deferrable proposal item and is not required for
+   `memory_ingest`. *Rationale: minimal surface; one new optional field, contract preserved.*
+
+4. **`as_of` is threaded as a `createdAt` insert parameter, not a post-insert UPDATE.**
+   Stamping at insert time is atomic and avoids a second write + a window where the row carries
+   a wrong timestamp. See §5.
+
+5. **Graceful degradation is first-class — but now *controllable*.** No LLM configured →
+   default behavior stores the blob as a **single** memory (truncated to `MAX_CONTENT_LENGTH`)
+   and reports `degraded: true`, mirroring `consolidation`/`compaction` (which degrade when
+   `getLLMClient()` returns null). **(A3)** A new `on_extraction_failure` option lets a caller
+   override this: `'degrade'` (default, product behavior), `'skip'` (write nothing, report
+   `skipped`), or `'error'` (throw, so a corpus driver can retry). Default preserves v1 product
+   behavior exactly.
+
+6. **Malformed model output never throws (by default).** Parsing follows the
+   `parseBatchJudgments`-style defensive approach already in `llm/client.ts`: extract a JSON
+   array, validate each item, drop junk. If parsing yields **zero** facts, the default
+   (`on_extraction_failure='degrade'`) falls back to the single-blob store (same as the no-LLM
+   path) so the tool never returns "ingested 0" silently on a parse failure. `'error'` mode
+   surfaces the failure instead.
+
+7. **(A2) Per-fact importance is assigned at extraction.** The extraction schema is an array of
+   `{ fact, importance? }`, not bare strings. The extraction LLM already reads every fact, so
+   emitting a per-fact salience in 0–1 is nearly free, and extraction is the **only** place per-
+   fact importance can be set. When the model omits importance for a fact, it falls back to the
+   call-level seed `importance` (default 0.5). *Rationale: this is the most important amendment —
+   it is the only insert-time decision that recovers importance fidelity for a bulk corpus.*
+
+8. **(A1) Merge timestamps are order-independent for backdated ingests.** Dedup is content-
+   similarity, **not** time-aware, and a multi-year export may be ingested in any order. When a
+   backdated (`as_of`) fact merges into an existing row, the surviving row's timestamps are
+   reconciled with `min`/`max` (true first-seen / true last-touched), not left to whichever
+   insert happened to land first. v1's "skip the existing row's `created_at` on merge" rule let
+   ingest **order** decide the surviving timestamp, flattening recency precisely for the most-
+   repeated (hence most-important) facts. Normal non-`as_of` stores are unchanged. See §5.4.
+
+9. **(A3) Partial extraction is observable, never silent.** If any chunk of a multi-chunk call
+   returns null/`[]`, the result reports `degraded: true` and a `failed_chunks` count. v1's
+   silent "that chunk contributes nothing, the call still looks fully successful" path is a
+   corpus-contamination hazard; v2 eliminates the silence.
+
+10. **(A4) Extraction targets durable facts.** Both mode prompts instruct the model to keep
+    facts worth remembering beyond the conversation (stable preferences, identity, project
+    facts, decisions) and to skip ephemeral session-local state (transient errors, one-off
+    debugging steps, "let's try X"). The two modes still differ only on the explicit-vs-inference
+    axis; durability applies to both. See §4.2.
+
+11. **(A6) PII-safe logging is a hard rule.** This tool handles sensitive content. We **never**
+    log raw content/chunk/blob or the model's raw response to stderr or into error messages —
+    only lengths, token estimates, chunk indices, and content-free failure shapes. See §4.4 and
+    the testing section.
+
+12. **(A7) Result stats are honest.** `IngestResult` reports `created` and `merged` separately
+    (we already compute `action` per fact), so a bulk run's numbers are interpretable and the
+    merge count — a corroboration signal — is visible. See §3.2.
+
+---
+
+## 3. Tool surface
+
+### 3.1 Input schema (Zod, registered in `server.ts`)
+
+```ts
+server.tool(
+  'memory_ingest',
+  TOOL_DESCRIPTIONS.memory_ingest,
+  {
+    content: z
+      .string()
+      .describe('Raw blob to decompose: a conversation transcript, document, or session summary.'),
+    source: z
+      .string()
+      .optional()
+      .describe("Provenance, e.g. 'session:abc', 'document', 'conversation'. Stored on each fact."),
+    mode: z
+      .enum(['conversation', 'document'])
+      .optional()
+      .describe(
+        "'conversation' (default): STRICT — only DURABLE facts explicitly stated, no inference. " +
+          "'document': broader — DURABLE facts with reasonable inference allowed. " +
+          'Both modes keep stable preferences/identity/project facts/decisions and skip ' +
+          'ephemeral task chatter. Use document for conversation transcripts.',
+      ),
+    tags: z
+      .array(z.string())
+      .optional()
+      .describe('Optional seed tags applied to EVERY extracted fact.'),
+    importance: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe(
+        'SEED importance 0-1, used as the fallback when the extraction model does not emit a ' +
+          'per-fact importance. Default: 0.5. Per-fact importance (when the model provides it) wins.',
+      ),
+    dry_run: z
+      .boolean()
+      .optional()
+      .describe('If true, run extraction and RETURN the facts WITHOUT writing anything. Default: false.'),
+    on_extraction_failure: z
+      .enum(['degrade', 'skip', 'error'])
+      .optional()
+      .describe(
+        "How to handle a chunk/call that yields no facts (no LLM, LLM error, or unparseable). " +
+          "'degrade' (default): store the blob as a single memory (product behavior). " +
+          "'skip': write nothing, return { ingested: 0, skipped: true }. " +
+          "'error': throw, so a bulk driver can retry. Default: 'degrade'.",
+      ),
+    as_of: z
+      .union([z.number(), z.string()])
+      .optional()
+      .describe(
+        'Backdate: stamp created_at/last_accessed_at of every extracted fact to this time ' +
+          '(epoch ms or ISO 8601) instead of now. For ingesting historical exports.',
+      ),
+  },
+  async (args) => {
+    try {
+      const text = await handleIngest(engine, args);
+      return { content: [{ type: 'text' as const, text }] };
+    } catch (err) {
+      return { content: [{ type: 'text' as const, text: formatError(err) }], isError: true };
+    }
+  },
+);
+```
+
+This sits alongside the existing five tools under the same
+`/* eslint-disable @typescript-eslint/no-deprecated */` block (the package still uses the
+deprecated `server.tool()` API; match it — do not introduce `registerTool` for one tool).
+
+`TOOL_DESCRIPTIONS.memory_ingest` is added to `prompts.ts` (one new entry; keep style
+consistent), e.g.:
+
+> "Ingest a raw blob (conversation, document, or session summary) and decompose it into atomic,
+> DURABLE memories via an LLM (extracts stable preferences/identity/project facts/decisions; skips
+> ephemeral task chatter). Unlike `memory_store` (one pre-formed fact), this extracts many facts
+> from one input, each with its own importance. Use `mode='conversation'` for strict
+> explicit-only extraction or `mode='document'` to allow reasonable inference (better for
+> conversation transcripts); `dry_run=true` to preview the decomposition (note: dry_run still
+> sends the blob to the configured LLM — it only skips local persistence). By default falls back
+> to a single store if no LLM is configured; set `on_extraction_failure` to `skip` or `error` to
+> change that."
+
+### 3.2 Output shape
+
+The MCP tool surface returns text (matching every other handler), but the handler builds it
+from a structured result. The engine method returns the structured object; the handler
+formats it.
+
+```ts
+// types.ts
+export interface IngestResult {
+  // ---- honest write stats (A7) ----
+  created: number;         // rows newly created (action === 'created')
+  merged: number;          // facts that hit an existing row (merged_duplicate / contradiction)
+  ingested: number;        // ALIAS for `created`, kept for back-compat of the v1 field name
+  memory_ids: string[];    // ids of all touched rows (created + merged); empty when dry_run
+
+  // ---- substance ----
+  facts: ExtractedFact[];  // the extracted atomic facts + their importance (always populated)
+
+  // ---- diagnostics (A3) ----
+  chunks?: number;         // number of LLM windows used (omitted when 1)
+  failed_chunks?: number;  // chunks that returned null/[] (omitted when 0)
+  degraded?: boolean;      // true when we fell back to single-blob store, OR a partial failure
+  partial?: boolean;       // true when SOME (not all) chunks failed but others produced facts
+  skipped?: boolean;       // true when on_extraction_failure='skip' wrote nothing
+}
+```
+
+`ExtractedFact` is `{ fact: string; importance?: number }` (see §4) — `facts` carries the
+per-fact importance so a `dry_run` preview shows the salience the model assigned, not just text.
+
+**Stat semantics (A7).** We already compute `action` per fact in the write loop (§5.1), so
+`created` and `merged` are free. `created` counts `action === 'created'`; `merged` counts
+`merged_duplicate` **and** `contradiction_resolved`. `ingested` is retained as an alias of
+`created` so v1 callers reading `ingested` still see the new-row count; new callers should read
+`created`/`merged` to interpret a bulk run (a high `merged` is corroboration, not failure).
+
+**Diagnostics (A3).** `failed_chunks` and `partial` make per-chunk failures visible instead of
+silent. `degraded` is set when we fell back to a single-blob store **or** when any chunk failed
+(`partial` distinguishes "some chunks failed but we still got facts" from "full degrade").
+`skipped` is only set under `on_extraction_failure='skip'`.
+
+`facts` is **always present** (it is the substance of a `dry_run` and cheap otherwise); all
+diagnostics are optional. The handler renders, e.g.:
+
+- normal: `Ingested 7 atomic facts: 6 new memories, 1 merged into existing (ids: a1b2…, …).`
+- dry_run: a numbered list of the proposed facts with their importance, plus `Dry run — nothing written.`
+- partial: `Ingested 4 facts (3 new, 1 merged); 1 of 3 chunks failed extraction — partial result.`
+- degraded: `No LLM configured — stored the blob as a single memory <id>.`
+- skipped: `Extraction failed and on_extraction_failure=skip — nothing written.`
+
+### 3.3 Engine interface change
+
+```ts
+// engine.ts
+export interface IngestOptions {
+  source?: string;
+  mode?: 'conversation' | 'document';
+  tags?: string[];
+  importance?: number; // SEED importance; per-fact importance from extraction overrides it
+  dry_run?: boolean;
+  as_of?: number; // normalized to epoch ms by the handler before reaching the engine
+  on_extraction_failure?: 'degrade' | 'skip' | 'error'; // default 'degrade' (A3)
+}
+
+export interface MemoryEngine {
+  store(content: string, opts: StoreOptions): Promise<StoreResult>;
+  ingest(content: string, opts: IngestOptions): Promise<IngestResult>; // NEW
+  recall(opts: RecallOptions): Promise<RecallResult>;
+  // …unchanged…
+}
+```
+
+`createMemoryEngine(modules)` (the test factory in `engine-impl.ts`) and `EngineModules`
+gain the `ingest` passthrough, exactly like the other methods.
+
+---
+
+## 4. Extraction
+
+### 4.1 LLM call
+
+New module: `src/storage/extraction.ts` (sits next to `consolidation.ts`/`compaction.ts`,
+which are the other LLM-on-write modules). It exports:
+
+```ts
+export interface ExtractedFact {
+  fact: string;
+  importance?: number; // 0–1, OPTIONAL; absent ⇒ caller falls back to the seed importance
+}
+
+export async function extractFacts(
+  config: MemoryConfig,
+  blob: string,
+  mode: 'conversation' | 'document',
+): Promise<ExtractedFact[] | null>; // null ⇒ no LLM or hard failure ⇒ caller handles per on_extraction_failure
+```
+
+`ExtractedFact` is the unit threaded everywhere downstream (it also appears in `IngestResult.facts`,
+§3.2). The return type is `ExtractedFact[] | null`, **not** `string[] | null` (A2): each fact
+carries its own optional importance.
+
+Internals reuse `llmComplete(config, systemPrompt, userPrompt, { maxTokens })` — the same plain
+chat-completions wrapper used (directly) by `compaction.ts` and (indirectly, via
+`batchJudgeMemoryRelations`) by `consolidation.ts`. We do **not** add structured-output /
+function-calling — the rest of the package parses JSON out of text content. Match that.
+`maxTokens` scales with chunk size (e.g. `Math.min(1500, ~blob_tokens)`), bounded. The per-fact
+`importance` field adds only a few tokens per element, so it does not meaningfully raise the
+output budget.
+
+### 4.2 Prompts (two mode variants)
+
+Both share an envelope: input wrapped in `<input>` tags (so the model can't confuse
+instructions with content), output **only** a JSON array of **objects** `{ "fact": "...",
+"importance": 0.0-1.0 }`. The two modes differ **only** on the explicit-vs-inference axis; the
+**durability filter (A4)** and the **per-fact importance instruction (A2)** apply to **both**.
+There is no third mode.
+
+**Shared rules (in both prompts):**
+
+> - Output ONLY a JSON array of objects, each `{ "fact": "<self-contained fact>", "importance":
+>   <0.0–1.0> }`. One atomic fact per element — never combine two facts with "and".
+> - Each fact must be self-contained: resolve pronouns to names, include the subject
+>   ("The user prefers dark mode", not "prefers dark mode").
+> - **Extract only DURABLE facts** worth remembering beyond this conversation: stable
+>   preferences, identity, project facts, decisions, learned constraints.
+> - **SKIP ephemeral / session-local state**: transient errors, one-off debugging steps,
+>   "let's try X", task chatter, pleasantries, meta-talk.
+> - **`importance`** reflects how durable/identity-defining the fact is: durable identity,
+>   standing preferences, and decisions → high (≈0.7–1.0); useful-but-replaceable project facts
+>   → mid (≈0.4–0.7); marginal/ephemeral facts you still chose to keep → low (≈0.1–0.4). When
+>   unsure, omit `importance` and the caller will use the seed default.
+> - If nothing durable is stated, output `[]`. Reply with ONLY the JSON array, no prose.
+
+**`conversation` (STRICT) — additional rule:**
+
+> - Extract ONLY facts that are **explicitly stated**. Do NOT infer, summarize, or editorialize.
+
+**`document` (BROADER) — additional rule:**
+
+> - **Reasonable inference is allowed** where the text clearly implies a durable fact, but do
+>   not fabricate. Prefer atomic facts; split compound statements.
+
+The user prompt is `<input>\n{chunk}\n</input>`. Keep the two system prompts as named
+constants in `extraction.ts` so the difference is one prompt, not branching code.
+
+> **Driver note (A4).** For multi-turn conversation transcripts, the eval driver should pass
+> `mode='document'`, not `'conversation'`. Durable facts in a transcript are frequently
+> synthesized **across** turns (a preference stated once, then relied on later) rather than
+> uttered as a single explicit sentence; STRICT explicit-only extraction loses them. `document`
+> permits the cross-turn synthesis while the durability filter keeps the flood of task chatter
+> out. (The driver chooses this per conversation; the tool does not hard-code it.)
+
+### 4.3 Structured-output / parsing
+
+The model returns text. Parse defensively, mirroring `parseBatchJudgments`, into
+`ExtractedFact[]`:
+
+```
+export function parseExtractedFacts(raw: string): ExtractedFact[] {
+  // 1. Find the first JSON array via /\[[\s\S]*\]/.
+  // 2. JSON.parse; if not an array → return [].
+  // 3. For each item, accept EITHER:
+  //      - an object { fact: string, importance?: number }  → preferred (A2), OR
+  //      - a bare string                                     → treat as { fact, importance: undefined }
+  //    (tolerating the plain-string form keeps us robust to a model that ignored the schema).
+  // 4. Drop junk: require a non-empty trimmed `fact`; cap `fact` length at MAX_CONTENT_LENGTH.
+  //    If `importance` is present but not a finite number, drop it (→ undefined); otherwise
+  //    CLAMP it to [0, 1].
+  // 5. Cap count at MAX_FACTS_PER_INGEST (e.g. 200) to bound a runaway response.
+  // 6. De-dupe exact-`fact`-string repeats within the batch (keep the first occurrence's importance).
+  // catch → return [].
+}
+```
+
+`parseExtractedFacts` is pure and exported → directly unit-testable with canned strings. **(A6)**
+On a parse miss it must not echo `raw` — return `[]` and let the caller log a content-free shape
+(e.g. `"no JSON array found in N-char response"`); see §4.4.
+
+### 4.4 Retry / error handling (A3 + A6)
+
+- `llmComplete` already swallows API errors and returns `null`. `extractFacts` treats `null` →
+  returns `null`. **No new retry loop** — the package has no retry anywhere and a single Haiku
+  call is cheap; adding retries would be inconsistent over-engineering. Retry, when wanted, is
+  the **driver's** job via `on_extraction_failure='error'`.
+- A malformed-but-non-null response → `parseExtractedFacts` returns `[]`. Both `null` and `[]`
+  count as a **chunk failure** for diagnostics.
+- **Per-chunk failures are tracked, not swallowed (A3).** The engine counts failed chunks. After
+  all chunks run:
+  - If **every** chunk failed (or no LLM) → the union is empty → apply `on_extraction_failure`:
+    `'degrade'` → single-blob store (`degraded: true`); `'skip'` → write nothing
+    (`skipped: true`, `ingested/created: 0`); `'error'` → throw.
+  - If **some** chunks failed but others produced facts → ingest the facts we have, and set
+    `partial: true`, `degraded: true`, `failed_chunks: <n>`. v1's silent partial path (the call
+    "looked fully successful" while a chunk's facts were dropped) is gone — this is a
+    corpus-contamination hazard the eval driver must be able to see and act on.
+- **PII-safe logging/errors (A6, hard rule).** `extractFacts`, `parseExtractedFacts`, the engine
+  loop, and `formatError`/the handler **must never** write raw content, a chunk, the blob, or the
+  model's raw response to stderr or into a thrown/returned error message. Log only **content-free
+  shapes**: blob/chunk **lengths**, token estimates, chunk **indices**, fact **counts**, and
+  failure descriptors like `"no JSON array found in {raw.length}-char response"` or
+  `"chunk 3/7 returned 0 facts"`. The `'error'`-mode exception message likewise carries counts
+  and indices only, never substrings of the input or output.
+
+---
+
+## 5. Write path
+
+### 5.1 Flow per ingest call (engine `ingest`)
+
+1. Normalize seed `importance` (default 0.5), `mode` (default `'conversation'`),
+   `on_extraction_failure` (default `'degrade'`), `as_of` → epoch ms.
+2. Chunk the blob (§6, with overlap per §7). For each chunk, `extractFacts(config, chunk, mode)`.
+   - Count `failedChunks` = chunks returning `null` **or** `[]` (A3). Track `totalChunks`.
+3. Union the `ExtractedFact[]` across chunks (preserve order; drop exact-`fact`-string dups
+   across chunks — the first occurrence keeps its `importance`).
+4. **If the union is empty** (no LLM, all chunks failed) → apply `on_extraction_failure` (A3):
+   - `'error'` → throw a content-free error (A6) so the driver can retry.
+   - `'skip'` → return `{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts: [],
+     skipped: true }` (when `dry_run`, same but the lone preview "fact" may be omitted).
+   - `'degrade'` (default) → **single-blob store**: `store(blobTruncatedToMax, { tags,
+     importance: seedImportance, source, createdAt })` and return `{ created: 1, merged: 0,
+     ingested: 1, memory_ids: [id], facts: [{ fact: blob…, importance: seedImportance }],
+     degraded: true }`. (When `dry_run`, `created: 0`, no write, `degraded: true` — the preview
+     shows there was no decomposition.)
+5. **If `dry_run`** → return `{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts }`
+   **without writing** (carry `chunks`/`failed_chunks`/`partial` diagnostics through).
+6. Otherwise, for **each** `ExtractedFact f`, call the **existing** `store(f.fact, { tags,
+   importance: f.importance ?? seedImportance, source, createdAt })` (A2 — per-fact importance
+   wins, seed is the fallback). Collect `result.id` into `memory_ids`. Tally by `result.action`:
+   `created` += `action === 'created'`; `merged` += `merged_duplicate` **or**
+   `contradiction_resolved` (A7). Set `ingested = created` (alias). Return `{ created, merged,
+   ingested, memory_ids, facts, chunks, ...(failedChunks ? { failed_chunks: failedChunks,
+   degraded: true, partial: true } : {}) }`.
+
+`store` is called in a loop in-process; `better-sqlite3` is synchronous and each `store` is its
+own transaction (as today). No batching transaction is added — keeps the change minimal and
+each fact independently dedups. `maybeRunMaintenance` already fires inside `storeImmediate`
+every `maintenanceInterval` stores, so a large ingest naturally triggers a consolidation pass;
+no extra orchestration needed.
+
+> **Bulk-driver note (out of scope for tool code).** For a reproducible eval corpus the driver
+> may want a single, deterministic consolidation pass at the **end** of the bulk load instead of
+> the `maintenanceInterval`-triggered passes interleaving mid-ingest. That is a driver concern:
+> the driver can raise `maintenanceInterval` (via `MEMORY_*` config) during the bulk run and run
+> one consolidation at the end. We deliberately add **no** tool code for this — `ingest` keeps
+> the existing `maybeRunMaintenance` behavior.
+
+### 5.2 `store` signature change — `createdAt`, not `string[]`
+
+```ts
+// engine.ts
+export interface StoreOptions {
+  tags?: string[];
+  importance?: number;
+  source?: string;     // NEW — ingest stamps provenance; insert path already supports `source`
+  createdAt?: number;  // NEW — epoch ms; when set, stamp created_at/updated_at/last_accessed_at
+}
+```
+
+- `source` is added because `insertMemory` **already** accepts `source` (`queries.ts`
+  `InsertMemoryParams.source`) but `storeImmediate` never forwards it. Threading it is a
+  one-line change and gives ingested facts real provenance.
+- `createdAt` is the `as_of` mechanism (§5.4).
+- **We do NOT add `content: string | string[]`.** The proposal lists it as a separate
+  affordance; `memory_ingest` does not need it (it loops over facts itself), and widening the
+  hot-path tool's input type is out of scope here.
+
+**Contract preservation:** both new fields are optional. Existing callers of `store` and the
+`memory_store` tool are unaffected. `StoreResult` is unchanged.
+
+### 5.3 Dedup interaction — rely on what exists, add nothing
+
+Extracted facts may duplicate existing memories or each other. We rely entirely on the existing
+two-tier dedup:
+
+- **Within the same ingest:** two near-identical facts → the second hits exact-dedup
+  (`EXACT_DEDUP_DISTANCE`) in `storeImmediate` and is `merged_duplicate`, or lands in the
+  consolidation band and is resolved on the next maintenance pass.
+- **Against prior memories:** identical — `storeImmediate`'s `vectorSearch` + consolidation
+  catch it.
+
+No new dedup logic. We count `created` vs `merged` (`merged_duplicate` + `contradiction_resolved`)
+so the result honestly reports both how many *new* rows landed and how many facts corroborated an
+existing memory (A7).
+
+**Per-fact importance on merge.** When a fact merges, the surviving row's importance is already
+reconciled by the existing `updateMemoryContent` SQL (`importance = MAX(importance, ?)`), so a
+high-importance corroborating fact correctly raises the survivor's importance and a low-importance
+one never lowers it. No change needed — per-fact importance (A2) composes with the existing merge
+rule for free.
+
+### 5.4 `createdAt` / `as_of` mechanism in `store`
+
+`storeImmediate`, `insertMemory`, and `updateMemoryContent` currently hard-code
+`now = Date.now()`. The change has two parts — the **created** path (singleton backdate) and the
+**merge** path (order-independent reconciliation, A1).
+
+**Created path (singleton, unchanged intent from v1):**
+
+- `insertMemory` gains an optional `createdAt` in `InsertMemoryParams`. When present, it is used
+  for `created_at`, `updated_at`, **and** `last_accessed_at` (all three). When absent, behavior
+  is byte-for-byte unchanged (`Date.now()`).
+- `storeImmediate` forwards `opts.createdAt` into `insertMemory`.
+- **Singleton `last_accessed_at = as_of` is intentional (documented decision).** A backdated fact
+  that creates a *new* row is faithful to its source date in every column: a 2023 fact **is**
+  cold, and stamping `last_accessed_at = as_of` lets recency/decay scoring treat it as old. We do
+  **not** stamp `last_accessed_at = now` for created backdated rows.
+
+**Merge path (A1 — REPLACES v1's "do not rewrite `created_at`" rule):**
+
+v1 said: on merge, leave the existing row's `created_at` alone, backdate applies to new rows only.
+That let ingest **order** decide the surviving timestamp — the merge target keeps whatever
+timestamp the first-landed insert happened to give it, regardless of which fact is actually older.
+For a multi-year export ingested in arbitrary order, this flattens recency precisely for the
+most-repeated (most-important) facts. **New rule:** when a backdated fact merges into an existing
+row, reconcile timestamps **order-independently**:
+
+```
+created_at        = min(existing.created_at,        incoming as_of)   // true first-seen
+last_accessed_at  = max(existing.last_accessed_at,  incoming as_of)   // true last-touched
+updated_at        = max(existing.updated_at,        incoming as_of)   // true last-touched
+```
+
+Implementation:
+
+- The exact-dedup merge branch in `storeImmediate` calls `updateMemoryContent` (content/embedding/
+  tags/importance) **and then**, only when `opts.createdAt` is set, a small new query
+  `updateMemoryTimestampsOnMerge(db, namespace, id, asOf)` that runs:
+  ```sql
+  UPDATE memories
+     SET created_at       = MIN(created_at, ?),
+         last_accessed_at = MAX(last_accessed_at, ?),
+         updated_at       = MAX(updated_at, ?)
+   WHERE id = ? AND namespace = ?
+  ```
+  (Three `?`-bindings of `asOf`.) This is additive — `updateMemoryContent` is unchanged, so the
+  consolidation-path caller of `updateMemoryContent` is unaffected. The min/max are computed in
+  SQL so the merge is atomic and order-independent regardless of which insert wins the race.
+- **Non-`as_of` merges are unchanged.** When `opts.createdAt` is absent, the new query is **not**
+  called; `updateMemoryContent`'s existing `updated_at = now` behavior stands, byte-for-byte.
+
+This is the only place v1 made an **order-dependent** timestamp decision; A1 removes it.
+
+---
+
+## 6. `as_of` backdating — schema impact
+
+**None.** `created_at`, `updated_at`, `last_accessed_at` are existing `INTEGER` columns. We are
+only choosing the value written — at insert (created path) and, for the A1 order-independent
+merge, in the new `updateMemoryTimestampsOnMerge` UPDATE (§5.4). Both reuse the same three
+existing columns. **No migration, no `SCHEMA_VERSION` bump.** (Contrast with the deferred title
+feature, which *would* need a migration; we are not doing it.)
+
+Handler-side normalization: `as_of` may be epoch ms (number) or ISO 8601 (string).
+`validateIngestInput` resolves it to epoch ms via `Date.parse` for strings, rejects
+non-finite/negative results with a clear error, and passes a `number` to the engine. The engine
+never sees the string form (keeps the engine contract numeric and simple).
+
+---
+
+## 7. Chunking
+
+Conversations can exceed the model context. Strategy:
+
+- **Token estimate:** reuse `estimateTokens` from `retrieval/scoring.ts` (already exported, used
+  by the budget packer) — no new estimator.
+- **Threshold:** a `MAX_INGEST_CHUNK_TOKENS` constant (≈ 6000 tokens, comfortably inside
+  Haiku's window with room for the prompt + output). If `estimateTokens(blob) <= threshold`,
+  one chunk, one LLM call.
+- **Splitting:** greedy line-oriented windows. Split on newlines (transcripts and documents are
+  line-structured), accumulate lines until the next line would exceed the threshold, emit the
+  window, continue. A single pathological line longer than the threshold is hard-split on
+  whitespace as a fallback. This keeps speaker turns / paragraphs intact at window boundaries far
+  more often than a blind character cut.
+- **Window overlap (A5):** prepend the last **~10–15% of window N's lines** to the front of
+  window N+1, so a fact whose supporting evidence straddles a window boundary is recoverable from
+  at least one window (it appears whole in the overlap region of the next window). The overlap is
+  bounded by line count, not characters, so it never pushes a window over the token threshold by
+  more than a small constant. The duplicate facts this naturally produces in the overlap region
+  are already collapsed by the union step's exact-`fact`-string drop (below), so overlap costs a
+  little extra extraction work, not duplicate rows.
+- **Residual lossiness (A5):** overlap recovers boundary-straddling evidence **between adjacent**
+  windows only. Evidence spread across *non-adjacent* windows, or a single fact synthesized from
+  more context than one window holds, is still not reconstructable from a single extraction call —
+  that is inherent to per-window extraction and is left to the normal dedup/consolidation pipeline,
+  not solved here. We document it rather than over-engineer a global pass.
+- **Union semantics:** extract per window, concatenate the `ExtractedFact` lists in order, drop
+  exact-`fact`-string duplicates across windows (first occurrence keeps its `importance`).
+  Cross-window *semantic* duplicates are left to the normal dedup pipeline (§5.3) — we do not embed
+  during extraction.
+- **Bound:** cap total chunks (e.g. `MAX_INGEST_CHUNKS = 50`) and total facts
+  (`MAX_FACTS_PER_INGEST`) to keep a hostile or enormous blob from fanning out unboundedly.
+
+Chunking lives in `extraction.ts` (`chunkBlob(blob): string[]`, with the ~10–15% overlap of
+A5 baked in) — pure, unit-testable.
+
+---
+
+## 8. `dry_run` control flow
+
+`dry_run` short-circuits **after** extraction, **before** any write (§5.1 step 5). It runs the
+full LLM extraction + chunking so the preview is faithful, then returns
+`{ created: 0, merged: 0, ingested: 0, memory_ids: [], facts }` (where `facts` is
+`ExtractedFact[]`, carrying the model's per-fact importance for inspection). No `store`, no
+embedding, no dedup, no maintenance.
+
+This is the safe-preview path for sensitive content: extraction reads the blob but nothing is
+persisted to SQLite. (Note: the blob is still sent to the configured LLM endpoint — that is
+inherent to extraction; `dry_run` controls *local persistence*, not whether the model sees the
+text. Call this out in the tool description so a user previewing sensitive content understands
+the model still receives it.) We deliberately **do not** add a separate no-egress / local-only
+preview mode: the eval-corpus user has **consented** to Haiku egress, and a non-egressing preview
+would not exercise the real extraction. The honest framing — `dry_run` egresses content to the
+configured LLM but persists nothing locally — is the contract. (PII-safe *logging* per A6 is
+orthogonal and always applies, including under `dry_run`.)
+
+---
+
+## 9. Degradation — no-LLM fallback
+
+`getLLMClient(config)` returns `null` when neither `llmApiKey` nor `llmBaseUrl` is set. In that
+case `extractFacts` returns `null` for every chunk and the union is empty. The behavior then
+follows `on_extraction_failure` (§5.1 step 4):
+
+- **`'degrade'` (default), `dry_run=false`:** stores the blob as a single memory
+  (`store(blobTruncated, { tags, importance: seedImportance, source, createdAt })`) and returns
+  `{ created: 1, merged: 0, ingested: 1, memory_ids: [id], facts: [{ fact: blob, importance:
+  seedImportance }], degraded: true }`. The blob is truncated to `MAX_CONTENT_LENGTH` so the
+  existing `store` content cap is respected.
+- **`'degrade'`, `dry_run=true`:** returns `{ created: 0, merged: 0, ingested: 0, memory_ids: [],
+  facts: [{ fact: blob }], degraded: true }` with no write.
+- **`'skip'`:** writes nothing, returns `{ created: 0, merged: 0, ingested: 0, memory_ids: [],
+  facts: [], skipped: true }`.
+- **`'error'`:** throws a content-free error (A6).
+
+With the default `'degrade'`, `memory_ingest` **never hard-fails** on a missing model — identical
+philosophy to consolidation/compaction "skip when no LLM" degradation. `'skip'`/`'error'` are
+opt-in for the corpus driver, which prefers a clean failure over a contaminating single-blob row.
+The handler's rendered text states the outcome explicitly so the caller knows decomposition did
+not happen.
+
+---
+
+## 10. Auto-save seam (note only — no change now)
+
+Proposal §5 wants `src/memory/auto-save.ts` (in the **IronCurtain runtime**, not this package)
+to eventually route session summaries through `ingest` instead of asking the agent to call
+`memory_store` once. That module builds a prompt instructing the agent to call `memory_store`;
+switching it to instruct `memory_ingest` (docker name) / `memory.ingest` (in-process) is a
+**one-line `toolName` change in `buildAutoSavePrompt`** plus the prompt body asking for a raw
+summary rather than a pre-condensed one. **We do not change it in this work** — we only note the
+seam. The MCP tool must exist and be registered first; the runtime switch is a follow-up so it
+can be tested end-to-end against the daemon.
+
+---
+
+## 11. Testing strategy
+
+Follow the existing harness exactly. Two layers:
+
+### 11.1 Pure-function unit tests (no DB, no LLM)
+File: `test/extraction.test.ts`. Mirrors `parseBatchJudgments` coverage in
+`test/llm-client.test.ts` style.
+- `parseExtractedFacts`: valid array of objects → `ExtractedFact[]` with trimmed `fact` and
+  preserved `importance`; **bare-string items tolerated** → `{ fact, importance: undefined }`
+  (A2); non-array JSON → `[]`; prose-wrapped array → extracted; empty/junk → `[]`; over-long
+  `fact` truncated; count capped; intra-batch exact-`fact` dups dropped (first keeps importance).
+- **Per-fact importance parsing (A2):** `importance` out of `[0,1]` → **clamped**; non-finite /
+  non-number `importance` → **dropped to undefined**; missing `importance` → undefined (caller
+  falls back to seed).
+- **PII-safe parse (A6):** `parseExtractedFacts` on a non-JSON response containing a known
+  sensitive substring returns `[]` and the function/caller log does not contain that substring —
+  only a content-free shape (`"no JSON array found in N-char response"`).
+- `chunkBlob`: short blob → 1 chunk; long blob → N chunks split on newlines; **adjacent chunks
+  overlap by ~10–15% of lines (A5)** — assert the tail lines of chunk N reappear at the head of
+  chunk N+1; pathological long line → hard-split; chunk count bounded.
+
+### 11.2 Engine `ingest` tests (real in-memory SQLite, mocked LLM)
+File: `test/ingest.test.ts`. Use the `mkdtempSync` + `initDatabase(TEST_MODEL)` pattern from
+`test/database.test.ts`. Two mocking choices, pick per the package's existing seams:
+- **Mock the LLM** by `vi.mock('../src/llm/client.js', …)` so `llmComplete` returns a canned
+  JSON array of `{ fact, importance }` objects (and `getLLMClient` returns a truthy stub) — lets
+  the *real* `store`/dedup/insert run. This is the highest-value path: it proves decomposition →
+  N rows end to end.
+- The **embedder** loads a real (small) model in these tests as it does in `database.test.ts`;
+  if model-load time is a concern, follow `maintenance.test.ts`'s approach. (The package already
+  tolerates real embedding in unit tests with the 30s timeout.)
+
+Assertions:
+- **Decomposition → N rows:** mock returns 3 facts → `getNamespaceStats().total_memories === 3`,
+  result `created === 3`, `ingested === 3` (alias), `merged === 0`, `memory_ids.length === 3`,
+  three distinct contents.
+- **Per-fact importance (A2):** mock returns facts with explicit `importance` (e.g. 0.9 / 0.2)
+  and one with importance **omitted** → assert each written row's `importance` equals the model's
+  value, and the omitted one equals the **seed** `importance` passed to the call (default 0.5).
+- **`dry_run` writes nothing:** same mock, `dry_run: true` → `total_memories === 0`,
+  `created === 0`, `facts.length === 3`, and `facts[i].importance` carries the model's value.
+- **`as_of` stamps dates (created path):** `as_of` = a fixed past epoch (and an ISO string
+  variant) → every newly-created row's `created_at`/`updated_at`/`last_accessed_at` equals it
+  (including `last_accessed_at = as_of`, the documented singleton decision); assert via
+  `getMemoriesByIds`. Also assert that omitting `as_of` yields `created_at ≈ Date.now()`.
+- **Order-independent merge timestamps (A1):** store a fact at `as_of = T_old`, then ingest a
+  duplicate fact (same content → exact-dedup merge) at `as_of = T_new > T_old`; assert the
+  surviving row has `created_at === T_old` (`min`), `last_accessed_at === T_new` and
+  `updated_at === T_new` (`max`). Then run the **reverse order** (ingest `T_new` first, merge
+  `T_old` second) and assert the **same** surviving timestamps — proving order-independence.
+  Also assert a non-`as_of` merge leaves `created_at` untouched and only bumps `updated_at`
+  (the new query is not called).
+- **Merge importance composes (A1/A2):** merging a higher-importance duplicate raises the
+  survivor's importance (existing `MAX(importance, ?)`), a lower one does not lower it.
+- **Honest stats (A7):** a call where 1 of 3 facts duplicates an existing row → `created === 2`,
+  `merged === 1`, `ingested === 2`, `memory_ids.length === 3`.
+- **Degradation, default (`'degrade'`, no LLM):** config with `llmApiKey: null, llmBaseUrl: null`
+  (the `configWithoutLLM()` helper from `llm-client.test.ts`) → one row, content === blob
+  (truncated), `created === 1`, `degraded === true`.
+- **`on_extraction_failure='skip'` (A3):** no/failed LLM + `skip` → `total_memories === 0`,
+  `created === 0`, `skipped === true`, no throw.
+- **`on_extraction_failure='error'` (A3):** no/failed LLM + `error` → `ingest` **rejects**; assert
+  it throws and that the **error message contains no input substring** (A6).
+- **Malformed response (default degrade):** mock `llmComplete` → `'not json at all'` → union
+  empty → degraded single-blob store (not a throw); `degraded === true`, one row.
+- **Partial extraction is observable (A3):** multi-chunk blob where the mock returns facts for
+  chunk 1 and `null` (or non-JSON) for chunk 2 → facts from chunk 1 are ingested AND
+  `partial === true`, `degraded === true`, `failed_chunks === 1`, `chunks === 2`.
+- **PII-safe on failure (A6):** spy on `console.error`/stderr; trigger a parse failure and an
+  LLM-error with a blob containing a known sensitive marker → assert **neither** stderr **nor**
+  the returned/thrown text contains that marker (only content-free shapes).
+- **Seed tags / source propagate** to every written fact; durability/importance come from the
+  model (per above), seed `importance` is the fallback only.
+- **Chunking integration (with overlap, A5):** a blob over the token threshold with a mock that
+  returns distinct facts per call → assert `llmComplete` called >1 time and facts unioned,
+  `chunks > 1`; a fact placed on the boundary line is recovered (appears once after the
+  exact-`fact` union dedups the overlap duplicate).
+
+### 11.3 Tool/registration tests
+File: extend `test/server.test.ts` and add `test/ingest-tool.test.ts` (mirrors `tools.test.ts`):
+- `listTools` now returns **6** tools including `memory_ingest` (update the existing
+  `lists all 5 memory tools` assertion in `test/server.test.ts` to 6 — note this is an
+  intentional, expected test change).
+- Schema has `content` required; `mode`/`dry_run`/`as_of`/`on_extraction_failure`/`tags`/
+  `importance`/`source` optional.
+- `validateIngestInput`: rejects empty content; rejects bad `as_of` (non-numeric string,
+  negative); normalizes ISO `as_of` → epoch ms; defaults `mode` to `'conversation'`; defaults
+  `on_extraction_failure` to `'degrade'`; rejects an `on_extraction_failure` outside the enum.
+- Handler routes to `engine.ingest` with a mock engine (à la `server.test.ts`
+  `createMockEngine`, extended with an `ingest` mock) and renders the expected text for the
+  normal / dry_run / **partial** / degraded / **skipped** results — including that the normal
+  render reports `created` and `merged` separately (A7).
+
+---
+
+## 12. Migration / back-compat
+
+- **DB schema:** **no change, no `SCHEMA_VERSION` bump.** `as_of` reuses existing timestamp
+  columns; facts are ordinary rows.
+- **`store` public contract:** **preserved.** `StoreOptions` gains two *optional* fields
+  (`source`, `createdAt`); `store(content, opts)` and `memory_store` behavior is identical when
+  they are absent. `StoreResult` unchanged.
+- **`MemoryEngine` interface:** gains one method (`ingest`). All implementers in this package
+  (`createMemoryEngineFromConfig`, `createMemoryEngine`/`EngineModules`) and every test mock
+  engine must add it — this is a compile-time-enforced, mechanical addition. (The `server.test.ts`
+  / `tools.test.ts` `createMockEngine` helpers get an `ingest: vi.fn()…`.)
+- **Published API:** additive. External MCP clients gain a new tool; nothing they used changes.
+
+---
+
+## 13. Explicit non-goals
+
+- **Auto-inferred tags (Question 1):** not designed here. Seed `tags` are applied verbatim to
+  every fact; no inference, no vocabulary convergence.
+- **Inferred titles (Question 2):** not designed here. No `title` column, no migration.
+- **`store` accepting `content: string | string[]`:** out of scope; a separate proposal item.
+- **Routing `auto-save.ts` through ingest:** noted as a seam (§10); not changed in this work.
+- **The historical-export / eval-corpus driver is a SEPARATE script**, not part of this tool.
+  `memory_ingest` provides the **insert-time** primitives the driver needs — per-fact importance
+  (A2), order-independent merge timestamps (A1), `on_extraction_failure` (A3), durability prompts
+  (A4), overlap (A5), PII-safe logging (A6), honest stats (A7), plus `as_of`/`dry_run`. The driver
+  keeps the **per-run policy** decisions that are genuinely its own and that this tool deliberately
+  does **not** absorb:
+  - Choosing `mode` / `as_of` / `on_extraction_failure` **per conversation** (e.g. `document` for
+    transcripts, real conversation date as `as_of`, `error` to force a retry).
+  - Controlling **maintenance cadence** for a reproducible corpus — e.g. raising
+    `maintenanceInterval` during the bulk load and running one consolidation at the end. The tool
+    keeps the existing `maybeRunMaintenance` behavior and adds **no** code for this (noted in §5.1).
+  - Choosing **Haiku-vs-local** extraction model via the existing `MEMORY_LLM_*` config; the tool
+    reuses whatever is configured and adds no model path.
+  The driver (reading a multi-year export, chunking by source conversation) lives outside the
+  server package and is not designed here.
+- **No third extraction mode (A4):** modes stay `conversation` / `document` on the explicit-vs-
+  inference axis; the durability filter is added to **both**, not as a separate mode.
+- **No no-egress / local-only preview mode:** the eval-corpus user has consented to Haiku egress;
+  `dry_run` previews without local persistence but still egresses content to the configured LLM
+  (§8). PII-safe *logging* (A6) is the orthogonal protection that always applies.
+- **No retry loop / no structured-output API:** intentionally consistent with the package's
+  existing single-call, parse-defensively LLM idiom. Retry is the driver's job via
+  `on_extraction_failure='error'`.
+- **No `SCHEMA_VERSION` bump:** timestamps (created path **and** the A1 merge reconciliation)
+  reuse existing `INTEGER` columns; no migration.
+
+---
+
+## 14. File-change summary
+
+| File | Change |
+|---|---|
+| `src/engine.ts` | Add `IngestOptions` (incl. `on_extraction_failure?`, A3), `ingest()` to `MemoryEngine`; add `source?`/`createdAt?` to `StoreOptions`. |
+| `src/types.ts` | Add `IngestResult` with `created`/`merged`/`ingested` (alias) + `failed_chunks`/`degraded`/`partial`/`skipped` diagnostics (A7/A3). |
+| `src/storage/extraction.ts` | **New.** `ExtractedFact` type (A2); `extractFacts` (returns `ExtractedFact[]\|null`), `parseExtractedFacts` (object-form + clamp + bare-string tolerance, A2; PII-safe failure shapes, A6), `chunkBlob` (with ~10–15% overlap, A5), two durability-filtered + importance-instructed mode prompts (A4/A2), constants. |
+| `src/storage/queries.ts` | `InsertMemoryParams.createdAt?`; `insertMemory` uses it (else `Date.now()`). **New** `updateMemoryTimestampsOnMerge(db, ns, id, asOf)` doing `created_at=MIN(.,?)`, `last_accessed_at=MAX(.,?)`, `updated_at=MAX(.,?)` (A1). `updateMemoryContent` unchanged. |
+| `src/engine-impl.ts` | `storeImmediate` forwards `source`/`createdAt` and, on an `as_of` exact-dedup merge, calls `updateMemoryTimestampsOnMerge` (A1); add `ingest` impl (per-fact importance threading A2, `on_extraction_failure` branching + partial-failure tracking A3, honest `created`/`merged` tally A7, PII-safe logging A6); add `ingest` to `EngineModules` + `createMemoryEngine`. |
+| `src/tools/ingest.ts` | **New.** `validateIngestInput` (validate/normalize `on_extraction_failure`, default `'degrade'`), `handleIngest`, `formatIngestResult` (render normal/dry_run/partial/degraded/skipped, A7/A3; content-free, A6), `as_of` normalization. |
+| `src/tools/validation.ts` | (Optional) `MAX_FACTS_PER_INGEST`, chunk/token/overlap constants if shared. |
+| `src/server.ts` | Register `memory_ingest` (in the existing eslint-disable block); schema gains `on_extraction_failure`. |
+| `src/prompts.ts` | Add `TOOL_DESCRIPTIONS.memory_ingest`. |
+| `test/extraction.test.ts`, `test/ingest.test.ts`, `test/ingest-tool.test.ts` | **New.** Cover per-fact importance (A2), order-independent merge (A1), failure modes (A3), overlap (A5), PII leak (A6), honest stats (A7). |
+| `test/server.test.ts` | Update tool-count assertion 5 → 6; add `ingest` to mock engine. |
+| `test/tools.test.ts` | Add `ingest` to `createMockEngine`. |

--- a/docs/designs/memory-parent-context-retrieval.md
+++ b/docs/designs/memory-parent-context-retrieval.md
@@ -8,9 +8,10 @@
 
 > **v3 changelog (back-compat-free simplification).** Product directive: **we do NOT care about
 > backwards compatibility; the system must work correctly out of the box.** v2's retrieval substrate
-> is unchanged — this is purely a *storage/migration* simplification plus a defaults sanity-check:
+> is unchanged — this is purely a _storage/migration_ simplification plus a defaults sanity-check:
+>
 > 1. **The migration runner is DELETED.** v2 carried a version-guarded `runMigrations(db)` with a
->    `PRAGMA table_info` idempotency guard whose *only* job was to upgrade pre-existing v3 DBs
+>    `PRAGMA table_info` idempotency guard whose _only_ job was to upgrade pre-existing v3 DBs
 >    in place. With no back-compat that machinery is gone. The `segments` table and
 >    `memories.segment_id` column are now part of the **canonical schema** that `createSchema`
 >    builds with `CREATE TABLE IF NOT EXISTS` for a fresh DB. There is no in-place migration. (§4)
@@ -70,12 +71,12 @@ Bandalert loss had no flag):
 
 ### Why this is the right shape (research grounding)
 
-- **Atomic/proposition decomposition as the *sole* stored unit is disfavored.** The flagship
+- **Atomic/proposition decomposition as the _sole_ stored unit is disfavored.** The flagship
   pro-proposition paper, **Dense X Retrieval (Chen et al., EMNLP 2024, arXiv:2312.06648)**, shows
-  propositions help only weak/zero-shot retrievers, rare-entity factoids, and *under a fixed
-  token budget*; the gains are flat for strong retrievers. It is a token-density argument, not
+  propositions help only weak/zero-shot retrievers, rare-entity factoids, and _under a fixed
+  token budget_; the gains are flat for strong retrievers. It is a token-density argument, not
   "context-free storage is free." **Decomposition Dilemmas (NAACL 2025, arXiv:2411.02400)** names
-  the exact failure modes we hit: *omission-of-context* and *over-decomposition*.
+  the exact failure modes we hit: _omission-of-context_ and _over-decomposition_.
 - **The dominant trend is the opposite — re-attach context.** **Anthropic Contextual Retrieval
   (Sept 2024)** prepends LLM-generated context to chunks (−35% to −67% retrieval-failure rate);
   **Jina Late Chunking (arXiv:2409.04701)** embeds-then-splits to preserve cross-references;
@@ -87,8 +88,8 @@ Bandalert loss had no flag):
   enriches notes with context + links, **TriMem** keeps multi-granularity records.
 - **Do not touch the ranker.** Our retrieval stack is already SOTA-aligned (hybrid dense+BM25 in
   `hybridScoreFusion` → composite scoring → cross-encoder rerank in `reranker.ts`; "ranking beats
-  structure," SmartSearch 2026). The lesson is *expand after ranking*, not *re-rank on a coarser
-  unit*. Re-expansion in this design happens strictly **after** step 9 of the pipeline.
+  structure," SmartSearch 2026). The lesson is _expand after ranking_, not _re-rank on a coarser
+  unit_. Re-expansion in this design happens strictly **after** step 9 of the pipeline.
 
 The contract failure is therefore a **storage** bug, not a retrieval bug, and the fix is a
 storage + post-ranking-expansion change that leaves the ranker byte-for-byte unchanged.
@@ -107,25 +108,41 @@ storage + post-ranking-expansion change that leaves the ranker byte-for-byte unc
    when **≥2 kept facts share it** — the Bandalert signature — so pinpoint queries (1 fact → no
    expand) are never regressed, and the evidenced loss is fixed with **no flag and no query
    classifier**. `'none'` force-off and `'parent'` force-expand-every-parent are explicit
-   overrides. `buildContext`/`memory_context` is also wired to `'auto'`. (§5.2)
+   overrides. `buildContext`/`memory_context`'s **task** (query-driven) branch is also wired to
+   `'auto'`; its no-task recent/important briefing has no query, so it returns facts only and does
+   not expand. (§5.2)
 4. **The RETURNED unit is a query-ranked ~300–400-token PASSAGE, not the 6000-token chunk.** On
    expansion, the shared segment is split into coherent passages and the passage(s) most similar to
    the query embedding are returned, up to budget. Storage may keep `segment = chunk`; only the
-   *returned* unit is passage-sized. Chosen **recall-time split-and-rank** over ingest-time
+   _returned_ unit is passage-sized. Chosen **recall-time split-and-rank** over ingest-time
    pre-split — simpler storage, only fires on auto-expand, reuses the step-1 query embedding. (§5.3)
-5. **Passages AUGMENT the facts; they do not replace them (breadth-first).** All kept facts are
-   returned exactly as `expand:'none'` would return them; the expanded passage(s) are **appended
-   after** all the facts, in segment-best-rank order. Parent-dedup applies to **passages** (one
-   passage per shared parent), **never to facts** — auto-expand never evicts a fact `expand:'none'`
-   would have kept. Because the greedy skip-not-break packer packs in order, a passage only ever
-   consumes leftover budget. (§5.3)
-6. **Budget machinery is simplified.** Passage-sized returns make the v1 two-tier
-   `expand_budget_fraction` unnecessary (its only job was to *reject* the oversized segment).
-   Expanded passages and facts share the budget under the existing greedy skip-not-break
-   `packToBudget`, with a small cap (`max_expand_passages`, default 2) so expansion can't evict every
-   fact. The `expand:'none'` path uses `packToBudget` byte-for-byte. The default recall budget is
-   **bumped 500 → 800** (`MEMORY_DEFAULT_TOKEN_BUDGET`) so a ~300–400-token passage plus a couple of
-   facts fits out of the box; `memory_context` is already 800. No flag, no tuning. (§5.4)
+5. **HYBRID expansion: breadth facts + one GUARANTEED passage (supersedes pure-AUGMENT).** An
+   earlier draft appended the passage(s) strictly **last**, lowest-priority, so the passage rode
+   only leftover budget. That made depth **budget-dependent**: if the breadth facts filled the
+   default budget, the passage was skipped and `expand:'auto'` silently degraded to `'none'` (the
+   lossy headlines the feature exists to fix). The corrected HYBRID rule **reserves budget for the
+   single highest-ranked passage so depth is guaranteed**: facts are packed into `budget − reserve`
+   (so the **top** facts are never evicted), then the top passage is force-included (it always fits
+   its reservation), then leftover budget is filled with the remaining facts + any further passages.
+   The passage displaces only the **lowest-priority tail** facts — every fact ranking above the
+   displaced tail is still returned (this preserves breadth, the original REPLACE-regression
+   guarantee). Additional passages beyond the first (and `parent` mode's extra parents) are
+   **supplementary** — leftover budget only, capped at `max_expand_passages`, never displacing a
+   fact. Parent-dedup applies to **passages** (one per shared parent), **never to facts**.
+   `expand:'none'` is byte-for-byte unchanged (no reservation, today's `packToBudget` over the fact
+   list). Edge: if even the one passage cannot fit the whole budget, fall back to facts only
+   (`expanded` false — no infinite reserve); at the default 800 a ~300–400-token passage + the top
+   facts both appear. The HYBRID packing does **not** change `packToBudget`'s own logic. (§5.3)
+6. **Budget machinery is simplified, with one reservation.** Passage-sized returns make the v1
+   two-tier `expand_budget_fraction` unnecessary (its only job was to _reject_ the oversized
+   segment). Facts and passages share the budget under the existing greedy skip-not-break
+   `packToBudget` — **unchanged**. The HYBRID change (decision 5) is purely a packing _orchestration_
+   around it: reserve `estimateTokens(topPassage)`, pack facts into `budget − reserve`, force-include
+   the top passage, fill leftover. The small cap (`max_expand_passages`, default 2) bounds the
+   supplementary passages. The `expand:'none'` path uses `packToBudget` byte-for-byte. The default
+   recall budget is **bumped 500 → 800** (`MEMORY_DEFAULT_TOKEN_BUDGET`) so a ~300–400-token passage
+   plus a couple of facts fits out of the box; `memory_context` is already 800. No flag, no tuning.
+   (§5.4)
 7. **The schema is canonical — there is no in-place migration.** The `segments` table and the
    `memories.segment_id` column are part of the schema `createSchema` builds with
    `CREATE TABLE IF NOT EXISTS` for a fresh DB. `SCHEMA_VERSION` bumps `'3' → '4'` as a plain
@@ -133,7 +150,7 @@ storage + post-ranking-expansion change that leaves the ranker byte-for-byte unc
    when it is older than `SCHEMA_VERSION` (a stale pre-change DB is rebuilt, not upgraded —
    acceptable under the back-compat-free directive, and self-healing with no manual step). A row
    with no parent simply has `segment_id = NULL` and recall returns the fact. (§4)
-8. **On exact-dedup merge, the survivor repoints to the *richer* parent** (the segment with the
+8. **On exact-dedup merge, the survivor repoints to the _richer_ parent** (the segment with the
    higher `fact_count`), so a later, richer ingest of the same fact is not discarded by ingest
    order. The merge path must read both segments' `fact_count`. (§6.2)
 9. **Expansion metadata is surfaced in every format.** `RecallResult` carries `expanded` and the
@@ -142,7 +159,7 @@ storage + post-ranking-expansion change that leaves the ranker byte-for-byte unc
 10. **The LLM-free `store` path is untouched.** Only `ingest` writes segments. `store` rows have
     `segment_id = NULL` forever and behave exactly as today. (§3.3)
 11. **Phase 2 (optional, deferred): contextualized embedding** — prepend a one-line segment
-    context to each fact *before embedding* (Anthropic-style). Designed in §7, gated behind ingest
+    context to each fact _before embedding_ (Anthropic-style). Designed in §7, gated behind ingest
     so `store` stays LLM-free. Unlike v1, Phase 1 now actually fixes the evidenced failure on a
     default recall, so Phase 2 is a pure recall-rate optimization. (§7, §11)
 
@@ -154,14 +171,14 @@ storage + post-ranking-expansion change that leaves the ranker byte-for-byte unc
 
 Three options were considered:
 
-| Option | What it is | Verdict |
-|---|---|---|
+| Option                                                  | What it is                                                                                                                      | Verdict    |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | **A. `segments` table + `segment_id` FK on `memories`** | New table `segments(id, namespace, content, source, created_at, …)`; each fact row gets a nullable `segment_id` pointing at it. | **CHOSEN** |
-| B. Self-referential `parent_id` on `memories` | The segment is itself a `memories` row; facts point at it via `parent_id`. | Rejected |
-| C. Metadata JSON pointer | Store the parent text (or an id) inside the existing `metadata` JSON column. | Rejected |
+| B. Self-referential `parent_id` on `memories`           | The segment is itself a `memories` row; facts point at it via `parent_id`.                                                      | Rejected   |
+| C. Metadata JSON pointer                                | Store the parent text (or an id) inside the existing `metadata` JSON column.                                                    | Rejected   |
 
 **Why A over B.** If the segment were a `memories` row it would land in **both** index structures,
-each by a *different* mechanism: `memories_fts` is populated by the `memories_ai` AFTER-INSERT
+each by a _different_ mechanism: `memories_fts` is populated by the `memories_ai` AFTER-INSERT
 trigger (`database.ts:111-114`, which writes **only** to `memories_fts`), while the `vec_memories`
 row is written **explicitly** inside `insertMemory` (`queries.ts:48-51`) — there is no trigger for
 the vector table. (v1 mis-stated that the trigger populates both; corrected here. The conclusion is
@@ -176,7 +193,7 @@ It also avoids overloading `memories`' lifecycle columns (`importance`, `is_comp
 `consolidated`, decay) — a segment is provenance, not a recallable memory, and shouldn't decay,
 consolidate, or compact.
 
-**Why A over C.** Metadata-JSON would duplicate a ~6000-token segment into *every* fact's
+**Why A over C.** Metadata-JSON would duplicate a ~6000-token segment into _every_ fact's
 `metadata` blob (7 facts → 7 copies of the same chunk), bloating each `memories` row, every
 `SELECT m.*` in `queries.ts`, and every `rowToMemory` parse (`engine-impl.ts:73`). Normalizing
 the segment into one row referenced by N facts is the obvious relational fit and makes
@@ -186,7 +203,7 @@ parent-dedup (§5.3) a trivial `GROUP BY segment_id`.
 
 Both of these are part of the canonical schema a fresh DB is born with — `createSchema`
 (`database.ts`) builds them in its existing `CREATE TABLE IF NOT EXISTS` style alongside
-`memories`. There is **no** `ALTER TABLE`/migration step; `memories` is *defined* with
+`memories`. There is **no** `ALTER TABLE`/migration step; `memories` is _defined_ with
 `segment_id` (§4).
 
 ```sql
@@ -222,8 +239,8 @@ Notes:
   800-token default budget.
 - **`fact_count`** is a cheap denormalization that lets recall decide whether expanding is
   worthwhile (a segment whose only fact is the one that matched adds little; a segment with 7
-  facts where only the headline was indexed is exactly the contract case). Optional to *use* in
-  phase 1; cheap to *populate*.
+  facts where only the headline was indexed is exactly the contract case). Optional to _use_ in
+  phase 1; cheap to _populate_.
 - **`REFERENCES segments(id)`** declares the FK. `foreign_keys = ON` is already set
   (`database.ts:42`). The reference is **not** `ON DELETE CASCADE` deliberately — see §6.3
   (forget/decay must null the pointer or orphan-collect, not cascade-delete facts).
@@ -280,7 +297,7 @@ This mirrors exactly how the schema is already declared: one body of
 
 `SCHEMA_VERSION` bumps **`'3' → '4'`** (`database.ts:30`). It remains a plain version stamp,
 written by the existing `ensureSchemaMeta` upsert (`upsert.run('schema_version', SCHEMA_VERSION)`)
-— **no migration logic reads it to transform data.** But it *is* read for one purpose: to detect
+— **no migration logic reads it to transform data.** But it _is_ read for one purpose: to detect
 and discard a stale on-disk schema so the system self-heals.
 
 The hazard: a pre-change DB has an **old `memories` table without `segment_id`**. `createSchema`'s
@@ -298,10 +315,10 @@ drop. This reuses the `SELECT … FROM sqlite_master` / `SELECT value FROM schem
 already in the file (`ensureSchemaMeta` already reads `schema_meta` for the embedding model).
 
 > **This deliberately discards old data.** Under the back-compat-free directive that is acceptable
-> and explicitly intended: a stale DB is *rebuilt*, not migrated. The corpus DB is regenerated via
+> and explicitly intended: a stale DB is _rebuilt_, not migrated. The corpus DB is regenerated via
 > `scripts/memory-corpus/build-corpus.ts` (which re-ingests, so segments get populated); user/session
 > DBs are recreated empty on first open. Option (b) — "document that old DB files must be deleted by
-> hand" — is rejected as the default because it is *not* out-of-the-box-correct: it requires a manual
+> hand" — is rejected as the default because it is _not_ out-of-the-box-correct: it requires a manual
 > step and the un-deleted DB crashes with `no such column`. The stamp-gated drop self-heals with zero
 > operator action, which is exactly the directive's bar.
 
@@ -323,16 +340,16 @@ The ~11-step `recall` pipeline (`pipeline.ts:36-125`) is **untouched** through d
 → vector KNN + FTS → `hybridScoreFusion` → tag filter → `computeCompositeScore` →
 `filterByRelevance` → `rerank` → `filterByRerankerScore` → load embeddings →
 `deduplicateByEmbedding` (`pipeline.ts:114`). The candidate set, scores, and ordering are identical
-to today. Re-expansion is inserted as a new **step 9b**, strictly *after* `deduplicateByEmbedding`
-and *before* `packToBudget` (`:117`) / `formatMemories` (`:125`).
+to today. Re-expansion is inserted as a new **step 9b**, strictly _after_ `deduplicateByEmbedding`
+and _before_ `packToBudget` (`:117`) / `formatMemories` (`:125`).
 
-**Passage ranking is NOT a change to the candidate ranker.** Step 9b ranks *passages of an
-already-selected segment* by similarity to the query embedding, to decide which slice of a parent
+**Passage ranking is NOT a change to the candidate ranker.** Step 9b ranks _passages of an
+already-selected segment_ by similarity to the query embedding, to decide which slice of a parent
 to **return**. This is a post-retrieval, return-shaping operation on a single segment's text — it
 never touches the candidate set, the fusion scores, the reranker, or the order of the kept facts.
 "Do not touch the ranker" (steps 1–9, byte-for-byte) and "rank passages on return" are orthogonal:
-the first is about *which memories win*; the second is about *which slice of a winner's parent to
-show*. The reused query embedding (from step 1, `embedQuery`, `pipeline.ts:43`) is a read of an
+the first is about _which memories win_; the second is about _which slice of a winner's parent to
+show_. The reused query embedding (from step 1, `embedQuery`, `pipeline.ts:43`) is a read of an
 existing value, not a re-run of any ranking stage.
 
 ### 5.2 The expansion option — `expand: 'none' | 'auto' | 'parent'`, default `'auto'`
@@ -348,17 +365,17 @@ max_expand_passages?: number;          // cap on returned passages, default 2 (�
 `expand` enum and `max_expand_passages` number, both passed through `handleRecall` →
 `engine.recall` → `retrievalRecall`.
 
-| Mode | Behavior |
-|---|---|
+| Mode                   | Behavior                                                                                                                                                                                               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **`'auto'` (default)** | After dedup (step 9b), if **≥2 kept facts share a non-null `segment_id`**, expand that shared parent (return its query-ranked passages). A single fact with a lone parent stays a fact (no expansion). |
-| **`'none'`** | Force off. Facts are returned, no segment lookup, no extra query, no budget change — **byte-for-byte today's** behavior. |
-| **`'parent'`** | Force expand: emit the parent passage for **every** kept fact that has a non-null `segment_id`, even a lone one. |
+| **`'none'`**           | Force off. Facts are returned, no segment lookup, no extra query, no budget change — **byte-for-byte today's** behavior.                                                                               |
+| **`'parent'`**         | Force expand: emit the parent passage for **every** kept fact that has a non-null `segment_id`, even a lone one.                                                                                       |
 
 **Why `'auto'` is the default (the off-by-default fix).** The Bandalert loss occurred on an
 **ordinary recall with no flag** — so an opt-in `'none'` default (v1) could never have fixed it; the
 load-bearing behavior was deferred out of the default path. `'auto'` fixes the evidenced failure on
-a default call, and it needs **no query classifier**: the discriminator is purely structural — *do
-≥2 of the kept facts point at the same parent?* That shared-parent grouping is the exact contract
+a default call, and it needs **no query classifier**: the discriminator is purely structural — _do
+≥2 of the kept facts point at the same parent?_ That shared-parent grouping is the exact contract
 signature (7 headline facts, one shared segment) and is **already computed** for parent-dedup
 (§5.3), so `'auto'` adds no new machinery. It does **not** regress pinpoint queries: a pinpoint
 recall returns one matched fact, which has at most one parent and therefore one fact per
@@ -369,60 +386,83 @@ answer ("what's my Anthropic API key var name?") into a passage lookup for no be
 evicting other facts under the default budget. `'auto'`'s ≥2-shared-parent gate is the minimal
 trigger that catches the contract case while leaving pinpoint recall untouched.
 
-**`buildContext`/`memory_context` is wired to `'auto'` too** (`engine-impl.ts:279`). The briefing
-path is the **no-human-in-loop** place where missing a clause is most costly — there is no agent to
-notice the headline is thin and ask a follow-up — so it gets the same auto-expansion. Its budget is
-**800** (`CONTEXT_DEFAULT_BUDGET`, `engine-impl.ts:270`), which a ~300-token passage comfortably
-fits alongside facts.
+**`buildContext`/`memory_context`'s task branch is wired to `'auto'` too** (`engine-impl.ts:373`).
+Auto-expansion applies to the **query-driven** recall path: when a `task` is supplied,
+`buildContext` runs a real `recall` against it with `expand:'auto'`, so the briefing's
+**no-human-in-loop** place — where missing a clause is most costly, since there is no agent to
+notice a thin headline and ask a follow-up — gets the same expansion. Its budget is **800**
+(`CONTEXT_DEFAULT_BUDGET`, `engine-impl.ts:365`), which a ~300-token passage comfortably fits
+alongside facts.
 
-### 5.3 Step 9b — parent re-expansion (passage AUGMENTs the facts; passage-only parent-dedup)
+**The no-task briefing returns facts only — it cannot expand.** When no `task` is given, the
+recent/important section (`engine-impl.ts:387`–`419`) is a direct SQL list built from
+`getRecentMemories`/`getImportantMemories`, formatted as bullet lines. There is **no query** in
+that path, so there is nothing to rank a segment's passages against; auto-expansion is a
+query-driven step and therefore does not run. "Wired to `'auto'`" means the query-driven (task)
+recall expands — it does **not** mean every `memory_context` path expands. A no-task briefing
+surfaces fact headlines only.
+
+### 5.3 Step 9b — parent re-expansion (HYBRID: breadth facts + one reserved passage; passage-only parent-dedup)
 
 Input: `kept` (the post-dedup `ScoredMemory[]`, `pipeline.ts:114`), already sorted by score, plus
-`queryEmbedding` (already computed at step 1, `pipeline.ts:43`).
+`queryEmbedding` (already computed at step 1, `pipeline.ts:43`), plus the recall `budget`. Step 9b
+**absorbs the budget pack** (the pipeline no longer calls `packToBudget` itself for the expand
+path): it returns the final packed, ordered display units. `rankSegmentPassages` (the
+split→embed→rank helper) is **shared** with `engine.expand`/`memory_expand` (§9.4).
 
-> **AUGMENT, not replace.** An earlier draft had an expanded segment's chosen passage *replace* its
-> sibling facts (the facts "collapsed into" the one passage). That is wrong for a multi-term source:
-> a contract segment's facts are about **different** terms (ownership, valuation, profit-sharing,
-> governance, execution), so collapsing them into one passage about **one** term destroys breadth —
-> on the live corpus, a "key terms" survey query returned a *worse* answer with `expand:'auto'` than
-> with `expand:'none'` (five distinct key-term facts evicted for one execution-terms passage). The
-> corrected design **keeps every fact** and treats the passage as **supplementary**: passages are
-> appended *after* all the facts. **Parent-dedup applies to passages (one per shared parent), never
-> to facts.**
+> **HYBRID, not pure-AUGMENT (and not REPLACE).** Two earlier drafts were both wrong at the edges.
+> (1) **REPLACE** had a chosen passage _replace_ its sibling facts — wrong for a multi-term source: a
+> contract segment's facts are about **different** terms (ownership, valuation, profit-sharing,
+> governance, execution), so collapsing them into one passage about **one** term destroys breadth (a
+> "key terms" survey query returned a _worse_ answer than `expand:'none'`). (2) **pure-AUGMENT** fixed
+> that by appending the passage strictly **last**, lowest-priority, riding only leftover budget — but
+> that made depth **budget-dependent**: if the breadth facts filled the default 800 budget, the
+> passage was skipped, `expanded` was false, and `expand:'auto'` silently degraded to the lossy
+> headlines the feature exists to fix. The corrected **HYBRID** keeps the breadth facts AND
+> **reserves budget for the one top passage so depth is guaranteed**, displacing only the
+> lowest-priority tail facts — never the top facts. **Parent-dedup applies to passages (one per shared
+> parent), never to facts.**
 
 ```
-if expand === 'none': proceed to packToBudget as today.   // unchanged path
+if expand === 'none': packToBudget(factUnits, budget) as today.   // unchanged path
 
 // expand === 'auto' | 'parent':
 1. Group kept facts by non-null segment_id, recording each group's best-ranked-fact position.
 2. Decide which segments to EXPAND:
      - expand === 'parent'  → every group with a non-null segment_id (size ≥1)
      - expand === 'auto'    → only groups whose size is ≥2 (a SHARED parent)
+   (no expandable segment → packToBudget(factUnits, budget); identical to 'none'.)
 3. Fetch the selected segments by id in one query (getSegmentsByIds(db, ns, ids)).
-4. For each expanded segment, SPLIT-AND-RANK to a passage (§5.3.1):
+4. For each expanded segment, SPLIT-AND-RANK to a passage via rankSegmentPassages (§5.3.1):
      - split segment.content into coherent passages (paragraph/turn/sentence boundaries,
        each capped ~300–400 tokens);
      - embed each passage and rank by cosine similarity to queryEmbedding;
      - choose the top passage per segment.
-5. Build the display list as AUGMENT:
-     a. Emit EVERY kept fact as a fact unit, in score order — byte-for-byte what `expand:'none'`
-        returns. No fact is ever dropped, skipped, or reordered by expansion. (store-path / degrade
-        NULL-segment facts and forgotten-parent facts are just normal facts here.)
-     b. APPEND the chosen passages AFTER all the facts, in segment-best-rank order (each passage
-        rides on its segment's best-ranked fact for date/importance rendering, with a distinct id
-        so it is not an id-collision duplicate of that fact). Apply passage parent-dedup (one
-        passage per segment), passage overlap-dedup (§5.3.2), and the max_expand_passages cap
-        (§5.4) to the appended passages only.
-6. The result is a score-ordered list of fact units followed by ≤max_expand_passages passage units.
+5. Build the candidate passage units, in segment-best-rank order: each rides its segment's
+   best-ranked fact for date/importance rendering, with a distinct id so it is not an
+   id-collision duplicate of that fact. Apply passage parent-dedup (one passage per segment),
+   passage overlap-dedup (§5.3.2), and the max_expand_passages cap (§5.4) here.
+6. HYBRID pack (does NOT change packToBudget's own logic — it orchestrates it):
+     - topPassage = passageUnits[0]; reserve = estimateTokens(topPassage).
+     - if no passage, or reserve > budget → packToBudget(factUnits, budget), expanded=false
+       (no infinite reserve; at a pathologically tiny budget auto≈none is acceptable).
+     - else: packedFacts = packToBudget(factUnits, budget − reserve)   // top facts never evicted
+             force-include topPassage                                   // depth guaranteed
+             fill leftover greedily (skip-not-break) with the not-yet-packed facts
+               + the supplementary passages (passageUnits[1..], already capped).
+7. The result is score-ordered facts, then the guaranteed top passage, then any supplementary
+   passages — facts above the displaced tail are all still present.
 ```
 
-Because the unchanged greedy skip-not-break `packToBudget` packs the display list **in order**,
-putting passages **last** means the breadth facts are packed first and a passage only ever consumes
-**leftover** budget. **This is the load-bearing property: auto-expand can never evict a fact that
-`expand:'none'` would have kept.** In the contract case the ~7 headline facts (about different
-terms) are all preserved AND the query-relevant clause passage (carrying e.g. the `$250k` cap, never
-a fact) is appended when budget allows — **the fix for the Bandalert failure, on a default `'auto'`
-recall with no flag, without sacrificing breadth.**
+The **reservation** is the load-bearing property: because the top facts are packed into
+`budget − reserve` _before_ the passage is force-included, the top facts are never evicted to fit
+the passage, yet the passage is **guaranteed** whenever it fits the whole budget — depth no longer
+degrades to `'none'` at the default budget. The passage displaces only the lowest-priority tail
+facts (the ones that did not fit `budget − reserve`); every fact ranking above the displaced tail is
+still returned. In the contract case the top headline facts (about different terms) are preserved
+AND the query-relevant clause passage (carrying e.g. the `$250k` cap, never a fact) is guaranteed at
+the default 800 budget — **the fix for the Bandalert failure, on a default `'auto'` recall with no
+flag, without sacrificing the top facts.**
 
 #### 5.3.1 Split-and-rank: the returned unit is a query-relevant passage, not the chunk
 
@@ -452,12 +492,12 @@ total recalls (only shared-parent groups). Ingest-time pre-split would precomput
 embeddings and avoid the recall-time embed, but adds a passages table and write-path cost on every
 ingest for a path that fires occasionally. Recall-time is the simpler default; ingest-time pre-split
 is a noted optimization (§8) if profiling shows the recall-time passage embed is hot. Either way the
-**storage unit may remain `segment = chunk`**; only the *returned* unit is passage-sized.
+**storage unit may remain `segment = chunk`**; only the _returned_ unit is passage-sized.
 
 #### 5.3.2 Overlap dedup (A6, minor)
 
 `chunkBlob` windows overlap ~10–15% (`extraction.ts` `chunkBlob` comment; the overlap preserves
-cross-references at chunk boundaries). If two *adjacent* segments are both expanded in one result —
+cross-references at chunk boundaries). If two _adjacent_ segments are both expanded in one result —
 e.g. a fact from each side of a boundary shares text — their chosen passages may contain the same
 sentences. Because the returned unit is now a **passage**, a cheap **passage-text overlap dedup**
 handles this: when emitting passages, drop a passage whose normalized text is a (near-)substring of
@@ -467,30 +507,34 @@ emitted passages, not an embedding pass. It is a no-op for the common single-exp
 ### 5.4 Budget accounting (simplified — passages are fact-sized, not chunk-sized) + out-of-the-box defaults
 
 **Default budget is bumped 500 → 800 so the system returns useful context with zero configuration.**
-The out-of-the-box directive requires that a *default* recall return the relevant passage **plus**
-a couple of facts. A passage is ~300–400 tokens and a fact ~150; at the old default of **500**,
-once the facts have packed first (AUGMENT) a single ~400-token passage rarely has room to ride
-along — so the shared-parent depth would simply not surface (auto ≈ none). Bumping
-`MEMORY_DEFAULT_TOKEN_BUDGET` (`config.ts:70`) to **800** comfortably fits 2–3 facts **and** one
-~300–400-token passage (~3×150 + 400 ≈ 850, packed greedily to ≤ 800), which is exactly the desired
-shape. `memory_context`
-stays **800** (`engine-impl.ts:270`); the two default budgets are now equal, which is intentional —
-both paths want the same "one passage + a few facts" envelope. **No flag and no config tuning are
-needed** to get parent context on shared-parent queries.
+The out-of-the-box directive requires that a _default_ recall return the relevant passage **plus**
+a couple of facts. A passage is ~300–400 tokens and a fact ~150. The HYBRID reservation (§5.3)
+guarantees the passage even when facts could fill the budget, so the bump is about leaving room for
+**enough facts alongside** the reserved passage: at **800**, reserving ~400 for the passage still
+packs 2–3 facts into the remaining ~400, which is exactly the desired shape. (At the old **500**,
+after a ~400-token reservation only ~100 tokens remain — barely one fact — so the breadth would be
+too thin even though depth was guaranteed.) Bumping `MEMORY_DEFAULT_TOKEN_BUDGET` (`config.ts:70`) to
+**800** fits 2–3 facts **and** one ~300–400-token passage. `memory_context` stays **800**
+(`engine-impl.ts:270`); the two default budgets are now equal, which is intentional — both paths want
+the same "one passage + a few facts" envelope. **No flag and no config tuning are needed** to get
+parent context on shared-parent queries.
 
-v1's elaborate two-tier `expand_budget_fraction` existed for **one** reason — to *reject* a
+v1's elaborate two-tier `expand_budget_fraction` existed for **one** reason — to _reject_ a
 6000-token segment that could never fit — and passage return removes that reason entirely. So the
 budget machinery is simplified:
 
-- Re-expansion produces display units that each carry their own `displayContent` (a chosen passage
-  for an expanded unit, fact text otherwise) and `displayTokens = estimateTokens(displayContent)`.
-- Packing reuses the **existing** `packToBudget` greedy *skip-not-break* discipline
-  (`scoring.ts:200-212`): walk the score-ordered display list; include a unit if it fits the
-  remaining budget, else `continue` (skip, don't break). No segment sub-budget, no second pass.
+- Re-expansion produces display units whose `content` is the chosen display text (a passage for an
+  expanded unit, fact text otherwise); the packer estimates tokens off that `content`.
+- Packing reuses the **existing** `packToBudget` greedy _skip-not-break_ discipline
+  (`scoring.ts:200-212`) **unchanged**, called twice by the HYBRID orchestration: once over the facts
+  into `budget − reserve`, then over the leftover (remaining facts + supplementary passages). The
+  top passage is force-included between those calls. No segment sub-budget; `packToBudget`'s own
+  logic is untouched.
 - The only added guard is a small **count cap**: at most `max_expand_passages` (default **2**)
-  passages may be appended across the whole result. With AUGMENT the cap is belt-and-suspenders
-  (passages are appended *after* the facts and only consume leftover budget, so they cannot evict a
-  fact regardless of the cap); it mainly bounds explicit `'parent'` calls with a raised budget.
+  passages across the whole result, applied when the passage units are built (so an overlap-dropped
+  passage does not waste a cap slot). Under HYBRID only the **first** passage is reserved/guaranteed;
+  the rest are supplementary (leftover budget only, never displacing a fact), so the cap mainly
+  bounds explicit `'parent'` calls with a raised budget.
 
 **Why a count cap of 2 against budget=800 with ~300–400-token passages and ~150-token facts.** One
 ~300–400-token passage leaves ~400–500 tokens — room for 2–3 facts; two passages (~600–800 tokens)
@@ -502,17 +546,20 @@ the supporting facts. A single dominant passage (the contract clause) plus the f
 is exactly the desired out-of-the-box shape.
 
 The `expand:'none'` path calls `packToBudget` with the unchanged fact list — **byte-for-byte today's
-behavior** (at whatever `token_budget` the caller passes; only the *default* changed). Under AUGMENT,
-expansion only ever **appends** passages after the full fact list and never relaxes the skip-not-break
-rule, so a budget that fits N facts always still fits those N facts — the passage is the unit that
-gets skipped, never a fact.
+behavior** (at whatever `token_budget` the caller passes; only the _default_ changed). Under HYBRID,
+the top facts are packed into `budget − reserve` before the passage is force-included, so the **top**
+facts are never evicted to fit the passage; only the lowest-priority tail facts (the ones that did
+not fit `budget − reserve`) are displaced. Every fact ranking above the displaced tail is still
+returned.
 
-**Trade-off (intended).** Because passages are appended last, the budget governs *depth*, not
-breadth: at a **tight** budget the passage may not fit at all, so `expand:'auto'` degrades to
-`expand:'none'` (all the facts, no passage) rather than dropping a fact — a strict no-regression
-floor. A **larger** budget simply surfaces more depth (the clause passage, then a second if
-`max_expand_passages` and budget allow). Breadth is constant across budgets; only how much parent
-context rides along varies.
+**Trade-off (intended).** The budget governs how many facts ride **alongside** the guaranteed
+passage, not whether depth appears at all. At a **default-ish** budget the top passage is reserved
+and guaranteed, displacing only the lowest-priority tail fact(s); a **larger** budget keeps more of
+those tail facts (and may surface a second passage if `max_expand_passages` and budget allow); only
+at a **pathologically tiny** budget — one that cannot fit even the single passage — does
+`expand:'auto'` fall back to `expand:'none'` (facts only, `expanded` false), the strict
+no-regression floor. So depth is guaranteed across the realistic budget range; what varies is how
+many breadth facts accompany it.
 
 ### 5.5 Formatting + expansion metadata in every format
 
@@ -532,11 +579,11 @@ which hides exactly the ids an agent needs to follow up. v2 surfaces, on the str
 - `expanded_segment_ids: string[]` — the `segment_id`s that were expanded (empty when none);
 - per-unit, in `raw` mode, the `segment_id` and an `expanded` flag (as v1).
 
-The `summary`/`answer` *text* is unchanged in shape; the structured fields ride alongside it.
+The `summary`/`answer` _text_ is unchanged in shape; the structured fields ride alongside it.
 
 **Agentic follow-up — the "get headlines → expand the one that matters" loop.** The realistic
 agentic usage is: a default `'auto'` recall returns mostly facts (no shared parent) plus maybe one
-expanded passage; the agent reads a headline fact, decides *that* one needs detail, and fetches its
+expanded passage; the agent reads a headline fact, decides _that_ one needs detail, and fetches its
 parent. Two affordances support this, both driven by the now-visible ids:
 
 - **`memory_expand(segment_id)`** — a small new tool that returns the parent segment's
@@ -555,8 +602,9 @@ unique among the kept set → the ≥2-shared-parent gate does **not** fire → 
 returned, identical to today. Auto-expansion only triggers when several kept facts genuinely share a
 parent — the briefing/contract shape, where the coarse passage is what the user wanted. Existing
 callers that need byte-for-byte-today behavior can pass `expand:'none'`; `buildContext`/
-`memory_context` deliberately uses `'auto'` (§5.2) because its no-human-in-loop briefings are
-exactly the shared-parent case. The pinpoint case is never *worse* than today.
+`memory_context`'s **task** (query-driven) branch deliberately uses `'auto'` (§5.2) because its
+no-human-in-loop briefings are exactly the shared-parent case. (The no-task recent/important
+briefing has no query and returns facts only.) The pinpoint case is never _worse_ than today.
 
 ---
 
@@ -592,7 +640,7 @@ for each chunk-group g with g.facts.length > 0:
 
 - `store` (`storeImmediate`) gains an optional `segmentId` in `StoreOptions`, forwarded into
   `insertMemory`'s new `segmentId` param (§3.3).
-- **On exact-dedup merge, repoint the survivor to the *richer* parent (order-independence, A4).**
+- **On exact-dedup merge, repoint the survivor to the _richer_ parent (order-independence, A4).**
   When a fact **merges** into an existing row (exact-dedup branch, `engine-impl.ts:95-108`), v1 kept
   the survivor's **first** `segment_id`. That makes the parent depend on ingest order: a later,
   richer ingest of the same fact — whose segment carries more clauses — would be discarded purely
@@ -618,7 +666,7 @@ for each chunk-group g with g.facts.length > 0:
   - `dry_run`: no segment and no fact rows written (today's behavior, `engine-impl.ts:247-249`).
   - `degrade` single-blob (`engine-impl.ts:219-238`): the blob is stored as one fact with
     `segment_id = NULL` — there was no decomposition, so there is no parent to retain. (The blob
-    *is* the content; re-expansion treats it as its own parent, §4.3.) **No segment row** for the
+    _is_ the content; re-expansion treats it as its own parent, §4.3.) **No segment row** for the
     degrade path.
   - `skip`: nothing written (unchanged).
 - **`maybeRunMaintenance`** still fires inside `storeImmediate` as today; segments are inert to
@@ -636,9 +684,9 @@ fact is forgotten (siblings may still reference it). Rules:
   has been independently removed falls back to emitting the fact (§5.3 step 3, missing-segment
   case) — robust to dangling pointers.
 - **Orphan collection (deferred, §8):** a maintenance sweep can `DELETE FROM segments WHERE id
-  NOT IN (SELECT segment_id FROM memories WHERE segment_id IS NOT NULL)`. Not required for phase 1
+NOT IN (SELECT segment_id FROM memories WHERE segment_id IS NOT NULL)`. Not required for phase 1
   (orphans are inert and cheap); listed as a follow-up. Because the FK is **not** `ON DELETE
-  CASCADE`, deleting facts never deletes segments and deleting a segment is only ever the explicit
+CASCADE`, deleting facts never deletes segments and deleting a segment is only ever the explicit
   orphan sweep.
 - **Decay/compaction** don't delete rows, so segment links survive; an expanded recall of a
   decayed fact still has its parent (though a decayed fact rarely surfaces, since its vector is
@@ -650,7 +698,7 @@ fact is forgotten (siblings may still reference it). Rules:
 
 **Idea (Anthropic Contextual Retrieval).** Before embedding a fact, prepend a short context
 string derived from its segment (a one-line topic, e.g. "Context: the Bandalert distribution
-contract. Fact: …"), so the fact's *vector* carries cross-reference signal it otherwise lacks.
+contract. Fact: …"), so the fact's _vector_ carries cross-reference signal it otherwise lacks.
 This improves the **retrieval key** (the embedded fact), distinct from §5 which improves the
 **returned unit**.
 
@@ -671,11 +719,11 @@ This improves the **retrieval key** (the embedded fact), distinct from §5 which
   return + auto-expansion are both in Phase 1, §11), so phase 1 actually solves the evidenced
   problem on its own. (This corrects v1, which claimed "phase 1 solves it" while the load-bearing
   behavior — expansion on a default recall — had been deferred behind an opt-in `'none'` default.)
-  Phase 2 is therefore a pure *recall-rate* optimization to layer on later behind a config flag
+  Phase 2 is therefore a pure _recall-rate_ optimization to layer on later behind a config flag
   (`MEMORY_INGEST_CONTEXTUALIZE_EMBEDDING`, default off).
 
-**Tradeoff stated:** phase 2 buys better *retrieval* of detail-bearing facts (the fact is more
-findable); phase 1 buys *returnability* of detail that was never a fact at all (the clause is in
+**Tradeoff stated:** phase 2 buys better _retrieval_ of detail-bearing facts (the fact is more
+findable); phase 1 buys _returnability_ of detail that was never a fact at all (the clause is in
 the segment). They are complementary; the evidenced loss is a returnability problem, so phase 1
 is mandatory and phase 2 is optional.
 
@@ -684,7 +732,7 @@ is mandatory and phase 2 is optional.
 ## 8. Reference-document handling & `mode='document'`
 
 - **Parent retention fixes the contract case even if decomposition stays lossy.** The headline
-  facts ("there is a distribution contract", "it has a buyout clause") are enough to *retrieve*
+  facts ("there is a distribution contract", "it has a buyout clause") are enough to _retrieve_
   the right segment; the **un-decomposed clauses** ($250k cap, IP terms, NDA) ride along in
   `segments.content` and are returned — as the query-relevant **passage** (§5.3) — on a default
   `'auto'` recall (the shared-parent gate fires because all the headline facts point at the one
@@ -695,8 +743,8 @@ is mandatory and phase 2 is optional.
   low-importance near-duplicate facts that muddy the index — the opposite of the ingest tool's
   design intent. With parent retention, the clauses are **recoverable** without being indexed.
   `mode='document'` keeps its current explicit-vs-inference contract (`extraction.ts:71-75`); the
-  segment carries the detail. (A future, *separate* "exhaustive reference mode" could be added if
-  evidence shows clause-level *retrieval* — not just return — is needed; explicitly out of scope.)
+  segment carries the detail. (A future, _separate_ "exhaustive reference mode" could be added if
+  evidence shows clause-level _retrieval_ — not just return — is needed; explicitly out of scope.)
 
 ---
 
@@ -759,9 +807,9 @@ Both are additive and optional — the `store`/`memory_store` contract is unchan
 `server.ts` `memory_recall` Zod block + `tools/recall.ts` `validateRecallInput` gain `expand`
 (enum `'none' | 'auto' | 'parent'`, optional, **default `'auto'`**) and `max_expand_passages`
 (positive int, optional, default `2`, validated like `validateTokenBudget` bounds). The tool
-description gains one sentence: *"`expand` defaults to `'auto'`, which returns the relevant source
+description gains one sentence: _"`expand` defaults to `'auto'`, which returns the relevant source
 passage when several matched facts come from the same source (e.g. a contract's clauses); use
-`'none'` for strictly pinpoint facts, or `'parent'` to force the source passage for every match."*
+`'none'` for strictly pinpoint facts, or `'parent'` to force the source passage for every match."_
 
 **New `memory_expand(segment_id, query?)` tool** (the agentic follow-up affordance, §5.5).
 Following the package's `server.tool()` idiom (deprecated but used uniformly under the file's
@@ -769,9 +817,12 @@ eslint-disable block — match it; do not migrate to `registerTool` piecemeal), 
 new `MemoryEngine.expand(segmentId, query?)` method (the only seam holding both `db` and `config`,
 per the package's config-injection constraint — a handler-local function cannot reach the embedder):
 fetch the segment by id, split-and-rank its passages against `query` (or return the whole segment up
-to a cap when `query` is absent), and return them. This is the "I got a headline, give me *this*
+to a cap when `query` is absent), and return them. This is the "I got a headline, give me _this_
 fact's parent" call; `expanded_segment_ids`/per-unit `segment_id` from the prior `recall` supply the
-id.
+id. The `query` path's split→embed→rank is the **shared `rankSegmentPassages` helper** (exported from
+`retrieval/expansion.ts`) — the same one recall expansion (§5.3) uses (it takes the top 1 per
+segment); `memory_expand` ranks all passages of the one segment. (DRY: one split/rank implementation,
+not two.)
 
 ### 9.5 What existing callers see
 
@@ -784,20 +835,20 @@ id.
   unchanged. **Conflict + resolution:** two defaults changed that the diagnostic must pin to keep
   its GO/NO-GO verdict comparable to its historical baseline — (1) the default `expand` is now
   `'auto'` (not `'none'`), and (2) the default `token_budget` is now **800** (not 500, §5.4). Both
-  affect the *packed output* without touching the candidate **ranker** (the candidate set, fusion,
+  affect the _packed output_ without touching the candidate **ranker** (the candidate set, fusion,
   composite, rerank and dedup are byte-for-byte unchanged; only the post-dedup display units and how
   many of them fit differ). To keep the verdict in `memory-corpus-and-diagnostic.md` measuring the
   same thing, the diagnostic must **pass `expand:'none'` AND its own explicit `token_budget`** (the
   value it baselined on) rather than inheriting the new defaults — which restores byte-for-byte its
-  prior packed output. (This is the one place the `'auto'`/800 defaults are *not* what we want: the
+  prior packed output. (This is the one place the `'auto'`/800 defaults are _not_ what we want: the
   diagnostic grades the ranker, not the return shape or the budget envelope.) Pinned that way the
   verdict is undisturbed; separate `expand:'auto'` / budget-800 diagnostic passes can later measure
   passage-return quality at the out-of-the-box settings.
 - **External MCP clients**: additive only — a tri-state `expand` recall option (defaulting to
-  `'auto'`, which can change the *returned* unit for shared-parent queries vs. v0 facts-only),
+  `'auto'`, which can change the _returned_ unit for shared-parent queries vs. v0 facts-only),
   `expanded`/`expanded_segment_ids` on `RecallResult` in every format, and the new
-  `memory_expand` tool. The candidate ranking they observe is unchanged; the *coarser return on
-  shared-parent queries* is the intended behavior change.
+  `memory_expand` tool. The candidate ranking they observe is unchanged; the _coarser return on
+  shared-parent queries_ is the intended behavior change.
 
 ---
 
@@ -805,7 +856,7 @@ id.
 
 Follow the existing harness exactly: `mkdtempSync(tmpdir(), 'memory-test-')` + `initDatabase(path,
 TEST_MODEL)` (`test/database.test.ts:41-44`), real small embedder under the 30s timeout, and the
-`vi.mock('../src/llm/client.js', …)` queue from `test/ingest.test.ts:11-26` so the *real*
+`vi.mock('../src/llm/client.js', …)` queue from `test/ingest.test.ts:11-26` so the _real_
 store/segment pipeline runs while extraction returns canned facts.
 
 ### 10.1 Canonical schema / stale-DB rebuild (`test/database.test.ts` extension)
@@ -815,9 +866,9 @@ are **deleted**. What remains is the canonical-schema assertion plus the stale-D
 
 - **Fresh DB is born with the canonical schema:** open a brand-new path via `initDatabase` →
   `segments` table exists, `memories` has a `segment_id` column, `schema_meta['schema_version']
-  === '4'`. (No migration step ran; `createSchema` built it directly.)
+=== '4'`. (No migration step ran; `createSchema` built it directly.)
 - **Stale DB (older `SCHEMA_VERSION`) is recreated cleanly:** build a DB with the **v3** shape
-  (create `memories` *without* `segment_id`, set `schema_meta['schema_version']='3'`, insert a row),
+  (create `memories` _without_ `segment_id`, set `schema_meta['schema_version']='3'`, insert a row),
   reopen via `initDatabase`, and assert: the schema is rebuilt (the `segment_id` column now exists,
   `segments` table exists), the version stamp is now `'4'`, the open does **not** throw
   `no such column: segment_id`, and the pre-change row is **gone** (drop-and-recreate deliberately
@@ -838,7 +889,7 @@ are **deleted**. What remains is the canonical-schema assertion plus the stale-D
   segment row; `segments_created` omitted/0.
 - **dry_run:** no segment rows, no fact rows (unchanged), `facts` still previewed.
 - **Merge repoints to richer parent (A4):** ingest a fact whose segment has `fact_count = 1`, then
-  ingest a duplicate (exact-dedup merge) from a *different* segment with `fact_count = 5` →
+  ingest a duplicate (exact-dedup merge) from a _different_ segment with `fact_count = 5` →
   survivor's `segment_id` is repointed to the **richer** (5-fact) segment, **regardless of ingest
   order** (run the test both orders; same result). A `NULL`-parent survivor adopts the incoming
   segment; a tie keeps the existing.
@@ -884,13 +935,15 @@ are **deleted**. What remains is the canonical-schema assertion plus the stale-D
   raw), not just `raw`; per-unit `segment_id` still appears in `raw`.
 - **`memory_expand(segment_id)`:** returns the parent's query-ranked passages for the id from a
   prior recall; with no `query`, returns the segment (up to a cap).
-- **`memory_context` auto-expands:** a `buildContext`/`memory_context` call over a shared-parent
-  corpus returns the passage (asserts the briefing path is wired to `'auto'`, budget 800).
+- **`memory_context` (task) auto-expands:** a `buildContext`/`memory_context` call **with a `task`**
+  over a shared-parent corpus returns the passage (asserts the query-driven briefing path is wired
+  to `'auto'`, budget 800). The no-task recent/important briefing has no query and returns facts
+  only — it does not expand.
 
 ### 10.5 Content-free fixtures
 
 Any expansion/segment fixtures that touch real corpus shape stay **content-free** (ids, counts,
-token estimates) per the sensitive-data rule; segment *text* in tests is synthetic
+token estimates) per the sensitive-data rule; segment _text_ in tests is synthetic
 ("Contract clause: distribution cap is $250k. …"), never private export content.
 
 ---
@@ -906,12 +959,13 @@ fix the evidenced loss; corrected here).
 1. **Phase 1 (this design, mandatory):** `segments` table + `segment_id` column as part of the
    canonical `createSchema` (no migration runner; stale DBs drop-and-recreate, §4) + ingest
    writes/links segments + **default `expand:'auto'`** re-expansion with **passage split-and-rank**
-   + parent-dedup + simplified passage-budget cap (default budget bumped to **800**, §5.4) + A4
-   richer-parent merge repoint + metadata in every format + `memory_expand` + `memory_context`
-   wired to `'auto'`. **Fixes the evidenced contract loss on a default recall, out of the box.**
+   - parent-dedup + simplified passage-budget cap (default budget bumped to **800**, §5.4) + A4
+     richer-parent merge repoint + metadata in every format + `memory_expand` + `memory_context`'s
+     task (query-driven) branch wired to `'auto'` (the no-task briefing has no query and returns facts
+     only). **Fixes the evidenced contract loss on a default recall, out of the box.**
 2. **Phase 2 (optional, deferred, §7):** contextualized embedding behind
-   `MEMORY_INGEST_CONTEXTUALIZE_EMBEDDING` (default off). Improves *retrieval* of detail-bearing
-   facts; requires a corpus rebuild. Phase 1 already fixes *return* of un-decomposed clauses.
+   `MEMORY_INGEST_CONTEXTUALIZE_EMBEDDING` (default off). Improves _retrieval_ of detail-bearing
+   facts; requires a corpus rebuild. Phase 1 already fixes _return_ of un-decomposed clauses.
 3. **Phase 3 (optional, deferred, §6.3/§8):** orphan-segment collection in maintenance;
    **ingest-time passage pre-split** (precompute + persist passages/embeddings if the recall-time
    passage embed proves hot); a possible exhaustive reference mode.
@@ -924,8 +978,8 @@ fix the evidenced loss; corrected here).
   → composite → rerank → dedup) and the existing `scoring.ts` functions are byte-for-byte unchanged;
   the candidate set, fusion, composite, rerank, and dedup are identical. **Passage split-and-rank
   (§5.3.1) is a post-retrieval, return-shaping step on an already-selected segment — it ranks
-  *passages of a winner's parent* by the reused query embedding to decide what to *show*, never
-  *which memories win*.** The two are orthogonal; "ranker untouched" holds.
+  _passages of a winner's parent_ by the reused query embedding to decide what to _show_, never
+  _which memories win_.** The two are orthogonal; "ranker untouched" holds.
 - **NOT making decomposition exhaustive.** `mode='document'` keeps its current contract; clauses
   are recovered via the passage, not via more facts (§8).
 - **The returned unit is a passage, not the raw 6000-token segment.** A whole-chunk return is
@@ -935,7 +989,7 @@ fix the evidenced loss; corrected here).
 - **NOT re-embedding facts.** Phase 1 adds no new fact-vector dimension and changes no existing
   embedding path; parent-less facts (the NULL-segment case, §4.3) work without an embedding change.
   (Passage embeddings are computed transiently at recall time and not persisted in Phase 1.) Note
-  this is orthogonal to the stale-DB rebuild (§4.2): the rebuild *re-ingests* the corpus from
+  this is orthogonal to the stale-DB rebuild (§4.2): the rebuild _re-ingests_ the corpus from
   scratch via `build-corpus.ts`, which embeds each fact through the normal path — it does not
   "re-embed in place."
 - **`'auto'` is on by default by design.** Auto-expansion fires only on the ≥2-shared-parent
@@ -946,19 +1000,21 @@ fix the evidenced loss; corrected here).
 
 ## 12. File-change summary
 
-| File | Change |
-|---|---|
-| `src/storage/database.ts` | `SCHEMA_VERSION '3'→'4'` (plain stamp); add `segments` table + inline `segment_id` column to the canonical `createSchema` (**no `runMigrations`, no `ALTER TABLE`**); in `initDatabase`, read on-disk `schema_meta['schema_version']` and **drop-and-recreate** the schema when older than `SCHEMA_VERSION` (stale-DB self-heal, §4.2); `MemoryRow.segment_id`; `SegmentRow` type. |
-| `src/config.ts` | Bump `MEMORY_DEFAULT_TOKEN_BUDGET` **500 → 800** (`config.ts:70`) so a passage + a couple of facts fit out of the box (§5.4); `memory_context` budget already 800 (`engine-impl.ts:270`), now equal. |
-| `src/storage/queries.ts` | `InsertMemoryParams.segmentId?`; `insertMemory` binds it (else NULL); new `insertSegment`, `getSegmentsByIds`, **`updateMemorySegmentIfRicher`** (A4 merge repoint, §6.2); (deferred) `deleteOrphanSegments`. |
-| `src/storage/extraction.ts` | Reuse `chunkBlob` output as segment content (no change to chunking); new **`splitToPassages(text)`** helper (coherent ~300–400-token passages) for recall-time split (§5.3.1). |
-| `src/engine.ts` | `StoreOptions.segmentId?`; new **`MemoryEngine.expand(segmentId, query?)`** method (powers `memory_expand`, §9.4); `RecallOptions`/`IngestResult` additions live in `types.ts`. |
-| `src/types.ts` | `RecallOptions.expand: 'none'\|'auto'\|'parent'` (default `'auto'`) + `max_expand_passages` (**replaces** `expand_budget_fraction`); `IngestResult.segments_created?`; `RecallResult.expanded?` + `expanded_segment_ids?` (**all formats**); `Memory.segment_id`. |
-| `src/engine-impl.ts` | `storeImmediate` forwards `segmentId` + calls `updateMemorySegmentIfRicher` on merge; `extractAllFacts` returns per-chunk groups; `ingestBlob` writes one segment per non-empty chunk and links facts; `rowToMemory` maps `segment_id`; `recall` threads `expand`/`max_expand_passages`; **`buildContext`/`memory_context` (`:279`) passes `expand:'auto'`**; new `expand()` impl. |
-| `src/retrieval/pipeline.ts` | Insert **step 9b** (auto/parent re-expansion: shared-parent grouping + passage split-and-rank against the reused step-1 query embedding + parent-dedup + overlap dedup) after dedup, before `packToBudget`; gate on `expand`. |
-| `src/retrieval/scoring.ts` | **Unchanged** `packToBudget` reused for both paths (passage units pack like facts); the v1 two-tier variant is dropped. Only addition: `max_expand_passages` count cap applied before packing. |
-| `src/retrieval/formatting.ts` | Display-unit content selection (passage vs fact); surface `expanded` + `expanded_segment_ids` in **every** format; per-unit `segment_id` in `raw`. |
-| `src/tools/recall.ts`, `src/server.ts` | `expand` (tri-state) + `max_expand_passages` schema + validation + description sentence; **new `memory_expand` tool** (`server.tool()` idiom) routed to `engine.expand`. |
-| `test/database.test.ts`, `test/ingest.test.ts`, `test/expand.test.ts`, recall-tool tests | New/extended per §10 (fresh DB born with canonical schema; **stale-DB drop-and-recreate**, no `test/migration.test.ts`; auto-fires-by-default; passage fits default budget 800 + leaves room for a fact + contains clause; passage query-relevant; merge repoints to richer; pinpoint does NOT expand; `memory_expand`; `memory_context` auto-expands). |
+| File                                                                                     | Change                                                                                                                                                                                                                                                                                                                                                                             |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/storage/database.ts`                                                                | `SCHEMA_VERSION '3'→'4'` (plain stamp); add `segments` table + inline `segment_id` column to the canonical `createSchema` (**no `runMigrations`, no `ALTER TABLE`**); in `initDatabase`, read on-disk `schema_meta['schema_version']` and **drop-and-recreate** the schema when older than `SCHEMA_VERSION` (stale-DB self-heal, §4.2); `MemoryRow.segment_id`; `SegmentRow` type. |
+| `src/config.ts`                                                                          | Bump `MEMORY_DEFAULT_TOKEN_BUDGET` **500 → 800** (`config.ts:70`) so a passage + a couple of facts fit out of the box (§5.4); `memory_context` budget already 800 (`engine-impl.ts:270`), now equal.                                                                                                                                                                               |
+| `src/storage/queries.ts`                                                                 | `InsertMemoryParams.segmentId?`; `insertMemory` binds it (else NULL); new `insertSegment`, `getSegmentsByIds`, **`updateMemorySegmentIfRicher`** (A4 merge repoint, §6.2); (deferred) `deleteOrphanSegments`.                                                                                                                                                                      |
+| `src/storage/extraction.ts`                                                              | Reuse `chunkBlob` output as segment content (no change to chunking); new **`splitToPassages(text)`** helper (coherent ~300–400-token passages) for recall-time split (§5.3.1).                                                                                                                                                                                                     |
+| `src/engine.ts`                                                                          | `StoreOptions.segmentId?`; new **`MemoryEngine.expand(segmentId, query?)`** method (powers `memory_expand`, §9.4; its `query` path uses the shared `rankSegmentPassages`); `RecallOptions`/`IngestResult` additions live in `types.ts`.                                                                                                                                            |
+| `src/types.ts`                                                                           | `RecallOptions.expand: 'none'\|'auto'\|'parent'` (default `'auto'`) + `max_expand_passages` (**replaces** `expand_budget_fraction`); `IngestResult.segments_created?`; `RecallResult.expanded?` + `expanded_segment_ids?` (**all formats**); `Memory.segment_id`.                                                                                                                  |
+| `src/engine-impl.ts`                                                                     | `storeImmediate` forwards `segmentId` + calls `updateMemorySegmentIfRicher` on merge; `extractAllFacts` returns per-chunk groups; `ingestBlob` writes one segment per non-empty chunk and links facts; `rowToMemory` maps `segment_id`; `recall` threads `expand`/`max_expand_passages`; **`buildContext`/`memory_context` (`:279`) passes `expand:'auto'`**; new `expand()` impl. |
+| `src/retrieval/pipeline.ts`                                                              | Call **step 9b** (`expandKeptFacts`) after dedup; it now **absorbs the budget pack** (pass `tokenBudget` in, no separate `packToBudget` call) and returns the final packed units + surviving `expandedSegmentIds`. Gate on `expand`.                                                                                                                                               |
+| `src/retrieval/expansion.ts`                                                             | **HYBRID** packing (§5.3): shared-parent grouping + passage split-and-rank + parent/overlap dedup + cap, then reserve the top passage's tokens, pack facts into `budget − reserve`, force-include the top passage, fill leftover. Export **`rankSegmentPassages`** (shared split→embed→rank helper, also used by `engine.expand`).                                                 |
+| `src/retrieval/scoring.ts`                                                               | **Unchanged** `packToBudget` (and `estimateTokens`) reused by the HYBRID orchestration (called twice: facts into `budget − reserve`, then leftover); its own logic is untouched. The v1 two-tier variant is dropped.                                                                                                                                                               |
+| `src/retrieval/formatting.ts`                                                            | Display-unit content selection (passage vs fact); surface `expanded` + `expanded_segment_ids` in **every** format; per-unit `segment_id` in `raw`.                                                                                                                                                                                                                                 |
+| `src/tools/recall.ts`, `src/server.ts`                                                   | `expand` (tri-state) + `max_expand_passages` schema + validation + description sentence; **new `memory_expand` tool** (`server.tool()` idiom) routed to `engine.expand`.                                                                                                                                                                                                           |
+| `test/database.test.ts`, `test/ingest.test.ts`, `test/expand.test.ts`, recall-tool tests | New/extended per §10 (fresh DB born with canonical schema; **stale-DB drop-and-recreate**, no `test/migration.test.ts`; auto-fires-by-default; passage fits default budget 800 + leaves room for a fact + contains clause; passage query-relevant; merge repoints to richer; pinpoint does NOT expand; `memory_expand`; `memory_context` auto-expands).                            |
+
 </content>
 </invoke>

--- a/docs/designs/memory-parent-context-retrieval.md
+++ b/docs/designs/memory-parent-context-retrieval.md
@@ -113,8 +113,12 @@ storage + post-ranking-expansion change that leaves the ranker byte-for-byte unc
    the query embedding are returned, up to budget. Storage may keep `segment = chunk`; only the
    *returned* unit is passage-sized. Chosen **recall-time split-and-rank** over ingest-time
    pre-split — simpler storage, only fires on auto-expand, reuses the step-1 query embedding. (§5.3)
-5. **When several top facts share a parent, the parent's passage is emitted once** and the duplicate
-   facts collapse into it (parent-dedup). (§5.3)
+5. **Passages AUGMENT the facts; they do not replace them (breadth-first).** All kept facts are
+   returned exactly as `expand:'none'` would return them; the expanded passage(s) are **appended
+   after** all the facts, in segment-best-rank order. Parent-dedup applies to **passages** (one
+   passage per shared parent), **never to facts** — auto-expand never evicts a fact `expand:'none'`
+   would have kept. Because the greedy skip-not-break packer packs in order, a passage only ever
+   consumes leftover budget. (§5.3)
 6. **Budget machinery is simplified.** Passage-sized returns make the v1 two-tier
    `expand_budget_fraction` unnecessary (its only job was to *reject* the oversized segment).
    Expanded passages and facts share the budget under the existing greedy skip-not-break
@@ -371,10 +375,20 @@ notice the headline is thin and ask a follow-up — so it gets the same auto-exp
 **800** (`CONTEXT_DEFAULT_BUDGET`, `engine-impl.ts:270`), which a ~300-token passage comfortably
 fits alongside facts.
 
-### 5.3 Step 9b — parent re-expansion (passage return + parent-dedup)
+### 5.3 Step 9b — parent re-expansion (passage AUGMENTs the facts; passage-only parent-dedup)
 
 Input: `kept` (the post-dedup `ScoredMemory[]`, `pipeline.ts:114`), already sorted by score, plus
 `queryEmbedding` (already computed at step 1, `pipeline.ts:43`).
+
+> **AUGMENT, not replace.** An earlier draft had an expanded segment's chosen passage *replace* its
+> sibling facts (the facts "collapsed into" the one passage). That is wrong for a multi-term source:
+> a contract segment's facts are about **different** terms (ownership, valuation, profit-sharing,
+> governance, execution), so collapsing them into one passage about **one** term destroys breadth —
+> on the live corpus, a "key terms" survey query returned a *worse* answer with `expand:'auto'` than
+> with `expand:'none'` (five distinct key-term facts evicted for one execution-terms passage). The
+> corrected design **keeps every fact** and treats the passage as **supplementary**: passages are
+> appended *after* all the facts. **Parent-dedup applies to passages (one per shared parent), never
+> to facts.**
 
 ```
 if expand === 'none': proceed to packToBudget as today.   // unchanged path
@@ -384,31 +398,31 @@ if expand === 'none': proceed to packToBudget as today.   // unchanged path
 2. Decide which segments to EXPAND:
      - expand === 'parent'  → every group with a non-null segment_id (size ≥1)
      - expand === 'auto'    → only groups whose size is ≥2 (a SHARED parent)
-   Groups not selected for expansion keep emitting their facts as today.
 3. Fetch the selected segments by id in one query (getSegmentsByIds(db, ns, ids)).
 4. For each expanded segment, SPLIT-AND-RANK to a passage (§5.3.1):
      - split segment.content into coherent passages (paragraph/turn/sentence boundaries,
        each capped ~300–400 tokens);
      - embed each passage and rank by cosine similarity to queryEmbedding;
-     - take the top passage(s) up to max_expand_passages and the budget (§5.4).
-5. Build an ORDERED display list, walking `kept` in score order:
-     - fact in an EXPANDED group: at the position of its best-ranked fact, emit the segment's
-       chosen PASSAGE(s) once; mark the segment emitted so the other facts sharing it are
-       SKIPPED (parent-dedup);
-     - fact in a non-expanded group (auto, lone parent): emit the FACT itself;
-     - fact with segment_id == null (store-path / degrade — a row that has no parent): emit the
-       FACT (it is its own parent, §4.3);
-     - fact whose segment_id is non-null but whose segment row is missing (forgotten parent,
-       §6.3): fall back to emitting the FACT.
-6. The result is a heterogeneous, score-ordered list of {passage | fact} display units, with each
-   expanded parent appearing at most once.
+     - choose the top passage per segment.
+5. Build the display list as AUGMENT:
+     a. Emit EVERY kept fact as a fact unit, in score order — byte-for-byte what `expand:'none'`
+        returns. No fact is ever dropped, skipped, or reordered by expansion. (store-path / degrade
+        NULL-segment facts and forgotten-parent facts are just normal facts here.)
+     b. APPEND the chosen passages AFTER all the facts, in segment-best-rank order (each passage
+        rides on its segment's best-ranked fact for date/importance rendering, with a distinct id
+        so it is not an id-collision duplicate of that fact). Apply passage parent-dedup (one
+        passage per segment), passage overlap-dedup (§5.3.2), and the max_expand_passages cap
+        (§5.4) to the appended passages only.
+6. The result is a score-ordered list of fact units followed by ≤max_expand_passages passage units.
 ```
 
-Parent-dedup is the answer to "several top facts share one parent": in the contract case, the
-~7 headline facts all carry the same `segment_id`, so step 5 emits the **one** contract segment's
-chosen passage once (carrying the relevant clause) and drops the 6 redundant headlines. The user
-gets the clause instead of 7 lossy headlines — **the exact fix for the Bandalert failure, on a
-default `'auto'` recall with no flag.**
+Because the unchanged greedy skip-not-break `packToBudget` packs the display list **in order**,
+putting passages **last** means the breadth facts are packed first and a passage only ever consumes
+**leftover** budget. **This is the load-bearing property: auto-expand can never evict a fact that
+`expand:'none'` would have kept.** In the contract case the ~7 headline facts (about different
+terms) are all preserved AND the query-relevant clause passage (carrying e.g. the `$250k` cap, never
+a fact) is appended when budget allows — **the fix for the Bandalert failure, on a default `'auto'`
+recall with no flag, without sacrificing breadth.**
 
 #### 5.3.1 Split-and-rank: the returned unit is a query-relevant passage, not the chunk
 
@@ -454,11 +468,12 @@ emitted passages, not an embedding pass. It is a no-op for the common single-exp
 
 **Default budget is bumped 500 → 800 so the system returns useful context with zero configuration.**
 The out-of-the-box directive requires that a *default* recall return the relevant passage **plus**
-a couple of facts. A passage is ~300–400 tokens and a fact ~150; at the old default of **500** a
-single ~400-token passage leaves only ~100 tokens — not even one more fact — so a shared-parent
-auto-expansion would crowd out the supporting facts. Bumping `MEMORY_DEFAULT_TOKEN_BUDGET`
-(`config.ts:70`) to **800** comfortably fits one ~300–400-token passage **and** 2–3 facts
-(~400 + 3×150 ≈ 850, packed greedily to ≤ 800), which is exactly the desired shape. `memory_context`
+a couple of facts. A passage is ~300–400 tokens and a fact ~150; at the old default of **500**,
+once the facts have packed first (AUGMENT) a single ~400-token passage rarely has room to ride
+along — so the shared-parent depth would simply not surface (auto ≈ none). Bumping
+`MEMORY_DEFAULT_TOKEN_BUDGET` (`config.ts:70`) to **800** comfortably fits 2–3 facts **and** one
+~300–400-token passage (~3×150 + 400 ≈ 850, packed greedily to ≤ 800), which is exactly the desired
+shape. `memory_context`
 stays **800** (`engine-impl.ts:270`); the two default budgets are now equal, which is intentional —
 both paths want the same "one passage + a few facts" envelope. **No flag and no config tuning are
 needed** to get parent context on shared-parent queries.
@@ -473,8 +488,9 @@ budget machinery is simplified:
   (`scoring.ts:200-212`): walk the score-ordered display list; include a unit if it fits the
   remaining budget, else `continue` (skip, don't break). No segment sub-budget, no second pass.
 - The only added guard is a small **count cap**: at most `max_expand_passages` (default **2**)
-  passages may be emitted across the whole result, so auto-expansion cannot turn a result into all
-  passages and evict every fact.
+  passages may be appended across the whole result. With AUGMENT the cap is belt-and-suspenders
+  (passages are appended *after* the facts and only consume leftover budget, so they cannot evict a
+  fact regardless of the cap); it mainly bounds explicit `'parent'` calls with a raised budget.
 
 **Why a count cap of 2 against budget=800 with ~300–400-token passages and ~150-token facts.** One
 ~300–400-token passage leaves ~400–500 tokens — room for 2–3 facts; two passages (~600–800 tokens)
@@ -486,9 +502,17 @@ the supporting facts. A single dominant passage (the contract clause) plus the f
 is exactly the desired out-of-the-box shape.
 
 The `expand:'none'` path calls `packToBudget` with the unchanged fact list — **byte-for-byte today's
-behavior** (at whatever `token_budget` the caller passes; only the *default* changed). Expansion only
-ever *substitutes* a passage for a fact at that fact's position and *drops* parent-deduped siblings;
-it never relaxes the skip-not-break rule, so a budget that fits N facts is never overrun.
+behavior** (at whatever `token_budget` the caller passes; only the *default* changed). Under AUGMENT,
+expansion only ever **appends** passages after the full fact list and never relaxes the skip-not-break
+rule, so a budget that fits N facts always still fits those N facts — the passage is the unit that
+gets skipped, never a fact.
+
+**Trade-off (intended).** Because passages are appended last, the budget governs *depth*, not
+breadth: at a **tight** budget the passage may not fit at all, so `expand:'auto'` degrades to
+`expand:'none'` (all the facts, no passage) rather than dropping a fact — a strict no-regression
+floor. A **larger** budget simply surfaces more depth (the clause passage, then a second if
+`max_expand_passages` and budget allow). Breadth is constant across budgets; only how much parent
+context rides along varies.
 
 ### 5.5 Formatting + expansion metadata in every format
 

--- a/docs/designs/memory-parent-context-retrieval.md
+++ b/docs/designs/memory-parent-context-retrieval.md
@@ -1,0 +1,940 @@
+# Design: Parent-context retention for `memory_ingest` — "index fine, return coarse"
+
+**Status:** Design v3 (back-compat-free simplification) — no implementation
+**Package:** `packages/memory-mcp-server/`
+**Extends:** [`memory-ingest-tool.md`](./memory-ingest-tool.md) (the ingest tool this changes)
+**Motivated by:** the contract-decomposition loss surfaced in
+[`memory-corpus-and-diagnostic.md`](./memory-corpus-and-diagnostic.md)
+
+> **v3 changelog (back-compat-free simplification).** Product directive: **we do NOT care about
+> backwards compatibility; the system must work correctly out of the box.** v2's retrieval substrate
+> is unchanged — this is purely a *storage/migration* simplification plus a defaults sanity-check:
+> 1. **The migration runner is DELETED.** v2 carried a version-guarded `runMigrations(db)` with a
+>    `PRAGMA table_info` idempotency guard whose *only* job was to upgrade pre-existing v3 DBs
+>    in place. With no back-compat that machinery is gone. The `segments` table and
+>    `memories.segment_id` column are now part of the **canonical schema** that `createSchema`
+>    builds with `CREATE TABLE IF NOT EXISTS` for a fresh DB. There is no in-place migration. (§4)
+> 2. **Stale DBs are rebuilt, not migrated.** A pre-existing DB from before this change (including
+>    the built corpus) is **not** upgraded — it is recreated. `SCHEMA_VERSION` bumps `'3' → '4'` as
+>    a plain version stamp; `initDatabase` reads the on-disk stamp and, when it is older than
+>    `SCHEMA_VERSION`, **drops and recreates** the schema before building it (self-healing, no manual
+>    step). The corpus is regenerated via `build-corpus.ts`; user/session DBs are recreated. (§4.1–§4.2)
+> 3. **"Back-compat" framing is dropped.** Store-path and degrade-path rows still carry
+>    `segment_id = NULL` and re-expansion still treats a NULL-segment fact as its own parent — but
+>    that is a **current** design property ("these rows have no parent"), not a legacy/migration
+>    artifact. The §4.4 "back-compat invariant" is gone; the NULL-segment case is restated as a
+>    normal current case in §5. (§5.3)
+> 4. **Defaults reaffirmed for out-of-the-box quality.** `expand:'auto'` stays the default (that IS
+>    the zero-config behavior). The default `memory_recall` budget is **bumped 500 → 800** so a
+>    ~300–400-token passage plus a couple of facts fits with no tuning; `memory_context` stays
+>    **800**. State explicitly: no caller flag and no config tuning are needed to get parent context
+>    on shared-parent queries. (§5.4)
+>
+> Everything else carries forward from v2 unchanged: `expand:'none'|'auto'|'parent'` (auto default),
+> query-ranked ~300–400-token passage return, merge-repoints-to-richer-parent,
+> `expanded`/`expanded_segment_ids` in all formats + `memory_expand`, segments-off-the-index, ranker
+> untouched, store path LLM-free, Phase 2 contextualized embedding deferred.
+
+---
+
+## 1. Overview
+
+`memory_ingest` decomposes a blob into atomic facts and stores **only** those facts
+(`engine-impl.ts:255-263` writes each `ExtractedFact` through `storeImmediate`; the source
+chunk is discarded after `extractAllFacts` returns at `engine-impl.ts:201`). Decomposition is
+**lossy by construction**: the detailed clauses of a multi-clause contract (a $250k distribution
+cap, buyout mechanics, IP terms, an NDA) were never turned into facts — only ~7 headline facts
+were — so `memory_recall` can only ever return the headlines. No amount of retrieval-stack
+quality recovers a detail that was never stored.
+
+This design keeps atomic facts as the **indexed/embedded retrieval key** (the ranking pipeline
+in `retrieval/pipeline.ts` is unchanged) but **retains the source segment** each fact was
+extracted from and links every fact to it, so recall can **re-expand** a top-ranked fact back to
+its parent — where the un-decomposed clauses still live verbatim. This is the SOTA
+"small-to-big" / parent-child pattern: index fine, return coarse. It changes the **stored and
+returned unit**, not the ranker.
+
+Two things make this actually return the clauses on a **default** recall (the whole point — the
+Bandalert loss had no flag):
+
+- **Auto-expansion (§5.2).** When **≥2 kept facts share a parent segment**, recall expands that
+  shared parent without any flag. That shared-parent grouping is exactly the contract signature
+  (7 headline facts, one segment) and is already computed for parent-dedup, so `'auto'` needs no
+  query classifier and does not regress a pinpoint query (1 fact → no expansion).
+- **Passage return (§5.3).** A 6000-token segment cannot fit the **800-token** default budget,
+  so v1 would have degraded right back to the headline. Instead of returning the whole chunk, recall
+  **splits the segment into coherent ~300–400-token passages and returns the passage(s) most
+  relevant to the query** (ranked by similarity to the query embedding already computed at pipeline
+  step 1). The "$250k cap" clause comes back as a ~300-token passage that **fits** 800 tokens and is
+  the one the query wanted — not 6000 tokens of conversation window.
+
+### Why this is the right shape (research grounding)
+
+- **Atomic/proposition decomposition as the *sole* stored unit is disfavored.** The flagship
+  pro-proposition paper, **Dense X Retrieval (Chen et al., EMNLP 2024, arXiv:2312.06648)**, shows
+  propositions help only weak/zero-shot retrievers, rare-entity factoids, and *under a fixed
+  token budget*; the gains are flat for strong retrievers. It is a token-density argument, not
+  "context-free storage is free." **Decomposition Dilemmas (NAACL 2025, arXiv:2411.02400)** names
+  the exact failure modes we hit: *omission-of-context* and *over-decomposition*.
+- **The dominant trend is the opposite — re-attach context.** **Anthropic Contextual Retrieval
+  (Sept 2024)** prepends LLM-generated context to chunks (−35% to −67% retrieval-failure rate);
+  **Jina Late Chunking (arXiv:2409.04701)** embeds-then-splits to preserve cross-references;
+  coherence-preserving chunking beats proposition chunking head-to-head in **Document Segmentation
+  Matters (ACL 2025 Findings)**.
+- **SOTA practice is "index fine, return coarse"** (small-to-big / parent-child): atomic facts are
+  the retrieval key, but a back-pointer to the source passage lets the system return the parent
+  context. 2026 memory systems converge here — **HippoRAG 2** keeps full passages, **A-MEM**
+  enriches notes with context + links, **TriMem** keeps multi-granularity records.
+- **Do not touch the ranker.** Our retrieval stack is already SOTA-aligned (hybrid dense+BM25 in
+  `hybridScoreFusion` → composite scoring → cross-encoder rerank in `reranker.ts`; "ranking beats
+  structure," SmartSearch 2026). The lesson is *expand after ranking*, not *re-rank on a coarser
+  unit*. Re-expansion in this design happens strictly **after** step 9 of the pipeline.
+
+The contract failure is therefore a **storage** bug, not a retrieval bug, and the fix is a
+storage + post-ranking-expansion change that leaves the ranker byte-for-byte unchanged.
+
+---
+
+## 2. Key design decisions (the short version)
+
+1. **A new `segments` table holds the source chunk; each fact carries a nullable
+   `segment_id` FK.** Chosen over self-referential `parent_id` on `memories` and over a
+   metadata-JSON pointer. (§3, §3.4)
+2. **Atomic facts stay the only indexed/embedded unit.** Segments are **not** embedded, **not**
+   in `vec_memories`, **not** in `memories_fts`. The ranker never sees a segment. (§3.1)
+3. **Re-expansion is a post-ranking step (9b), after dedup, controlled by a `recall` option
+   `expand: 'none' | 'auto' | 'parent'` defaulting to `'auto'`.** `'auto'` expands a parent only
+   when **≥2 kept facts share it** — the Bandalert signature — so pinpoint queries (1 fact → no
+   expand) are never regressed, and the evidenced loss is fixed with **no flag and no query
+   classifier**. `'none'` force-off and `'parent'` force-expand-every-parent are explicit
+   overrides. `buildContext`/`memory_context` is also wired to `'auto'`. (§5.2)
+4. **The RETURNED unit is a query-ranked ~300–400-token PASSAGE, not the 6000-token chunk.** On
+   expansion, the shared segment is split into coherent passages and the passage(s) most similar to
+   the query embedding are returned, up to budget. Storage may keep `segment = chunk`; only the
+   *returned* unit is passage-sized. Chosen **recall-time split-and-rank** over ingest-time
+   pre-split — simpler storage, only fires on auto-expand, reuses the step-1 query embedding. (§5.3)
+5. **When several top facts share a parent, the parent's passage is emitted once** and the duplicate
+   facts collapse into it (parent-dedup). (§5.3)
+6. **Budget machinery is simplified.** Passage-sized returns make the v1 two-tier
+   `expand_budget_fraction` unnecessary (its only job was to *reject* the oversized segment).
+   Expanded passages and facts share the budget under the existing greedy skip-not-break
+   `packToBudget`, with a small cap (`max_expand_passages`, default 2) so expansion can't evict every
+   fact. The `expand:'none'` path uses `packToBudget` byte-for-byte. The default recall budget is
+   **bumped 500 → 800** (`MEMORY_DEFAULT_TOKEN_BUDGET`) so a ~300–400-token passage plus a couple of
+   facts fits out of the box; `memory_context` is already 800. No flag, no tuning. (§5.4)
+7. **The schema is canonical — there is no in-place migration.** The `segments` table and the
+   `memories.segment_id` column are part of the schema `createSchema` builds with
+   `CREATE TABLE IF NOT EXISTS` for a fresh DB. `SCHEMA_VERSION` bumps `'3' → '4'` as a plain
+   version stamp; `initDatabase` reads the on-disk stamp and **drops-and-recreates** the schema
+   when it is older than `SCHEMA_VERSION` (a stale pre-change DB is rebuilt, not upgraded —
+   acceptable under the back-compat-free directive, and self-healing with no manual step). A row
+   with no parent simply has `segment_id = NULL` and recall returns the fact. (§4)
+8. **On exact-dedup merge, the survivor repoints to the *richer* parent** (the segment with the
+   higher `fact_count`), so a later, richer ingest of the same fact is not discarded by ingest
+   order. The merge path must read both segments' `fact_count`. (§6.2)
+9. **Expansion metadata is surfaced in every format.** `RecallResult` carries `expanded` and the
+   relevant `segment_id`(s) regardless of `format` (not just `raw`), and a `memory_expand(segment_id)`
+   affordance lets an agent that got headlines fetch the parent passages on demand. (§5.5, §9)
+10. **The LLM-free `store` path is untouched.** Only `ingest` writes segments. `store` rows have
+    `segment_id = NULL` forever and behave exactly as today. (§3.3)
+11. **Phase 2 (optional, deferred): contextualized embedding** — prepend a one-line segment
+    context to each fact *before embedding* (Anthropic-style). Designed in §7, gated behind ingest
+    so `store` stays LLM-free. Unlike v1, Phase 1 now actually fixes the evidenced failure on a
+    default recall, so Phase 2 is a pure recall-rate optimization. (§7, §11)
+
+---
+
+## 3. Storage / schema
+
+### 3.1 The decision: a `segments` table + `memories.segment_id` FK
+
+Three options were considered:
+
+| Option | What it is | Verdict |
+|---|---|---|
+| **A. `segments` table + `segment_id` FK on `memories`** | New table `segments(id, namespace, content, source, created_at, …)`; each fact row gets a nullable `segment_id` pointing at it. | **CHOSEN** |
+| B. Self-referential `parent_id` on `memories` | The segment is itself a `memories` row; facts point at it via `parent_id`. | Rejected |
+| C. Metadata JSON pointer | Store the parent text (or an id) inside the existing `metadata` JSON column. | Rejected |
+
+**Why A over B.** If the segment were a `memories` row it would land in **both** index structures,
+each by a *different* mechanism: `memories_fts` is populated by the `memories_ai` AFTER-INSERT
+trigger (`database.ts:111-114`, which writes **only** to `memories_fts`), while the `vec_memories`
+row is written **explicitly** inside `insertMemory` (`queries.ts:48-51`) — there is no trigger for
+the vector table. (v1 mis-stated that the trigger populates both; corrected here. The conclusion is
+unchanged.) A 6000-token segment as a `memories` row would therefore (a) pollute the ranker with a
+muddy-centroid blob — the exact problem decomposition exists to avoid (`memory-ingest-tool.md` §1) —
+and (b) double-count: both the segment and its facts would surface for the same query. A separate
+table keeps segments **off the index** by construction: neither the FTS trigger nor `insertMemory`
+fires for a `segments` row (only `memories` rows trigger the FTS insert and only `insertMemory`
+writes `vec_memories`), so the "facts are the only retrieval key" invariant is structural, not a
+discipline we must remember.
+It also avoids overloading `memories`' lifecycle columns (`importance`, `is_compacted`,
+`consolidated`, decay) — a segment is provenance, not a recallable memory, and shouldn't decay,
+consolidate, or compact.
+
+**Why A over C.** Metadata-JSON would duplicate a ~6000-token segment into *every* fact's
+`metadata` blob (7 facts → 7 copies of the same chunk), bloating each `memories` row, every
+`SELECT m.*` in `queries.ts`, and every `rowToMemory` parse (`engine-impl.ts:73`). Normalizing
+the segment into one row referenced by N facts is the obvious relational fit and makes
+parent-dedup (§5.3) a trivial `GROUP BY segment_id`.
+
+### 3.2 Schema (canonical — built directly in `createSchema`)
+
+Both of these are part of the canonical schema a fresh DB is born with — `createSchema`
+(`database.ts`) builds them in its existing `CREATE TABLE IF NOT EXISTS` style alongside
+`memories`. There is **no** `ALTER TABLE`/migration step; `memories` is *defined* with
+`segment_id` (§4).
+
+```sql
+CREATE TABLE IF NOT EXISTS segments (
+  id          TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  namespace   TEXT NOT NULL DEFAULT 'default',
+  content     TEXT NOT NULL,          -- the source chunk memory_ingest extracted facts from
+  source      TEXT,                   -- provenance, mirrors memories.source (e.g. 'session:abc')
+  mode        TEXT,                   -- 'conversation' | 'document' (the ingest mode used)
+  created_at  INTEGER NOT NULL,       -- mirrors the facts' created_at (honors as_of)
+  fact_count  INTEGER NOT NULL DEFAULT 0  -- how many facts were extracted from this segment
+);
+
+CREATE INDEX IF NOT EXISTS idx_segments_namespace ON segments(namespace);
+
+-- segment_id is declared inline in the canonical `CREATE TABLE memories (...)` (§4):
+--   segment_id TEXT REFERENCES segments(id)
+-- It is NULL for every store-path / degrade-path row (rows that genuinely have no parent).
+
+CREATE INDEX IF NOT EXISTS idx_memories_segment ON memories(segment_id) WHERE segment_id IS NOT NULL;
+```
+
+Notes:
+
+- **No vector / FTS tables for segments.** Intentional (§3.1). Segments are fetched only by
+  primary key during re-expansion, so a `namespace` index plus the PK is sufficient.
+- **`segments.content` reuses the chunk verbatim** — the same string `chunkBlob` produced
+  (`engine-impl.ts:200`) and handed to `extractFacts`. No re-chunking, no second representation.
+  It is capped by the existing chunking bound `MAX_INGEST_CHUNK_TOKENS = 6000`
+  (`extraction.ts:28`; `MAX_INGEST_CHUNK_CHARS = MAX_INGEST_CHUNK_TOKENS * 4`, `extraction.ts:41`),
+  so a segment is at most ~6000 tokens — already the unit the LLM saw. This 6000-token storage unit
+  is exactly why the **returned** unit must be a smaller passage (§5.3): 6000 tokens never fits the
+  800-token default budget.
+- **`fact_count`** is a cheap denormalization that lets recall decide whether expanding is
+  worthwhile (a segment whose only fact is the one that matched adds little; a segment with 7
+  facts where only the headline was indexed is exactly the contract case). Optional to *use* in
+  phase 1; cheap to *populate*.
+- **`REFERENCES segments(id)`** declares the FK. `foreign_keys = ON` is already set
+  (`database.ts:42`). The reference is **not** `ON DELETE CASCADE` deliberately — see §6.3
+  (forget/decay must null the pointer or orphan-collect, not cascade-delete facts).
+
+### 3.3 The store path stays segment-less
+
+`storeImmediate` (`engine-impl.ts:81-129`) never sets `segment_id`. `InsertMemoryParams`
+(`queries.ts:11-25`) gains an **optional** `segmentId?: string`; when absent, `insertMemory`
+binds `NULL` (exactly as it already does for `source`/`metadata`). The `memory_store` tool, the
+LLM-free write path, and every existing caller are byte-for-byte unchanged. Only `ingestBlob`
+passes a `segmentId`.
+
+### 3.4 Why facts remain the indexed unit (invariant restated)
+
+- Each fact is still embedded (`storeImmediate` calls `embed(content)`, `engine-impl.ts:89`) and
+  inserted into `vec_memories` (explicit insert in `insertMemory`, `queries.ts:48-51`) +
+  `memories_fts` (via the `memories_ai` trigger, `database.ts:111-114`) exactly as today.
+- Segments are inserted **only** into the `segments` table. No trigger fires for it (the FTS trigger
+  is scoped to `memories`), and nothing writes a `vec_memories` row for it (only `insertMemory`
+  does, and `insertSegment` is a separate query).
+- Therefore `vectorSearch`/`ftsSearch`/`hybridScoreFusion`/`computeCompositeScore`/`rerank`/
+  `deduplicateByEmbedding`/`packToBudget` all operate on the identical candidate set they do
+  today. **The ranker cannot regress because its inputs are unchanged.**
+
+---
+
+## 4. Schema is canonical — no in-place migration
+
+**Product directive:** we do **not** care about backwards compatibility; the system must work
+correctly out of the box. That removes the entire reason v2 carried a migration runner. The
+`segments` table and the `memories.segment_id` column are simply part of the canonical schema a
+fresh DB is born with — there is no in-place upgrade path.
+
+### 4.1 The canonical schema (built in `createSchema`)
+
+`createSchema` (`database.ts`) defines the final shape directly, in its existing
+`CREATE TABLE IF NOT EXISTS` style. Two changes vs. today:
+
+- The `CREATE TABLE IF NOT EXISTS memories (...)` block gains an inline column:
+  ```sql
+  segment_id TEXT REFERENCES segments(id)   -- NULL for store-path / degrade-path rows
+  ```
+  Declared inline, so a fresh `memories` table is born with the column — **no `ALTER TABLE`,
+  which means no idempotency problem** (`ALTER … ADD COLUMN` was the only thing that wasn't
+  re-runnable; it is gone).
+- The `segments` table + its index (§3.2) are added to `createSchema` alongside the existing
+  `CREATE TABLE IF NOT EXISTS` statements. `foreign_keys = ON` is already set (`database.ts:42`).
+
+This mirrors exactly how the schema is already declared: one body of
+`CREATE … IF NOT EXISTS` plus the existence-checked vec/fts virtual tables. There is no
+`runMigrations`, no `PRAGMA table_info` guard, and no "brand-new-vs-existing" branch.
+
+### 4.2 `SCHEMA_VERSION` is a stamp; stale DBs are dropped-and-recreated
+
+`SCHEMA_VERSION` bumps **`'3' → '4'`** (`database.ts:30`). It remains a plain version stamp,
+written by the existing `ensureSchemaMeta` upsert (`upsert.run('schema_version', SCHEMA_VERSION)`)
+— **no migration logic reads it to transform data.** But it *is* read for one purpose: to detect
+and discard a stale on-disk schema so the system self-heals.
+
+The hazard: a pre-change DB has an **old `memories` table without `segment_id`**. `createSchema`'s
+`CREATE TABLE IF NOT EXISTS memories` no-ops on it (the table already exists), so the new column is
+never added, and the first `SELECT … segment_id` / `INSERT … segment_id` throws
+`no such column: segment_id`. We must not crash confusingly.
+
+**Chosen handling — option (a): stamp-gated drop-and-recreate (works out of the box).** In
+`initDatabase`, before `createSchema`, read the on-disk `schema_meta['schema_version']` (the
+`schema_meta` table itself is read defensively — absent ⇒ treat as a fresh DB, no drop). If the
+stamp is **present and older than `SCHEMA_VERSION`**, drop the schema (the `memories`, `segments`,
+`schema_meta` tables and the `vec_memories` / `memories_fts` virtual tables) and let `createSchema`
+rebuild it from scratch. A fresh DB (no stamp) and a current DB (stamp `=== '4'`) both skip the
+drop. This reuses the `SELECT … FROM sqlite_master` / `SELECT value FROM schema_meta` read idioms
+already in the file (`ensureSchemaMeta` already reads `schema_meta` for the embedding model).
+
+> **This deliberately discards old data.** Under the back-compat-free directive that is acceptable
+> and explicitly intended: a stale DB is *rebuilt*, not migrated. The corpus DB is regenerated via
+> `scripts/memory-corpus/build-corpus.ts` (which re-ingests, so segments get populated); user/session
+> DBs are recreated empty on first open. Option (b) — "document that old DB files must be deleted by
+> hand" — is rejected as the default because it is *not* out-of-the-box-correct: it requires a manual
+> step and the un-deleted DB crashes with `no such column`. The stamp-gated drop self-heals with zero
+> operator action, which is exactly the directive's bar.
+
+### 4.3 The NULL-`segment_id` case is a normal current case (not a back-compat artifact)
+
+A `NULL` `segment_id` is a **first-class current state**, not a legacy remnant: store-path rows
+(`memory_store`, §3.3) and degrade-mode single-blob ingests (§6.2) genuinely have **no parent** —
+there was no decomposition, so there is nothing coarser to retain. Re-expansion (§5) treats a fact
+with `segment_id = NULL` as **its own parent** and returns the fact text unchanged. This is current
+design behavior described fully in §5.3; it is not "migration" or "pre-migration" behavior.
+
+---
+
+## 5. Retrieval — "index fine, return coarse"
+
+### 5.1 What is unchanged (the whole ranker)
+
+The ~11-step `recall` pipeline (`pipeline.ts:36-125`) is **untouched** through dedup: embed query
+→ vector KNN + FTS → `hybridScoreFusion` → tag filter → `computeCompositeScore` →
+`filterByRelevance` → `rerank` → `filterByRerankerScore` → load embeddings →
+`deduplicateByEmbedding` (`pipeline.ts:114`). The candidate set, scores, and ordering are identical
+to today. Re-expansion is inserted as a new **step 9b**, strictly *after* `deduplicateByEmbedding`
+and *before* `packToBudget` (`:117`) / `formatMemories` (`:125`).
+
+**Passage ranking is NOT a change to the candidate ranker.** Step 9b ranks *passages of an
+already-selected segment* by similarity to the query embedding, to decide which slice of a parent
+to **return**. This is a post-retrieval, return-shaping operation on a single segment's text — it
+never touches the candidate set, the fusion scores, the reranker, or the order of the kept facts.
+"Do not touch the ranker" (steps 1–9, byte-for-byte) and "rank passages on return" are orthogonal:
+the first is about *which memories win*; the second is about *which slice of a winner's parent to
+show*. The reused query embedding (from step 1, `embedQuery`, `pipeline.ts:43`) is a read of an
+existing value, not a re-run of any ranking stage.
+
+### 5.2 The expansion option — `expand: 'none' | 'auto' | 'parent'`, default `'auto'`
+
+`RecallOptions` (`types.ts:53-58`) gains:
+
+```ts
+expand?: 'none' | 'auto' | 'parent';   // default 'auto'
+max_expand_passages?: number;          // cap on returned passages, default 2 (§5.4)
+```
+
+`recall` tool schema (`tools/recall.ts`, the Zod block in `server.ts`) gains an optional
+`expand` enum and `max_expand_passages` number, both passed through `handleRecall` →
+`engine.recall` → `retrievalRecall`.
+
+| Mode | Behavior |
+|---|---|
+| **`'auto'` (default)** | After dedup (step 9b), if **≥2 kept facts share a non-null `segment_id`**, expand that shared parent (return its query-ranked passages). A single fact with a lone parent stays a fact (no expansion). |
+| **`'none'`** | Force off. Facts are returned, no segment lookup, no extra query, no budget change — **byte-for-byte today's** behavior. |
+| **`'parent'`** | Force expand: emit the parent passage for **every** kept fact that has a non-null `segment_id`, even a lone one. |
+
+**Why `'auto'` is the default (the off-by-default fix).** The Bandalert loss occurred on an
+**ordinary recall with no flag** — so an opt-in `'none'` default (v1) could never have fixed it; the
+load-bearing behavior was deferred out of the default path. `'auto'` fixes the evidenced failure on
+a default call, and it needs **no query classifier**: the discriminator is purely structural — *do
+≥2 of the kept facts point at the same parent?* That shared-parent grouping is the exact contract
+signature (7 headline facts, one shared segment) and is **already computed** for parent-dedup
+(§5.3), so `'auto'` adds no new machinery. It does **not** regress pinpoint queries: a pinpoint
+recall returns one matched fact, which has at most one parent and therefore one fact per
+`segment_id` → no expansion → the crisp fact, exactly as today.
+
+**Why not always-on (`'parent'` as default).** Force-expanding a lone-parent fact turns a pinpoint
+answer ("what's my Anthropic API key var name?") into a passage lookup for no benefit and risks
+evicting other facts under the default budget. `'auto'`'s ≥2-shared-parent gate is the minimal
+trigger that catches the contract case while leaving pinpoint recall untouched.
+
+**`buildContext`/`memory_context` is wired to `'auto'` too** (`engine-impl.ts:279`). The briefing
+path is the **no-human-in-loop** place where missing a clause is most costly — there is no agent to
+notice the headline is thin and ask a follow-up — so it gets the same auto-expansion. Its budget is
+**800** (`CONTEXT_DEFAULT_BUDGET`, `engine-impl.ts:270`), which a ~300-token passage comfortably
+fits alongside facts.
+
+### 5.3 Step 9b — parent re-expansion (passage return + parent-dedup)
+
+Input: `kept` (the post-dedup `ScoredMemory[]`, `pipeline.ts:114`), already sorted by score, plus
+`queryEmbedding` (already computed at step 1, `pipeline.ts:43`).
+
+```
+if expand === 'none': proceed to packToBudget as today.   // unchanged path
+
+// expand === 'auto' | 'parent':
+1. Group kept facts by non-null segment_id, recording each group's best-ranked-fact position.
+2. Decide which segments to EXPAND:
+     - expand === 'parent'  → every group with a non-null segment_id (size ≥1)
+     - expand === 'auto'    → only groups whose size is ≥2 (a SHARED parent)
+   Groups not selected for expansion keep emitting their facts as today.
+3. Fetch the selected segments by id in one query (getSegmentsByIds(db, ns, ids)).
+4. For each expanded segment, SPLIT-AND-RANK to a passage (§5.3.1):
+     - split segment.content into coherent passages (paragraph/turn/sentence boundaries,
+       each capped ~300–400 tokens);
+     - embed each passage and rank by cosine similarity to queryEmbedding;
+     - take the top passage(s) up to max_expand_passages and the budget (§5.4).
+5. Build an ORDERED display list, walking `kept` in score order:
+     - fact in an EXPANDED group: at the position of its best-ranked fact, emit the segment's
+       chosen PASSAGE(s) once; mark the segment emitted so the other facts sharing it are
+       SKIPPED (parent-dedup);
+     - fact in a non-expanded group (auto, lone parent): emit the FACT itself;
+     - fact with segment_id == null (store-path / degrade — a row that has no parent): emit the
+       FACT (it is its own parent, §4.3);
+     - fact whose segment_id is non-null but whose segment row is missing (forgotten parent,
+       §6.3): fall back to emitting the FACT.
+6. The result is a heterogeneous, score-ordered list of {passage | fact} display units, with each
+   expanded parent appearing at most once.
+```
+
+Parent-dedup is the answer to "several top facts share one parent": in the contract case, the
+~7 headline facts all carry the same `segment_id`, so step 5 emits the **one** contract segment's
+chosen passage once (carrying the relevant clause) and drops the 6 redundant headlines. The user
+gets the clause instead of 7 lossy headlines — **the exact fix for the Bandalert failure, on a
+default `'auto'` recall with no flag.**
+
+#### 5.3.1 Split-and-rank: the returned unit is a query-relevant passage, not the chunk
+
+Returning the **whole 6000-token chunk** is wrong twice over: (1) it can never fit the 800-token
+default budget, so under v1 it would have degraded straight back to the headline — the original bug;
+and (2) a 6000-token conversation window is the **least coherent** possible parent — an arbitrary
+token span, not a unit of meaning. Both are fixed by returning a **passage**:
+
+- **Split** `segment.content` on coherent boundaries — paragraph breaks, conversation turns, or
+  sentence boundaries as a fallback — into pieces each capped at ~300–400 tokens. A passage is a
+  coherent unit; an arbitrary token window is not.
+- **Rank** the passages by cosine similarity to the **query embedding already computed at step 1**
+  (`embedQuery`, `pipeline.ts:43`) — no second query embed. The passage embeddings are computed with
+  the same `embed`/`embedQuery` path the rest of the system uses.
+- **Return** the top passage(s), up to `max_expand_passages` and the budget (§5.4). The contract's
+  "$250k cap" clause comes back as the ~300-token passage the query actually wanted — which **fits**
+  the 800-token budget — not 6000 tokens of conversation.
+
+This also resolves the open question about feeding 6000 tokens to the `summary`/`answer` Haiku
+formatter (which runs with `maxTokens: tokenBudget`, §5.5): the text handed to the formatter is now
+passage-sized, so the formatter never sees the oversized chunk.
+
+**Decision: recall-time split-and-rank, not ingest-time pre-split.** Recall-time keeps storage
+simple (segment stays one `content` blob; no passages table, no per-passage embeddings persisted)
+and only does the split/embed work when auto-expansion actually fires — which is rare relative to
+total recalls (only shared-parent groups). Ingest-time pre-split would precompute passages + their
+embeddings and avoid the recall-time embed, but adds a passages table and write-path cost on every
+ingest for a path that fires occasionally. Recall-time is the simpler default; ingest-time pre-split
+is a noted optimization (§8) if profiling shows the recall-time passage embed is hot. Either way the
+**storage unit may remain `segment = chunk`**; only the *returned* unit is passage-sized.
+
+#### 5.3.2 Overlap dedup (A6, minor)
+
+`chunkBlob` windows overlap ~10–15% (`extraction.ts` `chunkBlob` comment; the overlap preserves
+cross-references at chunk boundaries). If two *adjacent* segments are both expanded in one result —
+e.g. a fact from each side of a boundary shares text — their chosen passages may contain the same
+sentences. Because the returned unit is now a **passage**, a cheap **passage-text overlap dedup**
+handles this: when emitting passages, drop a passage whose normalized text is a (near-)substring of
+an already-emitted passage. This is a small string check on the (few, ≤`max_expand_passages`)
+emitted passages, not an embedding pass. It is a no-op for the common single-expanded-parent case.
+
+### 5.4 Budget accounting (simplified — passages are fact-sized, not chunk-sized) + out-of-the-box defaults
+
+**Default budget is bumped 500 → 800 so the system returns useful context with zero configuration.**
+The out-of-the-box directive requires that a *default* recall return the relevant passage **plus**
+a couple of facts. A passage is ~300–400 tokens and a fact ~150; at the old default of **500** a
+single ~400-token passage leaves only ~100 tokens — not even one more fact — so a shared-parent
+auto-expansion would crowd out the supporting facts. Bumping `MEMORY_DEFAULT_TOKEN_BUDGET`
+(`config.ts:70`) to **800** comfortably fits one ~300–400-token passage **and** 2–3 facts
+(~400 + 3×150 ≈ 850, packed greedily to ≤ 800), which is exactly the desired shape. `memory_context`
+stays **800** (`engine-impl.ts:270`); the two default budgets are now equal, which is intentional —
+both paths want the same "one passage + a few facts" envelope. **No flag and no config tuning are
+needed** to get parent context on shared-parent queries.
+
+v1's elaborate two-tier `expand_budget_fraction` existed for **one** reason — to *reject* a
+6000-token segment that could never fit — and passage return removes that reason entirely. So the
+budget machinery is simplified:
+
+- Re-expansion produces display units that each carry their own `displayContent` (a chosen passage
+  for an expanded unit, fact text otherwise) and `displayTokens = estimateTokens(displayContent)`.
+- Packing reuses the **existing** `packToBudget` greedy *skip-not-break* discipline
+  (`scoring.ts:200-212`): walk the score-ordered display list; include a unit if it fits the
+  remaining budget, else `continue` (skip, don't break). No segment sub-budget, no second pass.
+- The only added guard is a small **count cap**: at most `max_expand_passages` (default **2**)
+  passages may be emitted across the whole result, so auto-expansion cannot turn a result into all
+  passages and evict every fact.
+
+**Why a count cap of 2 against budget=800 with ~300–400-token passages and ~150-token facts.** One
+~300–400-token passage leaves ~400–500 tokens — room for 2–3 facts; two passages (~600–800 tokens)
+already consume most or all of the 800 budget and would leave no room for facts, so beyond the cap
+the greedy packer skips additional passages anyway. The cap of 2 is therefore a cheap
+belt-and-suspenders bound — it matters mainly for explicit `'parent'` calls with a raised
+`token_budget`; at the default 800 the greedy packer mostly self-limits while still leaving room for
+the supporting facts. A single dominant passage (the contract clause) plus the facts that still fit
+is exactly the desired out-of-the-box shape.
+
+The `expand:'none'` path calls `packToBudget` with the unchanged fact list — **byte-for-byte today's
+behavior** (at whatever `token_budget` the caller passes; only the *default* changed). Expansion only
+ever *substitutes* a passage for a fact at that fact's position and *drops* parent-deduped siblings;
+it never relaxes the skip-not-break rule, so a budget that fits N facts is never overrun.
+
+### 5.5 Formatting + expansion metadata in every format
+
+`formatMemories` (`formatting.ts:13-31`) is fed the packed display units. The minimal change:
+the packer emits `ScoredMemory`-shaped units whose `content` is the chosen display text (a passage
+for an expanded unit, fact text otherwise). For an expanded unit we set `content = passage.text` and
+keep the best-ranked fact's `created_at`/`importance` so the existing `[date] … (importance: …)`
+rendering (`formatting.ts:53`, `:122-124`) still works without a new code path. `summary`/`answer`
+LLM formatting then summarizes over the **passage** text (passage-sized, so it fits the formatter's
+`maxTokens: tokenBudget`) — strictly more relevant information for the same prompt shape.
+
+**Metadata in ALL formats (not just `raw`).** v1 exposed `segment_id`/`expanded` only in `raw`,
+which hides exactly the ids an agent needs to follow up. v2 surfaces, on the structured
+`RecallResult` regardless of `format` mode:
+
+- `expanded: boolean` — true when any returned unit was an expanded passage;
+- `expanded_segment_ids: string[]` — the `segment_id`s that were expanded (empty when none);
+- per-unit, in `raw` mode, the `segment_id` and an `expanded` flag (as v1).
+
+The `summary`/`answer` *text* is unchanged in shape; the structured fields ride alongside it.
+
+**Agentic follow-up — the "get headlines → expand the one that matters" loop.** The realistic
+agentic usage is: a default `'auto'` recall returns mostly facts (no shared parent) plus maybe one
+expanded passage; the agent reads a headline fact, decides *that* one needs detail, and fetches its
+parent. Two affordances support this, both driven by the now-visible ids:
+
+- **`memory_expand(segment_id)`** — a small new tool that returns the parent segment's
+  query-ranked passages (or, with no query, the whole segment up to a cap) for a given
+  `segment_id`. This is the direct "fetch the parent of this fact" call. (§9.4)
+- **`expand: 'parent'` re-query** — re-issue the same `recall` with `expand:'parent'` to force the
+  matched fact's parent passage. Coarser than `memory_expand` but needs no new tool.
+
+Either way, because `RecallResult` now carries `segment_id`s in every format, the agent has the
+handle it needs without parsing `raw` text.
+
+### 5.6 No regression on pinpoint queries (restated for the `'auto'` default)
+
+With the default `'auto'`, a **pinpoint** recall returns one matched fact whose `segment_id` is
+unique among the kept set → the ≥2-shared-parent gate does **not** fire → the crisp fact is
+returned, identical to today. Auto-expansion only triggers when several kept facts genuinely share a
+parent — the briefing/contract shape, where the coarse passage is what the user wanted. Existing
+callers that need byte-for-byte-today behavior can pass `expand:'none'`; `buildContext`/
+`memory_context` deliberately uses `'auto'` (§5.2) because its no-human-in-loop briefings are
+exactly the shared-parent case. The pinpoint case is never *worse* than today.
+
+---
+
+## 6. Ingest changes
+
+### 6.1 Where segments are written
+
+`ingestBlob` (`engine-impl.ts:171-266`) already has the chunks (`chunkBlob`, `:200`) and, per
+chunk, the facts (currently unioned across chunks in `extractAllFacts`, `:140-165`). The change:
+**one `segments` row per chunk that produced ≥1 fact**, and each fact written from that chunk
+carries that chunk's `segment_id`.
+
+The current `extractAllFacts` **flattens** facts across chunks and loses the chunk→fact mapping
+(it returns a single `ExtractedFact[]`, `:144`). To link facts to segments we keep the mapping:
+`extractAllFacts` returns, instead of a flat list, a list of **per-chunk groups**
+`{ chunkText: string; facts: ExtractedFact[] }[]` plus the existing `totalChunks`/`failedChunks`
+diagnostics. The cross-chunk exact-`fact`-string dedup (`:158-161`) is preserved but now records,
+for a duplicate, which chunk **first** owned it (the dedup keeps first occurrence — that chunk's
+segment is the fact's parent). A fact deduped away in a later chunk does **not** create a second
+parent link; it stays attached to its first chunk's segment.
+
+### 6.2 The write loop (revised)
+
+```
+for each chunk-group g with g.facts.length > 0:
+    if not dry_run:
+        segId = insertSegment(db, { namespace, content: g.chunkText, source: opts.source,
+                                    mode, createdAt, factCount: g.facts.length })
+    for each fact f in g.facts:
+        store(f.fact, { tags, importance: f.importance ?? seedImportance,
+                        source: opts.source, createdAt, segmentId: segId })  // segmentId NEW
+```
+
+- `store` (`storeImmediate`) gains an optional `segmentId` in `StoreOptions`, forwarded into
+  `insertMemory`'s new `segmentId` param (§3.3).
+- **On exact-dedup merge, repoint the survivor to the *richer* parent (order-independence, A4).**
+  When a fact **merges** into an existing row (exact-dedup branch, `engine-impl.ts:95-108`), v1 kept
+  the survivor's **first** `segment_id`. That makes the parent depend on ingest order: a later,
+  richer ingest of the same fact — whose segment carries more clauses — would be discarded purely
+  because it arrived second, the exact order-dependence the ingest doc's A1 timestamp fix went to
+  lengths to avoid. v2 instead **repoints the survivor's `segment_id` to the segment with the higher
+  `fact_count`** (the richer parent — more facts extracted from it ⇒ more clauses likely to ride
+  along). Rule:
+  - if the survivor's existing `segment_id` is `NULL` (store-path survivor), adopt the incoming
+    `segmentId`;
+  - else compare `fact_count` of the two segments and keep the higher; ties keep the existing
+    (stable, order-independent given equal richness).
+  - **The merge path must read both segments' `fact_count`.** `updateMemoryContent`
+    (`engine-impl.ts`) is content-only and does not touch `segment_id`, so this needs a small new
+    query `updateMemorySegmentIfRicher(db, ns, survivorId, incomingSegmentId)` that looks up both
+    `fact_count`s and conditionally rewrites `memories.segment_id` (mirrors the A1
+    `updateMemoryTimestampsOnMerge` shape — runs only when `incomingSegmentId` is set, so non-ingest
+    merges are byte-for-byte unchanged).
+- **`as_of` / `source` / importance / dedup behavior are all preserved.** `createdAt` flows to
+  both the segment and its facts (so a segment's `created_at` matches its facts'), `source` is
+  mirrored onto the segment, and the existing per-fact importance + exact-dedup/merge machinery
+  (`memory-ingest-tool.md` §5.3) is unchanged.
+- **Degrade / skip / dry_run:**
+  - `dry_run`: no segment and no fact rows written (today's behavior, `engine-impl.ts:247-249`).
+  - `degrade` single-blob (`engine-impl.ts:219-238`): the blob is stored as one fact with
+    `segment_id = NULL` — there was no decomposition, so there is no parent to retain. (The blob
+    *is* the content; re-expansion treats it as its own parent, §4.3.) **No segment row** for the
+    degrade path.
+  - `skip`: nothing written (unchanged).
+- **`maybeRunMaintenance`** still fires inside `storeImmediate` as today; segments are inert to
+  maintenance (not in `memories`, so decay/consolidation/compaction never touch them).
+
+### 6.3 Segment lifecycle vs. forget / decay / compaction
+
+`memories` rows can be deleted (`forget`, `deleteMemories` `queries.ts:346`), decayed
+(`markDecayed` zeroes importance + removes the vector, `queries.ts:476`), or compacted
+(`is_compacted = 1`, `queries.ts:498`). Segments must not be cascade-deleted when a single child
+fact is forgotten (siblings may still reference it). Rules:
+
+- **Forget a fact:** the fact row is deleted; its `segment_id` link simply dangles for that
+  (now-gone) row. The segment stays as long as **any** fact references it. A fact whose segment
+  has been independently removed falls back to emitting the fact (§5.3 step 3, missing-segment
+  case) — robust to dangling pointers.
+- **Orphan collection (deferred, §8):** a maintenance sweep can `DELETE FROM segments WHERE id
+  NOT IN (SELECT segment_id FROM memories WHERE segment_id IS NOT NULL)`. Not required for phase 1
+  (orphans are inert and cheap); listed as a follow-up. Because the FK is **not** `ON DELETE
+  CASCADE`, deleting facts never deletes segments and deleting a segment is only ever the explicit
+  orphan sweep.
+- **Decay/compaction** don't delete rows, so segment links survive; an expanded recall of a
+  decayed fact still has its parent (though a decayed fact rarely surfaces, since its vector is
+  removed).
+
+---
+
+## 7. Phase 2 (optional, deferred) — contextualized embedding
+
+**Idea (Anthropic Contextual Retrieval).** Before embedding a fact, prepend a short context
+string derived from its segment (a one-line topic, e.g. "Context: the Bandalert distribution
+contract. Fact: …"), so the fact's *vector* carries cross-reference signal it otherwise lacks.
+This improves the **retrieval key** (the embedded fact), distinct from §5 which improves the
+**returned unit**.
+
+**Why deferred, not in phase 1:**
+
+- It changes the embedded text, so it **must** run only on the ingest path — the LLM-free `store`
+  path must never embed contextualized text (it has no segment and no LLM to derive context). The
+  clean threading is: `ingest` computes a per-segment `contextPrefix` once (one extra short Haiku
+  call per segment, or reuse the segment's first sentence with no LLM), and passes it to `store`
+  as a new optional `embedContext?: string`; `storeImmediate` embeds `embedContext + content` but
+  **stores** `content` unchanged (so display/FTS/dedup-on-content are unaffected; only the vector
+  shifts). When `embedContext` is absent (every `store` call), behavior is identical to today.
+- It risks **re-embedding drift**: facts embedded with context aren't directly comparable to
+  legacy facts embedded without it, and the corpus diagnostic (`memory-corpus-and-diagnostic.md`)
+  was tuned on un-contextualized vectors. Turning this on is a corpus rebuild, not a hot-swap.
+- The §5 parent-return fix already recovers the **clause content** for the contract case without
+  touching a single embedding — and in v2 it does so on a **default `'auto'` recall** (passage
+  return + auto-expansion are both in Phase 1, §11), so phase 1 actually solves the evidenced
+  problem on its own. (This corrects v1, which claimed "phase 1 solves it" while the load-bearing
+  behavior — expansion on a default recall — had been deferred behind an opt-in `'none'` default.)
+  Phase 2 is therefore a pure *recall-rate* optimization to layer on later behind a config flag
+  (`MEMORY_INGEST_CONTEXTUALIZE_EMBEDDING`, default off).
+
+**Tradeoff stated:** phase 2 buys better *retrieval* of detail-bearing facts (the fact is more
+findable); phase 1 buys *returnability* of detail that was never a fact at all (the clause is in
+the segment). They are complementary; the evidenced loss is a returnability problem, so phase 1
+is mandatory and phase 2 is optional.
+
+---
+
+## 8. Reference-document handling & `mode='document'`
+
+- **Parent retention fixes the contract case even if decomposition stays lossy.** The headline
+  facts ("there is a distribution contract", "it has a buyout clause") are enough to *retrieve*
+  the right segment; the **un-decomposed clauses** ($250k cap, IP terms, NDA) ride along in
+  `segments.content` and are returned — as the query-relevant **passage** (§5.3) — on a default
+  `'auto'` recall (the shared-parent gate fires because all the headline facts point at the one
+  contract segment). We do **not** need decomposition to become exhaustive to fix the failure —
+  that's the whole point of index-fine / return-coarse.
+- **Should `mode='document'` decompose more exhaustively?** **No (decision).** Pushing extraction
+  to emit a fact per clause re-introduces over-decomposition (NAACL 2025) and a flood of
+  low-importance near-duplicate facts that muddy the index — the opposite of the ingest tool's
+  design intent. With parent retention, the clauses are **recoverable** without being indexed.
+  `mode='document'` keeps its current explicit-vs-inference contract (`extraction.ts:71-75`); the
+  segment carries the detail. (A future, *separate* "exhaustive reference mode" could be added if
+  evidence shows clause-level *retrieval* — not just return — is needed; explicitly out of scope.)
+
+---
+
+## 9. Types, tool surface, what callers see
+
+### 9.1 Types (`types.ts`)
+
+```ts
+// RecallOptions gains:
+expand?: 'none' | 'auto' | 'parent'; // default 'auto'
+max_expand_passages?: number;        // default 2 (cap on returned passages, §5.4)
+
+// IngestResult gains (additive, optional):
+segments_created?: number;           // count of segment rows written (omitted when 0 / dry_run)
+
+// New row shape (storage/database.ts):
+export interface SegmentRow {
+  id: string; namespace: string; content: string;
+  source: string | null; mode: string | null;
+  created_at: number; fact_count: number;
+}
+```
+
+`MemoryRow` gains `segment_id: string | null`. `Memory` (the public DTO, `types.ts:6-20`) gains
+`segment_id: string | null` and `rowToMemory` (`engine-impl.ts:58-75`) maps it.
+
+`RecallResult` (`types.ts:60-64`) gains, **in every format mode** (not just `raw`):
+
+```ts
+expanded?: boolean;              // true when any returned unit was an expanded passage
+expanded_segment_ids?: string[]; // the segment_ids that were expanded (omitted/[] when none)
+```
+
+These additive fields are what enable the agentic follow-up loop (§5.5): an agent that received
+headlines reads `expanded_segment_ids` (or, for a non-expanded headline, the per-unit `segment_id`
+in `raw`) and calls `memory_expand` (§9.4) on the one it cares about.
+
+The v1 `expand_budget_fraction` option is **removed** (§5.4): passage return makes the two-tier
+segment sub-budget unnecessary; `max_expand_passages` replaces it as the single, simpler knob.
+
+### 9.2 `StoreOptions` / `InsertMemoryParams`
+
+`StoreOptions` (`engine.ts:20-30`) gains `segmentId?: string` (optional; only `ingest` sets it).
+`InsertMemoryParams` (`queries.ts:11-25`) gains `segmentId?: string`, bound as `NULL` when absent.
+Both are additive and optional — the `store`/`memory_store` contract is unchanged.
+
+### 9.3 New queries (`queries.ts`)
+
+- `insertSegment(db, { id?, namespace, content, source?, mode?, createdAt?, factCount })` — one
+  INSERT into `segments`; mirrors `insertMemory`'s shape (transaction + `createdAt ?? Date.now()`).
+- `getSegmentsByIds(db, namespace, ids): SegmentRow[]` — by-PK batch fetch for re-expansion
+  (mirrors `getMemoriesByIds`, `queries.ts:302-308`).
+- `updateMemorySegmentIfRicher(db, namespace, survivorId, incomingSegmentId)` — the A4 merge
+  repoint (§6.2): adopts `incomingSegmentId` when the survivor has no parent, else keeps whichever
+  of the two segments has the higher `fact_count`. Runs only when `incomingSegmentId` is set.
+- (deferred §6.3) `deleteOrphanSegments(db, namespace): number`.
+
+### 9.4 `recall` tool schema + new `memory_expand` tool
+
+`server.ts` `memory_recall` Zod block + `tools/recall.ts` `validateRecallInput` gain `expand`
+(enum `'none' | 'auto' | 'parent'`, optional, **default `'auto'`**) and `max_expand_passages`
+(positive int, optional, default `2`, validated like `validateTokenBudget` bounds). The tool
+description gains one sentence: *"`expand` defaults to `'auto'`, which returns the relevant source
+passage when several matched facts come from the same source (e.g. a contract's clauses); use
+`'none'` for strictly pinpoint facts, or `'parent'` to force the source passage for every match."*
+
+**New `memory_expand(segment_id, query?)` tool** (the agentic follow-up affordance, §5.5).
+Following the package's `server.tool()` idiom (deprecated but used uniformly under the file's
+eslint-disable block — match it; do not migrate to `registerTool` piecemeal), and routed through a
+new `MemoryEngine.expand(segmentId, query?)` method (the only seam holding both `db` and `config`,
+per the package's config-injection constraint — a handler-local function cannot reach the embedder):
+fetch the segment by id, split-and-rank its passages against `query` (or return the whole segment up
+to a cap when `query` is absent), and return them. This is the "I got a headline, give me *this*
+fact's parent" call; `expanded_segment_ids`/per-unit `segment_id` from the prior `recall` supply the
+id.
+
+### 9.5 What existing callers see
+
+- **The corpus driver** (`scripts/memory-corpus/build-corpus.ts`) calls `ingestBlob` directly; it
+  gets segment rows for free (one per non-empty chunk) and a new `segments_created` stat. Its
+  content-free logging (`memory-corpus-and-diagnostic.md` "Sensitive data") is unaffected — it
+  never logs segment text, only counts. **Sensitive-data / content-free constraints continue to
+  hold for all fixtures** (segments are content; fixtures stay ids/counts/numeric only).
+- **The diagnostic** (`diagnose-corpus.ts`) uses the production scorers and `packToBudget`
+  unchanged. **Conflict + resolution:** two defaults changed that the diagnostic must pin to keep
+  its GO/NO-GO verdict comparable to its historical baseline — (1) the default `expand` is now
+  `'auto'` (not `'none'`), and (2) the default `token_budget` is now **800** (not 500, §5.4). Both
+  affect the *packed output* without touching the candidate **ranker** (the candidate set, fusion,
+  composite, rerank and dedup are byte-for-byte unchanged; only the post-dedup display units and how
+  many of them fit differ). To keep the verdict in `memory-corpus-and-diagnostic.md` measuring the
+  same thing, the diagnostic must **pass `expand:'none'` AND its own explicit `token_budget`** (the
+  value it baselined on) rather than inheriting the new defaults — which restores byte-for-byte its
+  prior packed output. (This is the one place the `'auto'`/800 defaults are *not* what we want: the
+  diagnostic grades the ranker, not the return shape or the budget envelope.) Pinned that way the
+  verdict is undisturbed; separate `expand:'auto'` / budget-800 diagnostic passes can later measure
+  passage-return quality at the out-of-the-box settings.
+- **External MCP clients**: additive only — a tri-state `expand` recall option (defaulting to
+  `'auto'`, which can change the *returned* unit for shared-parent queries vs. v0 facts-only),
+  `expanded`/`expanded_segment_ids` on `RecallResult` in every format, and the new
+  `memory_expand` tool. The candidate ranking they observe is unchanged; the *coarser return on
+  shared-parent queries* is the intended behavior change.
+
+---
+
+## 10. Testing strategy
+
+Follow the existing harness exactly: `mkdtempSync(tmpdir(), 'memory-test-')` + `initDatabase(path,
+TEST_MODEL)` (`test/database.test.ts:41-44`), real small embedder under the 30s timeout, and the
+`vi.mock('../src/llm/client.js', …)` queue from `test/ingest.test.ts:11-26` so the *real*
+store/segment pipeline runs while extraction returns canned facts.
+
+### 10.1 Canonical schema / stale-DB rebuild (`test/database.test.ts` extension)
+
+There is no migration runner anymore, so the v2 "upgrade-path" and "idempotent ADD COLUMN" tests
+are **deleted**. What remains is the canonical-schema assertion plus the stale-DB self-heal:
+
+- **Fresh DB is born with the canonical schema:** open a brand-new path via `initDatabase` →
+  `segments` table exists, `memories` has a `segment_id` column, `schema_meta['schema_version']
+  === '4'`. (No migration step ran; `createSchema` built it directly.)
+- **Stale DB (older `SCHEMA_VERSION`) is recreated cleanly:** build a DB with the **v3** shape
+  (create `memories` *without* `segment_id`, set `schema_meta['schema_version']='3'`, insert a row),
+  reopen via `initDatabase`, and assert: the schema is rebuilt (the `segment_id` column now exists,
+  `segments` table exists), the version stamp is now `'4'`, the open does **not** throw
+  `no such column: segment_id`, and the pre-change row is **gone** (drop-and-recreate deliberately
+  discards old data, §4.2). A subsequent `store`/`recall` round-trips on the rebuilt DB.
+- **Re-open is a no-op:** `initDatabase` twice in a row on a current (`'4'`) DB does not drop or
+  throw (the stamp matches, so the drop branch is skipped).
+
+### 10.2 Ingest links segments (`test/ingest.test.ts` extension)
+
+- **Segment stored + linked:** mock returns 3 facts for one chunk → `segments` has 1 row whose
+  `content` equals the chunk, `fact_count === 3`; all 3 fact rows have the same non-null
+  `segment_id` pointing at it; `IngestResult.segments_created === 1`.
+- **Multi-chunk:** two chunks, distinct facts each → 2 segment rows, each fact linked to its own
+  chunk's segment; a boundary fact deduped across the overlap (§6.1) stays linked to its **first**
+  chunk's segment (no second link, no second parent).
+- **`as_of` on segment:** segment's `created_at` equals the facts' backdated `created_at`.
+- **Degrade single-blob:** no-LLM degrade path writes one fact with `segment_id = NULL` and **no**
+  segment row; `segments_created` omitted/0.
+- **dry_run:** no segment rows, no fact rows (unchanged), `facts` still previewed.
+- **Merge repoints to richer parent (A4):** ingest a fact whose segment has `fact_count = 1`, then
+  ingest a duplicate (exact-dedup merge) from a *different* segment with `fact_count = 5` →
+  survivor's `segment_id` is repointed to the **richer** (5-fact) segment, **regardless of ingest
+  order** (run the test both orders; same result). A `NULL`-parent survivor adopts the incoming
+  segment; a tie keeps the existing.
+
+### 10.3 Re-expansion (`test/pipeline.test.ts` / new `test/expand.test.ts`)
+
+- **`'auto'` fires on a shared parent — by DEFAULT, no flag (the contract case):** ingest one
+  segment carrying the full contract clauses and ~7 headline facts; a default `recall(query)` (no
+  `expand` arg) matching several headlines → `expanded === true`, exactly **one** passage is
+  returned (parent appears once), and it contains a clause string (e.g. the `$250k` cap) that was
+  **never** an extracted fact. This is the direct regression test for the Bandalert failure and it
+  must pass **without** passing `expand`.
+- **Passage return fits the default budget=800 and contains the clause:** with the default
+  `token_budget=800` (the bumped `MEMORY_DEFAULT_TOKEN_BUDGET`, §5.4), the expanded unit is a
+  ~300–400-token **passage** (not the 6000-token chunk), it **fits** the budget (assert total
+  returned tokens ≤ 800) **with room left for ≥1 supporting fact** (assert at least one fact is also
+  returned alongside the passage — the out-of-the-box "passage + a couple of facts" shape), and it
+  contains the `$250k` clause. (The v1 failure mode — 6000 tokens skipped by `packToBudget`, degrade
+  to headline — must NOT occur.)
+- **Passage is query-relevant:** a segment with several distinct clauses (cap / IP / NDA); a query
+  about the IP terms → the returned passage is the **IP** passage, not the cap passage (asserts the
+  split-and-rank picks the query-relevant slice, not just the first passage).
+- **Pinpoint single-fact does NOT expand (no regression):** a default recall whose match is a
+  single fact with a lone (or null) `segment_id` → `expanded === false`, the crisp **fact** is
+  returned, byte-for-byte today's output. Repeat with `expand:'none'` → identical.
+- **`'parent'` force-expands a lone parent:** the same single-fact query with `expand:'parent'`
+  → returns the parent passage (proves `'parent'` ignores the ≥2 gate while `'auto'` honors it).
+- **Budget / passage cap:** with `max_expand_passages` and a multi-clause segment under a raised
+  `token_budget`, no more than the cap of passages are returned and total tokens never exceed the
+  budget (skip-not-break preserved).
+- **Overlap dedup (A6):** two adjacent overlapping segments both expanded → a shared sentence is
+  not emitted twice (passage-text overlap dedup).
+- **Parent-less / forgotten-parent (current NULL-segment case):** `store` a plain memory (no
+  segment), default `recall` → returns the fact (its own parent, no expansion); a fact whose segment
+  was force-deleted falls back to the fact (missing-segment path). This is current design behavior
+  (§4.3), not a legacy path.
+
+### 10.4 Tool / registration (`test/recall-tool.test.ts` or existing tool tests)
+
+- `validateRecallInput` accepts/normalizes `expand` (defaults **`'auto'`**, accepts
+  `'none'`/`'auto'`/`'parent'`, rejects out-of-enum), validates `max_expand_passages` bounds.
+- `RecallResult` surfaces `expanded` + `expanded_segment_ids` in **every** format (summary/answer/
+  raw), not just `raw`; per-unit `segment_id` still appears in `raw`.
+- **`memory_expand(segment_id)`:** returns the parent's query-ranked passages for the id from a
+  prior recall; with no `query`, returns the segment (up to a cap).
+- **`memory_context` auto-expands:** a `buildContext`/`memory_context` call over a shared-parent
+  corpus returns the passage (asserts the briefing path is wired to `'auto'`, budget 800).
+
+### 10.5 Content-free fixtures
+
+Any expansion/segment fixtures that touch real corpus shape stay **content-free** (ids, counts,
+token estimates) per the sensitive-data rule; segment *text* in tests is synthetic
+("Contract clause: distribution cap is $250k. …"), never private export content.
+
+---
+
+## 11. Phasing & explicit non-goals
+
+### Phasing
+
+The load-bearing behavior — expansion on a **default** recall, returning a **passage** that fits the
+real budget — is in **Phase 1** (v1 had deferred it behind an opt-in default, so v1 did not actually
+fix the evidenced loss; corrected here).
+
+1. **Phase 1 (this design, mandatory):** `segments` table + `segment_id` column as part of the
+   canonical `createSchema` (no migration runner; stale DBs drop-and-recreate, §4) + ingest
+   writes/links segments + **default `expand:'auto'`** re-expansion with **passage split-and-rank**
+   + parent-dedup + simplified passage-budget cap (default budget bumped to **800**, §5.4) + A4
+   richer-parent merge repoint + metadata in every format + `memory_expand` + `memory_context`
+   wired to `'auto'`. **Fixes the evidenced contract loss on a default recall, out of the box.**
+2. **Phase 2 (optional, deferred, §7):** contextualized embedding behind
+   `MEMORY_INGEST_CONTEXTUALIZE_EMBEDDING` (default off). Improves *retrieval* of detail-bearing
+   facts; requires a corpus rebuild. Phase 1 already fixes *return* of un-decomposed clauses.
+3. **Phase 3 (optional, deferred, §6.3/§8):** orphan-segment collection in maintenance;
+   **ingest-time passage pre-split** (precompute + persist passages/embeddings if the recall-time
+   passage embed proves hot); a possible exhaustive reference mode.
+
+### Explicit non-goals
+
+- **NOT building a knowledge graph.** Segments are a flat parent layer, not nodes-and-edges. No
+  A-MEM-style inter-note links in phase 1.
+- **NOT changing the candidate ranker.** Steps 1–9 of `pipeline.ts` (embed → hybrid search → fusion
+  → composite → rerank → dedup) and the existing `scoring.ts` functions are byte-for-byte unchanged;
+  the candidate set, fusion, composite, rerank, and dedup are identical. **Passage split-and-rank
+  (§5.3.1) is a post-retrieval, return-shaping step on an already-selected segment — it ranks
+  *passages of a winner's parent* by the reused query embedding to decide what to *show*, never
+  *which memories win*.** The two are orthogonal; "ranker untouched" holds.
+- **NOT making decomposition exhaustive.** `mode='document'` keeps its current contract; clauses
+  are recovered via the passage, not via more facts (§8).
+- **The returned unit is a passage, not the raw 6000-token segment.** A whole-chunk return is
+  rejected (§5.3.1): it cannot fit the default budget (800, §5.4) and is the least-coherent parent. (A generated
+  abstract/summary tier between fact and passage is deferred/optional — passages already keep the
+  returned text small.)
+- **NOT re-embedding facts.** Phase 1 adds no new fact-vector dimension and changes no existing
+  embedding path; parent-less facts (the NULL-segment case, §4.3) work without an embedding change.
+  (Passage embeddings are computed transiently at recall time and not persisted in Phase 1.) Note
+  this is orthogonal to the stale-DB rebuild (§4.2): the rebuild *re-ingests* the corpus from
+  scratch via `build-corpus.ts`, which embeds each fact through the normal path — it does not
+  "re-embed in place."
+- **`'auto'` is on by default by design.** Auto-expansion fires only on the ≥2-shared-parent
+  signature, so pinpoint recall is never regressed; `expand:'none'` remains available for callers
+  (and the diagnostic, §9.5) that need byte-for-byte-today output.
+
+---
+
+## 12. File-change summary
+
+| File | Change |
+|---|---|
+| `src/storage/database.ts` | `SCHEMA_VERSION '3'→'4'` (plain stamp); add `segments` table + inline `segment_id` column to the canonical `createSchema` (**no `runMigrations`, no `ALTER TABLE`**); in `initDatabase`, read on-disk `schema_meta['schema_version']` and **drop-and-recreate** the schema when older than `SCHEMA_VERSION` (stale-DB self-heal, §4.2); `MemoryRow.segment_id`; `SegmentRow` type. |
+| `src/config.ts` | Bump `MEMORY_DEFAULT_TOKEN_BUDGET` **500 → 800** (`config.ts:70`) so a passage + a couple of facts fit out of the box (§5.4); `memory_context` budget already 800 (`engine-impl.ts:270`), now equal. |
+| `src/storage/queries.ts` | `InsertMemoryParams.segmentId?`; `insertMemory` binds it (else NULL); new `insertSegment`, `getSegmentsByIds`, **`updateMemorySegmentIfRicher`** (A4 merge repoint, §6.2); (deferred) `deleteOrphanSegments`. |
+| `src/storage/extraction.ts` | Reuse `chunkBlob` output as segment content (no change to chunking); new **`splitToPassages(text)`** helper (coherent ~300–400-token passages) for recall-time split (§5.3.1). |
+| `src/engine.ts` | `StoreOptions.segmentId?`; new **`MemoryEngine.expand(segmentId, query?)`** method (powers `memory_expand`, §9.4); `RecallOptions`/`IngestResult` additions live in `types.ts`. |
+| `src/types.ts` | `RecallOptions.expand: 'none'\|'auto'\|'parent'` (default `'auto'`) + `max_expand_passages` (**replaces** `expand_budget_fraction`); `IngestResult.segments_created?`; `RecallResult.expanded?` + `expanded_segment_ids?` (**all formats**); `Memory.segment_id`. |
+| `src/engine-impl.ts` | `storeImmediate` forwards `segmentId` + calls `updateMemorySegmentIfRicher` on merge; `extractAllFacts` returns per-chunk groups; `ingestBlob` writes one segment per non-empty chunk and links facts; `rowToMemory` maps `segment_id`; `recall` threads `expand`/`max_expand_passages`; **`buildContext`/`memory_context` (`:279`) passes `expand:'auto'`**; new `expand()` impl. |
+| `src/retrieval/pipeline.ts` | Insert **step 9b** (auto/parent re-expansion: shared-parent grouping + passage split-and-rank against the reused step-1 query embedding + parent-dedup + overlap dedup) after dedup, before `packToBudget`; gate on `expand`. |
+| `src/retrieval/scoring.ts` | **Unchanged** `packToBudget` reused for both paths (passage units pack like facts); the v1 two-tier variant is dropped. Only addition: `max_expand_passages` count cap applied before packing. |
+| `src/retrieval/formatting.ts` | Display-unit content selection (passage vs fact); surface `expanded` + `expanded_segment_ids` in **every** format; per-unit `segment_id` in `raw`. |
+| `src/tools/recall.ts`, `src/server.ts` | `expand` (tri-state) + `max_expand_passages` schema + validation + description sentence; **new `memory_expand` tool** (`server.tool()` idiom) routed to `engine.expand`. |
+| `test/database.test.ts`, `test/ingest.test.ts`, `test/expand.test.ts`, recall-tool tests | New/extended per §10 (fresh DB born with canonical schema; **stale-DB drop-and-recreate**, no `test/migration.test.ts`; auto-fires-by-default; passage fits default budget 800 + leaves room for a fact + contains clause; passage query-relevant; merge repoints to richer; pinpoint does NOT expand; `memory_expand`; `memory_context` auto-expands). |
+</content>
+</invoke>

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@cyanheads/git-mcp-server": "^2.8.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@mozilla/readability": "^0.6.0",
-    "@provos/memory-mcp-server": "^0.1.3",
+    "@provos/memory-mcp-server": "^0.2.0",
     "@utcp/code-mode": "^1.2.11",
     "@utcp/mcp": "^1.1.1",
     "@xterm/headless": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:web-ui": "npm test -w packages/web-ui",
     "test:watch": "vitest",
     "lint": "eslint src/ test/",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "check:cycles": "madge --circular --extensions ts --ts-config tsconfig.json src",
     "format": "prettier --log-level=warn --write 'src/**/*.ts' 'test/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",

--- a/packages/memory-mcp-server/CLAUDE.md
+++ b/packages/memory-mcp-server/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — memory-mcp-server
 
-Persistent memory MCP server with semantic search, LLM summarization, and automatic compaction.
+Persistent memory MCP server (7 tools) with semantic search, LLM summarization, automatic compaction, atomic-fact ingestion (`memory_ingest`), and parent-context retrieval (`memory_expand` / recall expansion).
 
 ## Commands
 
@@ -21,20 +21,22 @@ src/
 ├── index.ts              Entry point (stdio transport, config, shutdown)
 ├── engine.ts             MemoryEngine interface (public API surface)
 ├── engine-impl.ts        Wires storage, retrieval, embedding, LLM subsystems
-├── server.ts             MCP tool registration
+├── server.ts             MCP tool registration (7 tools)
 ├── config.ts             Env-based configuration (all MEMORY_* vars)
-├── types.ts              Shared types (Memory, StoreResult, RecallResult, etc.)
+├── types.ts              Shared types (Memory, StoreResult, IngestResult, RecallResult, ExpandResult, ExpandMode, etc.)
 ├── prompts.ts            Exportable system prompts and tool descriptions
 ├── storage/
-│   ├── database.ts       SQLite schema: memories, vec_memories (768-dim), memories_fts (FTS5)
-│   ├── queries.ts        Data access: insert, search (vector + FTS), delete, stats
+│   ├── database.ts       SQLite schema (SCHEMA_VERSION 4): memories (+ segment_id FK), segments (off-index source chunks), vec_memories (768-dim), memories_fts (FTS5). Stale-DB drop-and-recreate.
+│   ├── queries.ts        Data access: insert, search (vector + FTS), delete, stats; segment helpers (insertSegment, getSegmentsByIds, updateMemorySegmentIfRicher)
+│   ├── extraction.ts     LLM atomic-fact extraction (chunkBlob, extractFacts) + splitToPassages for expansion
 │   ├── constants.ts      Embedding dimensions, dedup thresholds
 │   ├── maintenance.ts    Three-phase: consolidation → decay → compaction
 │   ├── compaction.ts     LLM-driven clustering + summarization of old memories
 │   └── consolidation.ts  Deferred batch dedup/contradiction detection at store time
 ├── retrieval/
-│   ├── pipeline.ts       Full recall flow (10 steps, see below)
+│   ├── pipeline.ts       Full recall flow (steps below)
 │   ├── scoring.ts        Score-based hybrid fusion, composite scoring, relevance filter, reranker filter, budget packing
+│   ├── expansion.ts      Post-dedup parent re-expansion (NOT the ranker): group kept facts by segment, split-and-rank source passages, hybrid budget pack. Shared by recall (limit 1/segment) and memory_expand.
 │   ├── reranker.ts       Cross-encoder re-ranking (ms-marco-MiniLM, raw logits)
 │   ├── dedup.ts          Embedding-based deduplication
 │   └── formatting.ts     Output: summary (LLM), list (bullets), raw (JSON)
@@ -43,8 +45,10 @@ src/
 ├── llm/
 │   └── client.ts         OpenAI-compatible client, judgment helpers (single + batch)
 ├── tools/
-│   ├── store.ts          memory_store — persist content with tags, importance
-│   ├── recall.ts         memory_recall — semantic query with token budget
+│   ├── store.ts          memory_store — persist one pre-formed fact with tags, importance
+│   ├── ingest.ts         memory_ingest — LLM-decompose a raw blob into many atomic facts (mode, dry_run, as_of, on_extraction_failure)
+│   ├── recall.ts         memory_recall — semantic query with token budget, expand mode, structured output
+│   ├── expand.ts         memory_expand — fetch a source segment's query-ranked passages by segment_id
 │   ├── context.ts        memory_context — session briefing
 │   ├── forget.ts         memory_forget — bulk delete with dry_run/confirm
 │   ├── inspect.ts        memory_inspect — stats, recent, tags, export
@@ -65,7 +69,8 @@ src/
 7. **Cross-encoder re-ranking** — ms-marco-MiniLM-L-6-v2 via `AutoModelForSequenceClassification` (raw logits, NOT pipeline API which squashes to 1.0). Try/catch falls back gracefully
 8. **Re-ranker filter** — Relative gap (12 logit points from best), min 5 results
 9. **Dedup** — Embedding cosine similarity
-10. **Token budget packing** — Greedy skip (not break), then format
+   9b. **Parent re-expansion** (`retrieval/expansion.ts`, `expand:'auto'|'parent'` only) — POST-dedup, NOT part of the candidate ranker. Group kept facts by `segment_id`, fetch each shared segment by primary key (off-index), split-and-rank its passages against the step-1 query embedding, then hybrid-pack: reserve budget so the single top source passage is guaranteed (top facts never evicted), supplementary passages ride leftover budget up to `max_expand_passages`. `expand:'none'` is a byte-for-byte facts-only pack. Never touches the candidate set, fusion/composite/rerank scores, or selection order.
+10. **Token budget packing** — Greedy skip (not break), then format (folded into step 9b for the expansion modes; plain `packToBudget` for `expand:'none'`)
 
 ## Key Design Decisions
 
@@ -81,19 +86,22 @@ src/
 - **SQLite** with `better-sqlite3` (synchronous API, transactions)
 - **sqlite-vec** extension for vector nearest-neighbor search (768-dim, cosine distance)
 - **FTS5** for keyword search with BM25 ranking
+- **`segments` table** — source chunks `memory_ingest` decomposes facts from. OFF the retrieval index by construction: never embedded, never in `vec_memories`/`memories_fts`; fetched only by primary key during recall-time parent expansion ("index fine, return coarse"). Each ingested fact's `segment_id` is a FK to `segments`; `memory_store` rows keep `segment_id = NULL`. Segment helpers in `queries.ts`: `insertSegment` (one row per ingest chunk that produced ≥1 fact), `getSegmentsByIds` (batch primary-key fetch for expansion), `updateMemorySegmentIfRicher` (on an ingest merge, repoint the survivor to the parent with the higher `fact_count`).
+- **`SCHEMA_VERSION = '4'`** (`storage/database.ts`). The DB self-heals a stale on-disk schema on open via a NUMERIC version compare: an OLDER stamp is **dropped and recreated** (rebuild, not migrate — old data is deliberately discarded under the back-compat-free directive); a NEWER stamp **throws / fails closed** so an older binary never destroys a DB it can't understand; an unparseable stamp is treated as stale and rebuilt. This is a breaking 0.2.0 change (0.1.x DBs are wiped on first open).
 - **Maintenance pipeline**: consolidation (batch LLM dedup), decay (vitality sampling), compaction (cluster + summarize)
 - Dedup at store: cosine distance < 0.05 merged immediately; distance < 0.3 deferred to consolidation with LLM judgment
 
 ## Configuration
 
 All config via environment variables (prefix `MEMORY_`):
+
 - `MEMORY_NAMESPACE` — isolation namespace (default: `default`)
 - `MEMORY_DB_PATH` — SQLite database path
 - `MEMORY_EMBEDDING_MODEL` — HuggingFace model (default: `Xenova/bge-base-en-v1.5`)
 - `MEMORY_RERANKER_ENABLED` — cross-encoder toggle (default: `true`)
 - `MEMORY_RERANKER_MODEL` — reranker model (default: `Xenova/ms-marco-MiniLM-L-6-v2`)
 - `MEMORY_LLM_MODEL`, `MEMORY_LLM_BASE_URL`, `MEMORY_LLM_API_KEY` — LLM for summarization
-- `MEMORY_DEFAULT_TOKEN_BUDGET` — default recall budget (default: 2000)
+- `MEMORY_DEFAULT_TOKEN_BUDGET` — default recall budget (default: 800)
 
 ## Testing
 
@@ -106,6 +114,7 @@ All config via environment variables (prefix `MEMORY_`):
 ## Benchmark
 
 LoCoMo benchmark (`benchmark/`) evaluates retrieval quality:
+
 - Ingests multi-session conversations, asks factual questions, measures evidence recall/precision
 - Run: `cd benchmark && uv run locomo run --conversation-limit 1 --question-limit 20 --reader-provider anthropic`
 - Results in `benchmark/results/<timestamp>/`

--- a/packages/memory-mcp-server/README.md
+++ b/packages/memory-mcp-server/README.md
@@ -2,6 +2,8 @@
 
 A persistent memory server for LLM agents using the [Model Context Protocol](https://modelcontextprotocol.io/). Provides semantic search, optional LLM summarization, and automatic maintenance — all backed by a single SQLite file.
 
+> **0.2.0 — breaking schema change.** This release bumps the on-disk schema to version `4` (atomic-fact ingestion and parent-context retrieval add a `segments` table and a `segment_id` column). On startup, a database written by an **older** schema is **dropped and rebuilt** rather than migrated, discarding its contents; a database written by a **newer** schema fails closed (the server refuses to open it). Back up or re-ingest any 0.1.x database before upgrading.
+
 ## Why Another Memory Server?
 
 Most memory MCP servers fall into two camps: minimal and infrastructure-heavy. The official `@modelcontextprotocol/server-memory` stores a knowledge graph in a JSON file with substring search only — useful, but limited as memories grow. Mem0, Hindsight, and doobidoo offer semantic search and smart features, but require Python runtimes, Docker containers, or external databases (PostgreSQL, Qdrant, Neo4j).
@@ -9,7 +11,9 @@ Most memory MCP servers fall into two camps: minimal and infrastructure-heavy. T
 This server fills a specific gap: **a TypeScript MCP server with semantic search, LLM summarization, and automatic maintenance that runs from a single SQLite file with zero external dependencies.**
 
 - **Single command, single file** — `npx` to start, one `.db` file to back up. SQLite + sqlite-vec + FTS5 handle storage, vector search, and keyword search in-process.
-- **Works without an LLM, improves with one** — Extractive retrieval, cosine-only dedup, and bullet-point formatting work out of the box. Adding a cheap LLM endpoint (Haiku, Ollama, etc.) enables abstractive summarization, direct question answering, contradiction detection, and smarter consolidation.
+- **Works without an LLM, improves with one** — Extractive retrieval, cosine-only dedup, and bullet-point formatting work out of the box. Adding a cheap LLM endpoint (Haiku, Ollama, etc.) enables abstractive summarization, direct question answering, contradiction detection, smarter consolidation, and atomic-fact extraction from raw blobs (`memory_ingest`).
+- **Atomic-fact decomposition** — `memory_ingest` takes a raw conversation, document, or session summary and uses an LLM to break it into many durable, atomic-fact memories, each individually retrievable — instead of forcing the agent to call `memory_store` once per fact.
+- **Parent-context retrieval ("index fine, return coarse")** — facts are indexed at fine grain, but recall can return the query-ranked source passage a cluster of facts came from (e.g. a contract clause), so the agent gets the surrounding detail, not just thin headlines.
 - **Token-budget-aware responses** — Instead of dumping raw memories into your context window, the server summarizes and packs results to fit a specified token budget. The `memory_context` tool provides a structured session-start briefing — a capability unique to this server.
 
 For a detailed competitive analysis covering 11 memory systems, see [docs/designs/memory-server-comparison.md](../../docs/designs/memory-server-comparison.md).
@@ -19,6 +23,8 @@ For a detailed competitive analysis covering 11 memory systems, see [docs/design
 - **Score-based hybrid fusion** — vector similarity (BGE-base) + FTS5 BM25 keyword search, merged via Weaviate-style relativeScoreFusion with min-max normalized scores blended by alpha weighting. Unlike pure rank-based fusion (used by Letta, Zep, mind-mem, LangChain), score-based fusion retains the discriminating power of both retrieval signals — an approach validated by production search engines (Weaviate, Elasticsearch, Qdrant) and research (Bruch et al. 2023)
 - **Cross-encoder reranking** — ms-marco-MiniLM re-ranks candidates using raw logits with relative gap filtering, improving precision without aggressive cutoffs
 - **Composite scoring** — fusion relevance (incorporating vector + BM25 magnitudes) blended with recency, importance, and access pattern signals
+- **Atomic-fact decomposition** — `memory_ingest` decomposes a raw blob (conversation, document, session summary) into many durable atomic-fact memories via an LLM, each with its own importance; `mode="conversation"` extracts only explicitly stated facts while `mode="document"` allows reasonable inference
+- **Parent-context retrieval ("index fine, return coarse")** — source chunks live in a `segments` table kept OFF the retrieval index; each ingested fact links to its segment, and recall can return the query-ranked source passage when several matched facts share a parent. `memory_expand` fetches a parent passage on demand for the agentic "got a headline → read its source" follow-up
 - **Token-budget-aware retrieval** — returns pre-summarized context blocks sized to fit your context window
 - **Direct question answering** — `format="answer"` synthesizes across retrieved memories to answer questions directly, without a separate reader LLM
 - **SQLite-native, zero external dependencies** — embeddings and reranking run locally in-process; no Postgres, Neo4j, Redis, or Docker required. One `.db` file to back up
@@ -95,22 +101,70 @@ tags       (string[], optional) — For filtering, e.g. ["preference", "project:
 importance (number, optional)   — 0-1 scale, controls decay resistance. Default 0.5.
 ```
 
+### memory_ingest
+
+Decompose a raw blob (conversation, document, or session summary) into many atomic, durable memories via an LLM. Where `memory_store` persists one pre-formed fact, `memory_ingest` extracts many facts from one input — each with its own importance — and links them to the source segment they came from (so recall can later return that source passage).
+
+```
+content              (string, required)   — Raw blob to decompose
+source               (string, optional)   — Provenance stored on each fact, e.g. "session:abc"
+mode                 (string, optional)   — "conversation" (default, strict explicit-only) or
+                                            "document" (allows reasonable inference; better for transcripts)
+tags                 (string[], optional) — Seed tags applied to EVERY extracted fact
+importance           (number, optional)   — 0-1 SEED importance; per-fact importance from the model wins. Default 0.5.
+dry_run              (boolean, optional)  — Run extraction and return the proposed facts WITHOUT writing. Default false.
+                                            (Still calls the LLM; only skips persistence.)
+on_extraction_failure (string, optional)  — When a chunk yields no facts: "degrade" (default — store the
+                                            blob as a single memory), "skip" (write nothing), or "error" (throw)
+as_of                (number|string, opt) — Backdate facts to this time (epoch ms or ISO 8601) instead of now
+```
+
+Example (preview a decomposition without writing):
+
+```
+memory_ingest({ content: "...session transcript...", mode: "document", dry_run: true })
+→ Dry run — nothing written. 3 fact(s) proposed:
+  1. User prefers TypeScript over Python (importance: 0.7)
+  2. Project "foo" deploys via GitHub Actions (importance: 0.6)
+  3. ...
+```
+
 ### memory_recall
 
 Retrieve memories relevant to a query. Returns formatted results within a token budget.
 
 ```
-query        (string, required)   — Natural language query
-token_budget (integer, optional)  — Max tokens in response. Default 500.
-tags         (string[], optional) — Filter to memories with ALL these tags
-format       (string, optional)   — "summary" (default), "list", "raw", or "answer"
+query              (string, required)   — Natural language query
+token_budget       (integer, optional)  — Max tokens in response. Default 800.
+tags               (string[], optional) — Filter to memories with ALL these tags
+format             (string, optional)   — "summary" (default), "list", "raw", or "answer"
+expand             (string, optional)   — "auto" (default), "none", or "parent" — see below
+max_expand_passages (integer, optional) — Max source passages returned across the result. Default 2.
 ```
 
 **Format modes:**
+
 - `summary` — LLM-generated briefing (falls back to extractive clusters without LLM)
 - `list` — Bullet list with dates and importance scores
 - `raw` — Full JSON with all metadata
 - `answer` — LLM answers the query directly by synthesizing across retrieved memories (falls back to `list` without LLM)
+
+**Expand modes (parent-context retrieval):**
+
+- `auto` (default) — when several matched facts share the same source segment (e.g. a contract's clauses), return that segment's query-ranked source passage alongside the facts
+- `none` — strictly pinpoint facts, no source passages
+- `parent` — force the source passage for every matched fact that has one
+
+Alongside the human-readable text, `memory_recall` returns `structuredContent` with `memories_used`, `total_matches`, `expanded` (whether any source passage was returned), and `expanded_segment_ids` — the segment ids an agent can feed to `memory_expand` to drill into a source.
+
+### memory_expand
+
+Fetch the source passage(s) a recalled fact was extracted from, given a `segment_id` surfaced by a prior `memory_recall` (in `expanded_segment_ids`, or a `raw` result's `segment_id`). This is the agentic "I got a headline, give me THIS fact's parent" follow-up.
+
+```
+segment_id (string, required)   — A source segment id from a prior recall
+query      (string, optional)   — Rank the source passages by relevance to this query; omit for the whole source
+```
 
 ### memory_context
 
@@ -154,8 +208,8 @@ limit (integer, optional)   — Max items returned. Default 20.
                │ stdio (JSON-RPC)
 ┌──────────────▼───────────────────────────────────┐
 │  MCP Server (server.ts)                          │
-│  Tool handlers: store, recall, context,          │
-│                 forget, inspect                  │
+│  Tool handlers: store, ingest, recall, expand,   │
+│                 context, forget, inspect         │
 └──────────────┬───────────────────────────────────┘
                │
 ┌──────────────▼───────────────────────────────────┐
@@ -187,9 +241,14 @@ limit (integer, optional)   — Max items returned. Default 20.
 │  ┌────────────┬──────────────┬────────────────┐  │
 │  │  memories   │ vec_memories │  memories_fts  │  │
 │  │  (rows)     │ (768-dim)   │  (BM25 index)  │  │
-│  └────────────┴──────────────┴────────────────┘  │
+│  ├────────────┴──────────────┴────────────────┤  │
+│  │  segments (source chunks, OFF the index —   │  │
+│  │  never embedded, never in vec/FTS)          │  │
+│  └─────────────────────────────────────────────┘  │
 └──────────────────────────────────────────────────┘
 ```
+
+The `segments` table holds the raw source chunks that `memory_ingest` decomposes. It is deliberately kept **off the retrieval index** — segments are never embedded and never appear in `vec_memories` or `memories_fts`; they are fetched only by primary key during recall-time parent expansion. Each ingested fact carries a `segment_id` foreign key back to its source ("index fine, return coarse").
 
 ### Store path
 
@@ -197,6 +256,8 @@ limit (integer, optional)   — Max items returned. Default 20.
 2. Check for near-exact duplicates (cosine distance < 0.05) — auto-merge, no LLM
 3. Insert with `consolidated = false`
 4. Every N stores (default 50), run maintenance which includes batch consolidation
+
+`memory_ingest` reuses this store path per extracted fact, with an extra step in front: the raw blob is chunked, each chunk is sent to the LLM for atomic-fact extraction, one `segments` row is written per chunk that produced ≥1 fact, and every fact from that chunk is stored with its `segment_id` set. (`memory_store` never sets `segment_id`, so its rows stay un-parented.) If extraction yields no facts, `on_extraction_failure` decides whether to degrade to a single-blob store, skip, or throw.
 
 ### Retrieval pipeline
 
@@ -207,7 +268,7 @@ limit (integer, optional)   — Max items returned. Default 20.
 5. **Relevance gating** — drop candidates with fusion score < 5% of max
 6. **Cross-encoder reranking** — ms-marco-MiniLM-L-6-v2 re-scores candidates; relative gap filter (5 logit points from best)
 7. **Deduplication** — remove near-duplicates by embedding cosine similarity
-8. **Token budget packing** — greedily select memories by score until budget is filled (skip, not break)
+8. **Parent expansion + token budget packing** — for `expand="none"` this is a plain greedy budget pack of the kept facts (skip, not break). For `expand="auto"`/`"parent"` a post-dedup step (NOT part of the candidate ranker — it never touches the candidate set, scores, or selection order) groups the kept facts by `segment_id`, fetches each shared segment by primary key, splits-and-ranks its passages against the query embedding, and reserves budget so the single top source passage is guaranteed; additional passages ride leftover budget up to `max_expand_passages`
 9. **Formatting** — `answer` (LLM synthesis), `summary` (LLM briefing), `list` (bullets), or `raw` (JSON)
 
 ### Maintenance (amortized, no background processes)
@@ -220,34 +281,34 @@ limit (integer, optional)   — Max items returned. Default 20.
 
 Every LLM-enhanced feature has an extractive fallback:
 
-| Feature | With LLM | Without LLM |
-|---------|----------|-------------|
-| Recall formatting | Abstractive summary or direct answer | Extractive bullet list |
-| Dedup on store | Exact-match heuristic only | Same (LLM dedup deferred to consolidation) |
-| Consolidation | Batch LLM judgment | Mark all as consolidated |
-| Compaction | LLM-generated summaries | Skip compaction |
-| Contradiction detection | LLM classification | Only exact-match merging |
+| Feature                 | With LLM                             | Without LLM                                |
+| ----------------------- | ------------------------------------ | ------------------------------------------ |
+| Recall formatting       | Abstractive summary or direct answer | Extractive bullet list                     |
+| Dedup on store          | Exact-match heuristic only           | Same (LLM dedup deferred to consolidation) |
+| Consolidation           | Batch LLM judgment                   | Mark all as consolidated                   |
+| Compaction              | LLM-generated summaries              | Skip compaction                            |
+| Contradiction detection | LLM classification                   | Only exact-match merging                   |
 
 ## Configuration
 
 All settings are controlled via environment variables:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MEMORY_DB_PATH` | `~/.local/share/memory-mcp/default.db` | SQLite database path |
-| `MEMORY_NAMESPACE` | `default` | Namespace for memory isolation |
-| `MEMORY_EMBEDDING_MODEL` | `Xenova/bge-base-en-v1.5` | HuggingFace embedding model |
-| `MEMORY_EMBEDDING_DTYPE` | `q8` | Model quantization (q8, fp16, fp32) |
-| `MEMORY_RERANKER_ENABLED` | `true` | Enable cross-encoder reranking |
-| `MEMORY_RERANKER_MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | HuggingFace reranker model |
-| `MEMORY_LLM_API_KEY` | *(none)* | API key for LLM (enables enhanced features) |
-| `MEMORY_LLM_BASE_URL` | *(none)* | OpenAI-compatible endpoint (must support `/v1/chat/completions`) |
-| `MEMORY_LLM_MODEL` | `claude-haiku-4-5-20251001` | LLM model name |
-| `MEMORY_DEFAULT_TOKEN_BUDGET` | `500` | Default token budget for recall |
-| `MEMORY_MAINTENANCE_INTERVAL` | `50` | Stores between maintenance passes |
-| `MEMORY_DECAY_THRESHOLD` | `0.05` | Vitality below which memories decay |
-| `MEMORY_COMPACTION_MIN_GROUP` | `10` | Min decayed memories before compaction |
-| `MEMORY_CONSOLIDATION_BATCH_SIZE` | `50` | Max memories per consolidation pass |
+| Variable                          | Default                                | Description                                                      |
+| --------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| `MEMORY_DB_PATH`                  | `~/.local/share/memory-mcp/default.db` | SQLite database path                                             |
+| `MEMORY_NAMESPACE`                | `default`                              | Namespace for memory isolation                                   |
+| `MEMORY_EMBEDDING_MODEL`          | `Xenova/bge-base-en-v1.5`              | HuggingFace embedding model                                      |
+| `MEMORY_EMBEDDING_DTYPE`          | `q8`                                   | Model quantization (q8, fp16, fp32)                              |
+| `MEMORY_RERANKER_ENABLED`         | `true`                                 | Enable cross-encoder reranking                                   |
+| `MEMORY_RERANKER_MODEL`           | `Xenova/ms-marco-MiniLM-L-6-v2`        | HuggingFace reranker model                                       |
+| `MEMORY_LLM_API_KEY`              | _(none)_                               | API key for LLM (enables enhanced features)                      |
+| `MEMORY_LLM_BASE_URL`             | _(none)_                               | OpenAI-compatible endpoint (must support `/v1/chat/completions`) |
+| `MEMORY_LLM_MODEL`                | `claude-haiku-4-5-20251001`            | LLM model name                                                   |
+| `MEMORY_DEFAULT_TOKEN_BUDGET`     | `800`                                  | Default token budget for recall                                  |
+| `MEMORY_MAINTENANCE_INTERVAL`     | `50`                                   | Stores between maintenance passes                                |
+| `MEMORY_DECAY_THRESHOLD`          | `0.05`                                 | Vitality below which memories decay                              |
+| `MEMORY_COMPACTION_MIN_GROUP`     | `10`                                   | Min decayed memories before compaction                           |
+| `MEMORY_CONSOLIDATION_BATCH_SIZE` | `50`                                   | Max memories per consolidation pass                              |
 
 ## Agent Integration
 

--- a/packages/memory-mcp-server/package.json
+++ b/packages/memory-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provos/memory-mcp-server",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "Persistent memory MCP server with semantic search, LLM summarization, and automatic compaction",
   "license": "Apache-2.0",
@@ -18,7 +18,9 @@
     ".": "./dist/index.js",
     "./prompts": "./dist/prompts.js"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/memory-mcp-server/src/config.ts
+++ b/packages/memory-mcp-server/src/config.ts
@@ -67,7 +67,7 @@ export function loadConfig(env: EnvSource = process.env): MemoryConfig {
 
     consolidationBatchSize: envInt(env, 'MEMORY_CONSOLIDATION_BATCH_SIZE', 50),
 
-    defaultTokenBudget: envInt(env, 'MEMORY_DEFAULT_TOKEN_BUDGET', 500),
+    defaultTokenBudget: envInt(env, 'MEMORY_DEFAULT_TOKEN_BUDGET', 800),
 
     rerankerModel: env.MEMORY_RERANKER_MODEL ?? 'Xenova/ms-marco-MiniLM-L-6-v2',
     rerankerEnabled: env.MEMORY_RERANKER_ENABLED !== 'false',

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -166,7 +166,7 @@ async function extractAllFacts(
  * Decompose a blob into atomic-fact memories via the LLM, writing each fact
  * through the existing `store` pipeline. PII-safe: never logs raw content.
  */
-async function ingestBlob(
+export async function ingestBlob(
   db: Database.Database,
   config: MemoryConfig,
   content: string,

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -148,7 +148,9 @@ async function extractAllFacts(
 
   for (const chunk of chunks) {
     const chunkFacts = await extractFacts(config, chunk, mode);
-    if (chunkFacts === null || chunkFacts.length === 0) {
+    // Only `null` is a real failure (no LLM / hard-fail / unparseable). An empty
+    // array means the model validly found nothing durable — not a failed chunk.
+    if (chunkFacts === null) {
       failedChunks += 1;
       continue;
     }
@@ -186,17 +188,33 @@ export async function ingestBlob(
       createdAt,
     });
 
+  // Shared shape for the "nothing written" returns (clean-empty and skip).
+  const emptyResult = (extra?: Partial<IngestResult>): IngestResult => ({
+    created: 0,
+    merged: 0,
+    memory_ids: [],
+    facts: [],
+    ...extra,
+  });
+
   const chunks = chunkBlob(content);
   const { facts, totalChunks, failedChunks } = await extractAllFacts(config, chunks, mode);
   const multiChunk = totalChunks > 1;
 
-  // ---- All chunks failed (no LLM / hard failure / unparseable everywhere) ----
+  // ---- Empty fact union ----
   if (facts.length === 0) {
+    // No failures, just nothing durable: extraction SUCCEEDED and the model
+    // reported no durable facts. Write nothing and report a clean empty ingest —
+    // this is not a failure, so it never triggers the degrade/skip/error path.
+    if (failedChunks === 0) {
+      return emptyResult();
+    }
+    // Real failures produced no usable facts → on_extraction_failure path.
     if (onFailure === 'error') {
       throw new Error(`memory_ingest: extraction produced no facts (${failedChunks}/${totalChunks} chunks failed)`);
     }
     if (onFailure === 'skip') {
-      return { created: 0, merged: 0, ingested: 0, memory_ids: [], facts: [], skipped: true };
+      return emptyResult({ skipped: true });
     }
     // 'degrade': store the blob as a single memory (product behavior).
     const truncated = content.length > MAX_CONTENT_LENGTH ? content.slice(0, MAX_CONTENT_LENGTH) : content;
@@ -204,7 +222,6 @@ export async function ingestBlob(
       return {
         created: 0,
         merged: 0,
-        ingested: 0,
         memory_ids: [],
         facts: [{ fact: truncated, importance: seedImportance }],
         degraded: true,
@@ -214,7 +231,6 @@ export async function ingestBlob(
     return {
       created: 1,
       merged: 0,
-      ingested: 1,
       memory_ids: [result.id],
       facts: [{ fact: truncated, importance: seedImportance }],
       degraded: true,
@@ -229,7 +245,7 @@ export async function ingestBlob(
 
   // ---- Dry run: preview without writing ----
   if (dryRun) {
-    return { created: 0, merged: 0, ingested: 0, memory_ids: [], facts, ...diagnostics };
+    return { created: 0, merged: 0, memory_ids: [], facts, ...diagnostics };
   }
 
   // ---- Write each fact through the existing store pipeline ----
@@ -246,7 +262,7 @@ export async function ingestBlob(
     }
   }
 
-  return { created, merged, ingested: created, memory_ids: memoryIds, facts, ...diagnostics };
+  return { created, merged, memory_ids: memoryIds, facts, ...diagnostics };
 }
 
 // ---------- Context ----------

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -38,8 +38,9 @@ import {
   updateAccessStats,
 } from './storage/queries.js';
 import { maybeRunMaintenance, runMaintenance } from './storage/maintenance.js';
-import { embed, embedQuery, cosineSimilarity } from './embedding/embedder.js';
+import { embed, embedQuery } from './embedding/embedder.js';
 import { recall as retrievalRecall } from './retrieval/pipeline.js';
+import { rankSegmentPassages } from './retrieval/expansion.js';
 import { estimateTokens } from './retrieval/scoring.js';
 import { EXACT_DEDUP_DISTANCE } from './storage/constants.js';
 import { MAX_CONTENT_LENGTH } from './tools/validation.js';
@@ -340,24 +341,17 @@ async function expandSegment(
   }
   const segment = segments[0];
 
-  const passages = splitToPassages(segment.content);
-  if (passages.length === 0) {
-    return { segment_id: segmentId, passages: [], found: true };
-  }
-
+  // No query: return the first few passages of the segment (whole-segment fetch).
   if (query === undefined) {
+    const passages = splitToPassages(segment.content);
     return { segment_id: segmentId, passages: passages.slice(0, MAX_EXPAND_PASSAGES_NO_QUERY), found: true };
   }
 
+  // With a query: split-and-rank by similarity to the query embedding (the shared helper,
+  // also used by recall expansion). All passages, best-first.
   const queryEmbedding = await embedQuery(query, config);
-  const scored: Array<{ passage: string; sim: number }> = [];
-  for (const passage of passages) {
-    const passageEmbedding = await embed(passage, config);
-    scored.push({ passage, sim: cosineSimilarity(passageEmbedding, queryEmbedding) });
-  }
-  scored.sort((a, b) => b.sim - a.sim);
-
-  return { segment_id: segmentId, passages: scored.map((s) => s.passage), found: true };
+  const passages = await rankSegmentPassages(config, segment.content, queryEmbedding);
+  return { segment_id: segmentId, passages, found: true };
 }
 
 // ---------- Context ----------

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -14,6 +14,7 @@ import type {
   InspectOptions,
   Memory,
   MemoryStats,
+  ExpandResult,
 } from './types.js';
 import type { MemoryConfig } from './config.js';
 import type { MemoryRow } from './storage/database.js';
@@ -21,8 +22,11 @@ import { initDatabase } from './storage/database.js';
 import {
   generateId,
   insertMemory,
+  insertSegment,
+  getSegmentsByIds,
   updateMemoryContent,
   updateMemoryTimestampsOnMerge,
+  updateMemorySegmentIfRicher,
   vectorSearch,
   deleteMemories,
   findMemoriesByTags,
@@ -34,15 +38,18 @@ import {
   updateAccessStats,
 } from './storage/queries.js';
 import { maybeRunMaintenance, runMaintenance } from './storage/maintenance.js';
-import { embed, embedQuery } from './embedding/embedder.js';
+import { embed, embedQuery, cosineSimilarity } from './embedding/embedder.js';
 import { recall as retrievalRecall } from './retrieval/pipeline.js';
 import { estimateTokens } from './retrieval/scoring.js';
 import { EXACT_DEDUP_DISTANCE } from './storage/constants.js';
 import { MAX_CONTENT_LENGTH } from './tools/validation.js';
-import { chunkBlob, extractFacts } from './storage/extraction.js';
+import { chunkBlob, extractFacts, splitToPassages } from './storage/extraction.js';
 import type { ExtractedFact, IngestMode } from './storage/extraction.js';
 import { parseTags } from './utils/tags.js';
 import type Database from 'better-sqlite3';
+
+/** Cap on whole-segment passages returned by `memory_expand` when no query is given. */
+const MAX_EXPAND_PASSAGES_NO_QUERY = 3;
 
 // ---------- Row <-> Memory conversion ----------
 
@@ -71,6 +78,7 @@ function rowToMemory(row: MemoryRow): Memory {
       ((safeParseJson(row.metadata) as Record<string, unknown> | null)?.compacted_from as string[] | undefined) ?? null,
     source: row.source,
     metadata: safeParseJson(row.metadata) as Record<string, unknown> | null,
+    segment_id: row.segment_id,
   };
 }
 
@@ -104,6 +112,11 @@ async function storeImmediate(
     if (opts.createdAt !== undefined) {
       updateMemoryTimestampsOnMerge(db, namespace, exactMatch.id, opts.createdAt);
     }
+    // Repoint the survivor to the RICHER parent (A4). Only runs when an ingest
+    // segmentId is present; store-path merges (no segmentId) are unchanged.
+    if (opts.segmentId !== undefined) {
+      updateMemorySegmentIfRicher(db, namespace, exactMatch.id, opts.segmentId);
+    }
     return { id: exactMatch.id, action: 'merged_duplicate' };
   }
 
@@ -120,6 +133,7 @@ async function storeImmediate(
       source: opts.source,
       consolidated: false,
       createdAt: opts.createdAt,
+      segmentId: opts.segmentId,
     },
     embedding,
   );
@@ -132,18 +146,26 @@ async function storeImmediate(
 
 const DEFAULT_SEED_IMPORTANCE = 0.5;
 
+/** One source chunk and the facts extracted from it (the chunk→fact mapping). */
+interface ChunkGroup {
+  chunkText: string;
+  facts: ExtractedFact[];
+}
+
 /**
- * Extract facts from each chunk and union them, dropping exact-`fact`-string
- * duplicates across windows (first occurrence keeps its importance). Tracks how
- * many chunks returned null/[] for diagnostics (A3).
+ * Extract facts per chunk, KEEPING the chunk→fact mapping so each fact can be
+ * linked to its source segment (§6.1). Exact-`fact`-string duplicates across
+ * windows are still dropped, but the dedup keeps the FIRST occurrence — so a fact
+ * deduped away in a later chunk stays attached to its first chunk's group (no
+ * second parent link). Tracks how many chunks returned null for diagnostics (A3).
  */
 async function extractAllFacts(
   config: MemoryConfig,
   chunks: string[],
   mode: IngestMode,
-): Promise<{ facts: ExtractedFact[]; totalChunks: number; failedChunks: number }> {
+): Promise<{ groups: ChunkGroup[]; totalChunks: number; failedChunks: number }> {
   const seen = new Set<string>();
-  const facts: ExtractedFact[] = [];
+  const groups: ChunkGroup[] = [];
   let failedChunks = 0;
 
   for (const chunk of chunks) {
@@ -154,14 +176,21 @@ async function extractAllFacts(
       failedChunks += 1;
       continue;
     }
+    const ownedFacts: ExtractedFact[] = [];
     for (const fact of chunkFacts) {
-      if (seen.has(fact.fact)) continue;
+      if (seen.has(fact.fact)) continue; // already owned by an earlier chunk's group
       seen.add(fact.fact);
-      facts.push(fact);
+      ownedFacts.push(fact);
     }
+    groups.push({ chunkText: chunk, facts: ownedFacts });
   }
 
-  return { facts, totalChunks: chunks.length, failedChunks };
+  return { groups, totalChunks: chunks.length, failedChunks };
+}
+
+/** Flatten the per-chunk groups back to a single fact list (for diagnostics/preview). */
+function flattenGroups(groups: ChunkGroup[]): ExtractedFact[] {
+  return groups.flatMap((g) => g.facts);
 }
 
 /**
@@ -180,12 +209,13 @@ export async function ingestBlob(
   const createdAt = opts.as_of;
   const dryRun = opts.dry_run ?? false;
 
-  const store = (factContent: string, importance: number): Promise<StoreResult> =>
+  const store = (factContent: string, importance: number, segmentId?: string): Promise<StoreResult> =>
     storeImmediate(db, config, factContent, {
       tags: opts.tags,
       importance,
       source: opts.source,
       createdAt,
+      segmentId,
     });
 
   // Shared shape for the "nothing written" returns (clean-empty and skip).
@@ -198,7 +228,8 @@ export async function ingestBlob(
   });
 
   const chunks = chunkBlob(content);
-  const { facts, totalChunks, failedChunks } = await extractAllFacts(config, chunks, mode);
+  const { groups, totalChunks, failedChunks } = await extractAllFacts(config, chunks, mode);
+  const facts = flattenGroups(groups);
   const multiChunk = totalChunks > 1;
 
   // ---- Empty fact union ----
@@ -248,21 +279,85 @@ export async function ingestBlob(
     return { created: 0, merged: 0, memory_ids: [], facts, ...diagnostics };
   }
 
-  // ---- Write each fact through the existing store pipeline ----
+  // ---- Write one segment per non-empty chunk-group, then link its facts ----
   let created = 0;
   let merged = 0;
+  let segmentsCreated = 0;
   const memoryIds: string[] = [];
-  for (const fact of facts) {
-    const result = await store(fact.fact, fact.importance ?? seedImportance);
-    memoryIds.push(result.id);
-    if (result.action === 'created') {
-      created += 1;
-    } else {
-      merged += 1;
+  for (const group of groups) {
+    if (group.facts.length === 0) continue;
+
+    // One source segment per chunk that produced ≥1 fact. createdAt flows to both
+    // the segment and its facts so a segment's created_at matches its facts'.
+    const segmentId = insertSegment(db, {
+      namespace: config.namespace,
+      content: group.chunkText,
+      source: opts.source,
+      mode,
+      createdAt,
+      factCount: group.facts.length,
+    });
+    segmentsCreated += 1;
+
+    for (const fact of group.facts) {
+      const result = await store(fact.fact, fact.importance ?? seedImportance, segmentId);
+      memoryIds.push(result.id);
+      if (result.action === 'created') {
+        created += 1;
+      } else {
+        merged += 1;
+      }
     }
   }
 
-  return { created, merged, memory_ids: memoryIds, facts, ...diagnostics };
+  return {
+    created,
+    merged,
+    memory_ids: memoryIds,
+    facts,
+    ...diagnostics,
+    ...(segmentsCreated > 0 ? { segments_created: segmentsCreated } : {}),
+  };
+}
+
+// ---------- Expand (on-demand parent fetch) ----------
+
+/**
+ * Fetch a source segment by id and return its query-ranked passages (§9.4). With a
+ * `query`, passages are ranked by cosine similarity to the query embedding; without
+ * one, the first few passages of the segment are returned (whole-segment fetch). A
+ * missing/forgotten segment returns `{ found: false, passages: [] }`.
+ */
+async function expandSegment(
+  db: Database.Database,
+  config: MemoryConfig,
+  segmentId: string,
+  query?: string,
+): Promise<ExpandResult> {
+  const segments = getSegmentsByIds(db, config.namespace, [segmentId]);
+  if (segments.length === 0) {
+    return { segment_id: segmentId, passages: [], found: false };
+  }
+  const segment = segments[0];
+
+  const passages = splitToPassages(segment.content);
+  if (passages.length === 0) {
+    return { segment_id: segmentId, passages: [], found: true };
+  }
+
+  if (query === undefined) {
+    return { segment_id: segmentId, passages: passages.slice(0, MAX_EXPAND_PASSAGES_NO_QUERY), found: true };
+  }
+
+  const queryEmbedding = await embedQuery(query, config);
+  const scored: Array<{ passage: string; sim: number }> = [];
+  for (const passage of passages) {
+    const passageEmbedding = await embed(passage, config);
+    scored.push({ passage, sim: cosineSimilarity(passageEmbedding, queryEmbedding) });
+  }
+  scored.sort((a, b) => b.sim - a.sim);
+
+  return { segment_id: segmentId, passages: scored.map((s) => s.passage), found: true };
 }
 
 // ---------- Context ----------
@@ -280,6 +375,9 @@ async function buildContext(db: Database.Database, config: MemoryConfig, opts: C
       query: opts.task,
       token_budget: Math.floor(totalBudget * CONTEXT_TASK_BUDGET_FRACTION),
       format: 'summary',
+      // The no-human-in-loop briefing path is where missing a clause is most costly,
+      // so it gets the same auto-expansion as a default recall (§5.2).
+      expand: 'auto',
     });
     if (taskResult.memoryIds.length > 0) {
       sections.push(`## Task-Relevant Context\n\n${taskResult.text}`);
@@ -457,12 +555,16 @@ export function createMemoryEngineFromConfig(config: MemoryConfig): MemoryEngine
         token_budget: opts.token_budget ?? config.defaultTokenBudget,
         tags: opts.tags,
         format: opts.format ?? 'summary',
+        expand: opts.expand ?? 'auto',
+        max_expand_passages: opts.max_expand_passages,
       });
 
       return {
         content: result.text,
         memories_used: result.selectedCount,
         total_matches: result.totalCandidates,
+        expanded: result.expanded,
+        expanded_segment_ids: result.expandedSegmentIds,
       };
     },
 
@@ -476,6 +578,10 @@ export function createMemoryEngineFromConfig(config: MemoryConfig): MemoryEngine
 
     inspect(opts: InspectOptions): Promise<MemoryStats | Memory[] | string> {
       return Promise.resolve(inspectMemories(db, config, opts));
+    },
+
+    async expand(segmentId: string, query?: string): Promise<ExpandResult> {
+      return expandSegment(db, config, segmentId, query);
     },
 
     close(): void {
@@ -494,6 +600,7 @@ export interface EngineModules {
   context(opts: ContextOptions): Promise<string>;
   forget(opts: ForgetOptions): Promise<ForgetResult>;
   inspect(opts: InspectOptions): Promise<MemoryStats | Memory[] | string>;
+  expand(segmentId: string, query?: string): Promise<ExpandResult>;
   close(): void;
 }
 
@@ -505,6 +612,7 @@ export function createMemoryEngine(modules: EngineModules): MemoryEngine {
     context: (...args) => modules.context(...args),
     forget: (...args) => modules.forget(...args),
     inspect: (...args) => modules.inspect(...args),
+    expand: (...args) => modules.expand(...args),
     close: () => modules.close(),
   };
 }

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -2,9 +2,10 @@
  * MemoryEngine implementation that wires together the engine modules.
  */
 
-import type { MemoryEngine, StoreOptions } from './engine.js';
+import type { MemoryEngine, StoreOptions, IngestOptions } from './engine.js';
 import type {
   StoreResult,
+  IngestResult,
   RecallOptions,
   RecallResult,
   ContextOptions,
@@ -21,6 +22,7 @@ import {
   generateId,
   insertMemory,
   updateMemoryContent,
+  updateMemoryTimestampsOnMerge,
   vectorSearch,
   deleteMemories,
   findMemoriesByTags,
@@ -36,6 +38,9 @@ import { embed, embedQuery } from './embedding/embedder.js';
 import { recall as retrievalRecall } from './retrieval/pipeline.js';
 import { estimateTokens } from './retrieval/scoring.js';
 import { EXACT_DEDUP_DISTANCE } from './storage/constants.js';
+import { MAX_CONTENT_LENGTH } from './tools/validation.js';
+import { chunkBlob, extractFacts } from './storage/extraction.js';
+import type { ExtractedFact, IngestMode } from './storage/extraction.js';
 import { parseTags } from './utils/tags.js';
 import type Database from 'better-sqlite3';
 
@@ -94,6 +99,11 @@ async function storeImmediate(
     const mergedTags = [...new Set([...existingTags, ...newTags])];
 
     updateMemoryContent(db, namespace, exactMatch.id, content, embedding, importance, exactMatch.content, mergedTags);
+    // Order-independent timestamp reconciliation for backdated (`as_of`) merges (A1).
+    // Only runs when createdAt is set; non-`as_of` merges are byte-for-byte unchanged.
+    if (opts.createdAt !== undefined) {
+      updateMemoryTimestampsOnMerge(db, namespace, exactMatch.id, opts.createdAt);
+    }
     return { id: exactMatch.id, action: 'merged_duplicate' };
   }
 
@@ -107,13 +117,136 @@ async function storeImmediate(
       content,
       tags: opts.tags,
       importance,
+      source: opts.source,
       consolidated: false,
+      createdAt: opts.createdAt,
     },
     embedding,
   );
 
   await maybeRunMaintenance(db, config);
   return { id, action: 'created' };
+}
+
+// ---------- Ingest (LLM-backed fact decomposition) ----------
+
+const DEFAULT_SEED_IMPORTANCE = 0.5;
+
+/**
+ * Extract facts from each chunk and union them, dropping exact-`fact`-string
+ * duplicates across windows (first occurrence keeps its importance). Tracks how
+ * many chunks returned null/[] for diagnostics (A3).
+ */
+async function extractAllFacts(
+  config: MemoryConfig,
+  chunks: string[],
+  mode: IngestMode,
+): Promise<{ facts: ExtractedFact[]; totalChunks: number; failedChunks: number }> {
+  const seen = new Set<string>();
+  const facts: ExtractedFact[] = [];
+  let failedChunks = 0;
+
+  for (const chunk of chunks) {
+    const chunkFacts = await extractFacts(config, chunk, mode);
+    if (chunkFacts === null || chunkFacts.length === 0) {
+      failedChunks += 1;
+      continue;
+    }
+    for (const fact of chunkFacts) {
+      if (seen.has(fact.fact)) continue;
+      seen.add(fact.fact);
+      facts.push(fact);
+    }
+  }
+
+  return { facts, totalChunks: chunks.length, failedChunks };
+}
+
+/**
+ * Decompose a blob into atomic-fact memories via the LLM, writing each fact
+ * through the existing `store` pipeline. PII-safe: never logs raw content.
+ */
+async function ingestBlob(
+  db: Database.Database,
+  config: MemoryConfig,
+  content: string,
+  opts: IngestOptions,
+): Promise<IngestResult> {
+  const seedImportance = opts.importance ?? DEFAULT_SEED_IMPORTANCE;
+  const mode: IngestMode = opts.mode ?? 'conversation';
+  const onFailure = opts.on_extraction_failure ?? 'degrade';
+  const createdAt = opts.as_of;
+  const dryRun = opts.dry_run ?? false;
+
+  const store = (factContent: string, importance: number): Promise<StoreResult> =>
+    storeImmediate(db, config, factContent, {
+      tags: opts.tags,
+      importance,
+      source: opts.source,
+      createdAt,
+    });
+
+  const chunks = chunkBlob(content);
+  const { facts, totalChunks, failedChunks } = await extractAllFacts(config, chunks, mode);
+  const multiChunk = totalChunks > 1;
+
+  // ---- All chunks failed (no LLM / hard failure / unparseable everywhere) ----
+  if (facts.length === 0) {
+    if (onFailure === 'error') {
+      throw new Error(`memory_ingest: extraction produced no facts (${failedChunks}/${totalChunks} chunks failed)`);
+    }
+    if (onFailure === 'skip') {
+      return { created: 0, merged: 0, ingested: 0, memory_ids: [], facts: [], skipped: true };
+    }
+    // 'degrade': store the blob as a single memory (product behavior).
+    const truncated = content.length > MAX_CONTENT_LENGTH ? content.slice(0, MAX_CONTENT_LENGTH) : content;
+    if (dryRun) {
+      return {
+        created: 0,
+        merged: 0,
+        ingested: 0,
+        memory_ids: [],
+        facts: [{ fact: truncated, importance: seedImportance }],
+        degraded: true,
+      };
+    }
+    const result = await store(truncated, seedImportance);
+    return {
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: [result.id],
+      facts: [{ fact: truncated, importance: seedImportance }],
+      degraded: true,
+    };
+  }
+
+  const partial = failedChunks > 0;
+  const diagnostics: Pick<IngestResult, 'chunks' | 'failed_chunks' | 'degraded' | 'partial'> = {
+    ...(multiChunk ? { chunks: totalChunks } : {}),
+    ...(partial ? { failed_chunks: failedChunks, degraded: true, partial: true } : {}),
+  };
+
+  // ---- Dry run: preview without writing ----
+  if (dryRun) {
+    return { created: 0, merged: 0, ingested: 0, memory_ids: [], facts, ...diagnostics };
+  }
+
+  // ---- Write each fact through the existing store pipeline ----
+  let created = 0;
+  let merged = 0;
+  const memoryIds: string[] = [];
+  for (const fact of facts) {
+    const result = await store(fact.fact, fact.importance ?? seedImportance);
+    memoryIds.push(result.id);
+    if (result.action === 'created') {
+      created += 1;
+    } else {
+      merged += 1;
+    }
+  }
+
+  return { created, merged, ingested: created, memory_ids: memoryIds, facts, ...diagnostics };
 }
 
 // ---------- Context ----------
@@ -298,6 +431,10 @@ export function createMemoryEngineFromConfig(config: MemoryConfig): MemoryEngine
       return storeImmediate(db, config, content, opts);
     },
 
+    async ingest(content: string, opts: IngestOptions): Promise<IngestResult> {
+      return ingestBlob(db, config, content, opts);
+    },
+
     async recall(opts: RecallOptions): Promise<RecallResult> {
       const result = await retrievalRecall(db, config, {
         query: opts.query,
@@ -336,6 +473,7 @@ export function createMemoryEngineFromConfig(config: MemoryConfig): MemoryEngine
  */
 export interface EngineModules {
   store(content: string, opts: StoreOptions): Promise<StoreResult>;
+  ingest(content: string, opts: IngestOptions): Promise<IngestResult>;
   recall(opts: RecallOptions): Promise<RecallResult>;
   context(opts: ContextOptions): Promise<string>;
   forget(opts: ForgetOptions): Promise<ForgetResult>;
@@ -346,6 +484,7 @@ export interface EngineModules {
 export function createMemoryEngine(modules: EngineModules): MemoryEngine {
   return {
     store: (...args) => modules.store(...args),
+    ingest: (...args) => modules.ingest(...args),
     recall: (...args) => modules.recall(...args),
     context: (...args) => modules.context(...args),
     forget: (...args) => modules.forget(...args),

--- a/packages/memory-mcp-server/src/engine-impl.ts
+++ b/packages/memory-mcp-server/src/engine-impl.ts
@@ -260,9 +260,11 @@ export async function ingestBlob(
       };
     }
     const result = await store(truncated, seedImportance);
+    // The degraded blob can exact-dedup into an existing memory; report the real action.
+    const created = result.action === 'created' ? 1 : 0;
     return {
-      created: 1,
-      merged: 0,
+      created,
+      merged: 1 - created,
       memory_ids: [result.id],
       facts: [{ fact: truncated, importance: seedImportance }],
       degraded: true,

--- a/packages/memory-mcp-server/src/engine.ts
+++ b/packages/memory-mcp-server/src/engine.ts
@@ -15,6 +15,7 @@ import type {
   InspectOptions,
   Memory,
   MemoryStats,
+  ExpandResult,
 } from './types.js';
 
 export interface StoreOptions {
@@ -27,6 +28,11 @@ export interface StoreOptions {
    * value at insert time (the `as_of` backdate mechanism). Absent ⇒ Date.now().
    */
   createdAt?: number;
+  /**
+   * FK to the source segment. Set ONLY by `ingest`; the LLM-free `store` path
+   * never sets it, so its rows keep `segment_id = NULL`.
+   */
+  segmentId?: string;
 }
 
 export interface IngestOptions {
@@ -49,5 +55,11 @@ export interface MemoryEngine {
   context(opts: ContextOptions): Promise<string>;
   forget(opts: ForgetOptions): Promise<ForgetResult>;
   inspect(opts: InspectOptions): Promise<MemoryStats | Memory[] | string>;
+  /**
+   * Fetch a source segment's query-ranked passages on demand (the agentic
+   * "I got a headline, give me THIS fact's parent" follow-up, §9.4). With no
+   * `query`, returns the whole segment's passages up to a cap.
+   */
+  expand(segmentId: string, query?: string): Promise<ExpandResult>;
   close(): void;
 }

--- a/packages/memory-mcp-server/src/engine.ts
+++ b/packages/memory-mcp-server/src/engine.ts
@@ -6,6 +6,7 @@
 
 import type {
   StoreResult,
+  IngestResult,
   RecallOptions,
   RecallResult,
   ContextOptions,
@@ -19,10 +20,31 @@ import type {
 export interface StoreOptions {
   tags?: string[];
   importance?: number;
+  /** Provenance stamped on the row. The insert path already supports `source`. */
+  source?: string;
+  /**
+   * Epoch ms. When set, stamps created_at/updated_at/last_accessed_at to this
+   * value at insert time (the `as_of` backdate mechanism). Absent ⇒ Date.now().
+   */
+  createdAt?: number;
+}
+
+export interface IngestOptions {
+  source?: string;
+  mode?: 'conversation' | 'document';
+  tags?: string[];
+  /** SEED importance; per-fact importance from extraction overrides it. */
+  importance?: number;
+  dry_run?: boolean;
+  /** Normalized to epoch ms by the handler before reaching the engine. */
+  as_of?: number;
+  /** How to handle a chunk/call that yields no facts. Default 'degrade'. */
+  on_extraction_failure?: 'degrade' | 'skip' | 'error';
 }
 
 export interface MemoryEngine {
   store(content: string, opts: StoreOptions): Promise<StoreResult>;
+  ingest(content: string, opts: IngestOptions): Promise<IngestResult>;
   recall(opts: RecallOptions): Promise<RecallResult>;
   context(opts: ContextOptions): Promise<string>;
   forget(opts: ForgetOptions): Promise<ForgetResult>;

--- a/packages/memory-mcp-server/src/llm/client.ts
+++ b/packages/memory-mcp-server/src/llm/client.ts
@@ -1,6 +1,27 @@
 import OpenAI from 'openai';
 import type { MemoryConfig } from '../config.js';
 
+/**
+ * Describe an LLM error as a CONTENT-FREE shape for logging.
+ *
+ * The OpenAI SDK error embeds the request body (= the prompt, which for
+ * `memory_ingest` is raw sensitive content) and/or the response body in its
+ * `.message`, so we log ONLY the error name plus any numeric status/code — never
+ * the message, the request, or the response. Used by every llmComplete caller
+ * (extraction, compaction, consolidation), so the guarantee holds package-wide.
+ */
+function describeLlmError(err: unknown): string {
+  if (err instanceof Error) {
+    const parts = [err.name];
+    const withFields = err as { status?: unknown; code?: unknown };
+    if (typeof withFields.status === 'number') parts.push(`status=${withFields.status}`);
+    if (typeof withFields.code === 'number') parts.push(`code=${withFields.code}`);
+    return parts.join(' ');
+  }
+  // Non-Error throw: report only its primitive type, never its serialized value.
+  return `non-error throw (${typeof err})`;
+}
+
 let llmClient: OpenAI | null = null;
 let clientConfig: { baseUrl: string | null; apiKey: string | null } | null = null;
 
@@ -54,7 +75,9 @@ export async function llmComplete(
     });
     return response.choices[0]?.message?.content ?? null;
   } catch (err) {
-    console.error('[memory-server] LLM call failed:', err);
+    // PII-safe: log a content-free error shape only — the SDK error can embed the
+    // prompt/response body, which for memory_ingest is raw sensitive content.
+    console.error('[memory-server] LLM call failed:', describeLlmError(err));
     return null;
   }
 }

--- a/packages/memory-mcp-server/src/llm/client.ts
+++ b/packages/memory-mcp-server/src/llm/client.ts
@@ -6,16 +6,22 @@ import type { MemoryConfig } from '../config.js';
  *
  * The OpenAI SDK error embeds the request body (= the prompt, which for
  * `memory_ingest` is raw sensitive content) and/or the response body in its
- * `.message`, so we log ONLY the error name plus any numeric status/code — never
- * the message, the request, or the response. Used by every llmComplete caller
- * (extraction, compaction, consolidation), so the guarantee holds package-wide.
+ * `.message`, so we log ONLY the error name, the numeric status, and the short
+ * enum-like `code` (e.g. "invalid_api_key") — never the message, the request, or
+ * the response. Used by every llmComplete caller (extraction, compaction,
+ * consolidation), so the guarantee holds package-wide.
  */
 function describeLlmError(err: unknown): string {
   if (err instanceof Error) {
     const parts = [err.name];
     const withFields = err as { status?: unknown; code?: unknown };
     if (typeof withFields.status === 'number') parts.push(`status=${withFields.status}`);
-    if (typeof withFields.code === 'number') parts.push(`code=${withFields.code}`);
+    // `code` is a short enum-like string (e.g. "invalid_api_key") or a number —
+    // content-free either way. Bound the string length as a defensive guard
+    // against a pathological SDK that stuffs response content into it.
+    const code = withFields.code;
+    if (typeof code === 'number') parts.push(`code=${code}`);
+    else if (typeof code === 'string' && code.length > 0 && code.length <= 40) parts.push(`code=${code}`);
     return parts.join(' ');
   }
   // Non-Error throw: report only its primitive type, never its serialized value.

--- a/packages/memory-mcp-server/src/prompts.ts
+++ b/packages/memory-mcp-server/src/prompts.ts
@@ -145,6 +145,16 @@ export const TOOL_DESCRIPTIONS = {
     'and deduplicated. Use this PROACTIVELY whenever the user shares facts, preferences, ' +
     'decisions, or anything worth remembering across sessions. Store atomic facts — one idea per memory.',
 
+  memory_ingest:
+    'Ingest a raw blob (conversation, document, or session summary) and decompose it into atomic, ' +
+    'DURABLE memories via an LLM (extracts stable preferences/identity/project facts/decisions; skips ' +
+    'ephemeral task chatter). Unlike memory_store (one pre-formed fact), this extracts many facts from ' +
+    "one input, each with its own importance. Use mode='conversation' for strict explicit-only " +
+    "extraction or mode='document' to allow reasonable inference (better for conversation transcripts); " +
+    'dry_run=true to preview the decomposition (note: dry_run still sends the blob to the configured LLM ' +
+    '— it only skips local persistence). By default falls back to a single store if no LLM is configured; ' +
+    'set on_extraction_failure to skip or error to change that.',
+
   memory_recall:
     'Recall memories relevant to a query. Returns a pre-summarized context block optimized ' +
     'for your context window. Uses hybrid semantic + keyword search. Use format="answer" to get ' +

--- a/packages/memory-mcp-server/src/prompts.ts
+++ b/packages/memory-mcp-server/src/prompts.ts
@@ -159,7 +159,15 @@ export const TOOL_DESCRIPTIONS = {
     'Recall memories relevant to a query. Returns a pre-summarized context block optimized ' +
     'for your context window. Uses hybrid semantic + keyword search. Use format="answer" to get ' +
     'a direct answer to a question from stored memories. Use this when you need ' +
-    'context from prior sessions or before making recommendations that might conflict with stored preferences.',
+    'context from prior sessions or before making recommendations that might conflict with stored preferences. ' +
+    "`expand` defaults to 'auto', which returns the relevant source passage when several matched facts come " +
+    "from the same source (e.g. a contract's clauses); use 'none' for strictly pinpoint facts, or 'parent' to " +
+    'force the source passage for every match.',
+
+  memory_expand:
+    'Fetch the source passage(s) a recalled fact was extracted from, given a segment_id surfaced by a prior ' +
+    'memory_recall (in expanded_segment_ids or a raw result). Pass a query to get the most relevant passage ' +
+    'of that source; omit it to get the whole source. Use this to read the detail behind a thin headline fact.',
 
   memory_context:
     'Get a session briefing of relevant memories. Call this FIRST at the beginning of every ' +

--- a/packages/memory-mcp-server/src/retrieval/expansion.ts
+++ b/packages/memory-mcp-server/src/retrieval/expansion.ts
@@ -1,12 +1,16 @@
 /**
- * Step 9b — post-dedup parent re-expansion ("return coarse").
+ * Step 9b — post-dedup parent re-expansion ("return coarse"), AUGMENT semantics.
  *
  * This is NOT the candidate ranker. It runs strictly AFTER the pipeline has
  * selected and ordered its kept facts (steps 1–9). It only reshapes the RETURNED
- * unit: when several kept facts share one source segment, it emits a single
- * query-relevant PASSAGE of that segment in place of the redundant headlines.
- * It never touches the candidate set, the fusion/composite/rerank scores, or the
- * order in which facts were selected.
+ * unit set: it keeps EVERY kept fact (breadth-first — exactly what `expand:'none'`
+ * returns) and APPENDS the query-relevant source PASSAGE(s) of shared segments
+ * AFTER all the facts. Passages are supplementary, not a replacement: because the
+ * greedy skip-not-break `packToBudget` packs in order, facts are packed first and a
+ * passage only ever consumes leftover budget — so auto-expansion can never evict a
+ * fact that `expand:'none'` would have kept. Parent-dedup applies to PASSAGES (one
+ * passage per segment), never to facts. It never touches the candidate set, the
+ * fusion/composite/rerank scores, or the order in which facts were selected.
  */
 
 import type Database from 'better-sqlite3';
@@ -30,14 +34,16 @@ export interface ExpansionResult {
 }
 
 /**
- * Build the ordered display list from the post-dedup kept facts (§5.3).
+ * Build the display list from the post-dedup kept facts (§5.3), AUGMENT semantics.
  *
  * - `expand === 'none'`: byte-for-byte pass-through — every kept fact stays a fact.
- * - `expand === 'auto'`: expand a parent only when ≥2 kept facts share it.
- * - `expand === 'parent'`: expand the parent of every kept fact that has one.
+ * - `expand === 'auto'`: keep all facts; append the shared-parent passage(s) (a
+ *   segment is shared when ≥2 kept facts point at it) after the facts.
+ * - `expand === 'parent'`: keep all facts; append the parent passage of every kept
+ *   fact that has one (the ≥2 gate is dropped) after the facts.
  *
- * Expansion replaces a fact with its segment's query-ranked passage at the fact's
- * best position; parent-deduped siblings collapse into that one passage.
+ * Expansion never drops or reorders a fact; it only APPENDS supplementary passages
+ * after all the facts, in segment-best-rank order, capped at `maxExpandPassages`.
  */
 export async function expandKeptFacts(
   db: Database.Database,
@@ -68,17 +74,11 @@ export async function expandKeptFacts(
   const segments = getSegmentsByIds(db, config.namespace, segmentIdsToExpand);
   const segmentById = new Map(segments.map((s) => [s.id, s]));
 
-  // 4. Per expandable segment, split-and-rank to a chosen passage (capped count).
-  const chosenPassageBySegment = await choosePassages(
-    config,
-    segmentIdsToExpand,
-    segmentById,
-    queryEmbedding,
-    maxExpandPassages,
-  );
+  // 4. Per expandable segment, split-and-rank to a chosen passage (segment-best-rank order).
+  const chosenPassageBySegment = await choosePassages(config, segmentIdsToExpand, segmentById, queryEmbedding);
 
-  // 5. Walk kept in score order, emitting passages once (parent-dedup) and facts otherwise.
-  return buildDisplayList(kept, chosenPassageBySegment);
+  // 5. Keep all facts (breadth-first); append the chosen passages after them, capped.
+  return buildDisplayList(kept, segmentIdsToExpand, groups, chosenPassageBySegment, maxExpandPassages);
 }
 
 /** A fact emitted verbatim (not expanded). */
@@ -104,26 +104,24 @@ function groupBySegment(kept: ScoredMemory[]): Map<string, ScoredMemory[]> {
 /**
  * For each expandable segment, split its content into passages, embed them, and pick
  * the passage most similar to the query embedding. Returns the chosen passage text per
- * segment id. A segment with no row (forgotten parent) or no passages is skipped — its
- * facts then fall back to fact emission.
+ * segment id, keyed in segment-best-rank order. A segment with no row (forgotten parent)
+ * or no passages is skipped — its facts are simply not augmented with a passage.
  *
- * The global `maxExpandPassages` count cap is honored here: segments are visited in the
- * order they were selected (score order of their best fact) and once the cap is reached,
- * no further segment gets a passage (its facts fall back to facts).
+ * The `maxExpandPassages` cap is NOT applied here: it caps the passages that SURVIVE
+ * overlap-dedup in `buildDisplayList`, so a passage dropped as an overlap duplicate does
+ * not waste a cap slot.
  */
 async function choosePassages(
   config: MemoryConfig,
   segmentIdsToExpand: string[],
   segmentById: Map<string, SegmentRow>,
   queryEmbedding: Float32Array,
-  maxExpandPassages: number,
 ): Promise<Map<string, string>> {
   const chosen = new Map<string, string>();
 
   for (const segmentId of segmentIdsToExpand) {
-    if (chosen.size >= maxExpandPassages) break;
     const segment = segmentById.get(segmentId);
-    if (!segment) continue; // forgotten/missing parent → fall back to facts
+    if (!segment) continue; // forgotten/missing parent → no passage to append
 
     const passage = await rankBestPassage(config, segment.content, queryEmbedding);
     if (passage !== null) chosen.set(segmentId, passage);
@@ -160,39 +158,53 @@ async function rankBestPassage(
 }
 
 /**
- * Walk kept facts in score order. The FIRST fact of an expanded segment becomes the
- * passage unit (carrying that fact's date/importance so rendering is unchanged); later
- * facts sharing the same segment are dropped (parent-dedup). A fact whose segment was
- * not chosen for a passage (lone parent under auto, forgotten parent, or null segment)
- * is emitted verbatim. Overlap dedup drops a passage whose text is a near-substring of
- * an already-emitted passage (§5.3.2).
+ * Build the AUGMENT display list. First emit EVERY kept fact verbatim in score order —
+ * byte-for-byte what `expand:'none'` returns, so breadth is never lost. THEN append the
+ * chosen passages, one per shared segment, in segment-best-rank order. Because the
+ * downstream greedy skip-not-break `packToBudget` packs in order, placing passages last
+ * means facts are packed first and a passage only consumes leftover budget — auto-expand
+ * never evicts a fact `expand:'none'` would have kept.
+ *
+ * Each appended passage rides on its segment's best-ranked fact (carrying that fact's
+ * date/importance so rendering is unchanged) but gets a DISTINCT synthetic id: the
+ * host fact is also emitted, so a shared id would make id-keyed dedup/clustering
+ * (extractive-summary clustering, access-stat counting) treat the passage as a
+ * duplicate of its host fact and silently drop it. Parent-dedup applies to PASSAGES
+ * here (one passage per segment), never to facts. Overlap dedup drops a passage whose
+ * text is a near-substring of an already-appended passage (§5.3.2); the
+ * `maxExpandPassages` cap limits the passages that SURVIVE that dedup.
  */
-function buildDisplayList(kept: ScoredMemory[], chosenPassageBySegment: Map<string, string>): ExpansionResult {
-  const units: DisplayUnit[] = [];
-  const emittedSegments = new Set<string>();
+function buildDisplayList(
+  kept: ScoredMemory[],
+  segmentIdsToExpand: string[],
+  groups: Map<string, ScoredMemory[]>,
+  chosenPassageBySegment: Map<string, string>,
+  maxExpandPassages: number,
+): ExpansionResult {
+  // Breadth-first: keep every fact, in score order (identical to expand:'none').
+  const units: DisplayUnit[] = kept.map(toFactUnit);
+
   const emittedPassages: string[] = [];
   const expandedSegmentIds: string[] = [];
 
-  for (const mem of kept) {
-    const segmentId = mem.segment_id;
-    const passage = segmentId !== null ? chosenPassageBySegment.get(segmentId) : undefined;
+  // Append passages AFTER all facts, in segment-best-rank order, deduped and capped.
+  for (const segmentId of segmentIdsToExpand) {
+    if (expandedSegmentIds.length >= maxExpandPassages) break;
 
-    // Not an expanded segment → emit the fact verbatim.
-    if (segmentId === null || passage === undefined) {
-      units.push(toFactUnit(mem));
-      continue;
-    }
+    const passage = chosenPassageBySegment.get(segmentId);
+    // group[0] is the segment's best-ranked fact (groups preserve score order); the
+    // appended passage rides on it so date/importance/id rendering is unchanged.
+    const bestFact = groups.get(segmentId)?.[0];
+    if (passage === undefined || bestFact === undefined) continue;
 
-    // Expanded segment already emitted → parent-dedup, drop this sibling.
-    if (emittedSegments.has(segmentId)) continue;
-    emittedSegments.add(segmentId);
-
-    // Overlap dedup: skip a passage that is a near-substring of an already-emitted one.
+    // Overlap dedup: skip a passage that is a near-substring of an already-appended one.
     if (isOverlapping(passage, emittedPassages)) continue;
 
     emittedPassages.push(passage);
     expandedSegmentIds.push(segmentId);
-    units.push({ ...mem, content: passage, expanded: true });
+    // Distinct id (host fact id + segment) so the passage is its own display unit, not
+    // an id-collision duplicate of the host fact (which is also emitted, see above).
+    units.push({ ...bestFact, id: `${bestFact.id}#seg:${segmentId}`, content: passage, expanded: true });
   }
 
   return { units, expandedSegmentIds };

--- a/packages/memory-mcp-server/src/retrieval/expansion.ts
+++ b/packages/memory-mcp-server/src/retrieval/expansion.ts
@@ -1,16 +1,22 @@
 /**
- * Step 9b — post-dedup parent re-expansion ("return coarse"), AUGMENT semantics.
+ * Step 9b — post-dedup parent re-expansion ("return coarse"), HYBRID semantics.
  *
  * This is NOT the candidate ranker. It runs strictly AFTER the pipeline has
  * selected and ordered its kept facts (steps 1–9). It only reshapes the RETURNED
- * unit set: it keeps EVERY kept fact (breadth-first — exactly what `expand:'none'`
- * returns) and APPENDS the query-relevant source PASSAGE(s) of shared segments
- * AFTER all the facts. Passages are supplementary, not a replacement: because the
- * greedy skip-not-break `packToBudget` packs in order, facts are packed first and a
- * passage only ever consumes leftover budget — so auto-expansion can never evict a
- * fact that `expand:'none'` would have kept. Parent-dedup applies to PASSAGES (one
- * passage per segment), never to facts. It never touches the candidate set, the
- * fusion/composite/rerank scores, or the order in which facts were selected.
+ * unit set: it keeps the breadth facts (the same fact list `expand:'none'` returns)
+ * and surfaces the query-relevant source PASSAGE(s) of shared segments.
+ *
+ * HYBRID (not pure-AUGMENT): the single highest-ranked expanded passage is
+ * GUARANTEED whenever the budget can fit it — its tokens are RESERVED before facts
+ * are packed, so a default recall always gets depth and never silently degrades to
+ * the lossy headlines. Including that passage may displace only the LOWEST-priority
+ * kept facts (the tail that did not fit in `budget - reserve`); the top facts are
+ * never evicted to make room (that was the original REPLACE regression). Additional
+ * passages beyond the first are SUPPLEMENTARY — they ride leftover budget only, are
+ * capped at `max_expand_passages`, and never displace a fact. Parent-dedup applies
+ * to PASSAGES (one per segment), never to facts. It never touches the candidate set,
+ * the fusion/composite/rerank scores, or the order in which facts were selected, and
+ * it does NOT change `packToBudget`'s own logic.
  */
 
 import type Database from 'better-sqlite3';
@@ -21,6 +27,7 @@ import type { ScoredMemory } from './scoring.js';
 import { getSegmentsByIds } from '../storage/queries.js';
 import { splitToPassages } from '../storage/extraction.js';
 import { embed, cosineSimilarity } from '../embedding/embedder.js';
+import { estimateTokens, packToBudget } from './scoring.js';
 
 /** A heterogeneous recall display unit: a fact verbatim or an expanded passage. */
 export interface DisplayUnit extends ScoredMemory {
@@ -34,16 +41,53 @@ export interface ExpansionResult {
 }
 
 /**
- * Build the display list from the post-dedup kept facts (§5.3), AUGMENT semantics.
+ * Split a segment into coherent passages, embed each, and return them ranked
+ * best-first by cosine similarity to `queryEmbedding` (reusing the pipeline's
+ * step-1 query embedding — no second query embed). `limit` truncates the result
+ * to the top-N passages; omit it to rank the whole segment. Returns `[]` for a
+ * segment that yields no passages.
  *
- * - `expand === 'none'`: byte-for-byte pass-through — every kept fact stays a fact.
- * - `expand === 'auto'`: keep all facts; append the shared-parent passage(s) (a
- *   segment is shared when ≥2 kept facts point at it) after the facts.
- * - `expand === 'parent'`: keep all facts; append the parent passage of every kept
- *   fact that has one (the ≥2 gate is dropped) after the facts.
+ * Shared by recall expansion (which takes `limit: 1` per segment) and
+ * `memory_expand` / `engine.expand` (which ranks all passages of one segment).
+ * Lives in the retrieval layer; `engine-impl` already depends on retrieval
+ * (pipeline, scoring), so importing this introduces no new cross-layer cycle.
+ */
+export async function rankSegmentPassages(
+  config: MemoryConfig,
+  segmentText: string,
+  queryEmbedding: Float32Array,
+  limit?: number,
+): Promise<string[]> {
+  const passages = splitToPassages(segmentText);
+  if (passages.length === 0) return [];
+  // Single passage: no ranking needed; it is trivially the best (and only) one.
+  if (passages.length === 1) return passages;
+
+  const scored: Array<{ passage: string; sim: number }> = [];
+  for (const passage of passages) {
+    const passageEmbedding = await embed(passage, config);
+    scored.push({ passage, sim: cosineSimilarity(passageEmbedding, queryEmbedding) });
+  }
+  scored.sort((a, b) => b.sim - a.sim);
+
+  const ranked = scored.map((s) => s.passage);
+  return limit === undefined ? ranked : ranked.slice(0, limit);
+}
+
+/**
+ * Build the packed display list from the post-dedup kept facts (§5.3), HYBRID semantics.
  *
- * Expansion never drops or reorders a fact; it only APPENDS supplementary passages
- * after all the facts, in segment-best-rank order, capped at `maxExpandPassages`.
+ * - `expand === 'none'`: byte-for-byte pass-through — `packToBudget` over the fact list.
+ * - `expand === 'auto'`: keep the breadth facts; reserve + force-include the top
+ *   shared-parent passage (a segment is shared when ≥2 kept facts point at it); append
+ *   any further passages on leftover budget.
+ * - `expand === 'parent'`: same as auto but the ≥2 gate is dropped (every kept fact with
+ *   a parent is an expansion candidate).
+ *
+ * Returns the FINAL packed, score-ordered units (facts then passages), so the caller does
+ * not run `packToBudget` again. The top passage is guaranteed whenever the budget can fit
+ * it; the top facts are never evicted to make room for it (only the lowest-priority tail
+ * facts are).
  */
 export async function expandKeptFacts(
   db: Database.Database,
@@ -52,9 +96,12 @@ export async function expandKeptFacts(
   queryEmbedding: Float32Array,
   expand: ExpandMode,
   maxExpandPassages: number,
+  budget: number,
 ): Promise<ExpansionResult> {
+  const factUnits = kept.map(toFactUnit);
+
   if (expand === 'none') {
-    return { units: kept.map(toFactUnit), expandedSegmentIds: [] };
+    return { units: packToBudget(factUnits, budget), expandedSegmentIds: [] };
   }
 
   // 1. Group kept facts by non-null segment_id, recording first (best) position.
@@ -67,7 +114,7 @@ export async function expandKeptFacts(
     .map(([segmentId]) => segmentId);
 
   if (segmentIdsToExpand.length === 0) {
-    return { units: kept.map(toFactUnit), expandedSegmentIds: [] };
+    return { units: packToBudget(factUnits, budget), expandedSegmentIds: [] };
   }
 
   // 3. Fetch the selected segments in one query.
@@ -77,8 +124,11 @@ export async function expandKeptFacts(
   // 4. Per expandable segment, split-and-rank to a chosen passage (segment-best-rank order).
   const chosenPassageBySegment = await choosePassages(config, segmentIdsToExpand, segmentById, queryEmbedding);
 
-  // 5. Keep all facts (breadth-first); append the chosen passages after them, capped.
-  return buildDisplayList(kept, segmentIdsToExpand, groups, chosenPassageBySegment, maxExpandPassages);
+  // 5. Build the candidate passage units (overlap-deduped, capped), in segment-best-rank order.
+  const passageUnits = buildPassageUnits(segmentIdsToExpand, groups, chosenPassageBySegment, maxExpandPassages);
+
+  // 6. Pack facts + passages under a reservation that GUARANTEES the top passage's depth.
+  return packHybrid(factUnits, passageUnits, budget);
 }
 
 /** A fact emitted verbatim (not expanded). */
@@ -108,7 +158,7 @@ function groupBySegment(kept: ScoredMemory[]): Map<string, ScoredMemory[]> {
  * or no passages is skipped — its facts are simply not augmented with a passage.
  *
  * The `maxExpandPassages` cap is NOT applied here: it caps the passages that SURVIVE
- * overlap-dedup in `buildDisplayList`, so a passage dropped as an overlap duplicate does
+ * overlap-dedup in `buildPassageUnits`, so a passage dropped as an overlap duplicate does
  * not waste a cap slot.
  */
 async function choosePassages(
@@ -123,91 +173,119 @@ async function choosePassages(
     const segment = segmentById.get(segmentId);
     if (!segment) continue; // forgotten/missing parent → no passage to append
 
-    const passage = await rankBestPassage(config, segment.content, queryEmbedding);
-    if (passage !== null) chosen.set(segmentId, passage);
+    const ranked = await rankSegmentPassages(config, segment.content, queryEmbedding, 1);
+    if (ranked.length > 0) chosen.set(segmentId, ranked[0]);
   }
 
   return chosen;
 }
 
 /**
- * Split a segment into passages, embed each, and return the one most similar to the
- * query embedding (reused from pipeline step 1 — no second query embed). Returns null
- * when the segment yields no passages.
- */
-async function rankBestPassage(
-  config: MemoryConfig,
-  content: string,
-  queryEmbedding: Float32Array,
-): Promise<string | null> {
-  const passages = splitToPassages(content);
-  if (passages.length === 0) return null;
-  if (passages.length === 1) return passages[0];
-
-  let best = passages[0];
-  let bestSim = -Infinity;
-  for (const passage of passages) {
-    const passageEmbedding = await embed(passage, config);
-    const sim = cosineSimilarity(passageEmbedding, queryEmbedding);
-    if (sim > bestSim) {
-      bestSim = sim;
-      best = passage;
-    }
-  }
-  return best;
-}
-
-/**
- * Build the AUGMENT display list. First emit EVERY kept fact verbatim in score order —
- * byte-for-byte what `expand:'none'` returns, so breadth is never lost. THEN append the
- * chosen passages, one per shared segment, in segment-best-rank order. Because the
- * downstream greedy skip-not-break `packToBudget` packs in order, placing passages last
- * means facts are packed first and a passage only consumes leftover budget — auto-expand
- * never evicts a fact `expand:'none'` would have kept.
+ * Build the passage display units, one per shared segment, in segment-best-rank order,
+ * after passage overlap-dedup and the `maxExpandPassages` cap. No budget logic here —
+ * `packHybrid` decides which of these survive packing (the first is guaranteed, the rest
+ * are supplementary).
  *
- * Each appended passage rides on its segment's best-ranked fact (carrying that fact's
- * date/importance so rendering is unchanged) but gets a DISTINCT synthetic id: the
- * host fact is also emitted, so a shared id would make id-keyed dedup/clustering
- * (extractive-summary clustering, access-stat counting) treat the passage as a
- * duplicate of its host fact and silently drop it. Parent-dedup applies to PASSAGES
- * here (one passage per segment), never to facts. Overlap dedup drops a passage whose
- * text is a near-substring of an already-appended passage (§5.3.2); the
- * `maxExpandPassages` cap limits the passages that SURVIVE that dedup.
+ * Each passage rides on its segment's best-ranked fact (carrying that fact's
+ * date/importance so rendering is unchanged) but gets a DISTINCT synthetic id: the host
+ * fact is also emitted, so a shared id would make id-keyed dedup/clustering treat the
+ * passage as a duplicate of its host fact and silently drop it.
  */
-function buildDisplayList(
-  kept: ScoredMemory[],
+function buildPassageUnits(
   segmentIdsToExpand: string[],
   groups: Map<string, ScoredMemory[]>,
   chosenPassageBySegment: Map<string, string>,
   maxExpandPassages: number,
-): ExpansionResult {
-  // Breadth-first: keep every fact, in score order (identical to expand:'none').
-  const units: DisplayUnit[] = kept.map(toFactUnit);
-
+): DisplayUnit[] {
+  const passageUnits: DisplayUnit[] = [];
   const emittedPassages: string[] = [];
-  const expandedSegmentIds: string[] = [];
 
-  // Append passages AFTER all facts, in segment-best-rank order, deduped and capped.
   for (const segmentId of segmentIdsToExpand) {
-    if (expandedSegmentIds.length >= maxExpandPassages) break;
+    if (passageUnits.length >= maxExpandPassages) break;
 
     const passage = chosenPassageBySegment.get(segmentId);
     // group[0] is the segment's best-ranked fact (groups preserve score order); the
-    // appended passage rides on it so date/importance/id rendering is unchanged.
+    // passage rides on it so date/importance/id rendering is unchanged.
     const bestFact = groups.get(segmentId)?.[0];
     if (passage === undefined || bestFact === undefined) continue;
 
-    // Overlap dedup: skip a passage that is a near-substring of an already-appended one.
+    // Overlap dedup: skip a passage that is a near-substring of an already-chosen one.
     if (isOverlapping(passage, emittedPassages)) continue;
 
     emittedPassages.push(passage);
-    expandedSegmentIds.push(segmentId);
     // Distinct id (host fact id + segment) so the passage is its own display unit, not
     // an id-collision duplicate of the host fact (which is also emitted, see above).
-    units.push({ ...bestFact, id: `${bestFact.id}#seg:${segmentId}`, content: passage, expanded: true });
+    passageUnits.push({ ...bestFact, id: `${bestFact.id}#seg:${segmentId}`, content: passage, expanded: true });
   }
 
-  return { units, expandedSegmentIds };
+  return passageUnits;
+}
+
+/**
+ * HYBRID pack: reserve budget for the single top passage so DEPTH is guaranteed, pack the
+ * breadth facts into the remainder so the TOP facts are never evicted, then fill leftover
+ * with the remaining facts and the supplementary passages.
+ *
+ * Mechanism (no change to `packToBudget`'s own logic):
+ *   1. If the top passage cannot fit the whole budget, fall back to facts only
+ *      (`packToBudget(facts, budget)`); `expanded` is false — no infinite reserve.
+ *   2. Otherwise reserve `estimateTokens(topPassage)` and `packToBudget(facts,
+ *      budget - reserve)` — the breadth facts are packed FIRST, so they are never evicted
+ *      to fit the passage (only the lowest-priority tail facts that did not fit the
+ *      reduced budget are displaced).
+ *   3. Force-include the top passage (its tokens were reserved, so it always fits).
+ *   4. Fill the leftover budget greedily (skip-not-break) with the not-yet-included facts
+ *      and the supplementary passages — these only ever consume what is left, so they
+ *      never displace a fact.
+ *
+ * The returned order is score-ordered facts, then the guaranteed top passage, then any
+ * supplementary passages — matching the existing "facts then passages" display contract.
+ */
+function packHybrid(factUnits: DisplayUnit[], passageUnits: DisplayUnit[], budget: number): ExpansionResult {
+  // No passage candidates → facts only (no reservation, no expansion).
+  if (passageUnits.length === 0) {
+    return { units: packToBudget(factUnits, budget), expandedSegmentIds: [] };
+  }
+
+  const topPassage = passageUnits[0];
+  const reserve = estimateTokens(topPassage.content);
+
+  // The top passage cannot fit even the whole budget alone (no infinite reserve):
+  // fall back to facts only (`expanded` false).
+  if (reserve > budget) {
+    return { units: packToBudget(factUnits, budget), expandedSegmentIds: [] };
+  }
+
+  // Pack the breadth facts into the budget MINUS the reserved passage so the top facts
+  // are never evicted to make room — only the lowest-priority tail facts are displaced.
+  const packedFacts = packToBudget(factUnits, budget - reserve);
+  const usedTokens = packedFacts.reduce((sum, u) => sum + estimateTokens(u.content), 0);
+
+  const selected: DisplayUnit[] = [...packedFacts, topPassage];
+  const expandedSegmentIds: string[] = [segmentIdOf(topPassage)];
+  let remaining = budget - usedTokens - reserve;
+
+  // Fill leftover budget greedily (skip-not-break): facts that did not make the reserved
+  // pack, then the supplementary passages. These ride leftover budget only — they never
+  // displace a fact, and the cap was already applied when the passage units were built.
+  const includedFactIds = new Set(packedFacts.map((u) => u.id));
+  const leftover: DisplayUnit[] = [...factUnits.filter((u) => !includedFactIds.has(u.id)), ...passageUnits.slice(1)];
+  for (const unit of leftover) {
+    const tokens = estimateTokens(unit.content);
+    if (tokens > remaining) continue; // skip, don't break — a smaller later unit may fit
+    if (unit.expanded) expandedSegmentIds.push(segmentIdOf(unit));
+    selected.push(unit);
+    remaining -= tokens;
+  }
+
+  return { units: selected, expandedSegmentIds };
+}
+
+/** Recover the segment id a passage unit was built from (it rides the `#seg:<id>` suffix). */
+function segmentIdOf(passageUnit: DisplayUnit): string {
+  const marker = '#seg:';
+  const idx = passageUnit.id.indexOf(marker);
+  return idx === -1 ? (passageUnit.segment_id ?? '') : passageUnit.id.slice(idx + marker.length);
 }
 
 /** Normalize whitespace for overlap comparison. */

--- a/packages/memory-mcp-server/src/retrieval/expansion.ts
+++ b/packages/memory-mcp-server/src/retrieval/expansion.ts
@@ -63,11 +63,13 @@ export async function rankSegmentPassages(
   // Single passage: no ranking needed; it is trivially the best (and only) one.
   if (passages.length === 1) return passages;
 
-  const scored: Array<{ passage: string; sim: number }> = [];
-  for (const passage of passages) {
-    const passageEmbedding = await embed(passage, config);
-    scored.push({ passage, sim: cosineSimilarity(passageEmbedding, queryEmbedding) });
-  }
+  // Embed passages concurrently (each a single call → identical vectors to
+  // sequential) rather than awaiting one at a time.
+  const passageEmbeddings = await Promise.all(passages.map((passage) => embed(passage, config)));
+  const scored = passages.map((passage, i) => ({
+    passage,
+    sim: cosineSimilarity(passageEmbeddings[i], queryEmbedding),
+  }));
   scored.sort((a, b) => b.sim - a.sim);
 
   const ranked = scored.map((s) => s.passage);

--- a/packages/memory-mcp-server/src/retrieval/expansion.ts
+++ b/packages/memory-mcp-server/src/retrieval/expansion.ts
@@ -215,7 +215,12 @@ function buildPassageUnits(
     emittedPassages.push(passage);
     // Distinct id (host fact id + segment) so the passage is its own display unit, not
     // an id-collision duplicate of the host fact (which is also emitted, see above).
-    passageUnits.push({ ...bestFact, id: `${bestFact.id}#seg:${segmentId}`, content: passage, expanded: true });
+    passageUnits.push({
+      ...bestFact,
+      id: `${bestFact.id}${SEGMENT_UNIT_MARKER}${segmentId}`,
+      content: passage,
+      expanded: true,
+    });
   }
 
   return passageUnits;
@@ -281,11 +286,24 @@ function packHybrid(factUnits: DisplayUnit[], passageUnits: DisplayUnit[], budge
   return { units: selected, expandedSegmentIds };
 }
 
+/** Separates a passage unit's host-fact id from its segment id: `<factId>#seg:<segId>`. */
+const SEGMENT_UNIT_MARKER = '#seg:';
+
+/**
+ * The real `memories.id` behind a display unit. A passage unit's id is the synthetic
+ * `<factId>#seg:<segId>` (so it isn't an id-collision duplicate of its host fact); this
+ * strips the suffix back to the host fact's id. A plain fact unit returns its own id.
+ * Used by the pipeline to resolve embeddings and access-stat updates to real rows.
+ */
+export function realMemoryId(unitId: string): string {
+  const idx = unitId.indexOf(SEGMENT_UNIT_MARKER);
+  return idx === -1 ? unitId : unitId.slice(0, idx);
+}
+
 /** Recover the segment id a passage unit was built from (it rides the `#seg:<id>` suffix). */
 function segmentIdOf(passageUnit: DisplayUnit): string {
-  const marker = '#seg:';
-  const idx = passageUnit.id.indexOf(marker);
-  return idx === -1 ? (passageUnit.segment_id ?? '') : passageUnit.id.slice(idx + marker.length);
+  const idx = passageUnit.id.indexOf(SEGMENT_UNIT_MARKER);
+  return idx === -1 ? (passageUnit.segment_id ?? '') : passageUnit.id.slice(idx + SEGMENT_UNIT_MARKER.length);
 }
 
 /** Normalize whitespace for overlap comparison. */

--- a/packages/memory-mcp-server/src/retrieval/expansion.ts
+++ b/packages/memory-mcp-server/src/retrieval/expansion.ts
@@ -1,0 +1,214 @@
+/**
+ * Step 9b — post-dedup parent re-expansion ("return coarse").
+ *
+ * This is NOT the candidate ranker. It runs strictly AFTER the pipeline has
+ * selected and ordered its kept facts (steps 1–9). It only reshapes the RETURNED
+ * unit: when several kept facts share one source segment, it emits a single
+ * query-relevant PASSAGE of that segment in place of the redundant headlines.
+ * It never touches the candidate set, the fusion/composite/rerank scores, or the
+ * order in which facts were selected.
+ */
+
+import type Database from 'better-sqlite3';
+import type { MemoryConfig } from '../config.js';
+import type { SegmentRow } from '../storage/database.js';
+import type { ExpandMode } from '../types.js';
+import type { ScoredMemory } from './scoring.js';
+import { getSegmentsByIds } from '../storage/queries.js';
+import { splitToPassages } from '../storage/extraction.js';
+import { embed, cosineSimilarity } from '../embedding/embedder.js';
+
+/** A heterogeneous recall display unit: a fact verbatim or an expanded passage. */
+export interface DisplayUnit extends ScoredMemory {
+  /** True when `content` is an expanded parent passage (not the fact text). */
+  expanded: boolean;
+}
+
+export interface ExpansionResult {
+  units: DisplayUnit[];
+  expandedSegmentIds: string[];
+}
+
+/**
+ * Build the ordered display list from the post-dedup kept facts (§5.3).
+ *
+ * - `expand === 'none'`: byte-for-byte pass-through — every kept fact stays a fact.
+ * - `expand === 'auto'`: expand a parent only when ≥2 kept facts share it.
+ * - `expand === 'parent'`: expand the parent of every kept fact that has one.
+ *
+ * Expansion replaces a fact with its segment's query-ranked passage at the fact's
+ * best position; parent-deduped siblings collapse into that one passage.
+ */
+export async function expandKeptFacts(
+  db: Database.Database,
+  config: MemoryConfig,
+  kept: ScoredMemory[],
+  queryEmbedding: Float32Array,
+  expand: ExpandMode,
+  maxExpandPassages: number,
+): Promise<ExpansionResult> {
+  if (expand === 'none') {
+    return { units: kept.map(toFactUnit), expandedSegmentIds: [] };
+  }
+
+  // 1. Group kept facts by non-null segment_id, recording first (best) position.
+  const groups = groupBySegment(kept);
+
+  // 2. Decide which segments to expand for this mode.
+  const minGroupSize = expand === 'parent' ? 1 : 2;
+  const segmentIdsToExpand = [...groups.entries()]
+    .filter(([, members]) => members.length >= minGroupSize)
+    .map(([segmentId]) => segmentId);
+
+  if (segmentIdsToExpand.length === 0) {
+    return { units: kept.map(toFactUnit), expandedSegmentIds: [] };
+  }
+
+  // 3. Fetch the selected segments in one query.
+  const segments = getSegmentsByIds(db, config.namespace, segmentIdsToExpand);
+  const segmentById = new Map(segments.map((s) => [s.id, s]));
+
+  // 4. Per expandable segment, split-and-rank to a chosen passage (capped count).
+  const chosenPassageBySegment = await choosePassages(
+    config,
+    segmentIdsToExpand,
+    segmentById,
+    queryEmbedding,
+    maxExpandPassages,
+  );
+
+  // 5. Walk kept in score order, emitting passages once (parent-dedup) and facts otherwise.
+  return buildDisplayList(kept, chosenPassageBySegment);
+}
+
+/** A fact emitted verbatim (not expanded). */
+function toFactUnit(mem: ScoredMemory): DisplayUnit {
+  return { ...mem, expanded: false };
+}
+
+/** Group kept facts by non-null segment_id, preserving score order within each group. */
+function groupBySegment(kept: ScoredMemory[]): Map<string, ScoredMemory[]> {
+  const groups = new Map<string, ScoredMemory[]>();
+  for (const mem of kept) {
+    if (mem.segment_id === null) continue;
+    const existing = groups.get(mem.segment_id);
+    if (existing) {
+      existing.push(mem);
+    } else {
+      groups.set(mem.segment_id, [mem]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * For each expandable segment, split its content into passages, embed them, and pick
+ * the passage most similar to the query embedding. Returns the chosen passage text per
+ * segment id. A segment with no row (forgotten parent) or no passages is skipped — its
+ * facts then fall back to fact emission.
+ *
+ * The global `maxExpandPassages` count cap is honored here: segments are visited in the
+ * order they were selected (score order of their best fact) and once the cap is reached,
+ * no further segment gets a passage (its facts fall back to facts).
+ */
+async function choosePassages(
+  config: MemoryConfig,
+  segmentIdsToExpand: string[],
+  segmentById: Map<string, SegmentRow>,
+  queryEmbedding: Float32Array,
+  maxExpandPassages: number,
+): Promise<Map<string, string>> {
+  const chosen = new Map<string, string>();
+
+  for (const segmentId of segmentIdsToExpand) {
+    if (chosen.size >= maxExpandPassages) break;
+    const segment = segmentById.get(segmentId);
+    if (!segment) continue; // forgotten/missing parent → fall back to facts
+
+    const passage = await rankBestPassage(config, segment.content, queryEmbedding);
+    if (passage !== null) chosen.set(segmentId, passage);
+  }
+
+  return chosen;
+}
+
+/**
+ * Split a segment into passages, embed each, and return the one most similar to the
+ * query embedding (reused from pipeline step 1 — no second query embed). Returns null
+ * when the segment yields no passages.
+ */
+async function rankBestPassage(
+  config: MemoryConfig,
+  content: string,
+  queryEmbedding: Float32Array,
+): Promise<string | null> {
+  const passages = splitToPassages(content);
+  if (passages.length === 0) return null;
+  if (passages.length === 1) return passages[0];
+
+  let best = passages[0];
+  let bestSim = -Infinity;
+  for (const passage of passages) {
+    const passageEmbedding = await embed(passage, config);
+    const sim = cosineSimilarity(passageEmbedding, queryEmbedding);
+    if (sim > bestSim) {
+      bestSim = sim;
+      best = passage;
+    }
+  }
+  return best;
+}
+
+/**
+ * Walk kept facts in score order. The FIRST fact of an expanded segment becomes the
+ * passage unit (carrying that fact's date/importance so rendering is unchanged); later
+ * facts sharing the same segment are dropped (parent-dedup). A fact whose segment was
+ * not chosen for a passage (lone parent under auto, forgotten parent, or null segment)
+ * is emitted verbatim. Overlap dedup drops a passage whose text is a near-substring of
+ * an already-emitted passage (§5.3.2).
+ */
+function buildDisplayList(kept: ScoredMemory[], chosenPassageBySegment: Map<string, string>): ExpansionResult {
+  const units: DisplayUnit[] = [];
+  const emittedSegments = new Set<string>();
+  const emittedPassages: string[] = [];
+  const expandedSegmentIds: string[] = [];
+
+  for (const mem of kept) {
+    const segmentId = mem.segment_id;
+    const passage = segmentId !== null ? chosenPassageBySegment.get(segmentId) : undefined;
+
+    // Not an expanded segment → emit the fact verbatim.
+    if (segmentId === null || passage === undefined) {
+      units.push(toFactUnit(mem));
+      continue;
+    }
+
+    // Expanded segment already emitted → parent-dedup, drop this sibling.
+    if (emittedSegments.has(segmentId)) continue;
+    emittedSegments.add(segmentId);
+
+    // Overlap dedup: skip a passage that is a near-substring of an already-emitted one.
+    if (isOverlapping(passage, emittedPassages)) continue;
+
+    emittedPassages.push(passage);
+    expandedSegmentIds.push(segmentId);
+    units.push({ ...mem, content: passage, expanded: true });
+  }
+
+  return { units, expandedSegmentIds };
+}
+
+/** Normalize whitespace for overlap comparison. */
+function normalizeForOverlap(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** True when `passage` is a (near-)substring of any already-emitted passage, or vice-versa. */
+function isOverlapping(passage: string, emitted: string[]): boolean {
+  const norm = normalizeForOverlap(passage);
+  if (norm.length === 0) return true;
+  return emitted.some((prev) => {
+    const prevNorm = normalizeForOverlap(prev);
+    return prevNorm.includes(norm) || norm.includes(prevNorm);
+  });
+}

--- a/packages/memory-mcp-server/src/retrieval/formatting.ts
+++ b/packages/memory-mcp-server/src/retrieval/formatting.ts
@@ -1,4 +1,5 @@
 import type { ScoredMemory } from './scoring.js';
+import type { DisplayUnit } from './expansion.js';
 import type { MemoryConfig } from '../config.js';
 import { llmComplete } from '../llm/client.js';
 import { clusterByEmbeddingSimilarity } from './dedup.js';
@@ -8,10 +9,13 @@ export const FORMAT_MODES = ['summary', 'list', 'raw', 'answer'] as const;
 export type FormatMode = (typeof FORMAT_MODES)[number];
 
 /**
- * Format scored memories according to the requested format mode.
+ * Format display units according to the requested format mode. Units may be facts
+ * verbatim or expanded parent passages; an expanded unit's `content` is already the
+ * chosen passage text, while it keeps the best fact's date/importance so the
+ * `[date] … (importance:)` rendering is unchanged.
  */
 export async function formatMemories(
-  memories: ScoredMemory[],
+  memories: DisplayUnit[],
   embeddings: Map<string, Float32Array>,
   query: string,
   tokenBudget: number,
@@ -28,6 +32,24 @@ export async function formatMemories(
     case 'raw':
       return formatAsRaw(memories);
   }
+}
+
+function formatAsRaw(memories: DisplayUnit[]): string {
+  const items = memories.map((m) => ({
+    id: m.id,
+    content: m.content,
+    tags: parseTags(m.tags),
+    importance: m.importance,
+    created_at: m.created_at,
+    updated_at: m.updated_at,
+    last_accessed_at: m.last_accessed_at,
+    access_count: m.access_count,
+    is_compacted: m.is_compacted === 1,
+    source: m.source,
+    segment_id: m.segment_id,
+    expanded: m.expanded,
+  }));
+  return JSON.stringify(items, null, 2);
 }
 
 async function formatAsSummary(
@@ -125,20 +147,4 @@ function formatAsList(memories: ScoredMemory[]): string {
   });
 
   return lines.join('\n');
-}
-
-function formatAsRaw(memories: ScoredMemory[]): string {
-  const items = memories.map((m) => ({
-    id: m.id,
-    content: m.content,
-    tags: parseTags(m.tags),
-    importance: m.importance,
-    created_at: m.created_at,
-    updated_at: m.updated_at,
-    last_accessed_at: m.last_accessed_at,
-    access_count: m.access_count,
-    is_compacted: m.is_compacted === 1,
-    source: m.source,
-  }));
-  return JSON.stringify(items, null, 2);
 }

--- a/packages/memory-mcp-server/src/retrieval/pipeline.ts
+++ b/packages/memory-mcp-server/src/retrieval/pipeline.ts
@@ -8,7 +8,7 @@ import { hybridScoreFusion, computeCompositeScore, filterByRelevance, filterByRe
 import { deduplicateByEmbedding } from './dedup.js';
 import { rerank } from './reranker.js';
 import { formatMemories } from './formatting.js';
-import { expandKeptFacts } from './expansion.js';
+import { expandKeptFacts, realMemoryId } from './expansion.js';
 import { parseTags } from '../utils/tags.js';
 
 const DEFAULT_CANDIDATE_LIMIT = 50;
@@ -139,29 +139,28 @@ export async function recall(
     tokenBudget,
   );
 
-  // 10. Format — reuse embeddings already loaded for dedup. An expanded passage unit
-  //     keeps its best-ranked fact's `id` (the passage text rides on that fact), so its
-  //     entry in `selectedEmbeddings` is that fact's embedding. The no-LLM extractive
-  //     summary path therefore clusters the passage by its fact's embedding — benign,
-  //     since the passage's whole point is to be the relevant slice of that fact's parent.
-  const selectedIds = new Set(selected.map((m) => m.id));
+  // 10. Format — reuse embeddings already loaded for dedup. A passage unit carries the
+  //     synthetic id `<factId>#seg:<segId>`, so resolve each selected unit to its REAL
+  //     memory id to fetch the embedding, keyed by the unit's own id — so the no-LLM
+  //     extractive-clustering path still clusters the passage by its host fact's vector.
   const selectedEmbeddings = new Map<string, Float32Array>();
-  for (const [id, emb] of embeddings) {
-    if (selectedIds.has(id)) selectedEmbeddings.set(id, emb);
+  for (const unit of selected) {
+    const emb = embeddings.get(realMemoryId(unit.id));
+    if (emb !== undefined) selectedEmbeddings.set(unit.id, emb);
   }
   const text = await formatMemories(selected, selectedEmbeddings, query, tokenBudget, format, config);
 
-  // 11. Update access stats for returned memories. An appended passage unit carries a
-  //     synthetic id (no matching memories row), so it no-ops here — only real fact ids
-  //     bump their access_count, exactly once each.
-  const returnedIds = selected.map((m) => m.id);
-  updateAccessStats(db, config.namespace, returnedIds);
+  // 11. Update access stats. Resolve passage units' synthetic ids back to their host fact's
+  //     real memory id and de-duplicate — so a fact present as both a fact unit and a passage
+  //     unit is counted once, and the host fact is still counted when only the passage fit.
+  const realIds = [...new Set(selected.map((m) => realMemoryId(m.id)))];
+  updateAccessStats(db, config.namespace, realIds);
 
   // `expandKeptFacts` packs facts + passages itself, so `expandedSegmentIds` already
   // reflects only the passages that survived into the returned set.
   return {
     text,
-    memoryIds: returnedIds,
+    memoryIds: realIds,
     totalCandidates: allMemories.size,
     selectedCount: selected.length,
     expanded: expandedSegmentIds.length > 0,

--- a/packages/memory-mcp-server/src/retrieval/pipeline.ts
+++ b/packages/memory-mcp-server/src/retrieval/pipeline.ts
@@ -14,6 +14,7 @@ import {
 import { deduplicateByEmbedding } from './dedup.js';
 import { rerank } from './reranker.js';
 import { formatMemories } from './formatting.js';
+import { expandKeptFacts } from './expansion.js';
 import { parseTags } from '../utils/tags.js';
 
 const DEFAULT_CANDIDATE_LIMIT = 50;
@@ -21,12 +22,19 @@ const DEFAULT_CANDIDATE_LIMIT = 50;
  *  0.9 = cosine similarity > 0.1; generous enough for vague queries while filtering pure noise. */
 const MAX_VECTOR_DISTANCE = 0.9;
 
+/** Default cap on expanded passages across one result (§5.4). */
+const DEFAULT_MAX_EXPAND_PASSAGES = 2;
+
 /** Internal result from the retrieval pipeline, richer than the public RecallResult. */
 export interface PipelineRecallResult {
   text: string;
   memoryIds: string[];
   totalCandidates: number;
   selectedCount: number;
+  /** True when any returned display unit was an expanded parent passage. */
+  expanded: boolean;
+  /** The segment_ids that were expanded (empty when none). */
+  expandedSegmentIds: string[];
 }
 
 /**
@@ -38,7 +46,14 @@ export async function recall(
   config: MemoryConfig,
   options: Omit<RecallOptions, 'namespace'>,
 ): Promise<PipelineRecallResult> {
-  const { query, token_budget: tokenBudget = config.defaultTokenBudget, tags, format = 'summary' } = options;
+  const {
+    query,
+    token_budget: tokenBudget = config.defaultTokenBudget,
+    tags,
+    format = 'summary',
+    expand = 'auto',
+    max_expand_passages: maxExpandPassages = DEFAULT_MAX_EXPAND_PASSAGES,
+  } = options;
 
   // 1. Embed query (with asymmetric prefix for retrieval-optimized embedding)
   const queryEmbedding = await embedQuery(query, config);
@@ -63,6 +78,8 @@ export async function recall(
       memoryIds: [],
       totalCandidates: 0,
       selectedCount: 0,
+      expanded: false,
+      expandedSegmentIds: [],
     };
   }
 
@@ -113,10 +130,25 @@ export async function recall(
   // 8. Dedup
   const { kept } = deduplicateByEmbedding(afterRerankerFilter, embeddings);
 
-  // 9. Token budget packing
-  const selected = packToBudget(kept, tokenBudget);
+  // 9b. Parent re-expansion (return-shaping only; the ranker above is untouched).
+  //     For expand:'none' this is a byte-for-byte pass-through of `kept` as facts.
+  const { units, expandedSegmentIds } = await expandKeptFacts(
+    db,
+    config,
+    kept,
+    queryEmbedding,
+    expand,
+    maxExpandPassages,
+  );
 
-  // 10. Format — reuse embeddings already loaded for dedup
+  // 9. Token budget packing (passage units pack exactly like fact units).
+  const selected = packToBudget(units, tokenBudget);
+
+  // 10. Format — reuse embeddings already loaded for dedup. An expanded passage unit
+  //     keeps its best-ranked fact's `id` (the passage text rides on that fact), so its
+  //     entry in `selectedEmbeddings` is that fact's embedding. The no-LLM extractive
+  //     summary path therefore clusters the passage by its fact's embedding — benign,
+  //     since the passage's whole point is to be the relevant slice of that fact's parent.
   const selectedIds = new Set(selected.map((m) => m.id));
   const selectedEmbeddings = new Map<string, Float32Array>();
   for (const [id, emb] of embeddings) {
@@ -124,14 +156,22 @@ export async function recall(
   }
   const text = await formatMemories(selected, selectedEmbeddings, query, tokenBudget, format, config);
 
-  // 11. Update access stats for returned memories
+  // 11. Update access stats for returned memories.
   const returnedIds = selected.map((m) => m.id);
   updateAccessStats(db, config.namespace, returnedIds);
+
+  // A passage may have been packed out by the budget; only report segments whose
+  // expanded unit actually survived into the returned set.
+  const expandedInResult = expandedSegmentIds.filter((segId) =>
+    selected.some((u) => u.expanded && u.segment_id === segId),
+  );
 
   return {
     text,
     memoryIds: returnedIds,
     totalCandidates: allMemories.size,
     selectedCount: selected.length,
+    expanded: expandedInResult.length > 0,
+    expandedSegmentIds: expandedInResult,
   };
 }

--- a/packages/memory-mcp-server/src/retrieval/pipeline.ts
+++ b/packages/memory-mcp-server/src/retrieval/pipeline.ts
@@ -156,7 +156,9 @@ export async function recall(
   }
   const text = await formatMemories(selected, selectedEmbeddings, query, tokenBudget, format, config);
 
-  // 11. Update access stats for returned memories.
+  // 11. Update access stats for returned memories. An appended passage unit carries a
+  //     synthetic id (no matching memories row), so it no-ops here — only real fact ids
+  //     bump their access_count, exactly once each.
   const returnedIds = selected.map((m) => m.id);
   updateAccessStats(db, config.namespace, returnedIds);
 

--- a/packages/memory-mcp-server/src/retrieval/pipeline.ts
+++ b/packages/memory-mcp-server/src/retrieval/pipeline.ts
@@ -4,13 +4,7 @@ import type { MemoryConfig } from '../config.js';
 import type { RecallOptions } from '../types.js';
 import { vectorSearch, ftsSearch, updateAccessStats, getEmbeddingsForMemories } from '../storage/queries.js';
 import { embedQuery } from '../embedding/embedder.js';
-import {
-  hybridScoreFusion,
-  computeCompositeScore,
-  filterByRelevance,
-  filterByRerankerScore,
-  packToBudget,
-} from './scoring.js';
+import { hybridScoreFusion, computeCompositeScore, filterByRelevance, filterByRerankerScore } from './scoring.js';
 import { deduplicateByEmbedding } from './dedup.js';
 import { rerank } from './reranker.js';
 import { formatMemories } from './formatting.js';
@@ -130,19 +124,20 @@ export async function recall(
   // 8. Dedup
   const { kept } = deduplicateByEmbedding(afterRerankerFilter, embeddings);
 
-  // 9b. Parent re-expansion (return-shaping only; the ranker above is untouched).
-  //     For expand:'none' this is a byte-for-byte pass-through of `kept` as facts.
-  const { units, expandedSegmentIds } = await expandKeptFacts(
+  // 9b + 9. Parent re-expansion AND budget packing (return-shaping only; the ranker
+  //     above is untouched). For expand:'none' this is a byte-for-byte `packToBudget`
+  //     over `kept` as facts. For expand:'auto'|'parent' it reserves budget for the top
+  //     passage so depth is guaranteed, packs the breadth facts into the remainder so the
+  //     top facts are never evicted, then fills leftover — returning the final packed list.
+  const { units: selected, expandedSegmentIds } = await expandKeptFacts(
     db,
     config,
     kept,
     queryEmbedding,
     expand,
     maxExpandPassages,
+    tokenBudget,
   );
-
-  // 9. Token budget packing (passage units pack exactly like fact units).
-  const selected = packToBudget(units, tokenBudget);
 
   // 10. Format — reuse embeddings already loaded for dedup. An expanded passage unit
   //     keeps its best-ranked fact's `id` (the passage text rides on that fact), so its
@@ -162,18 +157,14 @@ export async function recall(
   const returnedIds = selected.map((m) => m.id);
   updateAccessStats(db, config.namespace, returnedIds);
 
-  // A passage may have been packed out by the budget; only report segments whose
-  // expanded unit actually survived into the returned set.
-  const expandedInResult = expandedSegmentIds.filter((segId) =>
-    selected.some((u) => u.expanded && u.segment_id === segId),
-  );
-
+  // `expandKeptFacts` packs facts + passages itself, so `expandedSegmentIds` already
+  // reflects only the passages that survived into the returned set.
   return {
     text,
     memoryIds: returnedIds,
     totalCandidates: allMemories.size,
     selectedCount: selected.length,
-    expanded: expandedInResult.length > 0,
-    expandedSegmentIds: expandedInResult,
+    expanded: expandedSegmentIds.length > 0,
+    expandedSegmentIds,
   };
 }

--- a/packages/memory-mcp-server/src/retrieval/scoring.ts
+++ b/packages/memory-mcp-server/src/retrieval/scoring.ts
@@ -196,9 +196,12 @@ export function filterByRerankerScore(ranked: ScoredMemory[]): ScoredMemory[] {
 /**
  * Greedily select memories by score until the token budget is filled.
  * Uses skip (not break) so smaller memories further down can still fit.
+ *
+ * Generic over `ScoredMemory` so it preserves the caller's subtype (e.g. the
+ * recall pipeline's expanded `DisplayUnit`s). The packing logic is unchanged.
  */
-export function packToBudget(ranked: ScoredMemory[], budget: number): ScoredMemory[] {
-  const selected: ScoredMemory[] = [];
+export function packToBudget<T extends ScoredMemory>(ranked: T[], budget: number): T[] {
+  const selected: T[] = [];
   let usedTokens = 0;
 
   for (const mem of ranked) {

--- a/packages/memory-mcp-server/src/server.ts
+++ b/packages/memory-mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { MemoryEngine } from './engine.js';
 import { FORMAT_MODES } from './retrieval/formatting.js';
+import { MAX_EXPAND_PASSAGES } from './tools/validation.js';
 import { handleStore } from './tools/store.js';
 import { handleIngest } from './tools/ingest.js';
 import { handleRecall } from './tools/recall.js';
@@ -152,8 +153,9 @@ function registerTools(server: McpServer, engine: MemoryEngine): void {
         .number()
         .int()
         .positive()
+        .max(MAX_EXPAND_PASSAGES)
         .optional()
-        .describe('Maximum source passages to return across the whole result. Default: 2.'),
+        .describe(`Maximum source passages to return across the whole result (1-${MAX_EXPAND_PASSAGES}). Default: 2.`),
     },
     async (args) => {
       try {

--- a/packages/memory-mcp-server/src/server.ts
+++ b/packages/memory-mcp-server/src/server.ts
@@ -1,6 +1,6 @@
 /**
  * MCP server definition and tool registration.
- * Registers all 5 memory tools with their input schemas from the design spec.
+ * Registers all 7 memory tools with their input schemas from the design spec.
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -10,6 +10,7 @@ import { FORMAT_MODES } from './retrieval/formatting.js';
 import { handleStore } from './tools/store.js';
 import { handleIngest } from './tools/ingest.js';
 import { handleRecall } from './tools/recall.js';
+import { handleExpand } from './tools/expand.js';
 import { handleContext } from './tools/context.js';
 import { handleForget } from './tools/forget.js';
 import { handleInspect } from './tools/inspect.js';
@@ -132,7 +133,7 @@ function registerTools(server: McpServer, engine: MemoryEngine): void {
         .int()
         .positive()
         .optional()
-        .describe('Maximum approximate tokens in the response. Default: 500.'),
+        .describe('Maximum approximate tokens in the response. Default: 800.'),
       tags: z.array(z.string()).optional().describe('Only search memories with ALL of these tags.'),
       format: z
         .enum(FORMAT_MODES)
@@ -140,10 +141,48 @@ function registerTools(server: McpServer, engine: MemoryEngine): void {
         .describe(
           "'summary': compressed narrative (default). 'list': bullet points. 'raw': full JSON objects. 'answer': directly answer the query from memories (requires LLM, falls back to list).",
         ),
+      expand: z
+        .enum(['none', 'auto', 'parent'])
+        .optional()
+        .describe(
+          "'auto' (default): return the relevant source passage when several matched facts share a source " +
+            "(e.g. a contract's clauses). 'none': strictly pinpoint facts. 'parent': force the source passage for every match.",
+        ),
+      max_expand_passages: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Maximum source passages to return across the whole result. Default: 2.'),
     },
     async (args) => {
       try {
         const text = await handleRecall(engine, args);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: formatError(err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'memory_expand',
+    TOOL_DESCRIPTIONS.memory_expand,
+    {
+      segment_id: z
+        .string()
+        .describe("A source segment id from a prior recall (expanded_segment_ids or a raw result's segment_id)."),
+      query: z
+        .string()
+        .optional()
+        .describe('Optional query to rank the source passages by relevance. Omit to get the whole source.'),
+    },
+    async (args) => {
+      try {
+        const text = await handleExpand(engine, args);
         return { content: [{ type: 'text' as const, text }] };
       } catch (err) {
         return {

--- a/packages/memory-mcp-server/src/server.ts
+++ b/packages/memory-mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { MemoryEngine } from './engine.js';
 import { FORMAT_MODES } from './retrieval/formatting.js';
 import { handleStore } from './tools/store.js';
+import { handleIngest } from './tools/ingest.js';
 import { handleRecall } from './tools/recall.js';
 import { handleContext } from './tools/context.js';
 import { handleForget } from './tools/forget.js';
@@ -50,6 +51,67 @@ function registerTools(server: McpServer, engine: MemoryEngine): void {
     async (args) => {
       try {
         const text = await handleStore(engine, args);
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: formatError(err) }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'memory_ingest',
+    TOOL_DESCRIPTIONS.memory_ingest,
+    {
+      content: z.string().describe('Raw blob to decompose: a conversation transcript, document, or session summary.'),
+      source: z
+        .string()
+        .optional()
+        .describe("Provenance, e.g. 'session:abc', 'document', 'conversation'. Stored on each fact."),
+      mode: z
+        .enum(['conversation', 'document'])
+        .optional()
+        .describe(
+          "'conversation' (default): STRICT — only DURABLE facts explicitly stated, no inference. " +
+            "'document': broader — DURABLE facts with reasonable inference allowed. " +
+            'Both modes keep stable preferences/identity/project facts/decisions and skip ' +
+            'ephemeral task chatter. Use document for conversation transcripts.',
+        ),
+      tags: z.array(z.string()).optional().describe('Optional seed tags applied to EVERY extracted fact.'),
+      importance: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe(
+          'SEED importance 0-1, used as the fallback when the extraction model does not emit a ' +
+            'per-fact importance. Default: 0.5. Per-fact importance (when the model provides it) wins.',
+        ),
+      dry_run: z
+        .boolean()
+        .optional()
+        .describe('If true, run extraction and RETURN the facts WITHOUT writing anything. Default: false.'),
+      on_extraction_failure: z
+        .enum(['degrade', 'skip', 'error'])
+        .optional()
+        .describe(
+          'How to handle a chunk/call that yields no facts (no LLM, LLM error, or unparseable). ' +
+            "'degrade' (default): store the blob as a single memory (product behavior). " +
+            "'skip': write nothing, return ingested 0. 'error': throw, so a bulk driver can retry.",
+        ),
+      as_of: z
+        .union([z.number(), z.string()])
+        .optional()
+        .describe(
+          'Backdate: stamp created_at/last_accessed_at of every extracted fact to this time ' +
+            '(epoch ms or ISO 8601) instead of now. For ingesting historical exports.',
+        ),
+    },
+    async (args) => {
+      try {
+        const text = await handleIngest(engine, args);
         return { content: [{ type: 'text' as const, text }] };
       } catch (err) {
         return {

--- a/packages/memory-mcp-server/src/server.ts
+++ b/packages/memory-mcp-server/src/server.ts
@@ -157,8 +157,19 @@ function registerTools(server: McpServer, engine: MemoryEngine): void {
     },
     async (args) => {
       try {
-        const text = await handleRecall(engine, args);
-        return { content: [{ type: 'text' as const, text }] };
+        const result = await handleRecall(engine, args);
+        // Surface the recall metadata (expansion segment handles) as structured
+        // content so MCP callers can drive the memory_expand follow-up loop in
+        // every format, while preserving the human-readable text exactly.
+        return {
+          content: [{ type: 'text' as const, text: result.text }],
+          structuredContent: {
+            memories_used: result.memories_used,
+            total_matches: result.total_matches,
+            expanded: result.expanded,
+            expanded_segment_ids: result.expanded_segment_ids,
+          },
+        };
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: formatError(err) }],

--- a/packages/memory-mcp-server/src/server.ts
+++ b/packages/memory-mcp-server/src/server.ts
@@ -19,7 +19,7 @@ import { TOOL_DESCRIPTIONS } from './prompts.js';
 export function createServer(engine: MemoryEngine): McpServer {
   const server = new McpServer({
     name: 'memory',
-    version: '0.1.0',
+    version: '0.2.0',
   });
 
   registerTools(server, engine);

--- a/packages/memory-mcp-server/src/storage/database.ts
+++ b/packages/memory-mcp-server/src/storage/database.ts
@@ -17,6 +17,23 @@ export interface MemoryRow {
   consolidated: number;
   source: string | null;
   metadata: string | null;
+  /** FK to the source segment a `memory_ingest` fact was extracted from. NULL for store-path / degrade-path rows. */
+  segment_id: string | null;
+}
+
+/**
+ * A source chunk `memory_ingest` extracted facts from. Off the retrieval index by
+ * construction: never embedded, never in `vec_memories`/`memories_fts`. Fetched
+ * only by primary key during recall-time re-expansion ("index fine, return coarse").
+ */
+export interface SegmentRow {
+  id: string;
+  namespace: string;
+  content: string;
+  source: string | null;
+  mode: string | null;
+  created_at: number;
+  fact_count: number;
 }
 
 export interface VectorSearchResult extends MemoryRow {
@@ -27,7 +44,7 @@ export interface FtsSearchResult extends MemoryRow {
   bm25_score: number;
 }
 
-const SCHEMA_VERSION = '3';
+const SCHEMA_VERSION = '4';
 const EMBEDDING_DIMENSIONS = 768;
 
 /**
@@ -43,14 +60,58 @@ export function initDatabase(dbPath: string, embeddingModel: string): Database.D
 
   sqliteVec.load(db);
 
+  // Self-heal a stale on-disk schema BEFORE createSchema runs. A pre-`'4'` DB has an
+  // old `memories` table without `segment_id`; `CREATE TABLE IF NOT EXISTS` would no-op
+  // on it and the first `segment_id` access would throw `no such column`. Under the
+  // back-compat-free directive we drop-and-recreate (deliberately discarding old data).
+  dropStaleSchema(db);
+
   createSchema(db);
   ensureSchemaMeta(db, embeddingModel);
 
   return db;
 }
 
+/**
+ * Read the on-disk `schema_version` stamp (defensively — the table may not exist on a
+ * fresh DB) and, when it is PRESENT and OLDER than SCHEMA_VERSION, drop the schema so
+ * `createSchema` rebuilds it from scratch. A fresh DB (no stamp) and a current DB
+ * (stamp === SCHEMA_VERSION) both skip the drop.
+ */
+function dropStaleSchema(db: Database.Database): void {
+  const hasSchemaMeta = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'`).get();
+  if (!hasSchemaMeta) return; // fresh DB — nothing to drop
+
+  const stamp = db.prepare(`SELECT value FROM schema_meta WHERE key = 'schema_version'`).get() as
+    | { value: string }
+    | undefined;
+  if (!stamp || stamp.value === SCHEMA_VERSION) return; // fresh or current — keep
+
+  // Stale stamp present: rebuild. Drop the virtual tables first (their shadow tables
+  // depend on nothing else), then the base tables.
+  db.exec(`
+    DROP TABLE IF EXISTS vec_memories;
+    DROP TABLE IF EXISTS memories_fts;
+    DROP TABLE IF EXISTS memories;
+    DROP TABLE IF EXISTS segments;
+    DROP TABLE IF EXISTS schema_meta;
+  `);
+}
+
 function createSchema(db: Database.Database): void {
   db.exec(`
+    CREATE TABLE IF NOT EXISTS segments (
+      id          TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+      namespace   TEXT NOT NULL DEFAULT 'default',
+      content     TEXT NOT NULL,
+      source      TEXT,
+      mode        TEXT,
+      created_at  INTEGER NOT NULL,
+      fact_count  INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_segments_namespace ON segments(namespace);
+
     CREATE TABLE IF NOT EXISTS memories (
       id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
       namespace TEXT NOT NULL DEFAULT 'default',
@@ -64,7 +125,8 @@ function createSchema(db: Database.Database): void {
       is_compacted INTEGER NOT NULL DEFAULT 0,
       source TEXT,
       metadata TEXT,
-      consolidated INTEGER NOT NULL DEFAULT 1
+      consolidated INTEGER NOT NULL DEFAULT 1,
+      segment_id TEXT REFERENCES segments(id)
     );
 
     CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);
@@ -73,6 +135,8 @@ function createSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_memories_accessed ON memories(namespace, last_accessed_at);
     CREATE INDEX IF NOT EXISTS idx_memories_unconsolidated
       ON memories(namespace, created_at) WHERE consolidated = 0;
+    CREATE INDEX IF NOT EXISTS idx_memories_segment
+      ON memories(segment_id) WHERE segment_id IS NOT NULL;
 
     CREATE TABLE IF NOT EXISTS schema_meta (
       key TEXT PRIMARY KEY,

--- a/packages/memory-mcp-server/src/storage/database.ts
+++ b/packages/memory-mcp-server/src/storage/database.ts
@@ -74,9 +74,18 @@ export function initDatabase(dbPath: string, embeddingModel: string): Database.D
 
 /**
  * Read the on-disk `schema_version` stamp (defensively — the table may not exist on a
- * fresh DB) and, when it is PRESENT and OLDER than SCHEMA_VERSION, drop the schema so
- * `createSchema` rebuilds it from scratch. A fresh DB (no stamp) and a current DB
- * (stamp === SCHEMA_VERSION) both skip the drop.
+ * fresh DB) and reconcile it against the current SCHEMA_VERSION using a NUMERIC compare:
+ *
+ *   - absent stamp (fresh DB)      → no-op (createSchema builds from scratch)
+ *   - on-disk  <  current          → drop-and-recreate (deliberately discard old data)
+ *   - on-disk  === current         → no-op (keep)
+ *   - on-disk  >  current          → THROW (fail closed): an older binary must NOT
+ *                                    destroy a newer DB it can't understand
+ *   - present-but-unparseable      → drop (treat as stale; it is not a recognizable
+ *                                    newer version)
+ *
+ * A pre-numeric string compare silently dropped a FUTURE schema opened by an older
+ * binary (downgrade data loss); numeric compare + fail-closed prevents that.
  */
 function dropStaleSchema(db: Database.Database): void {
   const hasSchemaMeta = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'`).get();
@@ -85,10 +94,38 @@ function dropStaleSchema(db: Database.Database): void {
   const stamp = db.prepare(`SELECT value FROM schema_meta WHERE key = 'schema_version'`).get() as
     | { value: string }
     | undefined;
-  if (!stamp || stamp.value === SCHEMA_VERSION) return; // fresh or current — keep
+  if (!stamp) return; // fresh — no stamp to compare
 
-  // Stale stamp present: rebuild. Drop the virtual tables first (their shadow tables
-  // depend on nothing else), then the base tables.
+  const current = Number(SCHEMA_VERSION);
+  const onDisk = Number(stamp.value);
+
+  // A present-but-unparseable stamp is not a recognizable newer version: treat it as
+  // stale and rebuild (matches the absent-`segment_id` self-heal intent).
+  if (Number.isNaN(onDisk)) {
+    rebuildSchema(db);
+    return;
+  }
+
+  if (onDisk === current) return; // current — keep
+
+  if (onDisk > current) {
+    // Fail closed: refuse to open (and never drop) a DB written by a newer binary.
+    throw new Error(
+      `Refusing to open memory database: on-disk schema version ${stamp.value} is newer than ` +
+        `this binary's schema version ${SCHEMA_VERSION}. Upgrade the memory server or point at a ` +
+        `compatible database; the newer database was left untouched.`,
+    );
+  }
+
+  // on-disk < current: stale older DB — drop-and-recreate.
+  rebuildSchema(db);
+}
+
+/**
+ * Drop the schema so `createSchema` rebuilds it from scratch. Drops the virtual tables
+ * first (their shadow tables depend on nothing else), then the base tables.
+ */
+function rebuildSchema(db: Database.Database): void {
   db.exec(`
     DROP TABLE IF EXISTS vec_memories;
     DROP TABLE IF EXISTS memories_fts;

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -43,6 +43,13 @@ const MAX_INGEST_CHUNK_CHARS = MAX_INGEST_CHUNK_TOKENS * 4;
 /** Fraction of a window's lines re-fed at the head of the next window (A5). */
 const CHUNK_OVERLAP_FRACTION = 0.12;
 
+/**
+ * Target token size for a recall-time passage (§5.3.1). A passage is the *returned*
+ * unit on auto-expansion: small enough to fit the recall budget (default 800) with
+ * room for supporting facts, large enough to carry a coherent clause.
+ */
+export const MAX_PASSAGE_TOKENS = 350;
+
 // ---------- Prompts ----------
 
 const SHARED_RULES =
@@ -247,6 +254,90 @@ export function chunkBlob(blob: string): string[] {
   }
 
   return chunks.slice(0, MAX_INGEST_CHUNKS);
+}
+
+// ---------- Passage splitting (recall-time return shaping) ----------
+
+/**
+ * Split a segment into COHERENT passages of at most ~MAX_PASSAGE_TOKENS, on
+ * meaning-preserving boundaries (paragraph breaks / conversation turns first,
+ * sentence boundaries as a fallback). Pure & unit-testable; used at recall time
+ * (§5.3.1) to return a query-relevant slice of an expanded parent rather than the
+ * whole 6000-token chunk.
+ *
+ * Greedy accumulation: pack atomic units (paragraphs, then sentences for an
+ * oversized paragraph) into a passage until the next unit would overflow the token
+ * cap, then start a new passage. An empty/whitespace-only input yields `[]`.
+ */
+export function splitToPassages(text: string): string[] {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return [];
+
+  const units = toAtomicUnits(trimmed);
+  return packUnitsToPassages(units);
+}
+
+/**
+ * Break text into atomic units no larger than the passage cap: paragraph/turn
+ * blocks first, splitting any block still over the cap into sentences (and, as a
+ * last resort for a giant sentence, a char-bounded cut so a unit never exceeds the
+ * cap).
+ */
+function toAtomicUnits(text: string): string[] {
+  const blocks = text
+    .split(/\n\s*\n+/)
+    .map((b) => b.trim())
+    .filter((b) => b.length > 0);
+  const units: string[] = [];
+  for (const block of blocks) {
+    if (estimateTokens(block) <= MAX_PASSAGE_TOKENS) {
+      units.push(block);
+      continue;
+    }
+    for (const sentence of splitIntoSentences(block)) {
+      if (estimateTokens(sentence) <= MAX_PASSAGE_TOKENS) {
+        units.push(sentence);
+      } else {
+        units.push(...hardCutToPassageChars(sentence));
+      }
+    }
+  }
+  return units;
+}
+
+/** Split a block into sentences on `.`/`!`/`?` + whitespace, keeping the punctuation. */
+function splitIntoSentences(block: string): string[] {
+  return block
+    .split(/(?<=[.!?])\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Last-resort char-bounded cut for a single oversized sentence (no usable boundary). */
+function hardCutToPassageChars(text: string): string[] {
+  const maxChars = MAX_PASSAGE_TOKENS * 4;
+  const pieces: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    pieces.push(text.slice(i, i + maxChars).trim());
+  }
+  return pieces.filter((p) => p.length > 0);
+}
+
+/** Greedily accumulate atomic units into passages bounded by the token cap. */
+function packUnitsToPassages(units: string[]): string[] {
+  const passages: string[] = [];
+  let current = '';
+  for (const unit of units) {
+    const candidate = current.length === 0 ? unit : `${current}\n\n${unit}`;
+    if (current.length > 0 && estimateTokens(candidate) > MAX_PASSAGE_TOKENS) {
+      passages.push(current);
+      current = unit;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) passages.push(current);
+  return passages;
 }
 
 // ---------- LLM call ----------

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -48,8 +48,11 @@ const CHUNK_OVERLAP_FRACTION = 0.12;
 const SHARED_RULES =
   '- Output ONLY a JSON array of objects, each { "fact": "<self-contained fact>", ' +
   '"importance": <0.0-1.0> }. One atomic fact per element — never combine two facts with "and".\n' +
-  '- Each fact must be self-contained: resolve pronouns to names, include the subject ' +
-  '("The user prefers dark mode", not "prefers dark mode").\n' +
+  '- Each fact must be self-contained: resolve pronouns to names and include the subject ' +
+  '("The user prefers dark mode", not "prefers dark mode"), AND name the specific thing the ' +
+  'fact is about — the project, product, document, game, or entity ("The user wants players to ' +
+  'pay off all loans before winning Debt Quest", not "...before winning the game"). If a fact ' +
+  'would be ambiguous out of context, name its referent.\n' +
   '- Extract only DURABLE facts worth remembering beyond this conversation: stable ' +
   'preferences, identity, project facts, decisions, learned constraints.\n' +
   '- SKIP ephemeral / session-local state: transient errors, one-off debugging steps, ' +

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -112,16 +112,19 @@ function coerceFact(item: unknown): ExtractedFact | null {
  * Parse the model's text response into ExtractedFact[]. Pure & defensive,
  * mirroring `parseBatchJudgments`.
  *
- * On a parse miss it returns [] and NEVER echoes `raw` (A6) — the caller logs a
- * content-free shape.
+ * Returns `null` on a PARSE FAILURE — no JSON array found, invalid JSON, or a
+ * non-array payload — which the caller treats as a chunk failure. Returns a
+ * (possibly empty) array on a successful parse; an empty array is a VALID
+ * outcome meaning the model reported no durable facts (the prompt instructs it
+ * to emit `[]` in that case), NOT a failure. NEVER echoes `raw` (A6).
  */
-export function parseExtractedFacts(raw: string): ExtractedFact[] {
+export function parseExtractedFacts(raw: string): ExtractedFact[] | null {
   try {
     const jsonMatch = raw.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) return [];
+    if (!jsonMatch) return null;
 
     const parsed = JSON.parse(jsonMatch[0]) as unknown;
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) return null;
 
     const facts: ExtractedFact[] = [];
     const seen = new Set<string>();
@@ -135,7 +138,7 @@ export function parseExtractedFacts(raw: string): ExtractedFact[] {
     }
     return facts;
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -252,10 +255,13 @@ export function chunkBlob(blob: string): string[] {
  * Extract atomic durable facts from a single chunk via one LLM call.
  *
  * Returns:
- *   - ExtractedFact[]  on success (may be [] if the model found nothing durable),
- *   - null             when no LLM is configured or the call hard-failed.
+ *   - ExtractedFact[]  on a successful parse — may be [] when the model parsed
+ *                      fine but reported no durable facts (a VALID outcome, NOT
+ *                      a failure),
+ *   - null             when no LLM is configured, the call hard-failed, or the
+ *                      response was unparseable.
  *
- * The caller treats both `null` and `[]` as a chunk failure for diagnostics.
+ * The caller treats only `null` as a chunk failure for diagnostics.
  * PII-safe: never logs the chunk or the raw response.
  */
 export async function extractFacts(
@@ -268,9 +274,10 @@ export async function extractFacts(
   if (raw === null) return null;
 
   const facts = parseExtractedFacts(raw);
-  if (facts.length === 0) {
-    // Content-free failure shape only (A6).
-    console.error(`[memory-server] extraction: no facts parsed from ${raw.length}-char response`);
+  if (facts === null) {
+    // Genuine parse failure — content-free failure shape only (A6).
+    console.error(`[memory-server] extraction: unparseable ${raw.length}-char response`);
+    return null;
   }
   return facts;
 }

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -1,0 +1,273 @@
+/**
+ * LLM-backed fact extraction for `memory_ingest`.
+ *
+ * Sits next to consolidation.ts / compaction.ts (the other LLM-on-write modules).
+ * Reuses `llmComplete` from llm/client.js and `estimateTokens` from retrieval/scoring.js.
+ *
+ * PII-safe rule (hard): this module NEVER logs raw content/chunk/blob or the model's
+ * raw response. Only lengths, token estimates, chunk indices, and content-free failure
+ * shapes are ever emitted.
+ */
+
+import type { MemoryConfig } from '../config.js';
+import { llmComplete } from '../llm/client.js';
+import { estimateTokens } from '../retrieval/scoring.js';
+import { MAX_CONTENT_LENGTH } from '../tools/validation.js';
+
+export interface ExtractedFact {
+  fact: string;
+  /** 0–1, OPTIONAL; absent ⇒ caller falls back to the seed importance. */
+  importance?: number;
+}
+
+export type IngestMode = 'conversation' | 'document';
+
+// ---------- Constants ----------
+
+/** Per-chunk token budget; comfortably inside Haiku's window with room for prompt + output. */
+export const MAX_INGEST_CHUNK_TOKENS = 6000;
+
+/** Cap total extracted facts per ingest to bound a runaway response. */
+export const MAX_FACTS_PER_INGEST = 200;
+
+/** Cap total chunks so a hostile/enormous blob can't fan out unboundedly. */
+export const MAX_INGEST_CHUNKS = 50;
+
+/**
+ * Char-based hard cap per piece, derived from the per-chunk token budget via the
+ * package's ~4-chars/token heuristic (`estimateTokens`). Used as a last-resort cut
+ * for whitespace-free input so no emitted piece can exceed MAX_INGEST_CHUNK_TOKENS.
+ */
+const MAX_INGEST_CHUNK_CHARS = MAX_INGEST_CHUNK_TOKENS * 4;
+
+/** Fraction of a window's lines re-fed at the head of the next window (A5). */
+const CHUNK_OVERLAP_FRACTION = 0.12;
+
+// ---------- Prompts ----------
+
+const SHARED_RULES =
+  '- Output ONLY a JSON array of objects, each { "fact": "<self-contained fact>", ' +
+  '"importance": <0.0-1.0> }. One atomic fact per element — never combine two facts with "and".\n' +
+  '- Each fact must be self-contained: resolve pronouns to names, include the subject ' +
+  '("The user prefers dark mode", not "prefers dark mode").\n' +
+  '- Extract only DURABLE facts worth remembering beyond this conversation: stable ' +
+  'preferences, identity, project facts, decisions, learned constraints.\n' +
+  '- SKIP ephemeral / session-local state: transient errors, one-off debugging steps, ' +
+  '"let\'s try X", task chatter, pleasantries, meta-talk.\n' +
+  '- "importance" reflects how durable/identity-defining the fact is: durable identity, ' +
+  'standing preferences, and decisions → high (~0.7-1.0); useful-but-replaceable project ' +
+  'facts → mid (~0.4-0.7); marginal/ephemeral facts you still chose to keep → low ' +
+  '(~0.1-0.4). When unsure, omit "importance" and the caller will use the seed default.\n' +
+  '- If nothing durable is stated, output []. Reply with ONLY the JSON array, no prose.';
+
+export const CONVERSATION_EXTRACTION_PROMPT =
+  'You extract atomic, durable facts from a conversation transcript for long-term memory.\n' +
+  SHARED_RULES +
+  '\n- Extract ONLY facts that are explicitly stated. Do NOT infer, summarize, or editorialize.';
+
+export const DOCUMENT_EXTRACTION_PROMPT =
+  'You extract atomic, durable facts from a document or session summary for long-term memory.\n' +
+  SHARED_RULES +
+  '\n- Reasonable inference is allowed where the text clearly implies a durable fact, but do ' +
+  'not fabricate. Prefer atomic facts; split compound statements.';
+
+function systemPromptFor(mode: IngestMode): string {
+  return mode === 'document' ? DOCUMENT_EXTRACTION_PROMPT : CONVERSATION_EXTRACTION_PROMPT;
+}
+
+// ---------- Parsing ----------
+
+interface RawFactObject {
+  fact?: unknown;
+  importance?: unknown;
+}
+
+function coerceFact(item: unknown): ExtractedFact | null {
+  // Accept a bare string OR an object { fact, importance? }.
+  if (typeof item === 'string') {
+    const fact = item.trim();
+    return fact.length > 0 ? { fact } : null;
+  }
+  if (item === null || typeof item !== 'object') return null;
+
+  const obj = item as RawFactObject;
+  if (typeof obj.fact !== 'string') return null;
+  const fact = obj.fact.trim();
+  if (fact.length === 0) return null;
+
+  const capped = fact.length > MAX_CONTENT_LENGTH ? fact.slice(0, MAX_CONTENT_LENGTH) : fact;
+
+  let importance: number | undefined;
+  if (typeof obj.importance === 'number' && Number.isFinite(obj.importance)) {
+    importance = Math.min(1, Math.max(0, obj.importance));
+  }
+
+  return importance === undefined ? { fact: capped } : { fact: capped, importance };
+}
+
+/**
+ * Parse the model's text response into ExtractedFact[]. Pure & defensive,
+ * mirroring `parseBatchJudgments`.
+ *
+ * On a parse miss it returns [] and NEVER echoes `raw` (A6) — the caller logs a
+ * content-free shape.
+ */
+export function parseExtractedFacts(raw: string): ExtractedFact[] {
+  try {
+    const jsonMatch = raw.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) return [];
+
+    const parsed = JSON.parse(jsonMatch[0]) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    const facts: ExtractedFact[] = [];
+    const seen = new Set<string>();
+    for (const item of parsed) {
+      const coerced = coerceFact(item);
+      if (!coerced) continue;
+      if (seen.has(coerced.fact)) continue;
+      seen.add(coerced.fact);
+      facts.push(coerced);
+      if (facts.length >= MAX_FACTS_PER_INGEST) break;
+    }
+    return facts;
+  } catch {
+    return [];
+  }
+}
+
+// ---------- Chunking ----------
+
+/**
+ * Cut a single string into char-bounded pieces of at most MAX_INGEST_CHUNK_CHARS
+ * (≈ MAX_INGEST_CHUNK_TOKENS at ~4 chars/token). Last-resort fallback for content
+ * with no usable whitespace (base64, minified JSON, one giant token) so that no
+ * emitted piece can exceed the token cap.
+ */
+function hardCutChars(text: string): string[] {
+  const pieces: string[] = [];
+  for (let i = 0; i < text.length; i += MAX_INGEST_CHUNK_CHARS) {
+    pieces.push(text.slice(i, i + MAX_INGEST_CHUNK_CHARS));
+  }
+  return pieces;
+}
+
+/**
+ * Hard-split a single pathological line (longer than the threshold) on whitespace
+ * into sub-lines that each fit under MAX_INGEST_CHUNK_TOKENS. Any resulting piece
+ * that still exceeds the budget — e.g. a single whitespace-free giant token —
+ * falls back to a char-based hard cut, so the token cap is a HARD bound regardless
+ * of input.
+ */
+function hardSplitLine(line: string): string[] {
+  const words = line.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 0) return capPieces([line]);
+
+  const pieces: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current.length === 0 ? word : `${current} ${word}`;
+    if (estimateTokens(candidate) > MAX_INGEST_CHUNK_TOKENS && current.length > 0) {
+      pieces.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) pieces.push(current);
+  return capPieces(pieces);
+}
+
+/** Replace any piece still over the token budget with char-bounded sub-pieces. */
+function capPieces(pieces: string[]): string[] {
+  const capped: string[] = [];
+  for (const piece of pieces) {
+    if (estimateTokens(piece) > MAX_INGEST_CHUNK_TOKENS) {
+      capped.push(...hardCutChars(piece));
+    } else {
+      capped.push(piece);
+    }
+  }
+  return capped;
+}
+
+/**
+ * Split a blob into line-oriented windows of ~MAX_INGEST_CHUNK_TOKENS, with a
+ * ~10-15% line overlap between adjacent windows (A5). Pathological long lines are
+ * hard-split on whitespace. Total chunk count is bounded by MAX_INGEST_CHUNKS.
+ */
+export function chunkBlob(blob: string): string[] {
+  if (estimateTokens(blob) <= MAX_INGEST_CHUNK_TOKENS) {
+    return [blob];
+  }
+
+  // Normalize lines, hard-splitting any single line that exceeds the threshold.
+  const rawLines = blob.split('\n');
+  const lines: string[] = [];
+  for (const line of rawLines) {
+    if (estimateTokens(line) > MAX_INGEST_CHUNK_TOKENS) {
+      lines.push(...hardSplitLine(line));
+    } else {
+      lines.push(line);
+    }
+  }
+
+  const chunks: string[] = [];
+  let window: string[] = [];
+  let windowTokens = 0;
+
+  const flush = (): void => {
+    if (window.length === 0) return;
+    chunks.push(window.join('\n'));
+    // Carry the tail ~CHUNK_OVERLAP_FRACTION of lines into the next window (A5).
+    const overlapCount = Math.min(window.length - 1, Math.max(1, Math.floor(window.length * CHUNK_OVERLAP_FRACTION)));
+    const overlap = overlapCount > 0 ? window.slice(window.length - overlapCount) : [];
+    window = [...overlap];
+    windowTokens = overlap.reduce((sum, l) => sum + estimateTokens(l) + 1, 0);
+  };
+
+  for (const line of lines) {
+    const lineTokens = estimateTokens(line) + 1; // +1 for the newline
+    if (windowTokens + lineTokens > MAX_INGEST_CHUNK_TOKENS && window.length > 0) {
+      flush();
+      if (chunks.length >= MAX_INGEST_CHUNKS) break;
+    }
+    window.push(line);
+    windowTokens += lineTokens;
+  }
+
+  if (chunks.length < MAX_INGEST_CHUNKS && window.length > 0) {
+    chunks.push(window.join('\n'));
+  }
+
+  return chunks.slice(0, MAX_INGEST_CHUNKS);
+}
+
+// ---------- LLM call ----------
+
+/**
+ * Extract atomic durable facts from a single chunk via one LLM call.
+ *
+ * Returns:
+ *   - ExtractedFact[]  on success (may be [] if the model found nothing durable),
+ *   - null             when no LLM is configured or the call hard-failed.
+ *
+ * The caller treats both `null` and `[]` as a chunk failure for diagnostics.
+ * PII-safe: never logs the chunk or the raw response.
+ */
+export async function extractFacts(
+  config: MemoryConfig,
+  blob: string,
+  mode: IngestMode,
+): Promise<ExtractedFact[] | null> {
+  const maxTokens = Math.min(1500, Math.max(300, estimateTokens(blob)));
+  const raw = await llmComplete(config, systemPromptFor(mode), `<input>\n${blob}\n</input>`, { maxTokens });
+  if (raw === null) return null;
+
+  const facts = parseExtractedFacts(raw);
+  if (facts.length === 0) {
+    // Content-free failure shape only (A6).
+    console.error(`[memory-server] extraction: no facts parsed from ${raw.length}-char response`);
+  }
+  return facts;
+}

--- a/packages/memory-mcp-server/src/storage/extraction.ts
+++ b/packages/memory-mcp-server/src/storage/extraction.ts
@@ -92,27 +92,31 @@ interface RawFactObject {
   importance?: unknown;
 }
 
+/** Trim and hard-cap a fact's text at MAX_CONTENT_LENGTH (applies to BOTH shapes). */
+function capFactText(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length > MAX_CONTENT_LENGTH ? trimmed.slice(0, MAX_CONTENT_LENGTH) : trimmed;
+}
+
 function coerceFact(item: unknown): ExtractedFact | null {
   // Accept a bare string OR an object { fact, importance? }.
   if (typeof item === 'string') {
-    const fact = item.trim();
+    const fact = capFactText(item);
     return fact.length > 0 ? { fact } : null;
   }
   if (item === null || typeof item !== 'object') return null;
 
   const obj = item as RawFactObject;
   if (typeof obj.fact !== 'string') return null;
-  const fact = obj.fact.trim();
+  const fact = capFactText(obj.fact);
   if (fact.length === 0) return null;
-
-  const capped = fact.length > MAX_CONTENT_LENGTH ? fact.slice(0, MAX_CONTENT_LENGTH) : fact;
 
   let importance: number | undefined;
   if (typeof obj.importance === 'number' && Number.isFinite(obj.importance)) {
     importance = Math.min(1, Math.max(0, obj.importance));
   }
 
-  return importance === undefined ? { fact: capped } : { fact: capped, importance };
+  return importance === undefined ? { fact } : { fact, importance };
 }
 
 /**

--- a/packages/memory-mcp-server/src/storage/queries.ts
+++ b/packages/memory-mcp-server/src/storage/queries.ts
@@ -17,10 +17,15 @@ export interface InsertMemoryParams {
   source?: string;
   metadata?: Record<string, unknown>;
   consolidated?: boolean;
+  /**
+   * Epoch ms backdate. When present, stamps created_at/updated_at/last_accessed_at
+   * to this value (the `as_of` mechanism). Absent ⇒ Date.now() (unchanged behavior).
+   */
+  createdAt?: number;
 }
 
 export function insertMemory(db: Database.Database, params: InsertMemoryParams, embedding: Float32Array): void {
-  const now = Date.now();
+  const now = params.createdAt ?? Date.now();
   const txn = db.transaction(() => {
     db.prepare(
       `INSERT INTO memories (id, namespace, content, tags, importance,
@@ -115,6 +120,33 @@ export function updateMemoryContent(
     ).run(Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength), id, namespace);
   });
   txn();
+}
+
+/**
+ * Reconcile a merged row's timestamps order-independently against a backdated
+ * `as_of` (A1). Additive — does NOT touch `updateMemoryContent`, which is shared
+ * with the consolidation contradiction path.
+ *
+ *   created_at       = MIN(created_at, asOf)   // true first-seen
+ *   last_accessed_at = MAX(last_accessed_at, asOf)
+ *   updated_at       = MAX(updated_at, asOf)
+ *
+ * Computed in SQL so the merge is atomic and order-independent regardless of
+ * which insert wins the race.
+ */
+export function updateMemoryTimestampsOnMerge(
+  db: Database.Database,
+  namespace: string,
+  id: string,
+  asOf: number,
+): void {
+  db.prepare(
+    `UPDATE memories
+        SET created_at       = MIN(created_at, ?),
+            last_accessed_at = MAX(last_accessed_at, ?),
+            updated_at       = MAX(updated_at, ?)
+      WHERE id = ? AND namespace = ?`,
+  ).run(asOf, asOf, asOf, id, namespace);
 }
 
 export function updateAccessStats(db: Database.Database, namespace: string, ids: string[]): void {

--- a/packages/memory-mcp-server/src/storage/queries.ts
+++ b/packages/memory-mcp-server/src/storage/queries.ts
@@ -1,5 +1,5 @@
 import type Database from 'better-sqlite3';
-import type { MemoryRow, VectorSearchResult, FtsSearchResult } from './database.js';
+import type { MemoryRow, SegmentRow, VectorSearchResult, FtsSearchResult } from './database.js';
 import { randomBytes } from 'node:crypto';
 
 export function generateId(): string {
@@ -22,6 +22,11 @@ export interface InsertMemoryParams {
    * to this value (the `as_of` mechanism). Absent ⇒ Date.now() (unchanged behavior).
    */
   createdAt?: number;
+  /**
+   * FK to the source segment (`memory_ingest` only). Absent ⇒ bound as NULL,
+   * exactly as the store path / degrade path require (a row with no parent).
+   */
+  segmentId?: string;
 }
 
 export function insertMemory(db: Database.Database, params: InsertMemoryParams, embedding: Float32Array): void {
@@ -29,8 +34,8 @@ export function insertMemory(db: Database.Database, params: InsertMemoryParams, 
   const txn = db.transaction(() => {
     db.prepare(
       `INSERT INTO memories (id, namespace, content, tags, importance,
-         created_at, updated_at, last_accessed_at, source, metadata, consolidated)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         created_at, updated_at, last_accessed_at, source, metadata, consolidated, segment_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       params.id,
       params.namespace,
@@ -43,6 +48,7 @@ export function insertMemory(db: Database.Database, params: InsertMemoryParams, 
       params.source ?? null,
       params.metadata ? JSON.stringify(params.metadata) : null,
       params.consolidated === false ? 0 : 1,
+      params.segmentId ?? null,
     );
 
     db.prepare(`INSERT INTO vec_memories (memory_id, embedding) VALUES (?, ?)`).run(
@@ -51,6 +57,90 @@ export function insertMemory(db: Database.Database, params: InsertMemoryParams, 
     );
   });
   txn();
+}
+
+// ---------- Segments ----------
+
+export interface InsertSegmentParams {
+  id?: string;
+  namespace: string;
+  content: string;
+  source?: string;
+  mode?: string;
+  createdAt?: number;
+  factCount: number;
+}
+
+/**
+ * Insert one source segment and return its id. Mirrors `insertMemory`'s shape
+ * (`createdAt ?? Date.now()`). Segments are off the retrieval index — no vec/FTS write.
+ */
+export function insertSegment(db: Database.Database, params: InsertSegmentParams): string {
+  const id = params.id ?? generateId();
+  const now = params.createdAt ?? Date.now();
+  db.prepare(
+    `INSERT INTO segments (id, namespace, content, source, mode, created_at, fact_count)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, params.namespace, params.content, params.source ?? null, params.mode ?? null, now, params.factCount);
+  return id;
+}
+
+/** Batch fetch segments by primary key for recall-time re-expansion. */
+export function getSegmentsByIds(db: Database.Database, namespace: string, ids: string[]): SegmentRow[] {
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(',');
+  return db
+    .prepare(`SELECT * FROM segments WHERE namespace = ? AND id IN (${placeholders})`)
+    .all(namespace, ...ids) as SegmentRow[];
+}
+
+/**
+ * Repoint a merged survivor's `segment_id` to the RICHER parent (A4, §6.2), so a
+ * later, richer ingest of the same fact is not discarded purely by ingest order.
+ * Runs ONLY when `incomingSegmentId` is set (non-ingest merges are unchanged):
+ *   - survivor has no parent (NULL)  → adopt the incoming segment;
+ *   - else keep whichever segment has the higher `fact_count`; a tie keeps the
+ *     existing (stable, order-independent given equal richness).
+ */
+export function updateMemorySegmentIfRicher(
+  db: Database.Database,
+  namespace: string,
+  survivorId: string,
+  incomingSegmentId: string,
+): void {
+  const row = db
+    .prepare(`SELECT segment_id FROM memories WHERE id = ? AND namespace = ?`)
+    .get(survivorId, namespace) as { segment_id: string | null } | undefined;
+  if (!row) return;
+
+  const existingSegmentId = row.segment_id;
+
+  // No existing parent → adopt the incoming one.
+  if (existingSegmentId === null) {
+    db.prepare(`UPDATE memories SET segment_id = ? WHERE id = ? AND namespace = ?`).run(
+      incomingSegmentId,
+      survivorId,
+      namespace,
+    );
+    return;
+  }
+
+  // Already pointing at the incoming segment → nothing to do.
+  if (existingSegmentId === incomingSegmentId) return;
+
+  const counts = getSegmentsByIds(db, namespace, [existingSegmentId, incomingSegmentId]);
+  const factCountById = new Map(counts.map((s) => [s.id, s.fact_count]));
+  const existingCount = factCountById.get(existingSegmentId) ?? 0;
+  const incomingCount = factCountById.get(incomingSegmentId) ?? 0;
+
+  // Keep the richer parent; ties keep the existing (order-independent).
+  if (incomingCount > existingCount) {
+    db.prepare(`UPDATE memories SET segment_id = ? WHERE id = ? AND namespace = ?`).run(
+      incomingSegmentId,
+      survivorId,
+      namespace,
+    );
+  }
 }
 
 // ---------- Update ----------

--- a/packages/memory-mcp-server/src/tools/expand.ts
+++ b/packages/memory-mcp-server/src/tools/expand.ts
@@ -1,0 +1,52 @@
+/**
+ * memory_expand tool handler.
+ *
+ * The agentic follow-up affordance (§9.4): given a `segment_id` surfaced by a prior
+ * recall (via `expanded_segment_ids` or a `raw` unit's `segment_id`), fetch that
+ * source segment's query-ranked passages — the "I got a headline, give me THIS
+ * fact's parent" call. Validates input and delegates to `engine.expand`.
+ */
+
+import type { MemoryEngine } from '../engine.js';
+import { MAX_QUERY_LENGTH } from './validation.js';
+
+export interface ExpandInput {
+  segment_id: string;
+  query?: string;
+}
+
+export function validateExpandInput(args: Record<string, unknown>): ExpandInput {
+  const segmentId = args.segment_id;
+  if (typeof segmentId !== 'string' || segmentId.trim().length === 0) {
+    throw new Error('segment_id is required and must be a non-empty string');
+  }
+
+  const query = args.query;
+  if (query !== undefined) {
+    if (typeof query !== 'string') {
+      throw new Error('query must be a string');
+    }
+    if (query.length > MAX_QUERY_LENGTH) {
+      throw new Error(`query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`);
+    }
+  }
+
+  return {
+    segment_id: segmentId.trim(),
+    query: query !== undefined ? query.trim() : undefined,
+  };
+}
+
+export async function handleExpand(engine: MemoryEngine, args: Record<string, unknown>): Promise<string> {
+  const input = validateExpandInput(args);
+  const result = await engine.expand(input.segment_id, input.query);
+
+  if (!result.found) {
+    return `No source segment found for id ${input.segment_id}.`;
+  }
+  if (result.passages.length === 0) {
+    return `Source segment ${input.segment_id} has no expandable content.`;
+  }
+
+  return result.passages.join('\n\n---\n\n');
+}

--- a/packages/memory-mcp-server/src/tools/ingest.ts
+++ b/packages/memory-mcp-server/src/tools/ingest.ts
@@ -1,7 +1,11 @@
 /**
  * memory_ingest tool handler.
- * Validates/normalizes input, delegates to the engine, and renders a content-free
- * result string. PII-safe: NEVER echoes raw content or model output.
+ * Validates/normalizes input, delegates to the engine, and renders the result.
+ * PII note: the non-dry-run renderings are content-free (ids + counts only), but
+ * `dry_run` intentionally returns a PREVIEW of the extracted fact text (model
+ * output) so callers can inspect the decomposition before writing — so a dry-run
+ * response is NOT content-free, and MCP clients that log tool output will capture
+ * that fact text.
  */
 
 import type { MemoryEngine, IngestOptions } from '../engine.js';
@@ -51,6 +55,19 @@ function normalizeAsOf(value: unknown): number | undefined {
   return ms;
 }
 
+/**
+ * Validate an optional enum-valued arg: undefined passes through, otherwise the
+ * value must be one of `allowed` (throws `errorMsg` if not). Returns the value
+ * narrowed to `T` without the caller needing a double cast.
+ */
+function optEnum<T>(value: unknown, allowed: readonly T[], errorMsg: string): T | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw new Error(errorMsg);
+  }
+  return value as T;
+}
+
 export function validateIngestInput(args: Record<string, unknown>): IngestInput {
   const content = args.content;
   if (typeof content !== 'string' || content.trim().length === 0) {
@@ -62,13 +79,7 @@ export function validateIngestInput(args: Record<string, unknown>): IngestInput 
     throw new Error('source must be a string');
   }
 
-  let mode: IngestMode = 'conversation';
-  if (args.mode !== undefined) {
-    if (typeof args.mode !== 'string' || !INGEST_MODES.includes(args.mode as IngestMode)) {
-      throw new Error("mode must be 'conversation' or 'document'");
-    }
-    mode = args.mode as IngestMode;
-  }
+  const mode = optEnum(args.mode, INGEST_MODES, "mode must be 'conversation' or 'document'") ?? 'conversation';
 
   const tags = validateTags(args.tags);
 
@@ -84,16 +95,12 @@ export function validateIngestInput(args: Record<string, unknown>): IngestInput 
     throw new Error('dry_run must be a boolean');
   }
 
-  let onExtractionFailure: OnExtractionFailure = 'degrade';
-  if (args.on_extraction_failure !== undefined) {
-    if (
-      typeof args.on_extraction_failure !== 'string' ||
-      !ON_EXTRACTION_FAILURES.includes(args.on_extraction_failure as OnExtractionFailure)
-    ) {
-      throw new Error("on_extraction_failure must be 'degrade', 'skip', or 'error'");
-    }
-    onExtractionFailure = args.on_extraction_failure as OnExtractionFailure;
-  }
+  const onExtractionFailure =
+    optEnum(
+      args.on_extraction_failure,
+      ON_EXTRACTION_FAILURES,
+      "on_extraction_failure must be 'degrade', 'skip', or 'error'",
+    ) ?? 'degrade';
 
   const asOf = normalizeAsOf(args.as_of);
 
@@ -113,19 +120,29 @@ function truncateId(id: string): string {
   return id.length > 8 ? `${id.slice(0, 8)}…` : id;
 }
 
+/** One-line "N of M chunks failed" suffix, or '' when extraction was complete. */
+function partialSuffix(result: IngestResult): string {
+  if (!result.partial) return '';
+  return ` ${result.failed_chunks ?? 0} of ${result.chunks ?? 0} chunks failed extraction`;
+}
+
 /**
- * Render the result as a content-free human-readable string. NEVER echoes raw
- * content or model output beyond the extracted facts the caller already provided.
+ * Render the dry-run preview. Unlike the other renderings this DOES include the
+ * extracted fact text (model output) — see the handler doc. Appends the partial
+ * warning so a preview built from an incomplete extraction is not mistaken for
+ * the full decomposition.
  */
 function renderDryRunPreview(result: IngestResult): string {
   const lines = result.facts.map((f, i) => {
     const imp = f.importance !== undefined ? ` (importance: ${f.importance})` : '';
     return `${i + 1}. ${f.fact}${imp}`;
   });
-  return [`Dry run — nothing written. ${result.facts.length} fact(s) proposed:`, ...lines].join('\n');
+  const header = `Dry run — nothing written. ${result.facts.length} fact(s) proposed:`;
+  const warning = result.partial ? `\n(incomplete —${partialSuffix(result)}; preview may be missing facts.)` : '';
+  return [header, ...lines].join('\n') + warning;
 }
 
-export function formatIngestResult(result: IngestResult): string {
+export function formatIngestResult(result: IngestResult, dryRun: boolean): string {
   if (result.skipped) {
     return 'Extraction failed and on_extraction_failure=skip — nothing written.';
   }
@@ -133,7 +150,7 @@ export function formatIngestResult(result: IngestResult): string {
   // Full degrade (no decomposition): set by the engine only when the fact union
   // was empty. `partial` distinguishes this from "some chunks failed but we got facts".
   if (result.degraded && !result.partial) {
-    if (result.created === 0) {
+    if (dryRun) {
       return 'No LLM configured or extraction failed — dry run, nothing written (no decomposition).';
     }
     const id = result.memory_ids[0] ?? '?';
@@ -141,7 +158,7 @@ export function formatIngestResult(result: IngestResult): string {
   }
 
   // Dry run preview (facts extracted, nothing written).
-  if (result.created === 0 && result.merged === 0 && result.memory_ids.length === 0) {
+  if (dryRun) {
     return renderDryRunPreview(result);
   }
 
@@ -153,9 +170,7 @@ export function formatIngestResult(result: IngestResult): string {
     '.';
 
   if (result.partial) {
-    const failed = result.failed_chunks ?? 0;
-    const total = result.chunks ?? 0;
-    return `${base} ${failed} of ${total} chunks failed extraction — partial result.`;
+    return `${base}${partialSuffix(result)} — partial result.`;
   }
 
   return base;
@@ -173,5 +188,5 @@ export async function handleIngest(engine: MemoryEngine, args: Record<string, un
     on_extraction_failure: input.on_extraction_failure,
   };
   const result = await engine.ingest(input.content, opts);
-  return formatIngestResult(result);
+  return formatIngestResult(result, input.dry_run);
 }

--- a/packages/memory-mcp-server/src/tools/ingest.ts
+++ b/packages/memory-mcp-server/src/tools/ingest.ts
@@ -30,8 +30,9 @@ export interface IngestInput {
 }
 
 /**
- * Normalize `as_of` (epoch ms number, numeric string, OR ISO 8601 string) to epoch ms.
- * Rejects non-finite / negative results.
+ * Normalize `as_of` (epoch ms number, numeric string, OR ISO 8601 string) to an
+ * INTEGER epoch ms. Rejects non-finite / negative results; truncates any fractional
+ * ms so the value round-trips through the SQLite `INTEGER` timestamp columns.
  */
 function normalizeAsOf(value: unknown): number | undefined {
   if (value === undefined) return undefined;
@@ -52,7 +53,7 @@ function normalizeAsOf(value: unknown): number | undefined {
   if (!Number.isFinite(ms) || ms < 0) {
     throw new Error('as_of must resolve to a non-negative epoch-ms timestamp');
   }
-  return ms;
+  return Math.floor(ms);
 }
 
 /**

--- a/packages/memory-mcp-server/src/tools/ingest.ts
+++ b/packages/memory-mcp-server/src/tools/ingest.ts
@@ -1,0 +1,177 @@
+/**
+ * memory_ingest tool handler.
+ * Validates/normalizes input, delegates to the engine, and renders a content-free
+ * result string. PII-safe: NEVER echoes raw content or model output.
+ */
+
+import type { MemoryEngine, IngestOptions } from '../engine.js';
+import type { IngestResult } from '../types.js';
+import { validateTags } from './validation.js';
+
+export type IngestMode = 'conversation' | 'document';
+export type OnExtractionFailure = 'degrade' | 'skip' | 'error';
+
+const INGEST_MODES: readonly IngestMode[] = ['conversation', 'document'];
+const ON_EXTRACTION_FAILURES: readonly OnExtractionFailure[] = ['degrade', 'skip', 'error'];
+
+export interface IngestInput {
+  content: string;
+  source?: string;
+  mode: IngestMode;
+  tags?: string[];
+  importance?: number;
+  dry_run: boolean;
+  on_extraction_failure: OnExtractionFailure;
+  as_of?: number;
+}
+
+/**
+ * Normalize `as_of` (epoch ms number, numeric string, OR ISO 8601 string) to epoch ms.
+ * Rejects non-finite / negative results.
+ */
+function normalizeAsOf(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+
+  let ms: number;
+  if (typeof value === 'number') {
+    ms = value;
+  } else if (typeof value === 'string') {
+    // A bare numeric string (e.g. "1700000000000") is epoch ms; otherwise parse as ISO.
+    // Guard empty/whitespace-only: Number('') is 0 (would slip through as epoch 0),
+    // but it was unparseable before — keep rejecting it via Date.parse → NaN.
+    const asNumber = value.trim().length === 0 ? NaN : Number(value);
+    ms = Number.isFinite(asNumber) ? asNumber : Date.parse(value);
+  } else {
+    throw new Error('as_of must be an epoch-ms number or an ISO 8601 string');
+  }
+
+  if (!Number.isFinite(ms) || ms < 0) {
+    throw new Error('as_of must resolve to a non-negative epoch-ms timestamp');
+  }
+  return ms;
+}
+
+export function validateIngestInput(args: Record<string, unknown>): IngestInput {
+  const content = args.content;
+  if (typeof content !== 'string' || content.trim().length === 0) {
+    throw new Error('content is required and must be a non-empty string');
+  }
+
+  const source = args.source;
+  if (source !== undefined && typeof source !== 'string') {
+    throw new Error('source must be a string');
+  }
+
+  let mode: IngestMode = 'conversation';
+  if (args.mode !== undefined) {
+    if (typeof args.mode !== 'string' || !INGEST_MODES.includes(args.mode as IngestMode)) {
+      throw new Error("mode must be 'conversation' or 'document'");
+    }
+    mode = args.mode as IngestMode;
+  }
+
+  const tags = validateTags(args.tags);
+
+  const importance = args.importance;
+  if (importance !== undefined) {
+    if (typeof importance !== 'number' || !Number.isFinite(importance) || importance < 0 || importance > 1) {
+      throw new Error('importance must be a number between 0 and 1');
+    }
+  }
+
+  const dryRun = args.dry_run;
+  if (dryRun !== undefined && typeof dryRun !== 'boolean') {
+    throw new Error('dry_run must be a boolean');
+  }
+
+  let onExtractionFailure: OnExtractionFailure = 'degrade';
+  if (args.on_extraction_failure !== undefined) {
+    if (
+      typeof args.on_extraction_failure !== 'string' ||
+      !ON_EXTRACTION_FAILURES.includes(args.on_extraction_failure as OnExtractionFailure)
+    ) {
+      throw new Error("on_extraction_failure must be 'degrade', 'skip', or 'error'");
+    }
+    onExtractionFailure = args.on_extraction_failure as OnExtractionFailure;
+  }
+
+  const asOf = normalizeAsOf(args.as_of);
+
+  return {
+    content: content.trim(),
+    source,
+    mode,
+    tags,
+    importance,
+    dry_run: dryRun ?? false,
+    on_extraction_failure: onExtractionFailure,
+    as_of: asOf,
+  };
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? `${id.slice(0, 8)}…` : id;
+}
+
+/**
+ * Render the result as a content-free human-readable string. NEVER echoes raw
+ * content or model output beyond the extracted facts the caller already provided.
+ */
+function renderDryRunPreview(result: IngestResult): string {
+  const lines = result.facts.map((f, i) => {
+    const imp = f.importance !== undefined ? ` (importance: ${f.importance})` : '';
+    return `${i + 1}. ${f.fact}${imp}`;
+  });
+  return [`Dry run — nothing written. ${result.facts.length} fact(s) proposed:`, ...lines].join('\n');
+}
+
+export function formatIngestResult(result: IngestResult): string {
+  if (result.skipped) {
+    return 'Extraction failed and on_extraction_failure=skip — nothing written.';
+  }
+
+  // Full degrade (no decomposition): set by the engine only when the fact union
+  // was empty. `partial` distinguishes this from "some chunks failed but we got facts".
+  if (result.degraded && !result.partial) {
+    if (result.created === 0) {
+      return 'No LLM configured or extraction failed — dry run, nothing written (no decomposition).';
+    }
+    const id = result.memory_ids[0] ?? '?';
+    return `No LLM configured or extraction failed — stored the blob as a single memory ${truncateId(id)}.`;
+  }
+
+  // Dry run preview (facts extracted, nothing written).
+  if (result.created === 0 && result.merged === 0 && result.memory_ids.length === 0) {
+    return renderDryRunPreview(result);
+  }
+
+  const idList = result.memory_ids.map(truncateId).join(', ');
+  const base =
+    `Ingested ${result.facts.length} atomic fact(s): ` +
+    `${result.created} new memor${result.created === 1 ? 'y' : 'ies'}, ${result.merged} merged into existing` +
+    (idList.length > 0 ? ` (ids: ${idList})` : '') +
+    '.';
+
+  if (result.partial) {
+    const failed = result.failed_chunks ?? 0;
+    const total = result.chunks ?? 0;
+    return `${base} ${failed} of ${total} chunks failed extraction — partial result.`;
+  }
+
+  return base;
+}
+
+export async function handleIngest(engine: MemoryEngine, args: Record<string, unknown>): Promise<string> {
+  const input = validateIngestInput(args);
+  const opts: IngestOptions = {
+    source: input.source,
+    mode: input.mode,
+    tags: input.tags,
+    importance: input.importance,
+    dry_run: input.dry_run,
+    as_of: input.as_of,
+    on_extraction_failure: input.on_extraction_failure,
+  };
+  const result = await engine.ingest(input.content, opts);
+  return formatIngestResult(result);
+}

--- a/packages/memory-mcp-server/src/tools/recall.ts
+++ b/packages/memory-mcp-server/src/tools/recall.ts
@@ -58,7 +58,20 @@ export function validateRecallInput(args: Record<string, unknown>): RecallInput 
   };
 }
 
-export async function handleRecall(engine: MemoryEngine, args: Record<string, unknown>): Promise<string> {
+/**
+ * Structured result of a `memory_recall` call. `text` is the human-readable
+ * payload; the remaining fields are the recall metadata an agent needs to drive
+ * the `memory_expand` follow-up loop (which segments were auto-expanded).
+ */
+export interface RecallToolResult {
+  text: string;
+  memories_used: number;
+  total_matches: number;
+  expanded: boolean;
+  expanded_segment_ids: string[];
+}
+
+export async function handleRecall(engine: MemoryEngine, args: Record<string, unknown>): Promise<RecallToolResult> {
   const input = validateRecallInput(args);
   const result = await engine.recall({
     query: input.query,
@@ -69,9 +82,13 @@ export async function handleRecall(engine: MemoryEngine, args: Record<string, un
     max_expand_passages: input.max_expand_passages,
   });
 
-  if (result.memories_used === 0) {
-    return 'No relevant memories found.';
-  }
+  const text = result.memories_used === 0 ? 'No relevant memories found.' : result.content;
 
-  return result.content;
+  return {
+    text,
+    memories_used: result.memories_used,
+    total_matches: result.total_matches,
+    expanded: result.expanded ?? false,
+    expanded_segment_ids: result.expanded_segment_ids ?? [],
+  };
 }

--- a/packages/memory-mcp-server/src/tools/recall.ts
+++ b/packages/memory-mcp-server/src/tools/recall.ts
@@ -4,17 +4,22 @@
  */
 
 import type { MemoryEngine } from '../engine.js';
+import type { ExpandMode } from '../types.js';
 import { FORMAT_MODES, type FormatMode } from '../retrieval/formatting.js';
-import { MAX_QUERY_LENGTH, validateTokenBudget, validateTags } from './validation.js';
+import { MAX_QUERY_LENGTH, validateTokenBudget, validateTags, validateMaxExpandPassages } from './validation.js';
 
 export interface RecallInput {
   query: string;
   token_budget?: number;
   tags?: string[];
   format?: FormatMode;
+  expand: ExpandMode;
+  max_expand_passages?: number;
 }
 
 const VALID_FORMATS: ReadonlySet<string> = new Set(FORMAT_MODES);
+const EXPAND_MODES: readonly ExpandMode[] = ['none', 'auto', 'parent'];
+const VALID_EXPAND_MODES: ReadonlySet<string> = new Set(EXPAND_MODES);
 
 export function validateRecallInput(args: Record<string, unknown>): RecallInput {
   const query = args.query;
@@ -35,11 +40,21 @@ export function validateRecallInput(args: Record<string, unknown>): RecallInput 
     }
   }
 
+  const expandArg = args.expand;
+  if (expandArg !== undefined && (typeof expandArg !== 'string' || !VALID_EXPAND_MODES.has(expandArg))) {
+    throw new Error(`expand must be one of: ${EXPAND_MODES.map((m) => `'${m}'`).join(', ')}`);
+  }
+  const expand = (expandArg as ExpandMode | undefined) ?? 'auto';
+
+  const maxExpandPassages = validateMaxExpandPassages(args.max_expand_passages);
+
   return {
     query: query.trim(),
     token_budget: tokenBudget,
     tags,
     format: format as RecallInput['format'],
+    expand,
+    max_expand_passages: maxExpandPassages,
   };
 }
 
@@ -50,6 +65,8 @@ export async function handleRecall(engine: MemoryEngine, args: Record<string, un
     token_budget: input.token_budget,
     tags: input.tags,
     format: input.format,
+    expand: input.expand,
+    max_expand_passages: input.max_expand_passages,
   });
 
   if (result.memories_used === 0) {

--- a/packages/memory-mcp-server/src/tools/validation.ts
+++ b/packages/memory-mcp-server/src/tools/validation.ts
@@ -9,6 +9,7 @@ export const MAX_TAGS = 50;
 export const MAX_TAG_LENGTH = 100;
 export const MAX_IDS = 100;
 export const MAX_LIMIT = 1000;
+export const MAX_EXPAND_PASSAGES = 20;
 
 /**
  * Validate and return a tags array, or undefined if not provided.
@@ -51,6 +52,20 @@ export function validateTokenBudget(value: unknown): number | undefined {
   }
   if (value > MAX_TOKEN_BUDGET) {
     throw new Error(`token_budget exceeds maximum of ${MAX_TOKEN_BUDGET}`);
+  }
+  return value;
+}
+
+/**
+ * Validate and return `max_expand_passages`, or undefined if not provided.
+ */
+export function validateMaxExpandPassages(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    throw new Error('max_expand_passages must be a positive integer');
+  }
+  if (value > MAX_EXPAND_PASSAGES) {
+    throw new Error(`max_expand_passages exceeds maximum of ${MAX_EXPAND_PASSAGES}`);
   }
   return value;
 }

--- a/packages/memory-mcp-server/src/types.ts
+++ b/packages/memory-mcp-server/src/types.ts
@@ -17,7 +17,12 @@ export interface Memory {
   compacted_from: string[] | null;
   source: string | null;
   metadata: Record<string, unknown> | null;
+  /** FK to the source segment a `memory_ingest` fact was extracted from. NULL otherwise. */
+  segment_id: string | null;
 }
+
+/** A recall-time return unit: either a fact verbatim or an expanded parent passage. */
+export type ExpandMode = 'none' | 'auto' | 'parent';
 
 export interface StoreResult {
   id: string;
@@ -48,6 +53,9 @@ export interface IngestResult {
   partial?: boolean;
   /** True when on_extraction_failure='skip' wrote nothing. */
   skipped?: boolean;
+
+  /** Count of `segments` rows written (omitted when 0 / dry_run). */
+  segments_created?: number;
 }
 
 export interface RecallOptions {
@@ -55,12 +63,34 @@ export interface RecallOptions {
   token_budget?: number;
   tags?: string[];
   format?: import('./retrieval/formatting.js').FormatMode;
+  /**
+   * Parent re-expansion mode (§5.2), default `'auto'`:
+   *   - `'auto'`   — expand a parent when ≥2 kept facts share it (the shared-parent signature);
+   *   - `'none'`   — force off (byte-for-byte today's facts-only behavior);
+   *   - `'parent'` — force-expand the parent of every kept fact that has one.
+   */
+  expand?: ExpandMode;
+  /** Cap on returned expanded passages across the whole result (§5.4). Default 2. */
+  max_expand_passages?: number;
 }
 
 export interface RecallResult {
   content: string;
   memories_used: number;
   total_matches: number;
+  /** True when any returned unit was an expanded parent passage (every format). */
+  expanded?: boolean;
+  /** The segment_ids that were expanded (every format; omitted/[] when none). */
+  expanded_segment_ids?: string[];
+}
+
+/** Result of `memory_expand`: the parent segment's query-ranked passages. */
+export interface ExpandResult {
+  segment_id: string;
+  /** Query-ranked passages of the parent (or whole-segment passages when no query). */
+  passages: string[];
+  /** False when the segment_id has no segment row (forgotten/never-ingested parent). */
+  found: boolean;
 }
 
 export interface ContextOptions {

--- a/packages/memory-mcp-server/src/types.ts
+++ b/packages/memory-mcp-server/src/types.ts
@@ -24,6 +24,34 @@ export interface StoreResult {
   action: 'created' | 'merged_duplicate' | 'contradiction_resolved';
 }
 
+export interface IngestResult {
+  // ---- honest write stats ----
+  /** Rows newly created (action === 'created'). */
+  created: number;
+  /** Facts that hit an existing row (merged_duplicate / contradiction_resolved). */
+  merged: number;
+  /** ALIAS for `created`, kept for back-compat of the v1 field name. */
+  ingested: number;
+  /** Ids of all touched rows (created + merged); empty when dry_run. */
+  memory_ids: string[];
+
+  // ---- substance ----
+  /** The extracted atomic facts + their importance (always populated). */
+  facts: import('./storage/extraction.js').ExtractedFact[];
+
+  // ---- diagnostics ----
+  /** Number of LLM windows used (omitted when 1). */
+  chunks?: number;
+  /** Chunks that returned null/[] (omitted when 0). */
+  failed_chunks?: number;
+  /** True when we fell back to single-blob store, OR a partial failure occurred. */
+  degraded?: boolean;
+  /** True when SOME (not all) chunks failed but others produced facts. */
+  partial?: boolean;
+  /** True when on_extraction_failure='skip' wrote nothing. */
+  skipped?: boolean;
+}
+
 export interface RecallOptions {
   query: string;
   token_budget?: number;

--- a/packages/memory-mcp-server/src/types.ts
+++ b/packages/memory-mcp-server/src/types.ts
@@ -30,8 +30,6 @@ export interface IngestResult {
   created: number;
   /** Facts that hit an existing row (merged_duplicate / contradiction_resolved). */
   merged: number;
-  /** ALIAS for `created`, kept for back-compat of the v1 field name. */
-  ingested: number;
   /** Ids of all touched rows (created + merged); empty when dry_run. */
   memory_ids: string[];
 

--- a/packages/memory-mcp-server/src/types.ts
+++ b/packages/memory-mcp-server/src/types.ts
@@ -45,7 +45,11 @@ export interface IngestResult {
   // ---- diagnostics ----
   /** Number of LLM windows used (omitted when 1). */
   chunks?: number;
-  /** Chunks that returned null/[] (omitted when 0). */
+  /**
+   * Chunks that FAILED extraction — returned `null` (no LLM / hard error / unparseable).
+   * A parsed empty array `[]` is a valid "nothing durable" result, NOT a failed chunk.
+   * Omitted when 0.
+   */
   failed_chunks?: number;
   /** True when we fell back to single-blob store, OR a partial failure occurred. */
   degraded?: boolean;

--- a/packages/memory-mcp-server/test/config.test.ts
+++ b/packages/memory-mcp-server/test/config.test.ts
@@ -13,7 +13,7 @@ describe('loadConfig', () => {
     expect(config.decayThreshold).toBe(0.05);
     expect(config.maintenanceInterval).toBe(50);
     expect(config.compactionMinGroup).toBe(10);
-    expect(config.defaultTokenBudget).toBe(500);
+    expect(config.defaultTokenBudget).toBe(800);
     expect(config.dbPath).toContain('memory-mcp');
   });
 

--- a/packages/memory-mcp-server/test/database.test.ts
+++ b/packages/memory-mcp-server/test/database.test.ts
@@ -307,4 +307,122 @@ describe('database', () => {
     expect(stats1.total_memories).toBe(1);
     expect(stats2.total_memories).toBe(1);
   });
+
+  describe('canonical schema & stale-DB rebuild (§4)', () => {
+    function columnNames(database: Database.Database, table: string): string[] {
+      const cols = database.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+      return cols.map((c) => c.name);
+    }
+
+    function tableNames(database: Database.Database): string[] {
+      const rows = database.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as Array<{
+        name: string;
+      }>;
+      return rows.map((r) => r.name);
+    }
+
+    function schemaVersion(database: Database.Database): string | undefined {
+      const row = database.prepare(`SELECT value FROM schema_meta WHERE key = 'schema_version'`).get() as
+        | { value: string }
+        | undefined;
+      return row?.value;
+    }
+
+    it('is born with the segments table, the segment_id column, and version 4', () => {
+      // beforeEach already opened a fresh DB via initDatabase.
+      expect(tableNames(db)).toContain('segments');
+      expect(columnNames(db, 'memories')).toContain('segment_id');
+      expect(schemaVersion(db)).toBe('4');
+    });
+
+    it('drops-and-recreates a stale v3-shaped DB cleanly (no `no such column`, old data gone)', async () => {
+      const staleDir = mkdtempSync(join(tmpdir(), 'memory-stale-'));
+      const stalePath = join(staleDir, 'stale.db');
+
+      // Build a v3-shaped DB by hand: a `memories` table WITHOUT segment_id, a
+      // schema_meta stamped '3', and one pre-change row.
+      const Database = (await import('better-sqlite3')).default;
+      const stale = new Database(stalePath);
+      stale.exec(`
+        CREATE TABLE memories (
+          id TEXT PRIMARY KEY,
+          namespace TEXT NOT NULL DEFAULT 'default',
+          content TEXT NOT NULL,
+          tags TEXT,
+          importance REAL NOT NULL DEFAULT 0.5,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          last_accessed_at INTEGER NOT NULL,
+          access_count INTEGER NOT NULL DEFAULT 0,
+          is_compacted INTEGER NOT NULL DEFAULT 0,
+          source TEXT,
+          metadata TEXT,
+          consolidated INTEGER NOT NULL DEFAULT 1
+        );
+        CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO schema_meta (key, value) VALUES ('schema_version', '3');
+        INSERT INTO memories (id, namespace, content, created_at, updated_at, last_accessed_at)
+          VALUES ('old-row', 'test', 'stale pre-change row', 1, 1, 1);
+      `);
+      stale.close();
+
+      // Reopen via initDatabase: must self-heal (drop-and-recreate), not crash.
+      const reopened = initDatabase(stalePath, TEST_MODEL);
+      try {
+        expect(tableNames(reopened)).toContain('segments');
+        expect(columnNames(reopened, 'memories')).toContain('segment_id');
+        expect(schemaVersion(reopened)).toBe('4');
+
+        // A `segment_id` SELECT must NOT throw `no such column`.
+        const selectSegment = (): unknown =>
+          reopened.prepare(`SELECT segment_id FROM memories WHERE namespace = ?`).all('test');
+        expect(selectSegment).not.toThrow();
+
+        // The pre-change row was discarded by the rebuild.
+        const oldRow = getMemoriesByIds(reopened, 'test', ['old-row']);
+        expect(oldRow).toHaveLength(0);
+
+        // The rebuilt DB round-trips store/recall (insert + read back).
+        const id = generateId();
+        insertMemory(
+          reopened,
+          { id, namespace: 'test', content: 'fresh after rebuild', tags: undefined, importance: 0.5 },
+          randomEmbedding(),
+        );
+        const back = getMemoriesByIds(reopened, 'test', [id]);
+        expect(back).toHaveLength(1);
+        expect(back[0].content).toBe('fresh after rebuild');
+        expect(back[0].segment_id).toBeNull();
+      } finally {
+        reopened.close();
+        rmSync(staleDir, { recursive: true, force: true });
+      }
+    });
+
+    it('re-opening a current (v4) DB is a no-op (no drop, no throw)', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'memory-reopen-'));
+      const path = join(dir, 'reopen.db');
+
+      const first = initDatabase(path, TEST_MODEL);
+      const id = generateId();
+      insertMemory(
+        first,
+        { id, namespace: 'test', content: 'survives reopen', tags: undefined, importance: 0.5 },
+        randomEmbedding(),
+      );
+      first.close();
+
+      const second = initDatabase(path, TEST_MODEL);
+      try {
+        expect(schemaVersion(second)).toBe('4');
+        // The row from the first open is still present (no drop happened).
+        const back = getMemoriesByIds(second, 'test', [id]);
+        expect(back).toHaveLength(1);
+        expect(back[0].content).toBe('survives reopen');
+      } finally {
+        second.close();
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/packages/memory-mcp-server/test/database.test.ts
+++ b/packages/memory-mcp-server/test/database.test.ts
@@ -424,5 +424,46 @@ describe('database', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('fails closed on a NEWER (v5) DB: throws and does NOT drop the data', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'memory-newer-'));
+      const path = join(dir, 'newer.db');
+
+      // Build a current v4 DB, insert a row, then bump its stamp to a future '5' to
+      // simulate a DB written by a newer binary being opened by this older one.
+      const seeded = initDatabase(path, TEST_MODEL);
+      const id = generateId();
+      insertMemory(
+        seeded,
+        { id, namespace: 'test', content: 'newer-schema row must survive', tags: undefined, importance: 0.5 },
+        randomEmbedding(),
+      );
+      seeded.prepare(`UPDATE schema_meta SET value = '5' WHERE key = 'schema_version'`).run();
+      seeded.close();
+
+      try {
+        // Opening must fail closed: throw a clear error, never drop.
+        expect(() => initDatabase(path, TEST_MODEL)).toThrow(/newer than/);
+
+        // The newer DB was left untouched: reopen it directly (bypassing the guard)
+        // and confirm the schema_meta stamp and the data both survive.
+        const Database = (await import('better-sqlite3')).default;
+        const survivor = new Database(path);
+        try {
+          const stamp = survivor.prepare(`SELECT value FROM schema_meta WHERE key = 'schema_version'`).get() as {
+            value: string;
+          };
+          expect(stamp.value).toBe('5');
+          const row = survivor.prepare(`SELECT content FROM memories WHERE id = ?`).get(id) as
+            | { content: string }
+            | undefined;
+          expect(row?.content).toBe('newer-schema row must survive');
+        } finally {
+          survivor.close();
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/memory-mcp-server/test/dedup.test.ts
+++ b/packages/memory-mcp-server/test/dedup.test.ts
@@ -19,6 +19,7 @@ function makeScoredMemory(id: string, content: string = 'test'): ScoredMemory {
     consolidated: 1,
     source: null,
     metadata: null,
+    segment_id: null,
     fusionScore: 0.5,
     compositeScore: 0.5,
   };

--- a/packages/memory-mcp-server/test/expand.test.ts
+++ b/packages/memory-mcp-server/test/expand.test.ts
@@ -148,20 +148,37 @@ describe('parent re-expansion (Bandalert contract)', () => {
     expect(result.created).toBe(7);
   }
 
-  it('auto-expands a shared parent BY DEFAULT (no expand arg) and returns the $250k clause that was never a fact', async () => {
+  it('auto-expands a shared parent BY DEFAULT (no expand arg): AUGMENTs the facts with the $250k clause that was never a fact', async () => {
     await ingestContract();
 
     // A DEFAULT recall — no `expand` argument at all.
     const result = await engine.recall({ query: 'Bandalert distribution agreement cap and revenue', format: 'list' });
 
     expect(result.expanded).toBe(true);
-    // Exactly one parent appears once (parent-dedup).
+    // PASSAGE parent-dedup: the one shared parent contributes exactly one passage.
     expect(result.expanded_segment_ids).toHaveLength(1);
 
-    // The returned content carries the $250k clause — which was NEVER an extracted fact.
+    // AUGMENT, not replace: the passage carries the $250k clause that was NEVER a fact …
     expect(result.content).toContain('$250k');
     const allHeadlineText = HEADLINE_FACTS.map((f) => f.fact).join(' ');
     expect(allHeadlineText).not.toContain('$250k'); // sanity: the clause is not a fact
+
+    // … AND the breadth facts are PRESERVED, not collapsed into the passage. Compare
+    // against expand:'none' at the SAME budget (the ranker is identical, so 'none' is
+    // the breadth baseline): every fact 'none' returns is still present under 'auto'.
+    // (Under the old REPLACE semantics these sibling facts were dropped — this is the
+    // assertion that would have failed then.) The full superset guarantee is asserted
+    // exhaustively in the breadth-preservation regression test below.
+    const none = await engine.recall({
+      query: 'Bandalert distribution agreement cap and revenue',
+      format: 'raw',
+      expand: 'none',
+    });
+    const noneFacts = (JSON.parse(none.content) as Array<{ content: string }>).map((i) => i.content);
+    expect(noneFacts.length).toBeGreaterThan(1); // several headline facts co-retrieve
+    for (const fact of noneFacts) {
+      expect(result.content).toContain(fact);
+    }
   });
 
   it('the expanded unit is a passage that fits the default 800 budget AND leaves room for ≥1 fact', async () => {
@@ -180,6 +197,65 @@ describe('parent re-expansion (Bandalert contract)', () => {
     const lines = result.content.split('\n').filter((l) => l.trim().length > 0);
     const factLines = lines.filter((l) => !l.includes('$250k'));
     expect(factLines.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('AUGMENT is breadth-preserving: every fact expand:none keeps is also kept under auto, and a passage is appended only on leftover budget (regression: passages must be LOWER priority than facts)', async () => {
+    await ingestContract();
+
+    const query = 'Bandalert distribution agreement cap and revenue';
+
+    // Raw format exposes each unit's `expanded` flag, so fact units and the appended
+    // passage unit can be separated cleanly. Helper: the set of FACT-unit contents.
+    const factContents = (raw: { content: string }): Set<string> => {
+      const items = JSON.parse(raw.content) as Array<{ content: string; expanded: boolean }>;
+      return new Set(items.filter((i) => !i.expanded).map((i) => i.content));
+    };
+    const passageCount = (raw: { content: string }): number => {
+      const items = JSON.parse(raw.content) as Array<{ expanded: boolean }>;
+      return items.filter((i) => i.expanded).length;
+    };
+
+    // --- Generous budget: facts are a SUPERSET of none's, AND the passage is appended. ---
+    const wideBudget = 800;
+    const noneWide = await engine.recall({ query, format: 'raw', expand: 'none', token_budget: wideBudget });
+    const autoWide = await engine.recall({ query, format: 'raw', expand: 'auto', token_budget: wideBudget });
+
+    const noneFacts = factContents(noneWide);
+    const autoFacts = factContents(autoWide);
+    expect(noneFacts.size).toBeGreaterThan(0); // the query genuinely retrieves facts
+
+    // EVERY fact expand:none returns is ALSO returned under expand:auto (the superset
+    // property — auto never silently drops a breadth fact). This is the assertion that
+    // would FAIL if expansion REPLACED sibling facts with the passage.
+    for (const fact of noneFacts) {
+      expect(autoFacts.has(fact)).toBe(true);
+    }
+    // … and on top of the full fact set, the passage is appended.
+    expect(autoWide.expanded).toBe(true);
+    expect(passageCount(autoWide)).toBe(1);
+    expect(autoWide.content).toContain('$250k');
+
+    // --- Tight budget: the DISCRIMINATING zone for pack order. Size the budget to
+    //     `passageTokens + allFactTokens - 1`: it fits ALL facts (facts-last leaves the
+    //     passage one token short, so the passage is skipped and every fact survives),
+    //     but it is also large enough that a HIGH-priority passage WOULD fit first and
+    //     then evict a breadth fact (passage-first leaves allFactTokens-1 of budget,
+    //     one token shy of the full fact set). The packer estimates tokens off each
+    //     unit's `content`, so measure those directly from a wide auto recall. ---
+    const wideItems = JSON.parse(autoWide.content) as Array<{ content: string; expanded: boolean }>;
+    const allFactTokens = wideItems.filter((i) => !i.expanded).reduce((sum, i) => sum + estimateTokens(i.content), 0);
+    const passageTokens = wideItems.filter((i) => i.expanded).reduce((sum, i) => sum + estimateTokens(i.content), 0);
+    const tightBudget = passageTokens + allFactTokens - 1;
+
+    const noneTight = await engine.recall({ query, format: 'raw', expand: 'none', token_budget: tightBudget });
+    const autoTight = await engine.recall({ query, format: 'raw', expand: 'auto', token_budget: tightBudget });
+
+    // Same fact set under both — auto did NOT evict a fact to make room for a passage.
+    // (With a HIGH-priority passage this set would be a strict subset of none's.)
+    expect(factContents(autoTight)).toEqual(factContents(noneTight));
+    // … and the passage is the thing that was skipped (not a fact).
+    expect(passageCount(autoTight)).toBe(0);
+    expect(autoTight.expanded).toBe(false);
   });
 
   it('picks the query-relevant passage (IP query → IP passage, not the cap passage)', async () => {

--- a/packages/memory-mcp-server/test/expand.test.ts
+++ b/packages/memory-mcp-server/test/expand.test.ts
@@ -1,0 +1,532 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type Database from 'better-sqlite3';
+
+// ---- Mock the LLM so extraction returns canned facts, but the REAL embedder + ----
+// ---- store/segment/recall pipeline run end-to-end. Recall uses format 'list' so ----
+// ---- the LLM formatter is never invoked (deterministic, no queue consumption). ----
+const llmMock = vi.hoisted(() => ({
+  responses: [] as Array<string | null>,
+  hasLLM: true,
+  calls: 0,
+}));
+
+vi.mock('../src/llm/client.js', () => ({
+  getLLMClient: vi.fn(() => (llmMock.hasLLM ? {} : null)),
+  llmComplete: vi.fn(async () => {
+    llmMock.calls += 1;
+    if (!llmMock.hasLLM) return null;
+    const next = llmMock.responses.shift();
+    return next === undefined ? null : next;
+  }),
+}));
+
+import { initDatabase } from '../src/storage/database.js';
+import type { SegmentRow } from '../src/storage/database.js';
+import { getMemoriesByIds } from '../src/storage/queries.js';
+import { createMemoryEngineFromConfig } from '../src/engine-impl.js';
+import type { MemoryEngine } from '../src/engine.js';
+import type { MemoryConfig } from '../src/config.js';
+import { loadConfig } from '../src/config.js';
+import { estimateTokens } from '../src/retrieval/scoring.js';
+
+const NAMESPACE = 'test';
+
+function setResponses(...responses: Array<string | null>): void {
+  llmMock.responses = responses;
+  llmMock.hasLLM = true;
+  llmMock.calls = 0;
+}
+
+function factsJson(facts: Array<{ fact: string; importance?: number }>): string {
+  return JSON.stringify(facts);
+}
+
+function testConfig(dbPath: string): MemoryConfig {
+  return {
+    ...loadConfig({}),
+    dbPath,
+    namespace: NAMESPACE,
+    llmApiKey: 'test-key',
+    llmBaseUrl: 'http://localhost:1234/v1',
+    maintenanceInterval: 10000,
+    // Determinism: the cross-encoder reranker re-orders conversational text
+    // unpredictably for synthetic content; disable it so the shared-parent facts
+    // reliably co-occur in the kept set. The candidate ranker is otherwise unchanged.
+    rerankerEnabled: false,
+  };
+}
+
+// ---- The synthetic contract segment. It contains a $250k distribution-cap clause
+// ---- and an IP-rights clause that are NEVER extracted as facts — only the headline
+// ---- facts below are. The clauses live only in the segment (the Bandalert shape).
+// ---- Each clause section is its own coherent, ON-TOPIC paragraph (no generic
+// ---- padding), long enough that the split produces DISTINCT cap / IP / NDA passages
+// ---- — so split-and-rank proves it returns the query-relevant slice, not the chunk.
+const REVENUE_CLAUSE =
+  'Distribution and revenue. The distribution cap is $250k per year of net distribution revenue. ' +
+  'Once cumulative distribution revenue exceeds that two-hundred-and-fifty-thousand-dollar ceiling, the ' +
+  'revenue split shifts from seventy-thirty to fifty-fifty in the artist favor for the remainder of the year. ' +
+  'The distribution cap resets every January, recoupable advances are charged against the label revenue share ' +
+  'before the split is computed, and statements of distribution revenue are delivered quarterly. Streaming, ' +
+  'download, physical, and synchronization revenue all count toward the distribution cap, while merchandise ' +
+  'revenue and live touring income are excluded from the cap and from the distribution revenue split entirely.';
+
+const IP_CLAUSE =
+  'Intellectual property. The intellectual property in the master recordings reverts to the artist after seven ' +
+  'years from release, and until reversion the label holds an exclusive license to exploit the masters. The ' +
+  'artist retains all songwriting and publishing rights, all copyright in the underlying musical compositions, ' +
+  'and the moral rights of authorship for the full duration of the agreement. Derivative works, remixes, and ' +
+  'sampling of the master recordings require the artist written consent, and any trademark in the artist name ' +
+  'and logo remains the sole intellectual property of the artist and is merely licensed to the label. The ' +
+  'reversion of intellectual property is automatic and does not require any further assignment, and on reversion ' +
+  'the label must deliver all master recordings, stems, and session files to the artist. Neighbouring rights ' +
+  'and performer royalties in the master recordings are collected by the artist nominated society, and the ' +
+  'intellectual property indemnity covers third-party infringement claims arising from the compositions.';
+
+const NDA_CLAUSE =
+  'Confidentiality. A mutual non-disclosure clause covers all financial terms, the existence of side letters, ' +
+  'and any unreleased recordings for the term of the agreement plus two years after termination. Neither party ' +
+  'may disclose confidential information to third parties except auditors and legal counsel under equivalent ' +
+  'confidentiality obligations. Breach of the non-disclosure clause entitles the non-breaching party to ' +
+  'injunctive relief, and the confidentiality obligations survive the expiry or termination of the agreement. ' +
+  'The non-disclosure clause expressly designates the distribution statements and the recoupment schedule as ' +
+  'confidential information, and any press release about the agreement requires the prior written approval of ' +
+  'both parties. The confidentiality obligations bind employees, contractors, and affiliates of each party, and ' +
+  'a residual-knowledge exception does not apply to the specifically enumerated confidential financial terms.';
+
+const CONTRACT_SEGMENT = [
+  'Contract overview. This document is the Bandalert distribution agreement between the label and the artist.',
+  '',
+  REVENUE_CLAUSE,
+  '',
+  IP_CLAUSE,
+  '',
+  NDA_CLAUSE,
+].join('\n');
+
+// Seven headline facts — the lossy decomposition. NONE of them states the $250k number
+// or the IP-reversion mechanics; those survive only inside CONTRACT_SEGMENT.
+const HEADLINE_FACTS = [
+  { fact: 'The Bandalert distribution agreement is between the label and the artist', importance: 0.8 },
+  { fact: 'The Bandalert agreement has a distribution revenue cap', importance: 0.7 },
+  { fact: 'The Bandalert agreement specifies a revenue split that changes above the cap', importance: 0.7 },
+  { fact: 'The Bandalert agreement has an intellectual property reversion clause', importance: 0.7 },
+  { fact: 'The Bandalert agreement lets the artist retain publishing rights', importance: 0.6 },
+  { fact: 'The Bandalert agreement contains a mutual non-disclosure clause', importance: 0.6 },
+  { fact: 'The Bandalert agreement resets terms annually', importance: 0.5 },
+];
+
+describe('parent re-expansion (Bandalert contract)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let engine: MemoryEngine;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'memory-expand-test-'));
+    dbPath = join(tmpDir, 'test.db');
+    const config = testConfig(dbPath);
+    engine = createMemoryEngineFromConfig(config);
+    db = initDatabase(dbPath, config.embeddingModel);
+  });
+
+  afterEach(() => {
+    engine.close();
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  async function ingestContract(): Promise<void> {
+    setResponses(factsJson(HEADLINE_FACTS));
+    const result = await engine.ingest(CONTRACT_SEGMENT, { mode: 'document' });
+    // One segment, seven linked headline facts.
+    expect(result.segments_created).toBe(1);
+    expect(result.created).toBe(7);
+  }
+
+  it('auto-expands a shared parent BY DEFAULT (no expand arg) and returns the $250k clause that was never a fact', async () => {
+    await ingestContract();
+
+    // A DEFAULT recall — no `expand` argument at all.
+    const result = await engine.recall({ query: 'Bandalert distribution agreement cap and revenue', format: 'list' });
+
+    expect(result.expanded).toBe(true);
+    // Exactly one parent appears once (parent-dedup).
+    expect(result.expanded_segment_ids).toHaveLength(1);
+
+    // The returned content carries the $250k clause — which was NEVER an extracted fact.
+    expect(result.content).toContain('$250k');
+    const allHeadlineText = HEADLINE_FACTS.map((f) => f.fact).join(' ');
+    expect(allHeadlineText).not.toContain('$250k'); // sanity: the clause is not a fact
+  });
+
+  it('the expanded unit is a passage that fits the default 800 budget AND leaves room for ≥1 fact', async () => {
+    await ingestContract();
+
+    const result = await engine.recall({ query: 'Bandalert distribution cap revenue split', format: 'list' });
+
+    expect(result.expanded).toBe(true);
+    // Total returned tokens fit the bumped default budget (800).
+    expect(estimateTokens(result.content)).toBeLessThanOrEqual(800);
+    // The whole 6000-char segment would never fit — assert the returned text is
+    // passage-sized, not the entire chunk.
+    expect(result.content.length).toBeLessThan(CONTRACT_SEGMENT.length);
+    // Out-of-the-box shape: a passage PLUS at least one supporting fact (a list line
+    // that is not the expanded passage). The list separates units by newline.
+    const lines = result.content.split('\n').filter((l) => l.trim().length > 0);
+    const factLines = lines.filter((l) => !l.includes('$250k'));
+    expect(factLines.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('picks the query-relevant passage (IP query → IP passage, not the cap passage)', async () => {
+    await ingestContract();
+
+    // An IP-focused query (no "Bandalert" token, which would pull the overview
+    // passage). Vector search still retrieves the contract's IP headline facts.
+    const result = await engine.recall({
+      query: 'intellectual property reversion publishing rights master recordings',
+      format: 'list',
+    });
+
+    expect(result.expanded).toBe(true);
+    // Split-and-rank must choose the IP passage, not the $250k cap passage.
+    expect(result.content).toContain('intellectual property');
+    expect(result.content).toContain('reverts');
+    expect(result.content).not.toContain('$250k');
+  });
+
+  it('a pinpoint single-fact recall does NOT expand (no regression), identical with expand:none', async () => {
+    // A lone fact with its OWN single-fact segment — only one fact shares the parent.
+    setResponses(factsJson([{ fact: 'The Anthropic API key env var is ANTHROPIC_API_KEY' }]));
+    await engine.ingest('My Anthropic API key env var is ANTHROPIC_API_KEY.', {});
+
+    const auto = await engine.recall({ query: 'what is the Anthropic API key variable name', format: 'list' });
+    expect(auto.expanded).toBe(false);
+    expect(auto.content).toContain('ANTHROPIC_API_KEY');
+
+    const none = await engine.recall({
+      query: 'what is the Anthropic API key variable name',
+      format: 'list',
+      expand: 'none',
+    });
+    expect(none.expanded).toBe(false);
+    expect(none.content).toBe(auto.content);
+  });
+
+  it("expand:'parent' force-expands a lone parent (ignores the ≥2 gate)", async () => {
+    // A single fact whose segment carries extra clause detail.
+    const segment = [
+      'Vendor terms. The SaaS vendor invoice is net-30.',
+      '',
+      'Penalties. A late payment incurs a 1.5% monthly interest charge and suspension after sixty days.',
+    ].join('\n');
+    setResponses(factsJson([{ fact: 'The SaaS vendor invoice payment term is net-30' }]));
+    await engine.ingest(segment, {});
+
+    // auto: a single fact → no shared parent → no expansion.
+    const auto = await engine.recall({ query: 'SaaS vendor invoice payment terms', format: 'list' });
+    expect(auto.expanded).toBe(false);
+
+    // parent: force-expand the lone parent → the penalty clause comes back.
+    const forced = await engine.recall({
+      query: 'SaaS vendor invoice payment terms',
+      format: 'list',
+      expand: 'parent',
+    });
+    expect(forced.expanded).toBe(true);
+    expect(forced.content).toContain('1.5%');
+  });
+
+  it('respects max_expand_passages and never exceeds the budget', async () => {
+    await ingestContract();
+
+    // Even forcing parent expansion with a raised budget, the count cap holds and the
+    // total never exceeds the budget (skip-not-break preserved).
+    const budget = 4000;
+    const result = await engine.recall({
+      query: 'Bandalert distribution cap intellectual property confidentiality',
+      format: 'list',
+      expand: 'parent',
+      max_expand_passages: 1,
+      token_budget: budget,
+    });
+
+    expect(result.expanded_segment_ids.length).toBeLessThanOrEqual(1);
+    expect(estimateTokens(result.content)).toBeLessThanOrEqual(budget);
+  });
+
+  it('a parent-less (store-path) memory recalls the fact, not a passage', async () => {
+    // store() never sets a segment_id → the fact is its own parent (§4.3).
+    await engine.store('The user prefers tabs over spaces', { importance: 0.6 });
+
+    const result = await engine.recall({ query: 'tabs or spaces preference', format: 'list' });
+    expect(result.expanded).toBe(false);
+    expect(result.content).toContain('tabs over spaces');
+  });
+
+  it('falls back to the fact when the parent segment was force-deleted (forgotten parent)', async () => {
+    await ingestContract();
+
+    // Force-delete the segment rows out from under the facts, leaving the memories'
+    // segment_id pointers dangling (the "forgotten parent" robustness case). FK
+    // enforcement is briefly disabled so the delete leaves a genuine dangling pointer.
+    db.pragma('foreign_keys = OFF');
+    db.prepare(`DELETE FROM segments WHERE namespace = ?`).run(NAMESPACE);
+    db.pragma('foreign_keys = ON');
+    expect(db.prepare(`SELECT COUNT(*) AS n FROM segments WHERE namespace = ?`).get(NAMESPACE)).toEqual({ n: 0 });
+
+    const result = await engine.recall({ query: 'Bandalert distribution agreement cap', format: 'list' });
+    // No segment to expand → emit the facts; no crash.
+    expect(result.expanded).toBe(false);
+    expect(result.content.toLowerCase()).toContain('bandalert');
+  });
+
+  it('surfaces expanded + expanded_segment_ids in every format, and per-unit segment_id in raw', async () => {
+    await ingestContract();
+    const query = 'Bandalert distribution cap and revenue split';
+
+    // 'list' and 'raw' never call the LLM; 'summary'/'answer' would, so feed a canned
+    // formatter response for those so the structured metadata can be asserted.
+    for (const format of ['list', 'raw'] as const) {
+      const result = await engine.recall({ query, format });
+      expect(result.expanded).toBe(true);
+      expect(result.expanded_segment_ids).toHaveLength(1);
+    }
+
+    // raw: the per-unit segment_id + expanded flag ride on the JSON.
+    const raw = await engine.recall({ query, format: 'raw' });
+    const items = JSON.parse(raw.content) as Array<{ segment_id: string | null; expanded: boolean }>;
+    const expandedUnit = items.find((i) => i.expanded);
+    expect(expandedUnit).toBeDefined();
+    expect(expandedUnit?.segment_id).toBe(raw.expanded_segment_ids[0]);
+
+    // summary: structured fields ride alongside the (canned) summary text.
+    setResponses('A concise briefing about the Bandalert distribution cap of $250k.');
+    const summary = await engine.recall({ query, format: 'summary' });
+    expect(summary.expanded).toBe(true);
+    expect(summary.expanded_segment_ids).toHaveLength(1);
+  });
+
+  describe('memory_expand tool path', () => {
+    function contractSegmentId(): string {
+      const seg = db.prepare(`SELECT * FROM segments WHERE namespace = ?`).get(NAMESPACE) as SegmentRow | undefined;
+      expect(seg).toBeDefined();
+      return seg?.id ?? '';
+    }
+
+    it('returns the query-ranked passages for a segment id', async () => {
+      await ingestContract();
+      const segId = contractSegmentId();
+
+      const result = await engine.expand(segId, 'intellectual property reversion');
+      expect(result.found).toBe(true);
+      expect(result.passages.length).toBeGreaterThan(0);
+      // Top-ranked passage is the IP passage.
+      expect(result.passages[0]).toContain('intellectual property');
+    });
+
+    it('returns whole-segment passages when no query is given', async () => {
+      await ingestContract();
+      const segId = contractSegmentId();
+
+      const result = await engine.expand(segId);
+      expect(result.found).toBe(true);
+      expect(result.passages.length).toBeGreaterThan(0);
+      expect(result.passages.join('\n')).toContain('$250k');
+    });
+
+    it('reports not-found for an unknown segment id', async () => {
+      const result = await engine.expand('does-not-exist');
+      expect(result.found).toBe(false);
+      expect(result.passages).toEqual([]);
+    });
+  });
+
+  it('links all seven facts to the one segment (parent-dedup precondition)', async () => {
+    await ingestContract();
+    const rows = db.prepare(`SELECT segment_id FROM memories WHERE namespace = ?`).all(NAMESPACE) as Array<{
+      segment_id: string | null;
+    }>;
+    const distinct = new Set(rows.map((r) => r.segment_id));
+    expect(distinct.size).toBe(1);
+    expect([...distinct][0]).not.toBeNull();
+
+    // The linked rows really exist and round-trip through getMemoriesByIds.
+    const ids = (db.prepare(`SELECT id FROM memories WHERE namespace = ?`).all(NAMESPACE) as Array<{ id: string }>).map(
+      (r) => r.id,
+    );
+    expect(getMemoriesByIds(db, NAMESPACE, ids)).toHaveLength(7);
+  });
+});
+
+// ---- Two DISTINCT shared-parent segments that genuinely co-retrieve. Used for the
+// ---- overlap-dedup (§5.3.2) and max_expand_passages-cap (§5.4) cases, which both
+// ---- require >1 segment auto-expanding in one result. Each segment has an OFF-query
+// ---- overview paragraph (so the query-relevant slice splits into its own passage) and
+// ---- ≥2 headline facts (so each auto-expands independently). ----
+
+// An identical arbitration clause — the boundary content chunkBlob's ~10–15% overlap
+// window copies verbatim into two ADJACENT segments. It is its own coherent paragraph,
+// so split-and-rank isolates it as a single passage, identical across both segments.
+const SHARED_ARB_CLAUSE =
+  'Dispute resolution. All disputes arising under this agreement are resolved exclusively by binding ' +
+  'arbitration seated in the state of Delaware under the commercial rules of the American Arbitration ' +
+  'Association, the arbitration award is final and binding on both parties and may be entered in any court of ' +
+  'competent jurisdiction, and the seat of arbitration may not be changed without the written consent of both ' +
+  'parties.';
+
+// Off-query padding that pushes each overview past the passage cap so the shared
+// arbitration clause splits off into its own passage rather than packing with the overview.
+const OVERVIEW_PAD =
+  'The operational appendix further details the supply chain logistics, the regional warehousing footprint, ' +
+  'the carrier selection matrix, and the customs brokerage arrangements for every supported market in the ' +
+  'territory schedule. ';
+
+function disputeSegment(overviewLead: string): string {
+  const overview = (overviewLead + ' ' + OVERVIEW_PAD.repeat(5)).trim();
+  return [overview, '', SHARED_ARB_CLAUSE].join('\n');
+}
+
+const ACME_SEGMENT = disputeSegment(
+  'Acme distribution overview. The Acme master distribution agreement covers worldwide physical and digital distribution.',
+);
+const GLOBEX_SEGMENT = disputeSegment(
+  'Globex catalogue overview. The Globex catalogue licensing deal covers streaming and synchronization rights.',
+);
+
+const ACME_FACTS = [
+  { fact: 'The Acme distribution agreement resolves disputes by binding arbitration in Delaware', importance: 0.7 },
+  { fact: 'The Acme distribution agreement uses American Arbitration Association rules', importance: 0.7 },
+];
+const GLOBEX_FACTS = [
+  { fact: 'The Globex licensing agreement resolves disputes by binding arbitration in Delaware', importance: 0.7 },
+  { fact: 'The Globex licensing agreement uses American Arbitration Association rules', importance: 0.7 },
+];
+
+const DISPUTE_QUERY = 'binding arbitration Delaware American Arbitration Association dispute resolution';
+
+describe('two distinct shared-parent segments (overlap dedup + passage cap)', () => {
+  let tmpDir: string;
+  let engine: MemoryEngine;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'memory-multiseg-expand-'));
+    engine = createMemoryEngineFromConfig(testConfig(join(tmpDir, 'test.db')));
+  });
+
+  afterEach(() => {
+    engine.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  // Ingest both dispute segments as two DISTINCT segments, each with 2 headline facts.
+  async function ingestBothSegments(): Promise<void> {
+    setResponses(factsJson(ACME_FACTS));
+    const acme = await engine.ingest(ACME_SEGMENT, { mode: 'document' });
+    expect(acme.segments_created).toBe(1); // one distinct segment
+    expect(acme.created).toBe(2); // ≥2 facts → auto-expand precondition
+
+    setResponses(factsJson(GLOBEX_FACTS));
+    const globex = await engine.ingest(GLOBEX_SEGMENT, { mode: 'document' });
+    expect(globex.segments_created).toBe(1); // a SECOND distinct segment
+    expect(globex.created).toBe(2);
+  }
+
+  it('overlap dedup: a sentence shared by two co-retrieved segments is emitted at most once (§5.3.2)', async () => {
+    await ingestBothSegments();
+
+    // Default 'auto' over a query that pulls the arbitration facts from BOTH segments.
+    // Each segment's split-and-rank picks the IDENTICAL shared arbitration passage; the
+    // overlap dedup must drop the duplicate so the shared sentence is not emitted twice.
+    const result = await engine.recall({
+      query: DISPUTE_QUERY,
+      format: 'raw',
+      token_budget: 4000,
+      max_expand_passages: 5, // well above 2 so the cap is NOT what limits the result
+    });
+
+    expect(result.expanded).toBe(true);
+    // Precondition: the query genuinely co-retrieved facts from both shared-parent
+    // groups (all four arbitration facts), so both segments were expansion candidates.
+    expect(result.total_matches).toBeGreaterThanOrEqual(4);
+
+    // The shared arbitration sentence appears AT MOST once across all returned passages.
+    const sharedMarker = 'binding arbitration seated in the state of Delaware';
+    const occurrences = result.content.split(sharedMarker).length - 1;
+    expect(occurrences).toBe(1);
+
+    // And exactly ONE passage/segment survived the overlap dedup (the duplicate dropped).
+    // Without the dedup, BOTH identical passages would be emitted (2 segment ids).
+    expect(result.expanded_segment_ids).toHaveLength(1);
+  });
+
+  it('max_expand_passages truncates to N even when more segments would expand (§5.4)', async () => {
+    await ingestBothSegments();
+
+    // A query whose relevant slice is each segment's DISTINCT overview, so the two chosen
+    // passages are NOT overlap-duplicates — without the cap, BOTH would expand. Force the
+    // ≥2 gate off the table with 'parent' and a budget large enough to fit both passages,
+    // so the ONLY thing that can limit the result to one passage is the cap itself.
+    const budget = 4000;
+    const overviewQuery = 'Acme Globex distribution catalogue licensing overview territories streaming rights';
+
+    // Control: with a generous cap, BOTH distinct segments expand (precondition — proves
+    // the cap test below is non-vacuous; without the cap, length would be 2).
+    const uncapped = await engine.recall({
+      query: overviewQuery,
+      format: 'raw',
+      token_budget: budget,
+      expand: 'parent',
+      max_expand_passages: 5,
+    });
+    expect(uncapped.expanded_segment_ids).toHaveLength(2);
+
+    // Cap at 1 → exactly ONE passage/segment is emitted (the cap truncates to N).
+    const capped = await engine.recall({
+      query: overviewQuery,
+      format: 'raw',
+      token_budget: budget,
+      expand: 'parent',
+      max_expand_passages: 1,
+    });
+    expect(capped.expanded).toBe(true);
+    expect(capped.expanded_segment_ids).toHaveLength(1);
+    // Budget adherence: the packer never overruns the budget (skip-not-break).
+    expect(estimateTokens(capped.content)).toBeLessThanOrEqual(budget);
+  });
+});
+
+describe('memory_context auto-expands a shared-parent corpus', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let engine: MemoryEngine;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'memory-context-expand-'));
+    dbPath = join(tmpDir, 'test.db');
+    engine = createMemoryEngineFromConfig(testConfig(dbPath));
+  });
+
+  afterEach(() => {
+    engine.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('returns the passage on a task briefing over the contract corpus', async () => {
+    setResponses(factsJson(HEADLINE_FACTS));
+    await engine.ingest(CONTRACT_SEGMENT, { mode: 'document' });
+
+    // memory_context's task recall is wired to expand:'auto'. Force the extractive
+    // (no-LLM) summary path so the assertion is deterministic.
+    llmMock.hasLLM = false;
+    const briefing = await engine.context({ task: 'Bandalert distribution agreement cap and revenue' });
+
+    expect(briefing).toContain('$250k');
+  });
+});

--- a/packages/memory-mcp-server/test/expand.test.ts
+++ b/packages/memory-mcp-server/test/expand.test.ts
@@ -31,10 +31,19 @@ import type { MemoryEngine } from '../src/engine.js';
 import type { MemoryConfig } from '../src/config.js';
 import { loadConfig } from '../src/config.js';
 import { estimateTokens } from '../src/retrieval/scoring.js';
-import { rankSegmentPassages } from '../src/retrieval/expansion.js';
+import { rankSegmentPassages, realMemoryId } from '../src/retrieval/expansion.js';
 import { embedQuery } from '../src/embedding/embedder.js';
 
 const NAMESPACE = 'test';
+
+describe('realMemoryId', () => {
+  it('strips the #seg: suffix back to the host fact id', () => {
+    expect(realMemoryId('fact-abc#seg:seg-xyz')).toBe('fact-abc');
+  });
+  it('returns a plain (non-passage) id unchanged', () => {
+    expect(realMemoryId('fact-abc')).toBe('fact-abc');
+  });
+});
 
 function setResponses(...responses: Array<string | null>): void {
   llmMock.responses = responses;

--- a/packages/memory-mcp-server/test/expand.test.ts
+++ b/packages/memory-mcp-server/test/expand.test.ts
@@ -31,6 +31,8 @@ import type { MemoryEngine } from '../src/engine.js';
 import type { MemoryConfig } from '../src/config.js';
 import { loadConfig } from '../src/config.js';
 import { estimateTokens } from '../src/retrieval/scoring.js';
+import { rankSegmentPassages } from '../src/retrieval/expansion.js';
+import { embedQuery } from '../src/embedding/embedder.js';
 
 const NAMESPACE = 'test';
 
@@ -199,63 +201,96 @@ describe('parent re-expansion (Bandalert contract)', () => {
     expect(factLines.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('AUGMENT is breadth-preserving: every fact expand:none keeps is also kept under auto, and a passage is appended only on leftover budget (regression: passages must be LOWER priority than facts)', async () => {
+  // Raw format exposes each unit's `expanded` flag, so fact units and the appended
+  // passage unit can be separated cleanly. Helpers shared by the hybrid tests below.
+  const rawFactContents = (raw: { content: string }): string[] => {
+    const items = JSON.parse(raw.content) as Array<{ content: string; expanded: boolean }>;
+    return items.filter((i) => !i.expanded).map((i) => i.content);
+  };
+  const rawPassageCount = (raw: { content: string }): number => {
+    const items = JSON.parse(raw.content) as Array<{ expanded: boolean }>;
+    return items.filter((i) => i.expanded).length;
+  };
+
+  it('HYBRID win: at a budget facts alone would fill, the top passage is STILL guaranteed by reservation while the TOP breadth facts survive (F1 — fails under pure-AUGMENT passage-last)', async () => {
     await ingestContract();
 
     const query = 'Bandalert distribution agreement cap and revenue';
 
-    // Raw format exposes each unit's `expanded` flag, so fact units and the appended
-    // passage unit can be separated cleanly. Helper: the set of FACT-unit contents.
-    const factContents = (raw: { content: string }): Set<string> => {
-      const items = JSON.parse(raw.content) as Array<{ content: string; expanded: boolean }>;
-      return new Set(items.filter((i) => !i.expanded).map((i) => i.content));
-    };
-    const passageCount = (raw: { content: string }): number => {
-      const items = JSON.parse(raw.content) as Array<{ expanded: boolean }>;
-      return items.filter((i) => i.expanded).length;
-    };
+    // Measure the real fact + passage token sizes from a wide auto recall (the packer
+    // estimates tokens off each unit's `content`).
+    const autoWide = await engine.recall({ query, format: 'raw', expand: 'auto', token_budget: 4000 });
+    const wideItems = JSON.parse(autoWide.content) as Array<{ content: string; expanded: boolean }>;
+    const factTokens = wideItems.filter((i) => !i.expanded).map((i) => estimateTokens(i.content));
+    const passageTokens = wideItems.filter((i) => i.expanded).reduce((sum, i) => sum + estimateTokens(i.content), 0);
+    const allFactTokens = factTokens.reduce((a, b) => a + b, 0);
+    const smallestFactTokens = Math.min(...factTokens);
+    expect(wideItems.filter((i) => i.expanded).length).toBe(1); // exactly one shared parent
+    expect(factTokens.length).toBeGreaterThanOrEqual(2); // ≥2 facts co-retrieve
 
-    // --- Generous budget: facts are a SUPERSET of none's, AND the passage is appended. ---
+    // Size the budget so facts ALONE would fill it (every fact fits, no spare room for a
+    // passage if facts were packed first — the pure-AUGMENT skip-the-passage zone), yet
+    // the reservation still fits the passage by displacing only the lowest-priority TAIL
+    // fact: budget = allFactTokens + passageTokens − smallestFactTokens. Facts-first packs
+    // all facts (allFactTokens ≤ budget) leaving only passageTokens − smallestFactTokens
+    // of room — one token short of the passage, so pure-AUGMENT would SKIP it. Hybrid
+    // reserves the passage, packs facts into budget − passageTokens (which is
+    // allFactTokens − smallestFactTokens — every fact but the smallest), and force-includes
+    // the passage. Require the smallest fact to be the strict minimum so exactly one is
+    // displaced.
+    expect(factTokens.filter((t) => t === smallestFactTokens)).toHaveLength(1);
+    const budget = allFactTokens + passageTokens - smallestFactTokens;
+    expect(allFactTokens).toBeLessThanOrEqual(budget); // facts alone all fit (would fill it)
+
+    const auto = await engine.recall({ query, format: 'raw', expand: 'auto', token_budget: budget });
+    const none = await engine.recall({ query, format: 'raw', expand: 'none', token_budget: budget });
+
+    // (a) DEPTH guaranteed: the single top passage is included even though facts could
+    //     have filled the budget. This is the assertion that FAILS under pure-AUGMENT
+    //     (passage-last), where the passage is skipped and `expanded` is false.
+    expect(auto.expanded).toBe(true);
+    expect(rawPassageCount(auto)).toBe(1);
+    expect(auto.content).toContain('$250k');
+
+    // (b) BREADTH preserved: every fact EXCEPT the displaced lowest-priority tail is still
+    //     present. `none` returns all facts in score order; the passage displaced only the
+    //     last (lowest-priority) one, so the TOP facts (all but the last) survive under auto.
+    const noneFacts = rawFactContents(none);
+    const autoFacts = new Set(rawFactContents(auto));
+    expect(noneFacts.length).toBeGreaterThanOrEqual(2);
+    const topFacts = noneFacts.slice(0, noneFacts.length - 1); // all but the displaced tail
+    for (const fact of topFacts) {
+      expect(autoFacts.has(fact)).toBe(true);
+    }
+    // Exactly one fact was displaced to make room for the guaranteed passage.
+    expect(autoFacts.size).toBe(noneFacts.length - 1);
+  });
+
+  it('no wholesale eviction: the passage displaces at most the lowest-priority tail fact(s); the facts above the tail are a SUPERSET kept (regression — passage must NOT get top priority and evict breadth)', async () => {
+    await ingestContract();
+
+    const query = 'Bandalert distribution agreement cap and revenue';
+
+    // Generous budget: facts AND the passage all fit — auto is a strict SUPERSET of none.
     const wideBudget = 800;
     const noneWide = await engine.recall({ query, format: 'raw', expand: 'none', token_budget: wideBudget });
     const autoWide = await engine.recall({ query, format: 'raw', expand: 'auto', token_budget: wideBudget });
 
-    const noneFacts = factContents(noneWide);
-    const autoFacts = factContents(autoWide);
-    expect(noneFacts.size).toBeGreaterThan(0); // the query genuinely retrieves facts
+    const noneFacts = rawFactContents(noneWide);
+    const autoFacts = new Set(rawFactContents(autoWide));
+    expect(noneFacts.length).toBeGreaterThan(0); // the query genuinely retrieves facts
 
     // EVERY fact expand:none returns is ALSO returned under expand:auto (the superset
-    // property — auto never silently drops a breadth fact). This is the assertion that
-    // would FAIL if expansion REPLACED sibling facts with the passage.
+    // property at a budget where everything fits — auto never silently drops a breadth
+    // fact). This FAILS if expansion REPLACED sibling facts with the passage, or if the
+    // passage were given TOP priority and evicted breadth.
     for (const fact of noneFacts) {
       expect(autoFacts.has(fact)).toBe(true);
     }
-    // … and on top of the full fact set, the passage is appended.
+    // … and on top of the full fact set, exactly the top passage is appended.
     expect(autoWide.expanded).toBe(true);
-    expect(passageCount(autoWide)).toBe(1);
+    expect(rawPassageCount(autoWide)).toBe(1);
     expect(autoWide.content).toContain('$250k');
-
-    // --- Tight budget: the DISCRIMINATING zone for pack order. Size the budget to
-    //     `passageTokens + allFactTokens - 1`: it fits ALL facts (facts-last leaves the
-    //     passage one token short, so the passage is skipped and every fact survives),
-    //     but it is also large enough that a HIGH-priority passage WOULD fit first and
-    //     then evict a breadth fact (passage-first leaves allFactTokens-1 of budget,
-    //     one token shy of the full fact set). The packer estimates tokens off each
-    //     unit's `content`, so measure those directly from a wide auto recall. ---
-    const wideItems = JSON.parse(autoWide.content) as Array<{ content: string; expanded: boolean }>;
-    const allFactTokens = wideItems.filter((i) => !i.expanded).reduce((sum, i) => sum + estimateTokens(i.content), 0);
-    const passageTokens = wideItems.filter((i) => i.expanded).reduce((sum, i) => sum + estimateTokens(i.content), 0);
-    const tightBudget = passageTokens + allFactTokens - 1;
-
-    const noneTight = await engine.recall({ query, format: 'raw', expand: 'none', token_budget: tightBudget });
-    const autoTight = await engine.recall({ query, format: 'raw', expand: 'auto', token_budget: tightBudget });
-
-    // Same fact set under both — auto did NOT evict a fact to make room for a passage.
-    // (With a HIGH-priority passage this set would be a strict subset of none's.)
-    expect(factContents(autoTight)).toEqual(factContents(noneTight));
-    // … and the passage is the thing that was skipped (not a fact).
-    expect(passageCount(autoTight)).toBe(0);
-    expect(autoTight.expanded).toBe(false);
   });
 
   it('picks the query-relevant passage (IP query → IP passage, not the cap passage)', async () => {
@@ -604,5 +639,35 @@ describe('memory_context auto-expands a shared-parent corpus', () => {
     const briefing = await engine.context({ task: 'Bandalert distribution agreement cap and revenue' });
 
     expect(briefing).toContain('$250k');
+  });
+});
+
+// `rankSegmentPassages` is the shared split→embed→rank helper (F6), used by BOTH recall
+// expansion (limit 1 per segment) and `engine.expand`/`memory_expand` (all passages).
+describe('rankSegmentPassages (shared split-and-rank helper)', () => {
+  const config = testConfig(join(tmpdir(), 'rank-helper-unused.db'));
+
+  it('ranks the query-relevant passage first and honors the limit', async () => {
+    const queryEmbedding = await embedQuery('intellectual property reversion publishing rights', config);
+
+    const all = await rankSegmentPassages(config, CONTRACT_SEGMENT, queryEmbedding);
+    // The whole segment splits into multiple coherent passages …
+    expect(all.length).toBeGreaterThan(1);
+    // … and the IP query ranks the IP passage first (not the $250k cap passage).
+    expect(all[0]).toContain('intellectual property');
+    expect(all[0]).not.toContain('$250k');
+
+    // The limit truncates to the top-N (the same best-first order recall expansion uses).
+    const topOne = await rankSegmentPassages(config, CONTRACT_SEGMENT, queryEmbedding, 1);
+    expect(topOne).toEqual(all.slice(0, 1));
+  });
+
+  it('returns [] for an empty segment and the lone passage for a short one', async () => {
+    const queryEmbedding = await embedQuery('anything', config);
+
+    expect(await rankSegmentPassages(config, '   ', queryEmbedding)).toEqual([]);
+
+    const short = 'A single short coherent sentence about nothing in particular.';
+    expect(await rankSegmentPassages(config, short, queryEmbedding)).toEqual([short]);
   });
 });

--- a/packages/memory-mcp-server/test/extraction.test.ts
+++ b/packages/memory-mcp-server/test/extraction.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   parseExtractedFacts,
   chunkBlob,
+  splitToPassages,
   MAX_INGEST_CHUNK_TOKENS,
+  MAX_PASSAGE_TOKENS,
   MAX_FACTS_PER_INGEST,
   MAX_INGEST_CHUNKS,
 } from '../src/storage/extraction.js';
@@ -214,5 +216,66 @@ describe('chunkBlob', () => {
     const blob = bigBlob(20000);
     const chunks = chunkBlob(blob);
     expect(chunks.length).toBeLessThanOrEqual(MAX_INGEST_CHUNKS);
+  });
+});
+
+describe('splitToPassages', () => {
+  it('returns [] for empty / whitespace-only input', () => {
+    expect(splitToPassages('')).toEqual([]);
+    expect(splitToPassages('   \n  \n ')).toEqual([]);
+  });
+
+  it('returns a single passage for short text', () => {
+    const passages = splitToPassages('Contract clause: the distribution cap is $250k.');
+    expect(passages).toHaveLength(1);
+    expect(passages[0]).toContain('$250k');
+  });
+
+  it('caps every passage at ~MAX_PASSAGE_TOKENS', () => {
+    // ~12 paragraphs of ~120 tokens each → must split into several bounded passages.
+    const para = (n: number): string =>
+      `Section ${n}. ` + 'This sentence carries roughly a dozen tokens of synthetic legal prose. '.repeat(8);
+    const text = Array.from({ length: 12 }, (_, i) => para(i)).join('\n\n');
+
+    const passages = splitToPassages(text);
+    expect(passages.length).toBeGreaterThan(1);
+    for (const passage of passages) {
+      expect(estimateTokens(passage)).toBeLessThanOrEqual(MAX_PASSAGE_TOKENS);
+    }
+  });
+
+  it('splits on paragraph boundaries, keeping coherent blocks together', () => {
+    const text = ['Clause A: distribution cap is $250k.', 'Clause B: IP reverts to the author.'].join('\n\n');
+    const passages = splitToPassages(text);
+    // Both short clauses fit one passage; the boundary is preserved within it.
+    expect(passages.join(' ')).toContain('$250k');
+    expect(passages.join(' ')).toContain('IP reverts');
+  });
+
+  it('falls back to sentence boundaries for an oversized paragraph', () => {
+    const sentence = 'This is a synthetic sentence with a handful of tokens. ';
+    const oneBigParagraph = sentence.repeat(60); // > cap, no paragraph breaks
+    const passages = splitToPassages(oneBigParagraph);
+    expect(passages.length).toBeGreaterThan(1);
+    for (const passage of passages) {
+      expect(estimateTokens(passage)).toBeLessThanOrEqual(MAX_PASSAGE_TOKENS);
+    }
+  });
+
+  it('char-cuts a whitespace-free oversized single token as a last resort (hardCutToPassageChars)', () => {
+    // A single giant token with NO whitespace and NO sentence boundary (e.g. a base64
+    // blob / minified payload). Paragraph- and sentence-splitting cannot break it, so
+    // the char-bounded hard cut is the only path that keeps each passage under the cap.
+    const giantToken = 'x'.repeat(MAX_PASSAGE_TOKENS * 4 + 200);
+    expect(estimateTokens(giantToken)).toBeGreaterThan(MAX_PASSAGE_TOKENS);
+
+    const passages = splitToPassages(giantToken);
+
+    // It MUST split (one whole-token passage would blow the cap) and every emitted
+    // passage stays at or under the budget — the hard bound, no slack.
+    expect(passages.length).toBeGreaterThan(1);
+    for (const passage of passages) {
+      expect(estimateTokens(passage)).toBeLessThanOrEqual(MAX_PASSAGE_TOKENS);
+    }
   });
 });

--- a/packages/memory-mcp-server/test/extraction.test.ts
+++ b/packages/memory-mcp-server/test/extraction.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  parseExtractedFacts,
+  chunkBlob,
+  MAX_INGEST_CHUNK_TOKENS,
+  MAX_FACTS_PER_INGEST,
+  MAX_INGEST_CHUNKS,
+} from '../src/storage/extraction.js';
+import { MAX_CONTENT_LENGTH } from '../src/tools/validation.js';
+import { estimateTokens } from '../src/retrieval/scoring.js';
+
+describe('parseExtractedFacts', () => {
+  it('parses an array of {fact, importance} objects', () => {
+    const raw =
+      '[{"fact": "The user prefers dark mode", "importance": 0.8}, {"fact": "User uses Vim", "importance": 0.6}]';
+    const facts = parseExtractedFacts(raw);
+    expect(facts).toEqual([
+      { fact: 'The user prefers dark mode', importance: 0.8 },
+      { fact: 'User uses Vim', importance: 0.6 },
+    ]);
+  });
+
+  it('trims whitespace from the fact string', () => {
+    const facts = parseExtractedFacts('[{"fact": "  spaced fact  ", "importance": 0.5}]');
+    expect(facts[0].fact).toBe('spaced fact');
+  });
+
+  it('tolerates bare-string items → importance undefined', () => {
+    const facts = parseExtractedFacts('["A bare fact", "Another bare fact"]');
+    expect(facts).toEqual([{ fact: 'A bare fact' }, { fact: 'Another bare fact' }]);
+    expect(facts[0].importance).toBeUndefined();
+  });
+
+  it('treats missing importance as undefined', () => {
+    const facts = parseExtractedFacts('[{"fact": "No importance here"}]');
+    expect(facts).toEqual([{ fact: 'No importance here' }]);
+    expect(facts[0].importance).toBeUndefined();
+  });
+
+  it('extracts a prose-wrapped JSON array', () => {
+    const raw = 'Here are the facts:\n[{"fact": "Extracted from prose", "importance": 0.4}]\nThat is all.';
+    const facts = parseExtractedFacts(raw);
+    expect(facts).toEqual([{ fact: 'Extracted from prose', importance: 0.4 }]);
+  });
+
+  it('returns [] for non-array JSON', () => {
+    expect(parseExtractedFacts('{"fact": "not an array"}')).toEqual([]);
+  });
+
+  it('returns [] for empty/junk input', () => {
+    expect(parseExtractedFacts('')).toEqual([]);
+    expect(parseExtractedFacts('not json at all')).toEqual([]);
+    expect(parseExtractedFacts('[]')).toEqual([]);
+  });
+
+  it('drops items with empty or whitespace-only facts', () => {
+    const facts = parseExtractedFacts('[{"fact": ""}, {"fact": "   "}, {"fact": "real"}]');
+    expect(facts).toEqual([{ fact: 'real' }]);
+  });
+
+  it('drops items missing a string fact', () => {
+    const facts = parseExtractedFacts('[{"importance": 0.5}, {"fact": 42}, {"fact": "ok"}]');
+    expect(facts).toEqual([{ fact: 'ok' }]);
+  });
+
+  describe('importance clamping (A2)', () => {
+    it('clamps importance above 1 to 1', () => {
+      const facts = parseExtractedFacts('[{"fact": "too high", "importance": 5}]');
+      expect(facts[0].importance).toBe(1);
+    });
+
+    it('clamps importance below 0 to 0', () => {
+      const facts = parseExtractedFacts('[{"fact": "too low", "importance": -3}]');
+      expect(facts[0].importance).toBe(0);
+    });
+
+    it('drops non-finite importance to undefined', () => {
+      const facts = parseExtractedFacts('[{"fact": "infinite", "importance": 1e999}]');
+      expect(facts[0].importance).toBeUndefined();
+    });
+
+    it('drops non-number importance to undefined', () => {
+      const facts = parseExtractedFacts('[{"fact": "stringy", "importance": "high"}]');
+      expect(facts[0].importance).toBeUndefined();
+    });
+  });
+
+  it('caps an over-long fact at MAX_CONTENT_LENGTH', () => {
+    const longFact = 'x'.repeat(MAX_CONTENT_LENGTH + 500);
+    const facts = parseExtractedFacts(JSON.stringify([{ fact: longFact, importance: 0.5 }]));
+    expect(facts).toHaveLength(1);
+    expect(facts[0].fact.length).toBe(MAX_CONTENT_LENGTH);
+  });
+
+  it('caps the number of facts at MAX_FACTS_PER_INGEST', () => {
+    const many = Array.from({ length: MAX_FACTS_PER_INGEST + 50 }, (_, i) => ({ fact: `fact ${i}` }));
+    const facts = parseExtractedFacts(JSON.stringify(many));
+    expect(facts.length).toBe(MAX_FACTS_PER_INGEST);
+  });
+
+  it('drops intra-batch exact-fact duplicates, keeping the first importance', () => {
+    const raw = '[{"fact": "dup", "importance": 0.9}, {"fact": "dup", "importance": 0.1}, {"fact": "unique"}]';
+    const facts = parseExtractedFacts(raw);
+    expect(facts).toEqual([{ fact: 'dup', importance: 0.9 }, { fact: 'unique' }]);
+  });
+
+  describe('PII-safe parse (A6)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns [] on a non-JSON response and never echoes the sensitive substring on ANY channel', () => {
+      // Widened beyond console.error to also cover process.stderr.write and
+      // console.warn — future-proofs the guarantee against a regression that emits
+      // via a different channel (T3).
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const sensitive = 'SSN-123-45-6789-SECRET';
+      const raw = `Sorry, I cannot comply. ${sensitive} appears in the input.`;
+
+      const facts = parseExtractedFacts(raw);
+
+      expect(facts).toEqual([]);
+      // parseExtractedFacts itself logs nothing, but assert defensively that nothing
+      // it might emit on any stderr channel carries the substring.
+      const allLogs = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...stderrSpy.mock.calls]
+        .map((c) => JSON.stringify(c))
+        .join('\n');
+      expect(allLogs).not.toContain(sensitive);
+    });
+  });
+});
+
+describe('chunkBlob', () => {
+  it('returns a single chunk for a short blob', () => {
+    const blob = 'line one\nline two\nline three';
+    const chunks = chunkBlob(blob);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(blob);
+  });
+
+  function bigBlob(lineCount: number): string {
+    // Each line ~ 200 chars (~50 tokens); lineCount lines comfortably exceeds the threshold.
+    const line = 'word '.repeat(40).trim();
+    return Array.from({ length: lineCount }, (_, i) => `${i}: ${line}`).join('\n');
+  }
+
+  it('splits a long blob into multiple newline-oriented chunks', () => {
+    const blob = bigBlob(600);
+    expect(estimateTokens(blob)).toBeGreaterThan(MAX_INGEST_CHUNK_TOKENS);
+
+    const chunks = chunkBlob(blob);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should stay within (roughly) the token threshold.
+    for (const chunk of chunks) {
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(MAX_INGEST_CHUNK_TOKENS + 200);
+    }
+  });
+
+  it('overlaps adjacent chunks by ~10–15% of lines (A5)', () => {
+    const blob = bigBlob(600);
+    const chunks = chunkBlob(blob);
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // The tail lines of chunk N must reappear as a contiguous prefix at the head
+    // of chunk N+1 (the ~10–15% line overlap, A5).
+    const firstLines = chunks[0].split('\n');
+    const secondLines = chunks[1].split('\n');
+
+    // The single last line of chunk 0 must reappear inside chunk 1's overlap region.
+    const lastLine = firstLines[firstLines.length - 1];
+    expect(secondLines).toContain(lastLine);
+
+    // Find how long the shared prefix is, then assert it is a real tail of chunk 0.
+    const overlapLen = secondLines.indexOf(lastLine) + 1;
+    expect(overlapLen).toBeGreaterThan(0);
+    const chunk0Tail = firstLines.slice(firstLines.length - overlapLen);
+    expect(secondLines.slice(0, overlapLen)).toEqual(chunk0Tail);
+  });
+
+  it('hard-splits a single pathological line longer than the threshold', () => {
+    const hugeLine = 'token '.repeat(MAX_INGEST_CHUNK_TOKENS * 2).trim();
+    expect(estimateTokens(hugeLine)).toBeGreaterThan(MAX_INGEST_CHUNK_TOKENS);
+
+    const chunks = chunkBlob(hugeLine);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(MAX_INGEST_CHUNK_TOKENS + 200);
+    }
+  });
+
+  it('enforces the token cap as a HARD bound on a whitespace-free giant line (P1)', () => {
+    // A 100k-char line with NO whitespace (e.g. base64 / minified JSON / one giant
+    // token). Whitespace-splitting alone would return it whole and blow the cap;
+    // the char-based hard cut must keep every emitted piece at or under the budget.
+    const hugeToken = 'A'.repeat(100_000);
+    expect(estimateTokens(hugeToken)).toBeGreaterThan(MAX_INGEST_CHUNK_TOKENS);
+
+    const chunks = chunkBlob(hugeToken);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      // HARD bound: no slack — each piece is ≤ the cap, not cap + epsilon.
+      expect(estimateTokens(chunk)).toBeLessThanOrEqual(MAX_INGEST_CHUNK_TOKENS);
+    }
+    // Round-trips losslessly (the cut only partitions, never drops characters).
+    expect(chunks.join('')).toBe(hugeToken);
+  });
+
+  it('bounds the total chunk count at MAX_INGEST_CHUNKS', () => {
+    const blob = bigBlob(20000);
+    const chunks = chunkBlob(blob);
+    expect(chunks.length).toBeLessThanOrEqual(MAX_INGEST_CHUNKS);
+  });
+});

--- a/packages/memory-mcp-server/test/extraction.test.ts
+++ b/packages/memory-mcp-server/test/extraction.test.ts
@@ -97,6 +97,13 @@ describe('parseExtractedFacts', () => {
     expect(facts[0].fact.length).toBe(MAX_CONTENT_LENGTH);
   });
 
+  it('caps an over-long BARE-STRING fact at MAX_CONTENT_LENGTH', () => {
+    const longFact = 'y'.repeat(MAX_CONTENT_LENGTH + 500);
+    const facts = parseExtractedFacts(JSON.stringify([longFact]));
+    expect(facts).toHaveLength(1);
+    expect(facts[0].fact.length).toBe(MAX_CONTENT_LENGTH);
+  });
+
   it('caps the number of facts at MAX_FACTS_PER_INGEST', () => {
     const many = Array.from({ length: MAX_FACTS_PER_INGEST + 50 }, (_, i) => ({ fact: `fact ${i}` }));
     const facts = parseExtractedFacts(JSON.stringify(many));

--- a/packages/memory-mcp-server/test/extraction.test.ts
+++ b/packages/memory-mcp-server/test/extraction.test.ts
@@ -43,13 +43,16 @@ describe('parseExtractedFacts', () => {
     expect(facts).toEqual([{ fact: 'Extracted from prose', importance: 0.4 }]);
   });
 
-  it('returns [] for non-array JSON', () => {
-    expect(parseExtractedFacts('{"fact": "not an array"}')).toEqual([]);
+  it('returns null for non-array JSON (parse failure)', () => {
+    expect(parseExtractedFacts('{"fact": "not an array"}')).toBeNull();
   });
 
-  it('returns [] for empty/junk input', () => {
-    expect(parseExtractedFacts('')).toEqual([]);
-    expect(parseExtractedFacts('not json at all')).toEqual([]);
+  it('returns null for unparseable input — no JSON array found', () => {
+    expect(parseExtractedFacts('')).toBeNull();
+    expect(parseExtractedFacts('not json at all')).toBeNull();
+  });
+
+  it('returns [] for a valid empty array (model validly found nothing durable)', () => {
     expect(parseExtractedFacts('[]')).toEqual([]);
   });
 
@@ -109,7 +112,7 @@ describe('parseExtractedFacts', () => {
       vi.restoreAllMocks();
     });
 
-    it('returns [] on a non-JSON response and never echoes the sensitive substring on ANY channel', () => {
+    it('returns null on a non-JSON response and never echoes the sensitive substring on ANY channel', () => {
       // Widened beyond console.error to also cover process.stderr.write and
       // console.warn — future-proofs the guarantee against a regression that emits
       // via a different channel (T3).
@@ -121,7 +124,7 @@ describe('parseExtractedFacts', () => {
 
       const facts = parseExtractedFacts(raw);
 
-      expect(facts).toEqual([]);
+      expect(facts).toBeNull();
       // parseExtractedFacts itself logs nothing, but assert defensively that nothing
       // it might emit on any stderr channel carries the substring.
       const allLogs = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...stderrSpy.mock.calls]

--- a/packages/memory-mcp-server/test/ingest-tool.test.ts
+++ b/packages/memory-mcp-server/test/ingest-tool.test.ts
@@ -91,6 +91,12 @@ describe('validateIngestInput', () => {
       expect(typeof input.as_of).toBe('number');
     });
 
+    it('truncates a fractional epoch ms to an integer (INTEGER column)', () => {
+      const input = validateIngestInput({ content: 'x', as_of: 1_700_000_000_000.5 });
+      expect(input.as_of).toBe(1_700_000_000_000);
+      expect(Number.isInteger(input.as_of)).toBe(true);
+    });
+
     it('rejects an empty / whitespace-only as_of string (P2 — Number("") is 0, must stay unparseable)', () => {
       expect(() => validateIngestInput({ content: 'x', as_of: '' })).toThrow('as_of');
       expect(() => validateIngestInput({ content: 'x', as_of: '   ' })).toThrow('as_of');

--- a/packages/memory-mcp-server/test/ingest-tool.test.ts
+++ b/packages/memory-mcp-server/test/ingest-tool.test.ts
@@ -11,6 +11,7 @@ function createMockEngine(ingestResult: IngestResult): MemoryEngine {
     context: vi.fn(),
     forget: vi.fn(),
     inspect: vi.fn(),
+    expand: vi.fn(),
     close: vi.fn(),
   };
 }

--- a/packages/memory-mcp-server/test/ingest-tool.test.ts
+++ b/packages/memory-mcp-server/test/ingest-tool.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { MemoryEngine } from '../src/engine.js';
+import type { IngestResult } from '../src/types.js';
+import { validateIngestInput, handleIngest, formatIngestResult } from '../src/tools/ingest.js';
+
+function createMockEngine(ingestResult: IngestResult): MemoryEngine {
+  return {
+    store: vi.fn().mockResolvedValue({ id: 'x', action: 'created' }),
+    ingest: vi.fn().mockResolvedValue(ingestResult),
+    recall: vi.fn(),
+    context: vi.fn(),
+    forget: vi.fn(),
+    inspect: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+describe('validateIngestInput', () => {
+  it('rejects missing content', () => {
+    expect(() => validateIngestInput({})).toThrow('content is required');
+  });
+
+  it('rejects empty / whitespace-only content', () => {
+    expect(() => validateIngestInput({ content: '   ' })).toThrow('content is required');
+  });
+
+  it('rejects non-string content', () => {
+    expect(() => validateIngestInput({ content: 42 })).toThrow('content is required');
+  });
+
+  it('trims content', () => {
+    const input = validateIngestInput({ content: '  hello  ' });
+    expect(input.content).toBe('hello');
+  });
+
+  it('defaults mode to conversation', () => {
+    const input = validateIngestInput({ content: 'x' });
+    expect(input.mode).toBe('conversation');
+  });
+
+  it('accepts mode=document', () => {
+    const input = validateIngestInput({ content: 'x', mode: 'document' });
+    expect(input.mode).toBe('document');
+  });
+
+  it('rejects an invalid mode', () => {
+    expect(() => validateIngestInput({ content: 'x', mode: 'summary' })).toThrow('mode must be');
+  });
+
+  it('defaults on_extraction_failure to degrade', () => {
+    const input = validateIngestInput({ content: 'x' });
+    expect(input.on_extraction_failure).toBe('degrade');
+  });
+
+  it('accepts skip and error for on_extraction_failure', () => {
+    expect(validateIngestInput({ content: 'x', on_extraction_failure: 'skip' }).on_extraction_failure).toBe('skip');
+    expect(validateIngestInput({ content: 'x', on_extraction_failure: 'error' }).on_extraction_failure).toBe('error');
+  });
+
+  it('rejects an on_extraction_failure outside the enum', () => {
+    expect(() => validateIngestInput({ content: 'x', on_extraction_failure: 'retry' })).toThrow(
+      'on_extraction_failure must be',
+    );
+  });
+
+  it('defaults dry_run to false', () => {
+    expect(validateIngestInput({ content: 'x' }).dry_run).toBe(false);
+  });
+
+  it('rejects a non-boolean dry_run', () => {
+    expect(() => validateIngestInput({ content: 'x', dry_run: 'yes' })).toThrow('dry_run must be a boolean');
+  });
+
+  describe('as_of normalization', () => {
+    it('passes through an epoch-ms number', () => {
+      const input = validateIngestInput({ content: 'x', as_of: 1_700_000_000_000 });
+      expect(input.as_of).toBe(1_700_000_000_000);
+    });
+
+    it('normalizes an ISO 8601 string to epoch ms', () => {
+      const iso = '2023-01-15T00:00:00.000Z';
+      const input = validateIngestInput({ content: 'x', as_of: iso });
+      expect(input.as_of).toBe(Date.parse(iso));
+    });
+
+    it('accepts a numeric STRING as epoch ms (P2)', () => {
+      const input = validateIngestInput({ content: 'x', as_of: '1700000000000' });
+      expect(input.as_of).toBe(1_700_000_000_000);
+      // The engine contract is numeric — never a string.
+      expect(typeof input.as_of).toBe('number');
+    });
+
+    it('rejects an empty / whitespace-only as_of string (P2 — Number("") is 0, must stay unparseable)', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: '' })).toThrow('as_of');
+      expect(() => validateIngestInput({ content: 'x', as_of: '   ' })).toThrow('as_of');
+    });
+
+    it('rejects a negative numeric as_of string (P2)', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: '-1700000000000' })).toThrow('as_of');
+    });
+
+    it('rejects a non-parseable as_of string', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: 'not a date' })).toThrow('as_of');
+    });
+
+    it('rejects a negative as_of number', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: -5 })).toThrow('as_of');
+    });
+
+    it('rejects a non-finite as_of number', () => {
+      expect(() => validateIngestInput({ content: 'x', as_of: Number.POSITIVE_INFINITY })).toThrow('as_of');
+    });
+
+    it('leaves as_of undefined when omitted', () => {
+      expect(validateIngestInput({ content: 'x' }).as_of).toBeUndefined();
+    });
+  });
+
+  it('validates tags and importance', () => {
+    const input = validateIngestInput({ content: 'x', tags: ['a', 'b'], importance: 0.7 });
+    expect(input.tags).toEqual(['a', 'b']);
+    expect(input.importance).toBe(0.7);
+  });
+
+  it('rejects importance out of [0,1]', () => {
+    expect(() => validateIngestInput({ content: 'x', importance: 1.5 })).toThrow('importance must be');
+  });
+});
+
+describe('handleIngest routing', () => {
+  it('routes to engine.ingest with normalized options', async () => {
+    const result: IngestResult = {
+      created: 2,
+      merged: 1,
+      ingested: 2,
+      memory_ids: ['a1b2c3d4e5', 'f6g7h8i9j0', 'k1l2m3n4o5'],
+      facts: [{ fact: 'f1' }, { fact: 'f2' }, { fact: 'f3' }],
+    };
+    const engine = createMockEngine(result);
+    const text = await handleIngest(engine, {
+      content: '  blob  ',
+      mode: 'document',
+      tags: ['seed'],
+      importance: 0.6,
+      as_of: '2023-01-15T00:00:00.000Z',
+    });
+
+    expect(engine.ingest).toHaveBeenCalledWith('blob', {
+      source: undefined,
+      mode: 'document',
+      tags: ['seed'],
+      importance: 0.6,
+      dry_run: false,
+      as_of: Date.parse('2023-01-15T00:00:00.000Z'),
+      on_extraction_failure: 'degrade',
+    });
+    expect(text).toContain('Ingested 3 atomic fact');
+    expect(text).toContain('2 new memories, 1 merged');
+  });
+});
+
+describe('formatIngestResult', () => {
+  it('renders a normal result reporting created and merged separately (A7)', () => {
+    const text = formatIngestResult({
+      created: 6,
+      merged: 1,
+      ingested: 6,
+      memory_ids: ['aaaaaaaa11', 'bbbbbbbb22'],
+      facts: Array.from({ length: 7 }, (_, i) => ({ fact: `f${i}` })),
+    });
+    expect(text).toContain('Ingested 7 atomic fact');
+    expect(text).toContain('6 new memories');
+    expect(text).toContain('1 merged into existing');
+    expect(text).toContain('aaaaaaaa…');
+  });
+
+  it('renders a dry_run preview with per-fact importance', () => {
+    const text = formatIngestResult({
+      created: 0,
+      merged: 0,
+      ingested: 0,
+      memory_ids: [],
+      facts: [{ fact: 'First fact', importance: 0.9 }, { fact: 'Second fact' }],
+    });
+    expect(text).toContain('Dry run — nothing written.');
+    expect(text).toContain('1. First fact (importance: 0.9)');
+    expect(text).toContain('2. Second fact');
+  });
+
+  it('renders a partial result', () => {
+    const text = formatIngestResult({
+      created: 3,
+      merged: 1,
+      ingested: 3,
+      memory_ids: ['id1', 'id2', 'id3', 'id4'],
+      facts: Array.from({ length: 4 }, (_, i) => ({ fact: `f${i}` })),
+      chunks: 3,
+      failed_chunks: 1,
+      degraded: true,
+      partial: true,
+    });
+    expect(text).toContain('Ingested 4 atomic fact');
+    expect(text).toContain('1 of 3 chunks failed extraction — partial result.');
+  });
+
+  it('renders a full degrade (single-blob store)', () => {
+    const text = formatIngestResult({
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: ['deadbeef99'],
+      facts: [{ fact: 'the whole blob', importance: 0.5 }],
+      degraded: true,
+    });
+    expect(text).toContain('stored the blob as a single memory deadbeef…');
+  });
+
+  it('renders a skipped result', () => {
+    const text = formatIngestResult({
+      created: 0,
+      merged: 0,
+      ingested: 0,
+      memory_ids: [],
+      facts: [],
+      skipped: true,
+    });
+    expect(text).toContain('nothing written');
+    expect(text).toContain('skip');
+  });
+});

--- a/packages/memory-mcp-server/test/ingest-tool.test.ts
+++ b/packages/memory-mcp-server/test/ingest-tool.test.ts
@@ -132,7 +132,6 @@ describe('handleIngest routing', () => {
     const result: IngestResult = {
       created: 2,
       merged: 1,
-      ingested: 2,
       memory_ids: ['a1b2c3d4e5', 'f6g7h8i9j0', 'k1l2m3n4o5'],
       facts: [{ fact: 'f1' }, { fact: 'f2' }, { fact: 'f3' }],
     };
@@ -161,69 +160,95 @@ describe('handleIngest routing', () => {
 
 describe('formatIngestResult', () => {
   it('renders a normal result reporting created and merged separately (A7)', () => {
-    const text = formatIngestResult({
-      created: 6,
-      merged: 1,
-      ingested: 6,
-      memory_ids: ['aaaaaaaa11', 'bbbbbbbb22'],
-      facts: Array.from({ length: 7 }, (_, i) => ({ fact: `f${i}` })),
-    });
+    const text = formatIngestResult(
+      {
+        created: 6,
+        merged: 1,
+        memory_ids: ['aaaaaaaa11', 'bbbbbbbb22'],
+        facts: Array.from({ length: 7 }, (_, i) => ({ fact: `f${i}` })),
+      },
+      false,
+    );
     expect(text).toContain('Ingested 7 atomic fact');
     expect(text).toContain('6 new memories');
     expect(text).toContain('1 merged into existing');
     expect(text).toContain('aaaaaaaa…');
   });
 
+  it('renders a clean empty result as a 0-fact ingest, not a dry run or failure', () => {
+    const text = formatIngestResult({ created: 0, merged: 0, memory_ids: [], facts: [] }, false);
+    expect(text).toContain('Ingested 0 atomic fact');
+    expect(text).not.toContain('Dry run');
+    expect(text).not.toContain('failed');
+  });
+
   it('renders a dry_run preview with per-fact importance', () => {
-    const text = formatIngestResult({
-      created: 0,
-      merged: 0,
-      ingested: 0,
-      memory_ids: [],
-      facts: [{ fact: 'First fact', importance: 0.9 }, { fact: 'Second fact' }],
-    });
+    const text = formatIngestResult(
+      {
+        created: 0,
+        merged: 0,
+        memory_ids: [],
+        facts: [{ fact: 'First fact', importance: 0.9 }, { fact: 'Second fact' }],
+      },
+      true,
+    );
     expect(text).toContain('Dry run — nothing written.');
     expect(text).toContain('1. First fact (importance: 0.9)');
     expect(text).toContain('2. Second fact');
   });
 
+  it('flags an incomplete dry_run preview when a chunk failed (A3/A4)', () => {
+    const text = formatIngestResult(
+      {
+        created: 0,
+        merged: 0,
+        memory_ids: [],
+        facts: [{ fact: 'Only fact from the good chunk' }],
+        chunks: 2,
+        failed_chunks: 1,
+        partial: true,
+      },
+      true,
+    );
+    expect(text).toContain('Dry run — nothing written.');
+    expect(text).toContain('1 of 2 chunks failed extraction');
+    expect(text).toMatch(/incomplete|missing facts/i);
+  });
+
   it('renders a partial result', () => {
-    const text = formatIngestResult({
-      created: 3,
-      merged: 1,
-      ingested: 3,
-      memory_ids: ['id1', 'id2', 'id3', 'id4'],
-      facts: Array.from({ length: 4 }, (_, i) => ({ fact: `f${i}` })),
-      chunks: 3,
-      failed_chunks: 1,
-      degraded: true,
-      partial: true,
-    });
+    const text = formatIngestResult(
+      {
+        created: 3,
+        merged: 1,
+        memory_ids: ['id1', 'id2', 'id3', 'id4'],
+        facts: Array.from({ length: 4 }, (_, i) => ({ fact: `f${i}` })),
+        chunks: 3,
+        failed_chunks: 1,
+        degraded: true,
+        partial: true,
+      },
+      false,
+    );
     expect(text).toContain('Ingested 4 atomic fact');
     expect(text).toContain('1 of 3 chunks failed extraction — partial result.');
   });
 
   it('renders a full degrade (single-blob store)', () => {
-    const text = formatIngestResult({
-      created: 1,
-      merged: 0,
-      ingested: 1,
-      memory_ids: ['deadbeef99'],
-      facts: [{ fact: 'the whole blob', importance: 0.5 }],
-      degraded: true,
-    });
+    const text = formatIngestResult(
+      {
+        created: 1,
+        merged: 0,
+        memory_ids: ['deadbeef99'],
+        facts: [{ fact: 'the whole blob', importance: 0.5 }],
+        degraded: true,
+      },
+      false,
+    );
     expect(text).toContain('stored the blob as a single memory deadbeef…');
   });
 
   it('renders a skipped result', () => {
-    const text = formatIngestResult({
-      created: 0,
-      merged: 0,
-      ingested: 0,
-      memory_ids: [],
-      facts: [],
-      skipped: true,
-    });
+    const text = formatIngestResult({ created: 0, merged: 0, memory_ids: [], facts: [], skipped: true }, false);
     expect(text).toContain('nothing written');
     expect(text).toContain('skip');
   });

--- a/packages/memory-mcp-server/test/ingest.test.ts
+++ b/packages/memory-mcp-server/test/ingest.test.ts
@@ -25,6 +25,7 @@ vi.mock('../src/llm/client.js', () => ({
 }));
 
 import { initDatabase } from '../src/storage/database.js';
+import type { SegmentRow } from '../src/storage/database.js';
 import { getNamespaceStats, getMemoriesByIds } from '../src/storage/queries.js';
 import { createMemoryEngineFromConfig } from '../src/engine-impl.js';
 import type { MemoryEngine } from '../src/engine.js';
@@ -413,6 +414,220 @@ describe('engine.ingest', () => {
       expect(result.degraded).toBe(true);
       expect(result.failed_chunks).toBeGreaterThanOrEqual(1);
       expect(result.chunks).toBeGreaterThan(1);
+    });
+  });
+
+  describe('segment linking (parent-context retention)', () => {
+    function allSegments(): SegmentRow[] {
+      return db.prepare(`SELECT * FROM segments WHERE namespace = ?`).all(NAMESPACE) as SegmentRow[];
+    }
+
+    it('stores one segment, links every fact to it, and reports segments_created', async () => {
+      setResponses(
+        factsJson([
+          { fact: 'The user is named Alice', importance: 0.9 },
+          { fact: 'Alice prefers dark mode', importance: 0.6 },
+          { fact: 'Alice works on the Iron project', importance: 0.5 },
+        ]),
+      );
+
+      const blob = 'Conversation: Alice said she is Alice, prefers dark mode, works on Iron.';
+      const result = await engine.ingest(blob, { mode: 'document' });
+
+      expect(result.segments_created).toBe(1);
+
+      const segments = allSegments();
+      expect(segments).toHaveLength(1);
+      expect(segments[0].content).toBe(blob);
+      expect(segments[0].fact_count).toBe(3);
+
+      const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(rows).toHaveLength(3);
+      for (const row of rows) {
+        expect(row.segment_id).toBe(segments[0].id);
+      }
+    });
+
+    it('multi-chunk: writes a segment per chunk; a boundary-deduped fact stays on its first chunk', async () => {
+      function bigBlob(): string {
+        const line = 'sentence words here '.repeat(8).trim();
+        return Array.from({ length: 250 }, (_, i) => `${i}: ${line}`).join('\n');
+      }
+      // First chunk yields fact A (and a SHARED fact); every later chunk re-emits the
+      // SHARED fact (deduped away) plus its own distinct fact.
+      const responses: string[] = [factsJson([{ fact: 'chunk-0 distinct fact' }, { fact: 'SHARED boundary fact' }])];
+      for (let i = 1; i < 50; i++) {
+        responses.push(factsJson([{ fact: 'SHARED boundary fact' }, { fact: `chunk-${i} distinct fact` }]));
+      }
+      setResponses(...responses);
+
+      const result = await engine.ingest(bigBlob(), { mode: 'document' });
+
+      const segments = allSegments();
+      expect(segments.length).toBeGreaterThanOrEqual(2);
+      expect(result.segments_created).toBe(segments.length);
+
+      // The shared boundary fact must be linked to exactly ONE segment (the first
+      // chunk's), not duplicated across the chunks that re-emitted it.
+      const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      const sharedRows = rows.filter((r) => r.content === 'SHARED boundary fact');
+      expect(sharedRows).toHaveLength(1);
+
+      // Its parent is the FIRST chunk's segment (the one whose other fact is chunk-0's).
+      const chunk0Row = rows.find((r) => r.content === 'chunk-0 distinct fact');
+      expect(chunk0Row).toBeDefined();
+      expect(sharedRows[0].segment_id).toBe(chunk0Row?.segment_id);
+    });
+
+    it('backdates the segment created_at to as_of (matches the facts)', async () => {
+      const T_OLD = Date.parse('2023-03-01T00:00:00.000Z');
+      setResponses(factsJson([{ fact: 'Backdated fact', importance: 0.5 }]));
+
+      const result = await engine.ingest('historical blob', { as_of: T_OLD });
+
+      const segments = allSegments();
+      expect(segments).toHaveLength(1);
+      expect(segments[0].created_at).toBe(T_OLD);
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.created_at).toBe(T_OLD);
+    });
+
+    it('degrade single-blob writes a fact with NULL segment and NO segment row', async () => {
+      disableLLM();
+      const result = await engine.ingest('unstructured content, no LLM', {});
+
+      expect(result.degraded).toBe(true);
+      expect(result.created).toBe(1);
+      expect(result.segments_created).toBeUndefined();
+      expect(allSegments()).toHaveLength(0);
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.segment_id).toBeNull();
+    });
+
+    it('dry_run writes neither facts nor segments', async () => {
+      setResponses(factsJson([{ fact: 'Preview fact', importance: 0.5 }]));
+      const result = await engine.ingest('blob', { dry_run: true });
+
+      expect(result.facts).toHaveLength(1);
+      expect(result.segments_created).toBeUndefined();
+      expect(allSegments()).toHaveLength(0);
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(0);
+    });
+
+    describe('merge repoints survivor to the richer parent (A4)', () => {
+      const FACT = 'Distribution cap is $250k';
+
+      // A 1-fact segment then a 5-fact segment (or vice-versa); the survivor must end
+      // up pointing at the 5-fact (richer) segment regardless of ingest order.
+      async function ingestPoorSegment(): Promise<string[]> {
+        setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+        const r = await engine.ingest('poor blob', {});
+        return r.memory_ids;
+      }
+
+      async function ingestRichSegment(): Promise<void> {
+        setResponses(
+          factsJson([
+            { fact: FACT, importance: 0.5 }, // the duplicate that merges
+            { fact: 'Rich extra fact 1' },
+            { fact: 'Rich extra fact 2' },
+            { fact: 'Rich extra fact 3' },
+            { fact: 'Rich extra fact 4' },
+          ]),
+        );
+        await engine.ingest('rich blob with many clauses', {});
+      }
+
+      function richSegmentId(): string {
+        const segs = db.prepare(`SELECT * FROM segments WHERE namespace = ?`).all(NAMESPACE) as SegmentRow[];
+        const rich = segs.find((s) => s.fact_count === 5);
+        expect(rich).toBeDefined();
+        return rich?.id ?? '';
+      }
+
+      it('poor-then-rich: survivor adopts the richer (5-fact) parent', async () => {
+        const [survivorId] = await ingestPoorSegment();
+        await ingestRichSegment();
+
+        const [row] = getMemoriesByIds(db, NAMESPACE, [survivorId]);
+        expect(row.segment_id).toBe(richSegmentId());
+      });
+
+      it('rich-then-poor: survivor keeps the richer (5-fact) parent (order-independent)', async () => {
+        await ingestRichSegment();
+        // The rich ingest created the survivor row already; capture it.
+        const richRows = db
+          .prepare(`SELECT id FROM memories WHERE namespace = ? AND content = ?`)
+          .all(NAMESPACE, FACT) as Array<{ id: string }>;
+        expect(richRows).toHaveLength(1);
+        const survivorId = richRows[0].id;
+        const richId = richSegmentId();
+
+        // Now a poorer (1-fact) ingest of the same fact merges — it must NOT downgrade.
+        setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+        await engine.ingest('poor blob', {});
+
+        const [row] = getMemoriesByIds(db, NAMESPACE, [survivorId]);
+        expect(row.segment_id).toBe(richId);
+      });
+
+      function survivorRowId(): string {
+        const rows = db
+          .prepare(`SELECT id FROM memories WHERE namespace = ? AND content = ?`)
+          .all(NAMESPACE, FACT) as Array<{ id: string }>;
+        expect(rows).toHaveLength(1);
+        return rows[0].id;
+      }
+
+      it('equal fact_count tie keeps the ORIGINAL parent (does not repoint to the incoming)', async () => {
+        // First ingest: a 2-fact segment carrying FACT (fact_count = 2).
+        setResponses(factsJson([{ fact: FACT, importance: 0.5 }, { fact: 'First-segment extra fact' }]));
+        await engine.ingest('first blob with two facts', {});
+        const survivorId = survivorRowId();
+        const firstSegmentId = getMemoriesByIds(db, NAMESPACE, [survivorId])[0].segment_id;
+        expect(firstSegmentId).not.toBeNull();
+
+        // Second ingest from a DIFFERENT segment, also fact_count = 2, re-emitting FACT
+        // (exact-dedup merge) → a TIE on fact_count.
+        setResponses(factsJson([{ fact: FACT, importance: 0.5 }, { fact: 'Second-segment extra fact' }]));
+        const second = await engine.ingest('second blob with two facts', {});
+        expect(second.merged).toBe(1);
+
+        // Sanity: two distinct segments exist, both with fact_count = 2 (genuine tie).
+        const segs = db.prepare(`SELECT * FROM segments WHERE namespace = ?`).all(NAMESPACE) as SegmentRow[];
+        expect(segs).toHaveLength(2);
+        expect(segs.every((s) => s.fact_count === 2)).toBe(true);
+        const incomingSegmentId = segs.find((s) => s.id !== firstSegmentId)?.id;
+        expect(incomingSegmentId).toBeDefined();
+
+        // Tie → survivor keeps its ORIGINAL parent, NOT the incoming one (read back the row).
+        const [row] = getMemoriesByIds(db, NAMESPACE, [survivorId]);
+        expect(row.segment_id).toBe(firstSegmentId);
+        expect(row.segment_id).not.toBe(incomingSegmentId);
+      });
+
+      it('a NULL-parent (store-path) survivor adopts the incoming segment on merge', async () => {
+        // store() never sets a segment_id → the survivor starts with segment_id = NULL.
+        const stored = await engine.store(FACT, { importance: 0.5 });
+        const survivorId = stored.id;
+        expect(getMemoriesByIds(db, NAMESPACE, [survivorId])[0].segment_id).toBeNull();
+
+        // An ingest re-emitting FACT writes a segment and merges into the store-path row.
+        setResponses(factsJson([{ fact: FACT, importance: 0.5 }, { fact: 'Incoming extra fact' }]));
+        const result = await engine.ingest('blob carrying a segment', {});
+        expect(result.merged).toBe(1);
+
+        const incomingSegmentId = (
+          db.prepare(`SELECT * FROM segments WHERE namespace = ?`).all(NAMESPACE) as SegmentRow[]
+        ).find((s) => s.fact_count === 2)?.id;
+        expect(incomingSegmentId).toBeDefined();
+
+        // Was NULL, now repointed to the incoming segment (read back from the DB).
+        const [row] = getMemoriesByIds(db, NAMESPACE, [survivorId]);
+        expect(row.segment_id).toBe(incomingSegmentId);
+      });
     });
   });
 

--- a/packages/memory-mcp-server/test/ingest.test.ts
+++ b/packages/memory-mcp-server/test/ingest.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type Database from 'better-sqlite3';
+
+// ---- Mock the LLM client so extraction returns canned JSON, but the REAL ----
+// ---- embedder + store/dedup/insert pipeline run end-to-end. ----
+const llmMock = vi.hoisted(() => ({
+  // A queue of responses; each llmComplete call shifts one. A non-array value
+  // (null) simulates a hard LLM failure for that call.
+  responses: [] as Array<string | null>,
+  hasLLM: true,
+  calls: 0,
+}));
+
+vi.mock('../src/llm/client.js', () => ({
+  getLLMClient: vi.fn(() => (llmMock.hasLLM ? {} : null)),
+  llmComplete: vi.fn(async () => {
+    llmMock.calls += 1;
+    if (!llmMock.hasLLM) return null;
+    const next = llmMock.responses.shift();
+    return next === undefined ? null : next;
+  }),
+}));
+
+import { initDatabase } from '../src/storage/database.js';
+import { getNamespaceStats, getMemoriesByIds } from '../src/storage/queries.js';
+import { createMemoryEngineFromConfig } from '../src/engine-impl.js';
+import type { MemoryEngine } from '../src/engine.js';
+import type { MemoryConfig } from '../src/config.js';
+import { loadConfig } from '../src/config.js';
+
+const NAMESPACE = 'test';
+
+function setResponses(...responses: Array<string | null>): void {
+  llmMock.responses = responses;
+  llmMock.hasLLM = true;
+  llmMock.calls = 0;
+}
+
+function disableLLM(): void {
+  llmMock.responses = [];
+  llmMock.hasLLM = false;
+  llmMock.calls = 0;
+}
+
+function factsJson(facts: Array<{ fact: string; importance?: number }>): string {
+  return JSON.stringify(facts);
+}
+
+function testConfig(dbPath: string): MemoryConfig {
+  return {
+    ...loadConfig({}),
+    dbPath,
+    namespace: NAMESPACE,
+    // The mock controls LLM availability; set non-null so the engine path is "LLM on".
+    llmApiKey: 'test-key',
+    llmBaseUrl: 'http://localhost:1234/v1',
+    // Avoid maintenance noise interleaving in small tests.
+    maintenanceInterval: 10000,
+  };
+}
+
+describe('engine.ingest', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let engine: MemoryEngine;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'memory-ingest-test-'));
+    dbPath = join(tmpDir, 'test.db');
+    const config = testConfig(dbPath);
+    engine = createMemoryEngineFromConfig(config);
+    db = initDatabase(dbPath, config.embeddingModel);
+  });
+
+  afterEach(() => {
+    engine.close();
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('decomposes a blob into N rows', async () => {
+    setResponses(
+      factsJson([
+        { fact: 'The user is named Alice', importance: 0.9 },
+        { fact: 'Alice prefers dark mode', importance: 0.6 },
+        { fact: 'Alice works on the Iron project', importance: 0.5 },
+      ]),
+    );
+
+    const result = await engine.ingest('conversation blob', { mode: 'document' });
+
+    expect(result.created).toBe(3);
+    expect(result.ingested).toBe(3);
+    expect(result.merged).toBe(0);
+    expect(result.memory_ids).toHaveLength(3);
+
+    const stats = getNamespaceStats(db, NAMESPACE);
+    expect(stats.total_memories).toBe(3);
+
+    const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+    const contents = rows.map((r) => r.content).sort();
+    expect(contents).toEqual(['Alice prefers dark mode', 'Alice works on the Iron project', 'The user is named Alice']);
+  });
+
+  it('lands per-fact importance on rows, falling back to the seed when omitted', async () => {
+    setResponses(
+      factsJson([
+        { fact: 'High salience fact', importance: 0.9 },
+        { fact: 'Low salience fact', importance: 0.2 },
+        { fact: 'No importance fact' }, // falls back to seed
+      ]),
+    );
+
+    const result = await engine.ingest('blob', { importance: 0.5 });
+    const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+    const byContent = new Map(rows.map((r) => [r.content, r.importance]));
+
+    expect(byContent.get('High salience fact')).toBeCloseTo(0.9, 5);
+    expect(byContent.get('Low salience fact')).toBeCloseTo(0.2, 5);
+    expect(byContent.get('No importance fact')).toBeCloseTo(0.5, 5);
+  });
+
+  it('dry_run writes nothing but returns the facts', async () => {
+    setResponses(
+      factsJson([{ fact: 'Fact one', importance: 0.7 }, { fact: 'Fact two', importance: 0.3 }, { fact: 'Fact three' }]),
+    );
+
+    const result = await engine.ingest('blob', { dry_run: true });
+
+    expect(result.created).toBe(0);
+    expect(result.facts).toHaveLength(3);
+    expect(result.facts[0].importance).toBe(0.7);
+    expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(0);
+  });
+
+  describe('as_of stamping (created path)', () => {
+    const T_OLD = Date.parse('2023-03-01T00:00:00.000Z');
+
+    it('stamps created/updated/last_accessed to a numeric as_of', async () => {
+      setResponses(factsJson([{ fact: 'Backdated fact', importance: 0.5 }]));
+      const result = await engine.ingest('blob', { as_of: T_OLD });
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.created_at).toBe(T_OLD);
+      expect(row.updated_at).toBe(T_OLD);
+      expect(row.last_accessed_at).toBe(T_OLD);
+    });
+
+    it('omitting as_of yields created_at ≈ Date.now()', async () => {
+      setResponses(factsJson([{ fact: 'Current fact', importance: 0.5 }]));
+      const before = Date.now();
+      const result = await engine.ingest('blob', {});
+      const after = Date.now();
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.created_at).toBeGreaterThanOrEqual(before);
+      expect(row.created_at).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('order-independent merge timestamps (A1)', () => {
+    const T_OLD = Date.parse('2022-01-01T00:00:00.000Z');
+    const T_NEW = Date.parse('2024-06-01T00:00:00.000Z');
+    const FACT = 'Alice prefers dark mode';
+
+    // NOTE on updated_at: the merge calls updateMemoryContent (which stamps
+    // updated_at = now) BEFORE updateMemoryTimestampsOnMerge runs MAX(updated_at, asOf).
+    // With asOf in the past, MAX(now, asOf) === now, so updated_at lands at ~now
+    // (the true "last touched" time — the merge just happened). created_at (MIN) and
+    // last_accessed_at (MAX, untouched by updateMemoryContent) are the clean reconciled
+    // values. This is the design's §5.4 SQL composed faithfully; see the report.
+    it('reconciles min(created)/max(last_accessed) when newer merges into older', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob A', { as_of: T_OLD });
+
+      const before = Date.now();
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob B', { as_of: T_NEW });
+      const after = Date.now();
+
+      expect(second.created).toBe(0);
+      expect(second.merged).toBe(1);
+      expect(second.memory_ids[0]).toBe(first.memory_ids[0]);
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.created_at).toBe(T_OLD); // MIN(T_OLD, T_NEW)
+      expect(row.last_accessed_at).toBe(T_NEW); // MAX(T_OLD, T_NEW)
+      expect(row.updated_at).toBeGreaterThanOrEqual(before); // MAX(now, T_NEW) === now
+      expect(row.updated_at).toBeLessThanOrEqual(after);
+    });
+
+    it('is order-independent: same survivor created/last_accessed in reverse ingest order', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob B', { as_of: T_NEW });
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob A', { as_of: T_OLD });
+
+      expect(second.merged).toBe(1);
+      expect(second.memory_ids[0]).toBe(first.memory_ids[0]);
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      // Same reconciled values regardless of which order the two as_ofs arrived.
+      expect(row.created_at).toBe(T_OLD); // MIN
+      expect(row.last_accessed_at).toBe(T_NEW); // MAX
+    });
+
+    it('a non-as_of merge leaves created_at untouched and bumps updated_at', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob A', { as_of: T_OLD });
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob B', {}); // no as_of
+
+      expect(second.merged).toBe(1);
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.created_at).toBe(T_OLD); // untouched (min not invoked)
+      expect(row.updated_at).toBeGreaterThan(T_OLD); // bumped to ~now by updateMemoryContent
+    });
+
+    // Proves the MAX(updated_at, ?) clause is LIVE rather than dead. Every other A1
+    // test uses a PAST as_of, where updateMemoryContent already stamped updated_at=now
+    // and MAX(now, past)=now — so the clause never moves the value. Only a FUTURE
+    // as_of (> the existing updated_at, i.e. > now) makes MAX pick the as_of, which is
+    // the assertion below. For the realistic backfill case (a PAST as_of, e.g. a
+    // multi-year export) updated_at correctly stays ≈ now — the merge just happened —
+    // which is exactly what the two reconcile tests above already verify.
+    it('moves updated_at to a FUTURE as_of greater than the existing updated_at (A1 — MAX clause is live)', async () => {
+      const T_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000; // ~1 year ahead, > now
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const first = await engine.ingest('blob A', {}); // created at ~now
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.5 }]));
+      const second = await engine.ingest('blob B', { as_of: T_FUTURE });
+
+      expect(second.merged).toBe(1);
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      // MAX(updated_at≈now, T_FUTURE) === T_FUTURE — the clause actually moved it.
+      expect(row.updated_at).toBe(T_FUTURE);
+      // last_accessed_at = MAX(≈now, T_FUTURE) likewise advances.
+      expect(row.last_accessed_at).toBe(T_FUTURE);
+      // created_at = MIN(≈now, T_FUTURE) stays at the original (~now), not the future.
+      expect(row.created_at).toBeLessThan(T_FUTURE);
+    });
+  });
+
+  describe('merge importance composes (A1/A2)', () => {
+    const FACT = 'Bob lives in Berlin';
+
+    it('a higher-importance duplicate raises the survivor importance', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.3 }]));
+      const first = await engine.ingest('blob', {});
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.9 }]));
+      await engine.ingest('blob', {});
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.importance).toBeCloseTo(0.9, 5);
+    });
+
+    it('a lower-importance duplicate does not lower the survivor importance', async () => {
+      setResponses(factsJson([{ fact: FACT, importance: 0.8 }]));
+      const first = await engine.ingest('blob', {});
+
+      setResponses(factsJson([{ fact: FACT, importance: 0.1 }]));
+      await engine.ingest('blob', {});
+
+      const [row] = getMemoriesByIds(db, NAMESPACE, first.memory_ids);
+      expect(row.importance).toBeCloseTo(0.8, 5);
+    });
+  });
+
+  it('reports honest stats when a fact duplicates an existing row (A7)', async () => {
+    setResponses(factsJson([{ fact: 'Existing fact', importance: 0.5 }]));
+    await engine.ingest('blob', {});
+
+    setResponses(
+      factsJson([
+        { fact: 'Existing fact', importance: 0.5 }, // duplicate → merged
+        { fact: 'Brand new fact one', importance: 0.5 },
+        { fact: 'Brand new fact two', importance: 0.5 },
+      ]),
+    );
+    const result = await engine.ingest('blob', {});
+
+    expect(result.created).toBe(2);
+    expect(result.merged).toBe(1);
+    expect(result.ingested).toBe(2);
+    expect(result.memory_ids).toHaveLength(3);
+  });
+
+  describe('extraction failure handling (A3)', () => {
+    it("default 'degrade' with no LLM stores the blob as a single memory", async () => {
+      disableLLM();
+      const blob = 'unstructured content with no LLM available';
+      const result = await engine.ingest(blob, {});
+
+      expect(result.created).toBe(1);
+      expect(result.degraded).toBe(true);
+      const stats = getNamespaceStats(db, NAMESPACE);
+      expect(stats.total_memories).toBe(1);
+      const [row] = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+      expect(row.content).toBe(blob);
+    });
+
+    it("'skip' writes nothing and reports skipped without throwing", async () => {
+      disableLLM();
+      const result = await engine.ingest('blob', { on_extraction_failure: 'skip' });
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(true);
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(0);
+    });
+
+    it("'error' rejects, with no input substring in the message (A6)", async () => {
+      disableLLM();
+      const sensitive = 'CREDIT-CARD-4111-1111-1111-1111';
+      await expect(engine.ingest(`secret blob ${sensitive}`, { on_extraction_failure: 'error' })).rejects.toThrow();
+
+      try {
+        await engine.ingest(`secret blob ${sensitive}`, { on_extraction_failure: 'error' });
+        throw new Error('expected ingest to reject');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).not.toContain(sensitive);
+      }
+    });
+
+    it('malformed (non-JSON) response degrades to a single-blob store (does not throw)', async () => {
+      setResponses('not json at all');
+      const result = await engine.ingest('blob to degrade', {});
+
+      expect(result.degraded).toBe(true);
+      expect(result.created).toBe(1);
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(1);
+    });
+  });
+
+  it('propagates seed tags and source to every written fact', async () => {
+    setResponses(
+      factsJson([
+        { fact: 'Tagged fact one', importance: 0.5 },
+        { fact: 'Tagged fact two', importance: 0.5 },
+      ]),
+    );
+    const result = await engine.ingest('blob', { tags: ['seed-tag'], source: 'session:abc' });
+
+    const rows = getMemoriesByIds(db, NAMESPACE, result.memory_ids);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.source).toBe('session:abc');
+      expect(row.tags).toContain('seed-tag');
+    }
+  });
+
+  describe('chunking integration (A5)', () => {
+    function bigBlob(): string {
+      // ~150 chars/line × 250 lines ≈ 9400 tokens → ~2-3 chunks (keeps embeds cheap).
+      const line = 'sentence words here '.repeat(8).trim();
+      return Array.from({ length: 250 }, (_, i) => `${i}: ${line}`).join('\n');
+    }
+
+    it('makes >1 LLM call, unions facts, and reports chunks>1', async () => {
+      // Two distinct facts per chunk; enough responses for however many chunks form.
+      const perChunk = (n: number): string => factsJson([{ fact: `chunk ${n} fact A` }, { fact: `chunk ${n} fact B` }]);
+      setResponses(...Array.from({ length: 50 }, (_, i) => perChunk(i)));
+
+      const result = await engine.ingest(bigBlob(), { mode: 'document' });
+
+      expect(llmMock.calls).toBeGreaterThan(1);
+      expect(result.chunks).toBeGreaterThan(1);
+      expect(result.created).toBeGreaterThan(2); // facts from multiple chunks unioned
+    });
+  });
+
+  describe('partial extraction is observable (A3)', () => {
+    function bigBlob(): string {
+      // ~150 chars/line × 250 lines ≈ 9400 tokens → ~2-3 chunks (keeps embeds cheap).
+      const line = 'sentence words here '.repeat(8).trim();
+      return Array.from({ length: 250 }, (_, i) => `${i}: ${line}`).join('\n');
+    }
+
+    it('ingests good chunks and flags partial/degraded/failed_chunks when one chunk fails', async () => {
+      // First chunk → facts; all subsequent chunks → null (hard LLM failure).
+      const responses: Array<string | null> = [
+        factsJson([{ fact: 'good chunk fact A' }, { fact: 'good chunk fact B' }]),
+      ];
+      for (let i = 0; i < 49; i++) responses.push(null);
+      setResponses(...responses);
+
+      const result = await engine.ingest(bigBlob(), { mode: 'document' });
+
+      expect(result.created).toBeGreaterThanOrEqual(2);
+      expect(result.partial).toBe(true);
+      expect(result.degraded).toBe(true);
+      expect(result.failed_chunks).toBeGreaterThanOrEqual(1);
+      expect(result.chunks).toBeGreaterThan(1);
+    });
+  });
+
+  describe('PII-safe logging on failure (A6)', () => {
+    it('does not leak a sensitive marker to ANY stderr channel on parse failure or LLM error', async () => {
+      // Widened beyond console.error to also cover process.stderr.write and
+      // console.warn — future-proofs the guarantee against a regression that emits
+      // via a different channel (T3).
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const sensitive = 'PASSPORT-X9988776655';
+
+      // Parse failure: non-JSON response containing the marker would only be in `raw`.
+      setResponses(`I refuse. The input mentioned ${sensitive}.`);
+      const r1 = await engine.ingest(`blob with ${sensitive}`, {});
+      expect(r1.degraded).toBe(true);
+
+      // LLM error path.
+      disableLLM();
+      const r2 = await engine.ingest(`another blob ${sensitive}`, { on_extraction_failure: 'skip' });
+      expect(r2.skipped).toBe(true);
+
+      const allLogs = [...errorSpy.mock.calls, ...warnSpy.mock.calls, ...stderrSpy.mock.calls]
+        .map((c) => JSON.stringify(c))
+        .join('\n');
+      expect(allLogs).not.toContain(sensitive);
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      stderrSpy.mockRestore();
+    });
+  });
+});

--- a/packages/memory-mcp-server/test/ingest.test.ts
+++ b/packages/memory-mcp-server/test/ingest.test.ts
@@ -307,6 +307,20 @@ describe('engine.ingest', () => {
       expect(row.content).toBe(blob);
     });
 
+    it('degrade reports merged (not created) when the blob exact-dedups into an existing memory', async () => {
+      disableLLM();
+      const blob = 'identical degraded blob with no durable facts';
+      const first = await engine.ingest(blob, {});
+      expect(first.created).toBe(1);
+      expect(first.merged).toBe(0);
+
+      const second = await engine.ingest(blob, {}); // same content → exact-dedup merge
+      expect(second.created).toBe(0);
+      expect(second.merged).toBe(1);
+      expect(second.degraded).toBe(true);
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(1); // merged, not a 2nd row
+    });
+
     it("'skip' writes nothing and reports skipped without throwing", async () => {
       disableLLM();
       const result = await engine.ingest('blob', { on_extraction_failure: 'skip' });

--- a/packages/memory-mcp-server/test/ingest.test.ts
+++ b/packages/memory-mcp-server/test/ingest.test.ts
@@ -95,7 +95,6 @@ describe('engine.ingest', () => {
     const result = await engine.ingest('conversation blob', { mode: 'document' });
 
     expect(result.created).toBe(3);
-    expect(result.ingested).toBe(3);
     expect(result.merged).toBe(0);
     expect(result.memory_ids).toHaveLength(3);
 
@@ -290,7 +289,6 @@ describe('engine.ingest', () => {
 
     expect(result.created).toBe(2);
     expect(result.merged).toBe(1);
-    expect(result.ingested).toBe(2);
     expect(result.memory_ids).toHaveLength(3);
   });
 
@@ -338,6 +336,21 @@ describe('engine.ingest', () => {
       expect(result.degraded).toBe(true);
       expect(result.created).toBe(1);
       expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(1);
+    });
+
+    it('a valid empty extraction ([]) is a clean 0-fact ingest, NOT a failure (no degrade/skip)', async () => {
+      // The prompt instructs the model to emit [] when nothing durable is present.
+      // That is a successful parse, so it must not inflate failed_chunks, must not
+      // degrade to a single-blob store, and must write nothing.
+      setResponses('[]');
+      const result = await engine.ingest('chit-chat with no durable facts', {});
+
+      expect(result.created).toBe(0);
+      expect(result.facts).toEqual([]);
+      expect(result.degraded).toBeFalsy();
+      expect(result.skipped).toBeFalsy();
+      expect(result.partial).toBeFalsy();
+      expect(getNamespaceStats(db, NAMESPACE).total_memories).toBe(0);
     });
   });
 

--- a/packages/memory-mcp-server/test/maintenance.test.ts
+++ b/packages/memory-mcp-server/test/maintenance.test.ts
@@ -53,6 +53,7 @@ describe('computeVitality', () => {
       consolidated: 1,
       source: null,
       metadata: null,
+      segment_id: null,
     };
 
     const vitality = computeVitality(mem, now);
@@ -75,6 +76,7 @@ describe('computeVitality', () => {
       consolidated: 1,
       source: null,
       metadata: null,
+      segment_id: null,
     };
 
     const vitality = computeVitality(mem, now);
@@ -96,6 +98,7 @@ describe('computeVitality', () => {
       consolidated: 1,
       source: null,
       metadata: null,
+      segment_id: null,
     };
 
     const highImp = computeVitality({ ...base, importance: 0.9 }, now);
@@ -119,6 +122,7 @@ describe('computeVitality', () => {
       consolidated: 1,
       source: null,
       metadata: null,
+      segment_id: null,
     };
 
     const accessed = computeVitality({ ...base, access_count: 10 }, now);
@@ -143,6 +147,7 @@ describe('computeVitality', () => {
       consolidated: 1,
       source: null,
       metadata: null,
+      segment_id: null,
     };
 
     expect(computeVitality(mem, now)).toBe(0);

--- a/packages/memory-mcp-server/test/reranker.test.ts
+++ b/packages/memory-mcp-server/test/reranker.test.ts
@@ -21,6 +21,7 @@ function makeScored(overrides: Partial<MemoryRow & ScoredMemory> = {}): ScoredMe
     consolidated: overrides.consolidated ?? 1,
     source: overrides.source ?? null,
     metadata: overrides.metadata ?? null,
+    segment_id: overrides.segment_id ?? null,
     fusionScore: overrides.fusionScore ?? 0.5,
     compositeScore: overrides.compositeScore ?? 0.5,
     vectorDistance: overrides.vectorDistance,

--- a/packages/memory-mcp-server/test/scoring.test.ts
+++ b/packages/memory-mcp-server/test/scoring.test.ts
@@ -26,6 +26,7 @@ function makeMemory(overrides: Partial<MemoryRow> = {}): MemoryRow {
     consolidated: overrides.consolidated ?? 1,
     source: overrides.source ?? null,
     metadata: overrides.metadata ?? null,
+    segment_id: overrides.segment_id ?? null,
   };
 }
 

--- a/packages/memory-mcp-server/test/server.test.ts
+++ b/packages/memory-mcp-server/test/server.test.ts
@@ -10,7 +10,6 @@ function createMockEngine(): MemoryEngine {
     ingest: vi.fn().mockResolvedValue({
       created: 1,
       merged: 0,
-      ingested: 1,
       memory_ids: ['test-id'],
       facts: [{ fact: 'A fact', importance: 0.5 }],
     }),

--- a/packages/memory-mcp-server/test/server.test.ts
+++ b/packages/memory-mcp-server/test/server.test.ts
@@ -4,7 +4,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { MemoryEngine } from '../src/engine.js';
 import { createServer } from '../src/server.js';
 
-function createMockEngine(): MemoryEngine {
+function createMockEngine(overrides: Partial<MemoryEngine> = {}): MemoryEngine {
   return {
     store: vi.fn().mockResolvedValue({ id: 'test-id', action: 'created' }),
     ingest: vi.fn().mockResolvedValue({
@@ -36,6 +36,7 @@ function createMockEngine(): MemoryEngine {
       found: true,
     }),
     close: vi.fn(),
+    ...overrides,
   };
 }
 
@@ -159,6 +160,35 @@ describe('MCP server', () => {
       max_expand_passages: undefined,
     });
     expect(result.content).toEqual([{ type: 'text', text: 'test recall' }]);
+  });
+
+  it('surfaces expansion metadata in the memory_recall tool result', async () => {
+    const engine = createMockEngine({
+      recall: vi.fn().mockResolvedValue({
+        content: 'expanded recall',
+        memories_used: 3,
+        total_matches: 12,
+        expanded: true,
+        expanded_segment_ids: ['seg-a', 'seg-b'],
+      }),
+    });
+    const { client } = await createConnectedClient(engine);
+
+    const result = await client.callTool({
+      name: 'memory_recall',
+      arguments: { query: 'contract clauses' },
+    });
+
+    // Human-readable text is preserved exactly as the recall content.
+    expect(result.content).toEqual([{ type: 'text', text: 'expanded recall' }]);
+    // The agent-facing expansion handles ride on structuredContent, available in
+    // every format (the engine-only metadata is now reachable by MCP callers).
+    expect(result.structuredContent).toEqual({
+      memories_used: 3,
+      total_matches: 12,
+      expanded: true,
+      expanded_segment_ids: ['seg-a', 'seg-b'],
+    });
   });
 
   it('calls engine.context via memory_context tool', async () => {

--- a/packages/memory-mcp-server/test/server.test.ts
+++ b/packages/memory-mcp-server/test/server.test.ts
@@ -7,6 +7,13 @@ import { createServer } from '../src/server.js';
 function createMockEngine(): MemoryEngine {
   return {
     store: vi.fn().mockResolvedValue({ id: 'test-id', action: 'created' }),
+    ingest: vi.fn().mockResolvedValue({
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: ['test-id'],
+      facts: [{ fact: 'A fact', importance: 0.5 }],
+    }),
     recall: vi.fn().mockResolvedValue({
       content: 'test recall',
       memories_used: 1,
@@ -40,14 +47,21 @@ async function createConnectedClient(engine: MemoryEngine) {
 }
 
 describe('MCP server', () => {
-  it('lists all 5 memory tools', async () => {
+  it('lists all 6 memory tools', async () => {
     const engine = createMockEngine();
     const { client } = await createConnectedClient(engine);
 
     const { tools } = await client.listTools();
     const toolNames = tools.map((t) => t.name).sort();
 
-    expect(toolNames).toEqual(['memory_context', 'memory_forget', 'memory_inspect', 'memory_recall', 'memory_store']);
+    expect(toolNames).toEqual([
+      'memory_context',
+      'memory_forget',
+      'memory_ingest',
+      'memory_inspect',
+      'memory_recall',
+      'memory_store',
+    ]);
   });
 
   it('memory_store tool has correct schema', async () => {
@@ -72,6 +86,25 @@ describe('MCP server', () => {
     expect(recallTool).toBeDefined();
     expect(recallTool!.description).toContain('Recall memories');
     expect(recallTool!.inputSchema.required).toContain('query');
+  });
+
+  it('memory_ingest tool has correct schema', async () => {
+    const engine = createMockEngine();
+    const { client } = await createConnectedClient(engine);
+
+    const { tools } = await client.listTools();
+    const ingestTool = tools.find((t) => t.name === 'memory_ingest');
+
+    expect(ingestTool).toBeDefined();
+    expect(ingestTool!.inputSchema.required).toContain('content');
+
+    // Everything except `content` is optional.
+    const required = ingestTool!.inputSchema.required ?? [];
+    const properties = ingestTool!.inputSchema.properties ?? {};
+    for (const optional of ['mode', 'dry_run', 'as_of', 'on_extraction_failure', 'tags', 'importance', 'source']) {
+      expect(properties).toHaveProperty(optional);
+      expect(required).not.toContain(optional);
+    }
   });
 
   it('memory_context tool has no required params', async () => {

--- a/packages/memory-mcp-server/test/server.test.ts
+++ b/packages/memory-mcp-server/test/server.test.ts
@@ -30,6 +30,11 @@ function createMockEngine(): MemoryEngine {
       storage_bytes: 4096,
       top_tags: [],
     }),
+    expand: vi.fn().mockResolvedValue({
+      segment_id: 'seg-1',
+      passages: ['Source passage one.', 'Source passage two.'],
+      found: true,
+    }),
     close: vi.fn(),
   };
 }
@@ -46,7 +51,7 @@ async function createConnectedClient(engine: MemoryEngine) {
 }
 
 describe('MCP server', () => {
-  it('lists all 6 memory tools', async () => {
+  it('lists all 7 memory tools', async () => {
     const engine = createMockEngine();
     const { client } = await createConnectedClient(engine);
 
@@ -55,6 +60,7 @@ describe('MCP server', () => {
 
     expect(toolNames).toEqual([
       'memory_context',
+      'memory_expand',
       'memory_forget',
       'memory_ingest',
       'memory_inspect',
@@ -149,6 +155,8 @@ describe('MCP server', () => {
       token_budget: undefined,
       tags: undefined,
       format: undefined,
+      expand: 'auto',
+      max_expand_passages: undefined,
     });
     expect(result.content).toEqual([{ type: 'text', text: 'test recall' }]);
   });

--- a/packages/memory-mcp-server/test/tools.test.ts
+++ b/packages/memory-mcp-server/test/tools.test.ts
@@ -242,13 +242,32 @@ describe('memory_recall', () => {
         }),
       });
       const result = await handleRecall(engine, { query: 'test' });
-      expect(result).toBe('No relevant memories found.');
+      expect(result.text).toBe('No relevant memories found.');
+      expect(result.memories_used).toBe(0);
+      expect(result.expanded).toBe(false);
+      expect(result.expanded_segment_ids).toEqual([]);
     });
 
     it('returns content when memories found', async () => {
       const engine = createMockEngine();
       const result = await handleRecall(engine, { query: 'test' });
-      expect(result).toBe('Recalled content');
+      expect(result.text).toBe('Recalled content');
+    });
+
+    it('surfaces expansion metadata from the engine', async () => {
+      const engine = createMockEngine({
+        recall: vi.fn().mockResolvedValue({
+          content: 'Recalled content',
+          memories_used: 3,
+          total_matches: 10,
+          expanded: true,
+          expanded_segment_ids: ['seg-1', 'seg-2'],
+        }),
+      });
+      const result = await handleRecall(engine, { query: 'test' });
+      expect(result.expanded).toBe(true);
+      expect(result.expanded_segment_ids).toEqual(['seg-1', 'seg-2']);
+      expect(result.total_matches).toBe(10);
     });
 
     it('threads expand and max_expand_passages through to the engine', async () => {

--- a/packages/memory-mcp-server/test/tools.test.ts
+++ b/packages/memory-mcp-server/test/tools.test.ts
@@ -12,7 +12,6 @@ function createMockEngine(overrides: Partial<MemoryEngine> = {}): MemoryEngine {
     ingest: vi.fn().mockResolvedValue({
       created: 1,
       merged: 0,
-      ingested: 1,
       memory_ids: ['abc123'],
       facts: [{ fact: 'A fact', importance: 0.5 }],
     }),

--- a/packages/memory-mcp-server/test/tools.test.ts
+++ b/packages/memory-mcp-server/test/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { MemoryEngine } from '../src/engine.js';
 import { validateStoreInput, handleStore, formatStoreResult } from '../src/tools/store.js';
 import { validateRecallInput, handleRecall } from '../src/tools/recall.js';
+import { validateExpandInput, handleExpand } from '../src/tools/expand.js';
 import { validateContextInput, handleContext } from '../src/tools/context.js';
 import { validateForgetInput, handleForget } from '../src/tools/forget.js';
 import { validateInspectInput, handleInspect } from '../src/tools/inspect.js';
@@ -31,6 +32,11 @@ function createMockEngine(overrides: Partial<MemoryEngine> = {}): MemoryEngine {
       newest_memory: '2026-03-11T00:00:00Z',
       storage_bytes: 1048576,
       top_tags: [{ tag: 'preference', count: 42 }],
+    }),
+    expand: vi.fn().mockResolvedValue({
+      segment_id: 'seg-1',
+      passages: ['Source passage one.', 'Source passage two.'],
+      found: true,
     }),
     close: vi.fn(),
     ...overrides,
@@ -181,6 +187,36 @@ describe('memory_recall', () => {
     it('rejects invalid format', () => {
       expect(() => validateRecallInput({ query: 'q', format: 'xml' })).toThrow('format must be one of');
     });
+
+    it("defaults expand to 'auto'", () => {
+      const result = validateRecallInput({ query: 'q' });
+      expect(result.expand).toBe('auto');
+    });
+
+    it("accepts 'none' / 'auto' / 'parent' for expand", () => {
+      expect(validateRecallInput({ query: 'q', expand: 'none' }).expand).toBe('none');
+      expect(validateRecallInput({ query: 'q', expand: 'auto' }).expand).toBe('auto');
+      expect(validateRecallInput({ query: 'q', expand: 'parent' }).expand).toBe('parent');
+    });
+
+    it('rejects an out-of-enum expand value', () => {
+      expect(() => validateRecallInput({ query: 'q', expand: 'all' })).toThrow('expand must be one of');
+      expect(() => validateRecallInput({ query: 'q', expand: 5 })).toThrow('expand must be one of');
+    });
+
+    it('validates max_expand_passages bounds', () => {
+      expect(validateRecallInput({ query: 'q', max_expand_passages: 3 }).max_expand_passages).toBe(3);
+      expect(validateRecallInput({ query: 'q' }).max_expand_passages).toBeUndefined();
+      expect(() => validateRecallInput({ query: 'q', max_expand_passages: 0 })).toThrow(
+        'max_expand_passages must be a positive integer',
+      );
+      expect(() => validateRecallInput({ query: 'q', max_expand_passages: 1.5 })).toThrow(
+        'max_expand_passages must be a positive integer',
+      );
+      expect(() => validateRecallInput({ query: 'q', max_expand_passages: 999 })).toThrow(
+        'max_expand_passages exceeds maximum',
+      );
+    });
   });
 
   describe('handleRecall', () => {
@@ -192,6 +228,8 @@ describe('memory_recall', () => {
         token_budget: undefined,
         tags: undefined,
         format: 'raw',
+        expand: 'auto',
+        max_expand_passages: undefined,
       });
     });
 
@@ -211,6 +249,63 @@ describe('memory_recall', () => {
       const engine = createMockEngine();
       const result = await handleRecall(engine, { query: 'test' });
       expect(result).toBe('Recalled content');
+    });
+
+    it('threads expand and max_expand_passages through to the engine', async () => {
+      const engine = createMockEngine();
+      await handleRecall(engine, { query: 'test', expand: 'parent', max_expand_passages: 3 });
+      expect(engine.recall).toHaveBeenCalledWith({
+        query: 'test',
+        token_budget: undefined,
+        tags: undefined,
+        format: undefined,
+        expand: 'parent',
+        max_expand_passages: 3,
+      });
+    });
+  });
+});
+
+// ── memory_expand validation ─────────────────────────────────────────
+
+describe('memory_expand', () => {
+  describe('validateExpandInput', () => {
+    it('accepts a segment_id', () => {
+      expect(validateExpandInput({ segment_id: 'seg-1' })).toEqual({ segment_id: 'seg-1', query: undefined });
+    });
+
+    it('accepts an optional query', () => {
+      const result = validateExpandInput({ segment_id: 'seg-1', query: 'cap clause' });
+      expect(result.query).toBe('cap clause');
+    });
+
+    it('rejects a missing/empty segment_id', () => {
+      expect(() => validateExpandInput({})).toThrow('segment_id is required');
+      expect(() => validateExpandInput({ segment_id: '  ' })).toThrow('segment_id is required');
+    });
+  });
+
+  describe('handleExpand', () => {
+    it("returns the parent's ranked passages joined", async () => {
+      const engine = createMockEngine({
+        expand: vi.fn().mockResolvedValue({
+          segment_id: 'seg-1',
+          passages: ['Cap clause: $250k.', 'IP clause: reverts.'],
+          found: true,
+        }),
+      });
+      const result = await handleExpand(engine, { segment_id: 'seg-1', query: 'cap' });
+      expect(engine.expand).toHaveBeenCalledWith('seg-1', 'cap');
+      expect(result).toContain('$250k');
+      expect(result).toContain('reverts');
+    });
+
+    it('reports not-found for an unknown segment id', async () => {
+      const engine = createMockEngine({
+        expand: vi.fn().mockResolvedValue({ segment_id: 'nope', passages: [], found: false }),
+      });
+      const result = await handleExpand(engine, { segment_id: 'nope' });
+      expect(result).toContain('No source segment found');
     });
   });
 });

--- a/packages/memory-mcp-server/test/tools.test.ts
+++ b/packages/memory-mcp-server/test/tools.test.ts
@@ -9,6 +9,13 @@ import { validateInspectInput, handleInspect } from '../src/tools/inspect.js';
 function createMockEngine(overrides: Partial<MemoryEngine> = {}): MemoryEngine {
   return {
     store: vi.fn().mockResolvedValue({ id: 'abc123', action: 'created' }),
+    ingest: vi.fn().mockResolvedValue({
+      created: 1,
+      merged: 0,
+      ingested: 1,
+      memory_ids: ['abc123'],
+      facts: [{ fact: 'A fact', importance: 0.5 }],
+    }),
     recall: vi.fn().mockResolvedValue({
       content: 'Recalled content',
       memories_used: 3,

--- a/scripts/debug-mcp-errors.ts
+++ b/scripts/debug-mcp-errors.ts
@@ -65,8 +65,9 @@ console.log('══════════════════════�
 console.log('Part 2: End-to-end through handleCallTool');
 console.log('═══════════════════════════════════════════════════\n');
 
-// Dynamically import handleCallTool (avoids top-level env var requirements)
-const { handleCallTool } = await import('../src/trusted-process/mcp-proxy-server.js');
+// Dynamically import handleCallTool (avoids top-level env var requirements).
+// It lives in the security pipeline; mcp-proxy-server is now a pure relay.
+const { handleCallTool } = await import('../src/trusted-process/tool-call-pipeline.js');
 
 // Build minimal mock deps (same pattern as unit tests)
 function createE2EDeps(mockClient: { callTool: (...args: unknown[]) => Promise<unknown> }) {
@@ -103,6 +104,9 @@ function createE2EDeps(mockClient: { callTool: (...args: unknown[]) => Promise<u
     circuitBreaker: { check: () => ({ allowed: true }) } as unknown as Parameters<
       typeof handleCallTool
     >[2]['circuitBreaker'],
+    whitelist: { match: () => undefined, add: () => {} } as unknown as Parameters<
+      typeof handleCallTool
+    >[2]['whitelist'],
     clientStates,
     resolvedSandboxConfigs,
     allowedDirectory: undefined,

--- a/scripts/memory-corpus/README.md
+++ b/scripts/memory-corpus/README.md
@@ -1,0 +1,260 @@
+# memory-corpus — claude.ai export → memory corpus builder
+
+`build-corpus.ts` ingests a claude.ai conversation export into a memory DB via
+the `memory_ingest` path (`ingestBlob`), one conversation at a time, backdated to
+each conversation's real date. It produces a representative, recency- and
+importance-spread eval corpus for the memory-mcp-server.
+
+It drives a single Node process (run via `tsx`) that owns the DB and imports the
+engine internals directly — the same pattern as the LoCoMo fixture builder.
+
+## ⚠️ SENSITIVE DATA — read first
+
+- The export (`conversations.json`) and the resulting DB contain **private
+  conversation content and PII**. Both live under the **gitignored
+  `donotcommit/`** directory and **must never be committed**.
+- Conversation `name`/`summary`/message `text`/`content` are **sensitive**. This
+  driver **never** writes any of them to logs or to the progress file. The
+  progress file (`progress.jsonl`) and the stderr progress lines carry **counts
+  and opaque uuids only** — no fact text, no transcript.
+- The SUMMARY printed at the end is content-free: it reports counts, importance
+  min/max/mean, and created_at min/max (epoch-derived ISO timestamps) — never
+  any conversation content.
+- Ingestion **egresses each conversation transcript to the configured LLM**
+  (Haiku) for fact extraction. `--dry-run` skips local persistence but **still
+  egresses** to Haiku — it is not a no-network mode. Run the real ingestion
+  yourself, with consent to that egress.
+
+## Environment
+
+- **`ANTHROPIC_API_KEY`** — **required**. The corpus needs the LLM; the driver
+  exits with an error if the key is missing (no silent degrade). Load it via
+  `--import dotenv/config` from your `.env`, or export it.
+
+The driver sets these `MEMORY_*` vars in-process before `loadConfig()`:
+
+| var                           | value                                     | why                                              |
+| ----------------------------- | ----------------------------------------- | ------------------------------------------------ |
+| `MEMORY_LLM_BASE_URL`         | `https://api.anthropic.com/v1/`           | OpenAI-compatible Haiku endpoint                 |
+| `MEMORY_LLM_API_KEY`          | `$ANTHROPIC_API_KEY`                      | extraction auth                                  |
+| `MEMORY_LLM_MODEL`            | `claude-haiku-4-5-20251001` (overridable) | extraction model                                 |
+| `MEMORY_DB_PATH`              | resolved `--db`                           | output DB                                        |
+| `MEMORY_NAMESPACE`            | `--namespace`                             | corpus isolation                                 |
+| `MEMORY_MAINTENANCE_INTERVAL` | `100000000`                               | suppress per-store maintenance (see determinism) |
+| `MEMORY_DECAY_THRESHOLD`      | `0`                                       | belt-and-suspenders: never decay                 |
+| `MEMORY_RERANKER_ENABLED`     | `false`                                   | no cross-encoder download during ingest          |
+
+## Run commands
+
+All paths default under `donotcommit/`; the driver `mkdirSync`s the DB directory.
+
+```bash
+# Validation: first 3 non-empty conversations (writes a small corpus)
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --limit 3
+
+# Dry-run: extract + preview only, write nothing (STILL egresses to Haiku)
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --limit 3 --dry-run
+
+# Single conversation by uuid
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --conversation <uuid>
+
+# Full run (all 503 conversations; 6 empty ones are skipped)
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts
+
+# Resume: skip conversations already recorded done; retry recorded failures
+npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --resume
+
+# Help
+npx tsx scripts/memory-corpus/build-corpus.ts --help
+```
+
+### Flags
+
+| flag                    | default                                        | meaning                                                  |
+| ----------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `--export <path>`       | `donotcommit/claude-export/conversations.json` | export JSON (top-level array)                            |
+| `--db <path>`           | `donotcommit/corpus/memories.memdb`            | output memdb                                             |
+| `--namespace <name>`    | `claude-export`                                | memory namespace                                         |
+| `--limit <N>`           | (all)                                          | process only first N **non-empty** conversations         |
+| `--conversation <uuid>` | (all)                                          | process only that conversation                           |
+| `--dry-run`             | off                                            | extract but write nothing (still egresses to Haiku)      |
+| `--resume`              | off                                            | skip conversations recorded done; retry `skipped-failed` |
+| `-h, --help`            | —                                              | show help                                                |
+
+## Per-conversation behavior
+
+- The 6 empty conversations (and any with no non-empty messages) are skipped and
+  recorded as `skipped-empty`.
+- The transcript is assembled as one `${sender}: ${text}` line per message with
+  non-empty `text` (we use `text`, not `content`), joined by newlines.
+- Ingest is called with `mode: 'document'` (durable facts across turns;
+  transcripts rarely state facts in one explicit sentence), `as_of` = the
+  conversation `created_at`, `source` = `claude-export:<uuid>`, `tags:
+['claude-export']`, and `on_extraction_failure: 'skip'`. Per-fact importance
+  comes from extraction (no call-level importance is passed).
+- `on_extraction_failure: 'skip'` means a fully-failed extraction writes nothing
+  and is recorded as `skipped-failed` — no single-blob contamination, and the
+  conversation is retried on `--resume`.
+
+### `progress.jsonl` (content-free)
+
+One line per conversation in the DB directory:
+
+```json
+{
+  "uuid": "...",
+  "status": "ingested|partial|skipped-empty|skipped-failed",
+  "created": 7,
+  "merged": 1,
+  "facts": 8,
+  "failed_chunks": 0,
+  "chunks": 2
+}
+```
+
+- `skipped-failed` when the ingest result is `skipped`.
+- `partial` when some (not all) chunks failed but others produced facts.
+- otherwise `ingested`.
+
+## Resumability
+
+On start the driver loads `progress.jsonl`. With `--resume`, it skips every uuid
+that has any record with status `ingested`, `partial`, or `skipped-empty`, and
+**retries** uuids whose only record is `skipped-failed`. Without `--resume`, an
+existing DB/progress emits a warning and the run **appends** (it does not reset).
+
+## Determinism rationale (why decay is off + consolidation-only)
+
+`maybeRunMaintenance` (called per-store inside `ingestBlob → store →
+storeImmediate`) runs the **full** `runMaintenance`, which includes a **DECAY**
+phase. `computeVitality` uses `now - created_at`; our backdated 2023–2024 facts
+have an age of ~1000 days against a ~90-day half-life, so a mid-bulk decay pass
+would mark them DECAYED (importance → 0) and **destroy the recency/importance
+spread that is the entire point of the corpus**.
+
+So the driver:
+
+1. Sets `MEMORY_MAINTENANCE_INTERVAL` very high (100,000,000) so per-store
+   maintenance **never fires mid-bulk**.
+2. Sets `MEMORY_DECAY_THRESHOLD=0` as belt-and-suspenders.
+3. At the very end runs **`runConsolidation(db, config)` ONLY** (deferred dedup /
+   contradiction resolution) — **never** `runMaintenance` (which would decay).
+
+The end-of-run SUMMARY queries the DB directly for importance min/max/mean and
+created_at min/max — these prove the corpus is **non-flat** (a spread of
+salience and a multi-year recency range).
+
+## Content-free guarantee
+
+Every artifact and log line this driver emits is content-free: opaque uuids
+(prefix only on stderr), integer counts, importance statistics, and
+epoch-derived timestamps. No conversation `name`/`summary`/`text`/`content`, no
+extracted fact text, and no model output is ever logged or written to
+`progress.jsonl` or the SUMMARY.
+
+---
+
+# diagnose-corpus — representativeness diagnostic (GO/NO-GO)
+
+`diagnose-corpus.ts` answers ONE question with a GO/NO-GO verdict: **is this
+corpus non-degenerate enough that evolving the composite retrieval scorer is
+meaningful** — i.e. are the metadata signals (recency, importance) ALIVE and do
+they actively reshape rankings, unlike the LoCoMo benchmark where flat metadata
+(importance ≡ 0.5, identical `created_at`) made those terms dead weight?
+
+The pure analysis logic lives in `diagnose-lib.ts` and is unit tested in
+isolation with SYNTHETIC fixtures (`test/diagnose-corpus.test.ts`) — including a
+degenerate LoCoMo-shaped fixture that must yield NO-GO and a healthy one that
+must yield GO (the anti-vacuity proof).
+
+## Three analyses, then a verdict
+
+**A. Distributional liveness** (real db, READ-ONLY SQL — no LLM, no retrieval):
+
+- **Recency**: min/max `created_at`, span days, distinct year-months, stddev,
+  fraction of rows per calendar year, histogram by quarter.
+- **Importance**: min/max/mean/stddev, distinct values, histogram (0.1 buckets),
+  fraction sitting **exactly** at the 0.5 seed.
+- **Access**: `access_count` distribution. On a fresh corpus this is ~0 — access
+  is a **LATENT, usage-driven** signal that stays zero until the corpus is
+  queried. This is reported honestly and does **not** fail the verdict.
+- **content_length**: min/max/mean/percentiles — a sanity check that facts are
+  ATOMIC-sized (tens–low-hundreds of chars), proving decomposition worked.
+
+**B. Self-supervised recall probe** (needs Haiku + retrieval; runs on a db
+**COPY** so the real corpus stays pristine — retrieval mutates access stats):
+
+- Sample `--sample N` facts (default 120) **stratified across recency buckets**
+  (seeded PRNG via `--seed`, so re-runs match) so older years are represented.
+- One Haiku call per sampled fact generates a natural question it answers; the
+  fact's id is the gold.
+- For each question, the REAL hybrid candidate pool (vector KNN + FTS5 +
+  production fusion) is retrieved and a **content-free** fixture row is written
+  to `donotcommit/corpus/diagnostic-fixture.jsonl`:
+  `{ query_id, gold_id, candidates: [{ id, is_gold, vector_distance, bm25_score,
+created_at, last_accessed_at, access_count, importance, content_length }] }`.
+  **No content/fact/query text** is ever in the fixture.
+- Purely on the fixture, `recall@token-budget` (default `--budget 300`, matching
+  the evolve dogfood) is computed for `composite` (full production),
+  `fusion-only`, `recency-only`, `importance-only`, `access-only`, `bm25-only`,
+  `vector-only`. The `composite`/`fusion-only` variants **reuse the production
+  scoring functions** (`computeCompositeScore`, `hybridScoreFusion`,
+  `packToBudget`, `estimateTokens`) so the diagnostic reflects what `evolve`
+  would actually tune; the single-signal variants are trivial reference rankers.
+- **Ranking influence**: mean Kendall-tau between the `composite` and
+  `fusion-only` per-query orderings. Tau well below 1.0 ⇒ the recency/importance
+  terms actively reshape rankings (the LIVE-lever test).
+
+**C. Verdict (GO/NO-GO)** with the numbers, the thresholds, and the reasoning:
+
+| condition                    | rule (default threshold)                                           |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `recency_live`               | span > 365 days AND ≥ 12 distinct year-months AND stddev ≥ 30 days |
+| `importance_live`            | importance stddev ≥ 0.05 AND fraction-at-0.5 < 0.5                 |
+| `reshapes_rankings`          | mean Kendall-tau(composite, fusion-only) < 0.9                     |
+| `not_single_signal_confound` | composite recall ≥ every single-signal baseline (supporting only)  |
+
+**GO** iff `recency_live AND importance_live AND reshapes_rankings` (the core
+anti-LoCoMo conditions). `not_single_signal_confound` is reported as supporting
+evidence but does **not** gate the verdict. **NO-GO** names which condition(s)
+failed. The process exits `0` on GO, `1` on NO-GO, `2` on error.
+
+## Run commands
+
+```bash
+# Full diagnostic (Part A read-only + Part B probe on a db copy)
+npx tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts
+
+# Smaller, faster probe with a fixed seed and tighter budget
+npx tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts --sample 40 --budget 200 --seed 7
+
+# Help (no API key needed)
+npx tsx scripts/memory-corpus/diagnose-corpus.ts --help
+
+# Pure-logic unit tests (no db, no LLM) — includes the LoCoMo-degenerate→NO-GO
+# and healthy→GO anti-vacuity cases
+npm test -- test/diagnose-corpus.test.ts
+```
+
+### Flags
+
+| flag                 | default                             | meaning                                           |
+| -------------------- | ----------------------------------- | ------------------------------------------------- |
+| `--db <path>`        | `donotcommit/corpus/memories.memdb` | corpus memdb (read-only for Part A, copied for B) |
+| `--namespace <name>` | `claude-export`                     | memory namespace                                  |
+| `--sample <N>`       | `120`                               | probe sample size, stratified by recency          |
+| `--budget <tokens>`  | `300`                               | recall@token-budget (matches evolve dogfood)      |
+| `--seed <int>`       | `1`                                 | deterministic sampling seed                       |
+
+## Pristineness + content-free guarantee
+
+- Part A opens the db **read-only** (`{ readonly: true }`) and only runs
+  `SELECT` — it never mutates the real corpus.
+- Part B copies the `.memdb` (+ WAL/SHM sidecars) to a temp dir and runs the
+  probe on the **copy**, then deletes the temp dir. The candidate pool is built
+  by calling `vectorSearch`/`ftsSearch`/`hybridScoreFusion` directly (NOT
+  `recall()`), so even the copy's access stats are never bumped and **no content
+  leaves the retrieval layer** — only numeric signals.
+- Every artifact (`diagnostic-fixture.jsonl`, `diagnostic-report.json`) and every
+  stdout/stderr line is content-free: opaque ids, numeric signals, and verdict
+  aggregates only. Both artifacts live under the gitignored `donotcommit/`.

--- a/scripts/memory-corpus/build-corpus.ts
+++ b/scripts/memory-corpus/build-corpus.ts
@@ -32,6 +32,7 @@ import { getNamespaceStats } from '../../packages/memory-mcp-server/src/storage/
 
 import {
   parseArgs,
+  wireMemoryLlmEnv,
   assembleTranscript,
   isEmptyConversation,
   buildSource,
@@ -51,23 +52,12 @@ import {
  * ANTHROPIC_API_KEY (we REQUIRE the LLM for the corpus — no silent degrade).
  */
 function buildConfig(args: CliArgs): MemoryConfig {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      'ANTHROPIC_API_KEY is required (the corpus needs the LLM). ' +
-        'Run with `--import dotenv/config` or export it in the environment.',
-    );
-  }
+  wireMemoryLlmEnv(args.namespace);
 
-  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
-  process.env.MEMORY_LLM_API_KEY = apiKey;
-  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
   process.env.MEMORY_DB_PATH = resolve(args.dbPath);
-  process.env.MEMORY_NAMESPACE = args.namespace;
   // Determinism: never let per-store maintenance (which runs DECAY) fire mid-bulk.
   process.env.MEMORY_MAINTENANCE_INTERVAL = '100000000';
   process.env.MEMORY_DECAY_THRESHOLD = '0';
-  process.env.MEMORY_RERANKER_ENABLED = 'false';
 
   return loadConfig();
 }
@@ -95,9 +85,11 @@ function selectConversations(conversations: ExportConversation[], args: CliArgs)
     return conversations;
   }
   const selected: ExportConversation[] = [];
+  let nonEmptyCount = 0;
   for (const conv of conversations) {
-    if (selected.filter((c) => !isEmptyConversation(c)).length >= args.limit) break;
+    if (nonEmptyCount >= args.limit) break;
     selected.push(conv);
+    if (!isEmptyConversation(conv)) nonEmptyCount += 1;
   }
   return selected;
 }

--- a/scripts/memory-corpus/build-corpus.ts
+++ b/scripts/memory-corpus/build-corpus.ts
@@ -1,0 +1,334 @@
+/**
+ * Corpus-build driver: ingest a claude.ai conversation export into a memory DB
+ * via the `memory_ingest` (ingestBlob) path.
+ *
+ * Run with tsx, loading .env for ANTHROPIC_API_KEY:
+ *   npx tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts --limit 3
+ *
+ * Pattern: a single Node process that owns the DB and imports the engine
+ * internals directly (mirrors the LoCoMo fixture builder). One LLM call per
+ * chunk goes to Haiku; nothing else egresses.
+ *
+ * SENSITIVE DATA: the export and the DB hold private conversation content. This
+ * driver NEVER writes conversation/fact text to logs or to the progress file —
+ * only counts and opaque uuids. See scripts/memory-corpus/README.md.
+ *
+ * DETERMINISM: per-store maintenance (which runs DECAY) is suppressed by a very
+ * high MEMORY_MAINTENANCE_INTERVAL and MEMORY_DECAY_THRESHOLD=0, so backdated
+ * 2023–2024 facts are not pruned mid-bulk. A single runConsolidation runs at the
+ * very end (never runMaintenance). See the README for the rationale.
+ */
+
+import { mkdirSync, readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type Database from 'better-sqlite3';
+
+import { loadConfig } from '../../packages/memory-mcp-server/src/config.js';
+import type { MemoryConfig } from '../../packages/memory-mcp-server/src/config.js';
+import { initDatabase } from '../../packages/memory-mcp-server/src/storage/database.js';
+import { ingestBlob } from '../../packages/memory-mcp-server/src/engine-impl.js';
+import { runConsolidation } from '../../packages/memory-mcp-server/src/storage/consolidation.js';
+import { getNamespaceStats } from '../../packages/memory-mcp-server/src/storage/queries.js';
+
+import {
+  parseArgs,
+  assembleTranscript,
+  isEmptyConversation,
+  buildSource,
+  resolveAsOf,
+  buildProgressRecord,
+  buildEmptyProgressRecord,
+  computeResumeSet,
+  type CliArgs,
+  type ExportConversation,
+  type ProgressRecord,
+} from './corpus-lib.js';
+
+// ---------- Config setup ----------
+
+/**
+ * Set the MEMORY_* env vars the engine reads, then load config. Requires
+ * ANTHROPIC_API_KEY (we REQUIRE the LLM for the corpus — no silent degrade).
+ */
+function buildConfig(args: CliArgs): MemoryConfig {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required (the corpus needs the LLM). ' +
+        'Run with `--import dotenv/config` or export it in the environment.',
+    );
+  }
+
+  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
+  process.env.MEMORY_LLM_API_KEY = apiKey;
+  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
+  process.env.MEMORY_DB_PATH = resolve(args.dbPath);
+  process.env.MEMORY_NAMESPACE = args.namespace;
+  // Determinism: never let per-store maintenance (which runs DECAY) fire mid-bulk.
+  process.env.MEMORY_MAINTENANCE_INTERVAL = '100000000';
+  process.env.MEMORY_DECAY_THRESHOLD = '0';
+  process.env.MEMORY_RERANKER_ENABLED = 'false';
+
+  return loadConfig();
+}
+
+// ---------- Export loading ----------
+
+function loadExport(exportPath: string): ExportConversation[] {
+  const raw = readFileSync(resolve(exportPath), 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Export is not a top-level JSON array of conversations.');
+  }
+  return parsed as ExportConversation[];
+}
+
+/**
+ * Apply the --conversation / --limit selection. --conversation wins and selects
+ * exactly one conversation; --limit caps the count of NON-EMPTY conversations.
+ */
+function selectConversations(conversations: ExportConversation[], args: CliArgs): ExportConversation[] {
+  if (args.conversation !== undefined) {
+    return conversations.filter((conv) => conv.uuid === args.conversation);
+  }
+  if (args.limit === undefined) {
+    return conversations;
+  }
+  const selected: ExportConversation[] = [];
+  for (const conv of conversations) {
+    if (selected.filter((c) => !isEmptyConversation(c)).length >= args.limit) break;
+    selected.push(conv);
+  }
+  return selected;
+}
+
+// ---------- Progress file (content-free) ----------
+
+function loadProgressRecords(progressPath: string): ProgressRecord[] {
+  if (!existsSync(progressPath)) return [];
+  const lines = readFileSync(progressPath, 'utf-8').split('\n');
+  const records: ProgressRecord[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    records.push(JSON.parse(trimmed) as ProgressRecord);
+  }
+  return records;
+}
+
+function appendProgress(progressPath: string, record: ProgressRecord): void {
+  appendFileSync(progressPath, `${JSON.stringify(record)}\n`);
+}
+
+// ---------- Direct-DB stats (content-free) ----------
+
+interface CorpusStats {
+  importanceMin: number | null;
+  importanceMax: number | null;
+  importanceMean: number | null;
+  createdAtMin: number | null;
+  createdAtMax: number | null;
+}
+
+/** Query importance + created_at spread directly — proves the corpus is non-flat. */
+function queryCorpusStats(db: Database.Database, namespace: string): CorpusStats {
+  const row = db
+    .prepare(
+      `SELECT MIN(importance) AS impMin, MAX(importance) AS impMax, AVG(importance) AS impMean,
+              MIN(created_at) AS createdMin, MAX(created_at) AS createdMax
+         FROM memories WHERE namespace = ?`,
+    )
+    .get(namespace) as {
+    impMin: number | null;
+    impMax: number | null;
+    impMean: number | null;
+    createdMin: number | null;
+    createdMax: number | null;
+  };
+  return {
+    importanceMin: row.impMin,
+    importanceMax: row.impMax,
+    importanceMean: row.impMean,
+    createdAtMin: row.createdMin,
+    createdAtMax: row.createdMax,
+  };
+}
+
+// ---------- Per-conversation ingest ----------
+
+interface RunTotals {
+  processed: number;
+  skippedEmpty: number;
+  skippedFailed: number;
+  partial: number;
+  created: number;
+  merged: number;
+}
+
+async function ingestConversation(
+  db: Database.Database,
+  config: MemoryConfig,
+  conv: ExportConversation,
+  dryRun: boolean,
+  progressPath: string,
+  totals: RunTotals,
+  position: string,
+): Promise<void> {
+  const transcript = assembleTranscript(conv);
+  const asOf = resolveAsOf(conv.created_at);
+  if (asOf === undefined) {
+    process.stderr.write(`${position} ${conv.uuid.slice(0, 8)} → WARNING: unparseable created_at, using now()\n`);
+  }
+  const result = await ingestBlob(db, config, transcript, {
+    mode: 'document',
+    as_of: asOf,
+    source: buildSource(conv.uuid),
+    tags: ['claude-export'],
+    on_extraction_failure: 'skip',
+    dry_run: dryRun,
+  });
+
+  const record = buildProgressRecord(conv.uuid, result);
+  appendProgress(progressPath, record);
+
+  totals.processed += 1;
+  totals.created += result.created;
+  totals.merged += result.merged;
+  if (record.status === 'skipped-failed') totals.skippedFailed += 1;
+  if (record.status === 'partial') totals.partial += 1;
+
+  logProgress(position, conv.uuid, result.created, result.merged);
+}
+
+function logProgress(position: string, uuid: string, created: number, merged: number): void {
+  // Content-free: uuid PREFIX only, no names/text.
+  process.stderr.write(`${position} ${uuid.slice(0, 8)} → created=${created} merged=${merged}\n`);
+}
+
+// ---------- Main ----------
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const config = buildConfig(args);
+  mkdirSync(dirname(config.dbPath), { recursive: true });
+  const progressPath = resolve(dirname(config.dbPath), 'progress.jsonl');
+
+  const priorRecords = loadProgressRecords(progressPath);
+  const dbExists = existsSync(config.dbPath);
+  if (!args.resume && dbExists && priorRecords.length > 0) {
+    process.stderr.write('WARNING: db/progress already exist and --resume not set; appending to existing corpus.\n');
+  }
+  const resumeSkip = args.resume ? computeResumeSet(priorRecords) : new Set<string>();
+
+  const allConversations = loadExport(args.exportPath);
+  const selected = selectConversations(allConversations, args);
+
+  const db = initDatabase(config.dbPath, config.embeddingModel);
+  const startMs = Date.now();
+  const totals: RunTotals = { processed: 0, skippedEmpty: 0, skippedFailed: 0, partial: 0, created: 0, merged: 0 };
+
+  try {
+    for (let i = 0; i < selected.length; i += 1) {
+      const conv = selected[i];
+      const position = `[${i + 1}/${selected.length}]`;
+
+      if (args.resume && resumeSkip.has(conv.uuid)) {
+        process.stderr.write(`${position} ${conv.uuid.slice(0, 8)} → skip (already done)\n`);
+        continue;
+      }
+
+      if (isEmptyConversation(conv)) {
+        appendProgress(progressPath, buildEmptyProgressRecord(conv.uuid));
+        totals.skippedEmpty += 1;
+        process.stderr.write(`${position} ${conv.uuid.slice(0, 8)} → skip (empty)\n`);
+        continue;
+      }
+
+      await ingestConversation(db, config, conv, args.dryRun, progressPath, totals, position);
+    }
+
+    if (!args.dryRun) {
+      const summary = await runConsolidation(db, config);
+      process.stderr.write(
+        `consolidation: consolidated=${summary.consolidated} merged=${summary.merged} superseded=${summary.superseded}\n`,
+      );
+    }
+
+    printSummary(db, config, selected.length, totals, startMs, args.dryRun);
+  } finally {
+    db.close();
+  }
+}
+
+function printSummary(
+  db: Database.Database,
+  config: MemoryConfig,
+  total: number,
+  totals: RunTotals,
+  startMs: number,
+  dryRun: boolean,
+): void {
+  const stats = queryCorpusStats(db, config.namespace);
+  const namespaceTotal = getNamespaceStats(db, config.namespace).total_memories;
+  const elapsedSec = ((Date.now() - startMs) / 1000).toFixed(1);
+
+  const lines = [
+    '',
+    '===== CORPUS BUILD SUMMARY =====',
+    `dry_run:              ${dryRun}`,
+    `conversations total:  ${total}`,
+    `  processed:          ${totals.processed}`,
+    `  skipped-empty:      ${totals.skippedEmpty}`,
+    `  skipped-failed:     ${totals.skippedFailed}`,
+    `  partial:            ${totals.partial}`,
+    `memories created:     ${totals.created}`,
+    `memories merged:      ${totals.merged}`,
+    `namespace total rows: ${namespaceTotal}`,
+    `importance min/max/mean: ${fmt(stats.importanceMin)} / ${fmt(stats.importanceMax)} / ${fmt(stats.importanceMean)}`,
+    `created_at min/max:   ${fmtTime(stats.createdAtMin)} / ${fmtTime(stats.createdAtMax)}`,
+    `elapsed seconds:      ${elapsedSec}`,
+    '================================',
+  ];
+  process.stderr.write(`${lines.join('\n')}\n`);
+}
+
+function fmt(value: number | null): string {
+  return value === null ? 'n/a' : value.toFixed(3);
+}
+
+function fmtTime(epochMs: number | null): string {
+  return epochMs === null ? 'n/a' : new Date(epochMs).toISOString();
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'build-corpus — ingest a claude.ai conversation export into a memory DB',
+      '',
+      'Usage: tsx --import dotenv/config scripts/memory-corpus/build-corpus.ts [flags]',
+      '',
+      'Flags:',
+      '  --export <path>        export JSON (default donotcommit/claude-export/conversations.json)',
+      '  --db <path>            output memdb (default donotcommit/corpus/memories.memdb)',
+      '  --namespace <name>     memory namespace (default claude-export)',
+      '  --limit <N>            process only first N non-empty conversations',
+      '  --conversation <uuid>  process only that conversation',
+      '  --dry-run              extract but write nothing (still egresses to Haiku)',
+      '  --resume               skip conversations already recorded done; retry failed',
+      '  -h, --help             show this help',
+      '',
+      'Requires ANTHROPIC_API_KEY (load via --import dotenv/config).',
+      '',
+    ].join('\n'),
+  );
+}
+
+run().catch((err: unknown) => {
+  process.stderr.write(`build-corpus failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/memory-corpus/corpus-lib.ts
+++ b/scripts/memory-corpus/corpus-lib.ts
@@ -1,0 +1,248 @@
+/**
+ * Pure logic for the claude.ai conversation-export corpus builder.
+ *
+ * Everything here is side-effect free and content-free in its outputs (no fact
+ * text, no transcript text leaks into logs or progress artifacts). It is unit
+ * tested in isolation with synthetic fixtures — no DB, no LLM, no filesystem.
+ *
+ * The I/O driver that wires these helpers to the memory engine lives in
+ * `build-corpus.ts`.
+ */
+
+// ---------- Export shapes (subset of the claude.ai export schema) ----------
+
+/** A single message inside a conversation export. Only the fields we read. */
+export interface ExportMessage {
+  uuid: string;
+  /** SENSITIVE content. Never logged or written to an artifact. */
+  text: string;
+  sender: string;
+}
+
+/** A single conversation in the export array. Only the fields we read. */
+export interface ExportConversation {
+  uuid: string;
+  /** SENSITIVE content. Never logged or written to an artifact. */
+  created_at: string;
+  /** Optional because it comes from untrusted JSON; absent ⇒ treated as empty. */
+  chat_messages?: ExportMessage[];
+}
+
+// ---------- Transcript assembly ----------
+
+/**
+ * Build a transcript from a conversation's messages: one `${sender}: ${text}`
+ * line per message with non-empty `text`, joined by newlines. Messages whose
+ * `text` is empty/whitespace are dropped (some messages carry only structured
+ * `content`/attachments). We deliberately use `text`, never `content`.
+ */
+export function assembleTranscript(conversation: ExportConversation): string {
+  return nonEmptyMessages(conversation)
+    .map((msg) => `${msg.sender}: ${msg.text}`)
+    .join('\n');
+}
+
+function nonEmptyMessages(conversation: ExportConversation): ExportMessage[] {
+  const messages = conversation.chat_messages ?? [];
+  return messages.filter((msg) => typeof msg.text === 'string' && msg.text.trim().length > 0);
+}
+
+/**
+ * A conversation is empty for our purposes when it has no messages with
+ * non-empty `text`. These are skipped (recorded as `skipped-empty`).
+ */
+export function isEmptyConversation(conversation: ExportConversation): boolean {
+  return nonEmptyMessages(conversation).length === 0;
+}
+
+/**
+ * Provenance string stamped on every fact extracted from a conversation, e.g.
+ * `claude-export:3f2a...`. The uuid is an opaque identifier, not content.
+ */
+export function buildSource(uuid: string): string {
+  return `claude-export:${uuid}`;
+}
+
+/**
+ * Resolve a conversation's `created_at` (ISO 8601) to an epoch-ms `as_of`.
+ * Returns `undefined` for a missing/unparseable timestamp so the engine falls
+ * back to `Date.now()` instead of stamping `NaN` into the INTEGER column (which
+ * would corrupt the recency spread the corpus depends on). The timestamp is not
+ * sensitive content, so the caller may warn with the uuid.
+ */
+export function resolveAsOf(createdAt: string | undefined): number | undefined {
+  if (typeof createdAt !== 'string') return undefined;
+  const epoch = Date.parse(createdAt);
+  return Number.isFinite(epoch) ? epoch : undefined;
+}
+
+// ---------- Progress records (content-free) ----------
+
+/**
+ * Terminal status for one conversation. Every value is content-free.
+ * - `ingested`  — facts written (no chunk failures)
+ * - `partial`   — some chunks failed but others produced facts
+ * - `skipped-empty`  — the conversation had no non-empty messages
+ * - `skipped-failed` — extraction yielded nothing (on_extraction_failure='skip')
+ */
+export type ConversationStatus = 'ingested' | 'partial' | 'skipped-empty' | 'skipped-failed';
+
+/** One line in `progress.jsonl`. COUNTS ONLY — never fact text or transcript. */
+export interface ProgressRecord {
+  uuid: string;
+  status: ConversationStatus;
+  created: number;
+  merged: number;
+  facts: number;
+  failed_chunks: number;
+  chunks: number;
+}
+
+/** The subset of an `IngestResult` the progress builder reads. */
+export interface IngestResultLike {
+  created: number;
+  merged: number;
+  facts: { length: number };
+  chunks?: number;
+  failed_chunks?: number;
+  partial?: boolean;
+  skipped?: boolean;
+}
+
+/**
+ * Map an ingest result to a content-free progress record. `status` is
+ * skipped-failed when the result is `skipped`, partial when `partial`, else
+ * ingested. The fact count comes from `facts.length` (a count, never text).
+ */
+export function buildProgressRecord(uuid: string, result: IngestResultLike): ProgressRecord {
+  const status: ConversationStatus = result.skipped ? 'skipped-failed' : result.partial ? 'partial' : 'ingested';
+  return {
+    uuid,
+    status,
+    created: result.created,
+    merged: result.merged,
+    facts: result.facts.length,
+    failed_chunks: result.failed_chunks ?? 0,
+    chunks: result.chunks ?? 1,
+  };
+}
+
+/** Progress record for a conversation skipped because it had no content. */
+export function buildEmptyProgressRecord(uuid: string): ProgressRecord {
+  return { uuid, status: 'skipped-empty', created: 0, merged: 0, facts: 0, failed_chunks: 0, chunks: 0 };
+}
+
+// ---------- Resume-set computation ----------
+
+/** Statuses that count as "done" for resume — only `skipped-failed` is retried. */
+const RESUME_DONE_STATUSES: ReadonlySet<ConversationStatus> = new Set<ConversationStatus>([
+  'ingested',
+  'partial',
+  'skipped-empty',
+]);
+
+/**
+ * Given the records already in the progress file, compute the set of conversation
+ * uuids to skip on `--resume`. A uuid is skipped if any of its records has a
+ * "done" status; `skipped-failed`-only uuids are retried (not in the set).
+ */
+export function computeResumeSet(records: readonly ProgressRecord[]): Set<string> {
+  const skip = new Set<string>();
+  for (const record of records) {
+    if (RESUME_DONE_STATUSES.has(record.status)) {
+      skip.add(record.uuid);
+    }
+  }
+  return skip;
+}
+
+// ---------- Argument parsing ----------
+
+export interface CliArgs {
+  exportPath: string;
+  dbPath: string;
+  namespace: string;
+  /** Process only the first N non-empty conversations; undefined ⇒ all. */
+  limit?: number;
+  /** Process only this conversation uuid; undefined ⇒ all. */
+  conversation?: string;
+  dryRun: boolean;
+  resume: boolean;
+  help: boolean;
+}
+
+export const DEFAULT_ARGS: Readonly<Pick<CliArgs, 'exportPath' | 'dbPath' | 'namespace'>> = {
+  exportPath: 'donotcommit/claude-export/conversations.json',
+  dbPath: 'donotcommit/corpus/memories.memdb',
+  namespace: 'claude-export',
+};
+
+/**
+ * Parse the driver's CLI flags. Throws on a missing value for a flag that needs
+ * one, or on an unrecognized flag, so a typo fails loudly instead of silently
+ * running against the wrong target.
+ */
+export function parseArgs(argv: readonly string[]): CliArgs {
+  const args: CliArgs = {
+    exportPath: DEFAULT_ARGS.exportPath,
+    dbPath: DEFAULT_ARGS.dbPath,
+    namespace: DEFAULT_ARGS.namespace,
+    dryRun: false,
+    resume: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--export':
+        args.exportPath = requireValue(argv, (i += 1), flag);
+        break;
+      case '--db':
+        args.dbPath = requireValue(argv, (i += 1), flag);
+        break;
+      case '--namespace':
+        args.namespace = requireValue(argv, (i += 1), flag);
+        break;
+      case '--limit':
+        args.limit = parsePositiveInt(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '--conversation':
+        args.conversation = requireValue(argv, (i += 1), flag);
+        break;
+      case '--dry-run':
+        args.dryRun = true;
+        break;
+      case '--resume':
+        args.resume = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  return args;
+}
+
+function requireValue(argv: readonly string[], index: number, flag: string): string {
+  if (index >= argv.length) {
+    throw new Error(`Flag ${flag} requires a value`);
+  }
+  const value = argv[index];
+  if (value.startsWith('--')) {
+    throw new Error(`Flag ${flag} requires a value`);
+  }
+  return value;
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Flag ${flag} requires a positive integer, got: ${raw}`);
+  }
+  return parsed;
+}

--- a/scripts/memory-corpus/corpus-lib.ts
+++ b/scripts/memory-corpus/corpus-lib.ts
@@ -156,6 +156,33 @@ export function computeResumeSet(records: readonly ProgressRecord[]): Set<string
   return skip;
 }
 
+// ---------- Engine env wiring ----------
+
+/**
+ * Wire the `MEMORY_*` env vars that point the engine's LLM client at Anthropic's
+ * Haiku, plus the namespace and a disabled reranker. Both drivers call this
+ * BEFORE `loadConfig()`. Requires `ANTHROPIC_API_KEY` (we REQUIRE the LLM for the
+ * corpus/diagnostic — no silent degrade) and throws a clear error if it's absent.
+ *
+ * The base URL and default model are pinned here so the two drivers can never
+ * drift apart. Determinism vars (db path, maintenance interval, decay threshold)
+ * are the build driver's concern and stay there.
+ */
+export function wireMemoryLlmEnv(namespace: string): void {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required (the corpus needs the LLM). ' +
+        'Run with `--import dotenv/config` or export it in the environment.',
+    );
+  }
+  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
+  process.env.MEMORY_LLM_API_KEY = apiKey;
+  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
+  process.env.MEMORY_NAMESPACE = namespace;
+  process.env.MEMORY_RERANKER_ENABLED = 'false';
+}
+
 // ---------- Argument parsing ----------
 
 export interface CliArgs {
@@ -228,7 +255,11 @@ export function parseArgs(argv: readonly string[]): CliArgs {
   return args;
 }
 
-function requireValue(argv: readonly string[], index: number, flag: string): string {
+/**
+ * Read the value following a flag at `index`, or throw if absent / itself a flag.
+ * Shared by both driver scripts' `parseArgs`.
+ */
+export function requireValue(argv: readonly string[], index: number, flag: string): string {
   if (index >= argv.length) {
     throw new Error(`Flag ${flag} requires a value`);
   }
@@ -239,7 +270,8 @@ function requireValue(argv: readonly string[], index: number, flag: string): str
   return value;
 }
 
-function parsePositiveInt(raw: string, flag: string): number {
+/** Parse a strictly-positive integer flag value, or throw. Shared by both drivers. */
+export function parsePositiveInt(raw: string, flag: string): number {
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`Flag ${flag} requires a positive integer, got: ${raw}`);

--- a/scripts/memory-corpus/diagnose-corpus.ts
+++ b/scripts/memory-corpus/diagnose-corpus.ts
@@ -1,0 +1,611 @@
+/**
+ * Corpus representativeness diagnostic.
+ *
+ * Answers ONE question with a GO/NO-GO verdict: is this corpus non-degenerate
+ * enough that evolving the composite retrieval scorer is meaningful — i.e. are
+ * the metadata signals (recency, importance) ALIVE and do they actively reshape
+ * rankings, unlike the LoCoMo benchmark where flat metadata (importance ≡ 0.5,
+ * identical created_at) made those terms dead weight?
+ *
+ * Three analyses, then a verdict:
+ *   A. Distributional liveness — real db, READ-ONLY SQL. No LLM, no retrieval.
+ *   B. Self-supervised recall probe — Haiku question generation + the REAL
+ *      hybrid candidate pool, run on a COPY of the db so the real corpus stays
+ *      pristine (retrieval mutates access stats). Emits a CONTENT-FREE fixture.
+ *   C. Verdict — GO iff recency_live AND importance_live AND reshapes_rankings.
+ *
+ * Run with tsx, loading .env for ANTHROPIC_API_KEY:
+ *   npx tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts
+ *
+ * SENSITIVE DATA: the corpus DB holds private conversation facts. This driver
+ * NEVER writes fact/query text to stdout, logs, the fixture, or the report —
+ * only opaque ids and numeric signals. The fixture and report live under the
+ * gitignored `donotcommit/`. See scripts/memory-corpus/README.md.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import Database from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
+
+import { loadConfig } from '../../packages/memory-mcp-server/src/config.js';
+import type { MemoryConfig } from '../../packages/memory-mcp-server/src/config.js';
+import { initDatabase } from '../../packages/memory-mcp-server/src/storage/database.js';
+import type { MemoryRow } from '../../packages/memory-mcp-server/src/storage/database.js';
+import { vectorSearch, ftsSearch } from '../../packages/memory-mcp-server/src/storage/queries.js';
+import { hybridScoreFusion } from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
+import { embedQuery } from '../../packages/memory-mcp-server/src/embedding/embedder.js';
+import { getLLMClient } from '../../packages/memory-mcp-server/src/llm/client.js';
+
+import {
+  summarizeRecency,
+  summarizeImportance,
+  summarizeNumeric,
+  percentiles,
+  histogram,
+  recallTable,
+  meanCompositeVsFusionTau,
+  stratifiedSample,
+  mulberry32,
+  evaluateVerdict,
+  SINGLE_SIGNAL_VARIANTS,
+  type FixtureQuery,
+  type FixtureCandidate,
+  type SampleRow,
+  type RecencySummary,
+  type ImportanceSummary,
+  type NumericSummary,
+  type VerdictResult,
+} from './diagnose-lib.js';
+
+// ---------- CLI ----------
+
+interface DiagnoseArgs {
+  dbPath: string;
+  namespace: string;
+  sample: number;
+  budget: number;
+  seed: number;
+  help: boolean;
+}
+
+const DEFAULTS = {
+  dbPath: 'donotcommit/corpus/memories.memdb',
+  namespace: 'claude-export',
+  sample: 120,
+  budget: 300,
+  seed: 1,
+};
+
+function parseArgs(argv: readonly string[]): DiagnoseArgs {
+  const args: DiagnoseArgs = { ...DEFAULTS, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--db':
+        args.dbPath = requireValue(argv, (i += 1), flag);
+        break;
+      case '--namespace':
+        args.namespace = requireValue(argv, (i += 1), flag);
+        break;
+      case '--sample':
+        args.sample = parsePositiveInt(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '--budget':
+        args.budget = parsePositiveInt(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '--seed':
+        args.seed = parseIntFlag(requireValue(argv, (i += 1), flag), flag);
+        break;
+      case '-h':
+      case '--help':
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+  return args;
+}
+
+function requireValue(argv: readonly string[], index: number, flag: string): string {
+  if (index >= argv.length) throw new Error(`Flag ${flag} requires a value`);
+  const value = argv[index];
+  if (value.startsWith('--')) throw new Error(`Flag ${flag} requires a value`);
+  return value;
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`Flag ${flag} requires a positive integer, got: ${raw}`);
+  return n;
+}
+
+function parseIntFlag(raw: string, flag: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n)) throw new Error(`Flag ${flag} requires an integer, got: ${raw}`);
+  return n;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'diagnose-corpus — representativeness diagnostic for a memory corpus (GO/NO-GO)',
+      '',
+      'Answers: are the metadata signals (recency, importance) ALIVE and do they',
+      'reshape rankings — i.e. is evolving the composite scorer meaningful on this',
+      'corpus, unlike the flat-metadata LoCoMo benchmark?',
+      '',
+      'Usage: tsx --import dotenv/config scripts/memory-corpus/diagnose-corpus.ts [flags]',
+      '',
+      'Flags:',
+      `  --db <path>          corpus memdb (default ${DEFAULTS.dbPath})`,
+      `  --namespace <name>   memory namespace (default ${DEFAULTS.namespace})`,
+      `  --sample <N>         probe sample size, stratified by recency (default ${DEFAULTS.sample})`,
+      `  --budget <tokens>    recall@token-budget (default ${DEFAULTS.budget}, matches evolve dogfood)`,
+      `  --seed <int>         deterministic sampling seed (default ${DEFAULTS.seed})`,
+      '  -h, --help           show this help',
+      '',
+      'Part A (distributional stats) reads the real db READ-ONLY and needs no LLM.',
+      'Part B (recall probe) copies the db to a temp path, embeds Haiku-generated',
+      'questions, and needs ANTHROPIC_API_KEY (load via --import dotenv/config).',
+      '',
+      'Artifacts (content-free, under gitignored donotcommit/):',
+      '  donotcommit/corpus/diagnostic-fixture.jsonl   per-query candidate signals',
+      '  donotcommit/corpus/diagnostic-report.json     aggregate verdict numbers',
+      '',
+    ].join('\n'),
+  );
+}
+
+// ---------- Config ----------
+
+/** Wire MEMORY_* env so the engine helpers (embedder, LLM client) load Haiku. */
+function buildConfig(args: DiagnoseArgs): MemoryConfig {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'ANTHROPIC_API_KEY is required for the recall probe (Haiku question generation). ' +
+        'Run with `--import dotenv/config` or export it.',
+    );
+  }
+  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
+  process.env.MEMORY_LLM_API_KEY = apiKey;
+  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
+  process.env.MEMORY_NAMESPACE = args.namespace;
+  process.env.MEMORY_RERANKER_ENABLED = 'false';
+  return loadConfig();
+}
+
+// ---------- Part A: distributional stats (real db, READ-ONLY) ----------
+
+interface RawSignals {
+  ids: string[];
+  createdAt: number[];
+  importance: number[];
+  accessCount: number[];
+  contentLength: number[];
+}
+
+/** Pull the raw per-row signal arrays. READ-ONLY: only SELECT, never mutates. */
+function readRawSignals(db: Database.Database, namespace: string): RawSignals {
+  const rows = db
+    .prepare(
+      `SELECT id, created_at, importance, access_count, length(content) AS content_length
+         FROM memories WHERE namespace = ?`,
+    )
+    .all(namespace) as Array<{
+    id: string;
+    created_at: number;
+    importance: number;
+    access_count: number;
+    content_length: number;
+  }>;
+  return {
+    ids: rows.map((r) => r.id),
+    createdAt: rows.map((r) => r.created_at),
+    importance: rows.map((r) => r.importance),
+    accessCount: rows.map((r) => r.access_count),
+    contentLength: rows.map((r) => r.content_length),
+  };
+}
+
+interface DistributionalReport {
+  rowCount: number;
+  recency: RecencySummary;
+  importance: ImportanceSummary;
+  access: { numeric: NumericSummary; histogram: Record<string, number>; allZero: boolean };
+  contentLength: { numeric: NumericSummary; percentiles: Record<string, number | null> };
+}
+
+function summarizeDistribution(raw: RawSignals): DistributionalReport {
+  const accessNumeric = summarizeNumeric(raw.accessCount);
+  return {
+    rowCount: raw.ids.length,
+    recency: summarizeRecency(raw.createdAt),
+    importance: summarizeImportance(raw.importance),
+    access: {
+      numeric: accessNumeric,
+      histogram: histogram(raw.accessCount, 1, 0, 0),
+      allZero: accessNumeric.max === 0 || accessNumeric.max === null,
+    },
+    contentLength: {
+      numeric: summarizeNumeric(raw.contentLength),
+      percentiles: percentiles(raw.contentLength, [0, 0.25, 0.5, 0.75, 0.9, 1]),
+    },
+  };
+}
+
+// ---------- Part B: recall probe (db COPY) ----------
+
+const DEFAULT_CANDIDATE_LIMIT = 50;
+const MAX_VECTOR_DISTANCE = 0.9;
+
+/** Copy the memdb (+ WAL/SHM sidecars if present) into a temp dir; return the copy path. */
+function copyDbToTemp(dbPath: string): { copyPath: string; tempDir: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), 'corpus-diag-'));
+  const copyPath = join(tempDir, 'corpus-copy.memdb');
+  copyFileSync(dbPath, copyPath);
+  for (const suffix of ['-wal', '-shm']) {
+    if (existsSync(dbPath + suffix)) copyFileSync(dbPath + suffix, copyPath + suffix);
+  }
+  return { copyPath, tempDir };
+}
+
+/** Open a db read-only with the sqlite-vec extension loaded (for vector_distance_cosine). */
+function openReadOnly(dbPath: string): Database.Database {
+  const db = new Database(dbPath, { readonly: true });
+  sqliteVec.load(db);
+  return db;
+}
+
+const QUESTION_SYSTEM_PROMPT =
+  'Given a single fact, output ONLY a short, natural question that a user might ask ' +
+  'which this fact answers. No preamble, no quotes, no explanation — just the question.';
+
+/** One Haiku call: fact text in, a natural question out. Returns null on failure. */
+async function generateQuestion(config: MemoryConfig, factContent: string): Promise<string | null> {
+  const client = getLLMClient(config);
+  if (!client) return null;
+  try {
+    const response = await client.chat.completions.create({
+      model: config.llmModel,
+      messages: [
+        { role: 'system', content: QUESTION_SYSTEM_PROMPT },
+        { role: 'user', content: factContent },
+      ],
+      max_tokens: 60,
+      temperature: 0,
+    });
+    const text = response.choices[0]?.message?.content?.trim();
+    return text && text.length > 0 ? text : null;
+  } catch {
+    // Content-free: never log the prompt (the fact) or the SDK error body.
+    process.stderr.write('  question generation failed for one fact (skipping)\n');
+    return null;
+  }
+}
+
+/**
+ * Build the CONTENT-FREE candidate pool for a query by running the REAL hybrid
+ * retrieval (vector KNN + FTS5 + production fusion). We call the search/fusion
+ * helpers directly rather than `recall()` so that (a) nothing mutates access
+ * stats and (b) only numeric signals — never content — leave this function.
+ */
+function buildCandidatePool(
+  db: Database.Database,
+  namespace: string,
+  queryEmbedding: Float32Array,
+  queryText: string,
+  goldId: string,
+): FixtureCandidate[] {
+  const vectorResults = vectorSearch(db, namespace, queryEmbedding, DEFAULT_CANDIDATE_LIMIT).filter(
+    (r) => r.distance < MAX_VECTOR_DISTANCE,
+  );
+  const ftsResults = ftsSearch(db, namespace, queryText, DEFAULT_CANDIDATE_LIMIT);
+
+  const all = new Map<string, MemoryRow>();
+  for (const m of vectorResults) all.set(m.id, m);
+  for (const m of ftsResults) all.set(m.id, m);
+
+  const distanceById = new Map(vectorResults.map((r) => [r.id, r.distance]));
+  const bm25ById = new Map(ftsResults.map((r) => [r.id, r.bm25_score]));
+
+  // Fuse only to confirm the pool is well-formed; the fixture stores raw signals,
+  // and the pure lib re-derives fusion from them at analysis time.
+  hybridScoreFusion(vectorResults, ftsResults, all);
+
+  const candidates: FixtureCandidate[] = [];
+  for (const [id, m] of all) {
+    candidates.push({
+      id,
+      is_gold: id === goldId,
+      vector_distance: distanceById.get(id),
+      bm25_score: bm25ById.get(id),
+      created_at: m.created_at,
+      last_accessed_at: m.last_accessed_at,
+      access_count: m.access_count,
+      importance: m.importance,
+      content_length: m.content.length,
+    });
+  }
+  return candidates;
+}
+
+/** Read a sampled fact's content from the COPY db (content stays local, never persisted). */
+function readContent(db: Database.Database, namespace: string, id: string): string | null {
+  const row = db.prepare(`SELECT content FROM memories WHERE namespace = ? AND id = ?`).get(namespace, id) as
+    | { content: string }
+    | undefined;
+  return row?.content ?? null;
+}
+
+interface ProbeResult {
+  queries: FixtureQuery[];
+  generated: number;
+  skipped: number;
+}
+
+/**
+ * Run the self-supervised probe on the db COPY: for each sampled fact, generate
+ * a question (Haiku), retrieve the candidate pool, and record a content-free
+ * fixture row. Appends each row to the fixture file as it goes.
+ */
+async function runRecallProbe(
+  db: Database.Database,
+  config: MemoryConfig,
+  sampleIds: readonly string[],
+  fixturePath: string,
+): Promise<ProbeResult> {
+  writeFileSync(fixturePath, '');
+  const queries: FixtureQuery[] = [];
+  let generated = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < sampleIds.length; i += 1) {
+    const goldId = sampleIds[i];
+    const content = readContent(db, config.namespace, goldId);
+    if (content === null) {
+      skipped += 1;
+      continue;
+    }
+
+    const question = await generateQuestion(config, content);
+    if (question === null) {
+      skipped += 1;
+      continue;
+    }
+
+    const queryEmbedding = await embedQuery(question, config);
+    const candidates = buildCandidatePool(db, config.namespace, queryEmbedding, question, goldId);
+
+    const query: FixtureQuery = { query_id: `probe-${i}`, gold_id: goldId, candidates };
+    queries.push(query);
+    appendFileSync(fixturePath, `${JSON.stringify(query)}\n`);
+    generated += 1;
+
+    if ((i + 1) % 20 === 0) {
+      process.stderr.write(`  probe ${i + 1}/${sampleIds.length} (generated=${generated} skipped=${skipped})\n`);
+    }
+  }
+
+  return { queries, generated, skipped };
+}
+
+// ---------- Report assembly + printing ----------
+
+interface FullReport {
+  meta: {
+    namespace: string;
+    sample_requested: number;
+    sample_probed: number;
+    budget: number;
+    seed: number;
+    generated_at: string;
+  };
+  distributional: DistributionalReport;
+  probe: {
+    recall_at_budget: Record<string, number>;
+    composite_vs_fusion_tau: number;
+    not_single_signal_confound: boolean;
+    single_signal_variants: readonly string[];
+  };
+  verdict: VerdictResult;
+}
+
+function fmt(n: number | null, digits = 3): string {
+  return n === null ? 'n/a' : n.toFixed(digits);
+}
+
+function fmtTime(epochMs: number | null): string {
+  return epochMs === null ? 'n/a' : new Date(epochMs).toISOString();
+}
+
+function printReport(report: FullReport): void {
+  const { distributional: d, probe: p, verdict: v } = report;
+  const out: string[] = [];
+  out.push('');
+  out.push('===== CORPUS REPRESENTATIVENESS DIAGNOSTIC =====');
+  out.push(`namespace:            ${report.meta.namespace}`);
+  out.push(`rows:                 ${d.rowCount}`);
+  out.push(`sample probed:        ${report.meta.sample_probed} / ${report.meta.sample_requested} requested`);
+  out.push(`budget:               ${report.meta.budget} tokens   seed: ${report.meta.seed}`);
+  out.push('');
+
+  out.push('--- A. Recency ---');
+  out.push(`  span:               ${fmtTime(d.recency.numeric.min)} → ${fmtTime(d.recency.numeric.max)}`);
+  out.push(`  span days:          ${fmt(d.recency.spanDays, 1)}`);
+  out.push(`  distinct yr-months: ${d.recency.distinctYearMonths}`);
+  out.push(
+    `  stddev (days):      ${fmt(d.recency.numeric.stddev === null ? null : d.recency.numeric.stddev / 86400000, 1)}`,
+  );
+  out.push(`  fraction by year:   ${formatFractionMap(d.recency.fractionByYear)}`);
+  out.push(`  histogram (quarter):${formatCountMap(d.recency.histogramByQuarter)}`);
+
+  out.push('--- A. Importance ---');
+  out.push(
+    `  min/max/mean:       ${fmt(d.importance.numeric.min)} / ${fmt(d.importance.numeric.max)} / ${fmt(d.importance.numeric.mean)}`,
+  );
+  out.push(`  stddev:             ${fmt(d.importance.numeric.stddev)}`);
+  out.push(`  distinct values:    ${d.importance.distinctValues}`);
+  out.push(`  fraction at 0.5:    ${fmt(d.importance.fractionAtSeed)}`);
+  out.push(`  histogram (0.1):    ${formatCountMap(d.importance.histogram)}`);
+
+  out.push('--- A. Access (LATENT — zero until the corpus is queried) ---');
+  out.push(
+    `  min/max/mean:       ${fmt(d.access.numeric.min)} / ${fmt(d.access.numeric.max)} / ${fmt(d.access.numeric.mean)}`,
+  );
+  out.push(
+    `  all zero:           ${d.access.allZero} ${d.access.allZero ? '(expected on a fresh corpus — not a failure)' : ''}`,
+  );
+
+  out.push('--- A. Content length (atomicity sanity) ---');
+  out.push(
+    `  min/max/mean:       ${fmt(d.contentLength.numeric.min, 0)} / ${fmt(d.contentLength.numeric.max, 0)} / ${fmt(d.contentLength.numeric.mean, 0)}`,
+  );
+  out.push(`  percentiles:        ${formatPercentiles(d.contentLength.percentiles)}`);
+
+  out.push('');
+  out.push('--- B. Recall@budget by ranking variant ---');
+  for (const [variant, recall] of Object.entries(p.recall_at_budget)) {
+    out.push(`  ${variant.padEnd(18)}${fmt(recall)}`);
+  }
+  out.push(`  composite vs fusion Kendall-tau: ${fmt(p.composite_vs_fusion_tau)}`);
+  out.push(`  composite ≥ every single-signal baseline (confound check): ${p.not_single_signal_confound}`);
+
+  out.push('');
+  out.push('--- Thresholds ---');
+  out.push(`  distinct year-months ≥ ${v.thresholds.minDistinctYearMonths}`);
+  out.push(`  recency stddev (days) ≥ ${v.thresholds.minRecencyStddevDays}`);
+  out.push(`  importance stddev ≥ ${v.thresholds.minImportanceStddev}`);
+  out.push(`  fraction at 0.5 < ${v.thresholds.maxFractionAtSeed}`);
+  out.push(`  composite-vs-fusion tau < ${v.thresholds.maxReshapeTau}`);
+
+  out.push('');
+  out.push('--- C. Verdict ---');
+  out.push(`  recency_live:               ${v.recencyLive}`);
+  out.push(`  importance_live:            ${v.importanceLive}`);
+  out.push(`  reshapes_rankings:          ${v.reshapesRankings}`);
+  out.push(`  not_single_signal_confound: ${v.notSingleSignalConfound} (supporting evidence)`);
+  if (!v.go) out.push(`  failed conditions:          ${v.failedConditions.join(', ')}`);
+  out.push('');
+  out.push(`  >>> ${v.go ? 'GO' : 'NO-GO'} <<<`);
+  out.push('================================================');
+  out.push('');
+  process.stdout.write(out.join('\n'));
+}
+
+function formatFractionMap(m: Record<string, number>): string {
+  return Object.entries(m)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v.toFixed(2)}`)
+    .join(' ');
+}
+
+function formatCountMap(m: Record<string, number>): string {
+  return Object.entries(m)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+}
+
+function formatPercentiles(m: Record<string, number | null>): string {
+  return Object.entries(m)
+    .map(([k, v]) => `${k}=${v === null ? 'n/a' : Math.round(v)}`)
+    .join(' ');
+}
+
+// ---------- Main ----------
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const config = buildConfig(args);
+  const dbPath = resolve(args.dbPath);
+  if (!existsSync(dbPath)) {
+    throw new Error(`Corpus db not found: ${dbPath} (build it first with build-corpus.ts)`);
+  }
+  config.dbPath = dbPath;
+
+  const outDir = dirname(dbPath);
+  mkdirSync(outDir, { recursive: true });
+  const fixturePath = join(outDir, 'diagnostic-fixture.jsonl');
+  const reportPath = join(outDir, 'diagnostic-report.json');
+
+  // ---- Part A: distributional stats on the REAL db, READ-ONLY ----
+  process.stderr.write('Part A: distributional stats (read-only)…\n');
+  const roDb = openReadOnly(dbPath);
+  let raw: RawSignals;
+  try {
+    raw = readRawSignals(roDb, config.namespace);
+  } finally {
+    roDb.close();
+  }
+  if (raw.ids.length === 0) {
+    throw new Error(`Namespace '${config.namespace}' has no memories in ${dbPath}.`);
+  }
+  const distributional = summarizeDistribution(raw);
+
+  // ---- Part B: recall probe on a COPY of the db ----
+  process.stderr.write('Part B: recall probe (on a db copy)…\n');
+  const sampleRows: SampleRow[] = raw.ids.map((id, i) => ({ id, created_at: raw.createdAt[i] }));
+  const sampleIds = stratifiedSample(sampleRows, args.sample, mulberry32(args.seed));
+
+  const { copyPath, tempDir } = copyDbToTemp(dbPath);
+  let probe: ProbeResult;
+  const copyDb = initDatabase(copyPath, config.embeddingModel);
+  try {
+    probe = await runRecallProbe(copyDb, config, sampleIds, fixturePath);
+  } finally {
+    copyDb.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+  if (probe.queries.length === 0) {
+    throw new Error('Recall probe produced no queries (all questions failed). Cannot evaluate the verdict.');
+  }
+
+  // ---- Part C: verdict (pure logic on the fixture + distributional stats) ----
+  const now = Date.now();
+  const table = recallTable(probe.queries, args.budget, now);
+  const tau = meanCompositeVsFusionTau(probe.queries, now);
+  const verdict = evaluateVerdict({
+    recency: distributional.recency,
+    importance: distributional.importance,
+    reshapeTau: tau,
+    recallTable: table,
+  });
+
+  const report: FullReport = {
+    meta: {
+      namespace: config.namespace,
+      sample_requested: args.sample,
+      sample_probed: probe.generated,
+      budget: args.budget,
+      seed: args.seed,
+      generated_at: new Date().toISOString(),
+    },
+    distributional,
+    probe: {
+      recall_at_budget: table,
+      composite_vs_fusion_tau: tau,
+      not_single_signal_confound: verdict.notSingleSignalConfound,
+      single_signal_variants: SINGLE_SIGNAL_VARIANTS,
+    },
+    verdict,
+  };
+
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  printReport(report);
+  process.stderr.write(`\nfixture: ${fixturePath}\nreport:  ${reportPath}\n`);
+  process.exitCode = verdict.go ? 0 : 1;
+}
+
+run().catch((err: unknown) => {
+  process.stderr.write(`diagnose-corpus failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(2);
+});

--- a/scripts/memory-corpus/diagnose-corpus.ts
+++ b/scripts/memory-corpus/diagnose-corpus.ts
@@ -36,8 +36,9 @@ import type { MemoryRow } from '../../packages/memory-mcp-server/src/storage/dat
 import { vectorSearch, ftsSearch } from '../../packages/memory-mcp-server/src/storage/queries.js';
 import { hybridScoreFusion } from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
 import { embedQuery } from '../../packages/memory-mcp-server/src/embedding/embedder.js';
-import { getLLMClient } from '../../packages/memory-mcp-server/src/llm/client.js';
+import { llmComplete } from '../../packages/memory-mcp-server/src/llm/client.js';
 
+import { requireValue, parsePositiveInt, wireMemoryLlmEnv } from './corpus-lib.js';
 import {
   summarizeRecency,
   summarizeImportance,
@@ -109,19 +110,6 @@ function parseArgs(argv: readonly string[]): DiagnoseArgs {
   return args;
 }
 
-function requireValue(argv: readonly string[], index: number, flag: string): string {
-  if (index >= argv.length) throw new Error(`Flag ${flag} requires a value`);
-  const value = argv[index];
-  if (value.startsWith('--')) throw new Error(`Flag ${flag} requires a value`);
-  return value;
-}
-
-function parsePositiveInt(raw: string, flag: string): number {
-  const n = Number(raw);
-  if (!Number.isInteger(n) || n <= 0) throw new Error(`Flag ${flag} requires a positive integer, got: ${raw}`);
-  return n;
-}
-
 function parseIntFlag(raw: string, flag: string): number {
   const n = Number(raw);
   if (!Number.isInteger(n)) throw new Error(`Flag ${flag} requires an integer, got: ${raw}`);
@@ -163,18 +151,7 @@ function printHelp(): void {
 
 /** Wire MEMORY_* env so the engine helpers (embedder, LLM client) load Haiku. */
 function buildConfig(args: DiagnoseArgs): MemoryConfig {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      'ANTHROPIC_API_KEY is required for the recall probe (Haiku question generation). ' +
-        'Run with `--import dotenv/config` or export it.',
-    );
-  }
-  process.env.MEMORY_LLM_BASE_URL = 'https://api.anthropic.com/v1/';
-  process.env.MEMORY_LLM_API_KEY = apiKey;
-  process.env.MEMORY_LLM_MODEL = process.env.MEMORY_LLM_MODEL ?? 'claude-haiku-4-5-20251001';
-  process.env.MEMORY_NAMESPACE = args.namespace;
-  process.env.MEMORY_RERANKER_ENABLED = 'false';
+  wireMemoryLlmEnv(args.namespace);
   return loadConfig();
 }
 
@@ -264,27 +241,14 @@ const QUESTION_SYSTEM_PROMPT =
   'Given a single fact, output ONLY a short, natural question that a user might ask ' +
   'which this fact answers. No preamble, no quotes, no explanation — just the question.';
 
-/** One Haiku call: fact text in, a natural question out. Returns null on failure. */
+/**
+ * One Haiku call: fact text in, a natural question out. Returns null on failure
+ * or when no LLM is configured. `llmComplete` already returns null on error and
+ * logs only a PII-safe error shape (never the fact prompt or SDK body).
+ */
 async function generateQuestion(config: MemoryConfig, factContent: string): Promise<string | null> {
-  const client = getLLMClient(config);
-  if (!client) return null;
-  try {
-    const response = await client.chat.completions.create({
-      model: config.llmModel,
-      messages: [
-        { role: 'system', content: QUESTION_SYSTEM_PROMPT },
-        { role: 'user', content: factContent },
-      ],
-      max_tokens: 60,
-      temperature: 0,
-    });
-    const text = response.choices[0]?.message?.content?.trim();
-    return text && text.length > 0 ? text : null;
-  } catch {
-    // Content-free: never log the prompt (the fact) or the SDK error body.
-    process.stderr.write('  question generation failed for one fact (skipping)\n');
-    return null;
-  }
+  const q = await llmComplete(config, QUESTION_SYSTEM_PROMPT, factContent, { maxTokens: 60 });
+  return q?.trim() || null;
 }
 
 /**

--- a/scripts/memory-corpus/diagnose-lib.ts
+++ b/scripts/memory-corpus/diagnose-lib.ts
@@ -1,0 +1,599 @@
+/**
+ * Pure logic for the corpus representativeness diagnostic.
+ *
+ * The diagnostic answers ONE question: is the corpus non-degenerate enough that
+ * evolving the composite retrieval scorer is meaningful — i.e. are the metadata
+ * signals (recency, importance) ALIVE and do they actively reshape rankings,
+ * unlike the LoCoMo benchmark where flat metadata (importance ≡ 0.5, identical
+ * created_at) made those terms dead weight?
+ *
+ * Everything here is side-effect free and content-free: it operates on the
+ * content-free fixture rows produced by the recall probe (vector_distance,
+ * bm25_score, created_at, importance, ...) and on raw numeric arrays read from
+ * the db. NO fact/query/content text ever flows through this module. It is unit
+ * tested in isolation with SYNTHETIC fixtures — no DB, no LLM, no filesystem.
+ *
+ * The composite/fusion variants REUSE the production scoring functions
+ * (`computeCompositeScore`, `hybridScoreFusion`, `estimateTokens`,
+ * `packToBudget`) so the diagnostic reflects exactly what `evolve` would tune.
+ * The single-signal baselines (recency-only, importance-only, ...) are
+ * deliberately NOT production code — they are trivial reference rankers whose
+ * only job is to be a confound floor.
+ *
+ * The I/O driver that wires these helpers to the real db and Haiku lives in
+ * `diagnose-corpus.ts`.
+ */
+
+import type { MemoryRow } from '../../packages/memory-mcp-server/src/storage/database.js';
+import type { ScoredMemory } from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
+import {
+  hybridScoreFusion,
+  computeCompositeScore,
+  packToBudget,
+} from '../../packages/memory-mcp-server/src/retrieval/scoring.js';
+
+// ---------- Fixture row shapes (content-free) ----------
+
+/**
+ * One candidate retrieved for a probe query. Carries ONLY the signals the
+ * scorers consume — never any content/fact/query text. `vector_distance` is
+ * absent when the candidate came only from FTS; `bm25_score` is absent when it
+ * came only from vector search.
+ */
+export interface FixtureCandidate {
+  id: string;
+  is_gold: boolean;
+  /** Cosine distance from the query embedding (lower = closer). FTS-only ⇒ undefined. */
+  vector_distance?: number;
+  /** Raw FTS5 bm25() score (negative; more negative = better). Vector-only ⇒ undefined. */
+  bm25_score?: number;
+  created_at: number;
+  last_accessed_at: number;
+  access_count: number;
+  importance: number;
+  /** Character length of the fact's content — drives the token-budget pack. */
+  content_length: number;
+}
+
+/** One probe query: a sampled fact's id (gold) and the candidate pool it drew. */
+export interface FixtureQuery {
+  query_id: string;
+  gold_id: string;
+  candidates: FixtureCandidate[];
+}
+
+// ---------- Ranking variants ----------
+
+/** The ranking variants the recall@budget table is computed for. */
+export const RANKING_VARIANTS = [
+  'composite',
+  'fusion-only',
+  'recency-only',
+  'importance-only',
+  'access-only',
+  'bm25-only',
+  'vector-only',
+] as const;
+
+export type RankingVariant = (typeof RANKING_VARIANTS)[number];
+
+/** The single-signal baselines — used for the confound check. */
+export const SINGLE_SIGNAL_VARIANTS: readonly RankingVariant[] = [
+  'recency-only',
+  'importance-only',
+  'access-only',
+  'bm25-only',
+  'vector-only',
+];
+
+// ---------- Fixture → ScoredMemory reconstruction ----------
+
+/**
+ * Rebuild the minimal `MemoryRow` shape the production scorers read from a
+ * content-free fixture candidate. `content` is a synthetic placeholder of the
+ * recorded length so `estimateTokens(content)` reproduces the real token cost
+ * WITHOUT carrying any real text — token estimation is length-only (~4 chars).
+ */
+function candidateToRow(c: FixtureCandidate): MemoryRow {
+  return {
+    id: c.id,
+    namespace: 'diagnostic',
+    content: 'x'.repeat(Math.max(0, Math.round(c.content_length))),
+    tags: null,
+    importance: c.importance,
+    created_at: c.created_at,
+    updated_at: c.created_at,
+    last_accessed_at: c.last_accessed_at,
+    access_count: c.access_count,
+    is_compacted: 0,
+    consolidated: 1,
+    source: null,
+    metadata: null,
+  };
+}
+
+/**
+ * Recompute the production fusion + composite scores for a query's candidate
+ * pool by feeding the recorded vector distances and bm25 scores back through
+ * the REAL `hybridScoreFusion` and `computeCompositeScore`. This is the heart
+ * of fidelity: the `composite`/`fusion-only` orderings are exactly what the
+ * live pipeline would produce for this pool.
+ *
+ * `now` is the reference time for recency/access decay (caller-supplied so it is
+ * deterministic in tests). Returns the scored candidates in production-fusion
+ * order alongside the fusionMax used for normalization.
+ */
+export function scoreFixtureQuery(query: FixtureQuery, now: number): ScoredMemory[] {
+  const allMemories = new Map<string, MemoryRow>();
+  const vectorResults = [];
+  const ftsResults = [];
+
+  for (const c of query.candidates) {
+    const row = candidateToRow(c);
+    allMemories.set(c.id, row);
+    if (c.vector_distance !== undefined) {
+      vectorResults.push({ ...row, distance: c.vector_distance });
+    }
+    if (c.bm25_score !== undefined) {
+      ftsResults.push({ ...row, bm25_score: c.bm25_score });
+    }
+  }
+
+  const { scored, fusionMax } = hybridScoreFusion(vectorResults, ftsResults, allMemories);
+  for (const mem of scored) {
+    mem.compositeScore = computeCompositeScore(mem, now, fusionMax || 1);
+  }
+  return scored;
+}
+
+// ---------- Single-signal rankers ----------
+
+/**
+ * The key each single-signal ranker sorts by — higher = ranked first. These are
+ * intentionally trivial: they exist so the confound check can prove the
+ * composite isn't reducible to any one signal. Candidates missing a vector/bm25
+ * signal sort last for that variant (worst possible key).
+ */
+function signalKey(c: FixtureCandidate, variant: RankingVariant): number {
+  switch (variant) {
+    case 'recency-only':
+      return c.created_at;
+    case 'importance-only':
+      return c.importance;
+    case 'access-only':
+      return c.access_count;
+    case 'bm25-only':
+      // bm25 is negative (more negative = better) ⇒ negate so higher = better.
+      return c.bm25_score === undefined ? -Infinity : -c.bm25_score;
+    case 'vector-only':
+      // distance: lower = better ⇒ negate so higher = better.
+      return c.vector_distance === undefined ? -Infinity : -c.vector_distance;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Produce the ordered candidate list for a ranking variant. `composite` and
+ * `fusion-only` go through the production scorers; the single-signal variants
+ * sort by their trivial key. Ties break by `id` so the order is deterministic.
+ */
+export function rankCandidates(query: FixtureQuery, variant: RankingVariant, now: number): FixtureCandidate[] {
+  const byId = new Map(query.candidates.map((c) => [c.id, c]));
+
+  if (variant === 'composite' || variant === 'fusion-only') {
+    const scored = scoreFixtureQuery(query, now);
+    const key = variant === 'composite' ? (m: ScoredMemory) => m.compositeScore : (m: ScoredMemory) => m.fusionScore;
+    return [...scored]
+      .sort((a, b) => key(b) - key(a) || a.id.localeCompare(b.id))
+      .flatMap((m) => {
+        const c = byId.get(m.id);
+        return c ? [c] : [];
+      });
+  }
+
+  return [...query.candidates].sort(
+    (a, b) => signalKey(b, variant) - signalKey(a, variant) || a.id.localeCompare(b.id),
+  );
+}
+
+// ---------- recall@token-budget ----------
+
+/**
+ * Greedily pack the ranked candidates to the token budget (reusing the
+ * production `estimateTokens` + `packToBudget` skip-not-break semantics) and
+ * report whether the gold candidate landed in the packed set.
+ */
+export function recallAtBudget(query: FixtureQuery, ranked: FixtureCandidate[], budget: number): boolean {
+  const scored: ScoredMemory[] = ranked.map((c) => ({
+    ...candidateToRow(c),
+    fusionScore: 0,
+    compositeScore: 0,
+  }));
+  const packed = packToBudget(scored, budget);
+  return packed.some((m) => m.id === query.gold_id);
+}
+
+/** Mean recall@budget over all queries for one ranking variant. */
+export function meanRecallForVariant(
+  queries: readonly FixtureQuery[],
+  variant: RankingVariant,
+  budget: number,
+  now: number,
+): number {
+  if (queries.length === 0) return 0;
+  let hits = 0;
+  for (const query of queries) {
+    const ranked = rankCandidates(query, variant, now);
+    if (recallAtBudget(query, ranked, budget)) hits += 1;
+  }
+  return hits / queries.length;
+}
+
+/** recall@budget for every ranking variant. */
+export function recallTable(
+  queries: readonly FixtureQuery[],
+  budget: number,
+  now: number,
+): Record<RankingVariant, number> {
+  const table = {} as Record<RankingVariant, number>;
+  for (const variant of RANKING_VARIANTS) {
+    table[variant] = meanRecallForVariant(queries, variant, budget, now);
+  }
+  return table;
+}
+
+// ---------- Kendall-tau (ranking influence) ----------
+
+/**
+ * Kendall-tau rank correlation between two orderings of the same id set.
+ * +1 = identical order, -1 = reversed, 0 = uncorrelated. Tau well below 1.0
+ * between `composite` and `fusion-only` means the recency/importance terms are
+ * actively reshaping the ranking (the LIVE-lever test).
+ *
+ * Ids present in one ordering but not the other are dropped (we only compare the
+ * shared set). Returns 1.0 for sets of size < 2 (no pairs ⇒ trivially agreeing).
+ */
+export function kendallTau(orderA: readonly string[], orderB: readonly string[]): number {
+  const setB = new Set(orderB);
+  const common = orderA.filter((id) => setB.has(id));
+  const rankB = new Map<string, number>();
+  orderB.forEach((id, i) => rankB.set(id, i));
+
+  const n = common.length;
+  if (n < 2) return 1.0;
+
+  let concordant = 0;
+  let discordant = 0;
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      // In orderA, common[i] precedes common[j] by construction.
+      const bi = rankB.get(common[i]);
+      const bj = rankB.get(common[j]);
+      if (bi === undefined || bj === undefined) continue;
+      if (bi < bj) concordant += 1;
+      else discordant += 1;
+    }
+  }
+  const totalPairs = (n * (n - 1)) / 2;
+  if (totalPairs === 0) return 1.0;
+  return (concordant - discordant) / totalPairs;
+}
+
+/**
+ * Mean Kendall-tau between the `composite` and `fusion-only` per-query
+ * orderings across all queries. The anti-LoCoMo "reshapes rankings" signal.
+ */
+export function meanCompositeVsFusionTau(queries: readonly FixtureQuery[], now: number): number {
+  if (queries.length === 0) return 1.0;
+  let sum = 0;
+  for (const query of queries) {
+    const composite = rankCandidates(query, 'composite', now).map((c) => c.id);
+    const fusion = rankCandidates(query, 'fusion-only', now).map((c) => c.id);
+    sum += kendallTau(composite, fusion);
+  }
+  return sum / queries.length;
+}
+
+// ---------- Distributional summarizers ----------
+
+export interface NumericSummary {
+  count: number;
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  stddev: number | null;
+}
+
+/** min/max/mean/stddev (population) of a numeric array. Empty ⇒ all null. */
+export function summarizeNumeric(values: readonly number[]): NumericSummary {
+  if (values.length === 0) {
+    return { count: 0, min: null, max: null, mean: null, stddev: null };
+  }
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+  }
+  const mean = sum / values.length;
+  let sqDiff = 0;
+  for (const v of values) sqDiff += (v - mean) ** 2;
+  const stddev = Math.sqrt(sqDiff / values.length);
+  return { count: values.length, min, max, mean, stddev };
+}
+
+/** Percentiles (linear interpolation) of a numeric array at the given fractions [0,1]. */
+export function percentiles(values: readonly number[], fractions: readonly number[]): Record<string, number | null> {
+  const result: Record<string, number | null> = {};
+  if (values.length === 0) {
+    for (const f of fractions) result[`p${Math.round(f * 100)}`] = null;
+    return result;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  for (const f of fractions) {
+    const key = `p${Math.round(f * 100)}`;
+    const rank = f * (sorted.length - 1);
+    const lo = Math.floor(rank);
+    const hi = Math.ceil(rank);
+    result[key] = lo === hi ? sorted[lo] : sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+  }
+  return result;
+}
+
+/**
+ * Histogram of a numeric array into fixed-width buckets. Returns a label→count
+ * map; labels are the bucket's lower bound formatted to `decimals`. Values are
+ * assigned to `floor((v - origin) / width)`.
+ */
+export function histogram(values: readonly number[], width: number, origin = 0, decimals = 1): Record<string, number> {
+  const buckets: Record<string, number> = {};
+  for (const v of values) {
+    const idx = Math.floor((v - origin) / width);
+    const lower = origin + idx * width;
+    const label = lower.toFixed(decimals);
+    buckets[label] = (buckets[label] ?? 0) + 1;
+  }
+  return buckets;
+}
+
+// ---------- Recency-specific summaries ----------
+
+/** Convert an epoch-ms timestamp to a `YYYY-MM` (UTC) bucket label. */
+export function yearMonth(epochMs: number): string {
+  const d = new Date(epochMs);
+  const y = d.getUTCFullYear();
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+/** Convert an epoch-ms timestamp to a `YYYY-Qn` (UTC) quarter label. */
+export function yearQuarter(epochMs: number): string {
+  const d = new Date(epochMs);
+  const q = Math.floor(d.getUTCMonth() / 3) + 1;
+  return `${d.getUTCFullYear()}-Q${q}`;
+}
+
+export interface RecencySummary {
+  numeric: NumericSummary;
+  distinctYearMonths: number;
+  spanDays: number | null;
+  fractionByYear: Record<string, number>;
+  histogramByQuarter: Record<string, number>;
+}
+
+/** Recency distribution over an array of created_at epoch-ms timestamps. */
+export function summarizeRecency(createdAt: readonly number[]): RecencySummary {
+  const numeric = summarizeNumeric(createdAt);
+  const months = new Set(createdAt.map(yearMonth));
+  const byYear: Record<string, number> = {};
+  for (const ts of createdAt) {
+    const y = String(new Date(ts).getUTCFullYear());
+    byYear[y] = (byYear[y] ?? 0) + 1;
+  }
+  const fractionByYear: Record<string, number> = {};
+  for (const [y, n] of Object.entries(byYear)) {
+    fractionByYear[y] = createdAt.length === 0 ? 0 : n / createdAt.length;
+  }
+  const histogramByQuarter: Record<string, number> = {};
+  for (const ts of createdAt) {
+    const q = yearQuarter(ts);
+    histogramByQuarter[q] = (histogramByQuarter[q] ?? 0) + 1;
+  }
+  const spanDays =
+    numeric.min !== null && numeric.max !== null ? (numeric.max - numeric.min) / (1000 * 60 * 60 * 24) : null;
+  return { numeric, distinctYearMonths: months.size, spanDays, fractionByYear, histogramByQuarter };
+}
+
+export interface ImportanceSummary {
+  numeric: NumericSummary;
+  distinctValues: number;
+  fractionAtSeed: number;
+  histogram: Record<string, number>;
+}
+
+/** The seed importance value the engine stamps before extraction overrides it. */
+export const IMPORTANCE_SEED = 0.5;
+
+/** Importance distribution, including the fraction sitting EXACTLY at the seed. */
+export function summarizeImportance(importance: readonly number[]): ImportanceSummary {
+  const numeric = summarizeNumeric(importance);
+  const distinct = new Set(importance).size;
+  const atSeed = importance.filter((v) => v === IMPORTANCE_SEED).length;
+  return {
+    numeric,
+    distinctValues: distinct,
+    fractionAtSeed: importance.length === 0 ? 0 : atSeed / importance.length,
+    histogram: histogram(importance, 0.1, 0, 1),
+  };
+}
+
+// ---------- Stratified sampler ----------
+
+/**
+ * Small deterministic PRNG (mulberry32) so sampling is reproducible across runs
+ * given a `--seed`. Math.random is fine in a script, but the diagnostic must be
+ * re-runnable to the same sample for comparison.
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** A row eligible for sampling — only the bucketing key matters here. */
+export interface SampleRow {
+  id: string;
+  created_at: number;
+}
+
+/**
+ * Stratified sample of `total` ids across recency buckets so older years are
+ * represented, not just recent ones. Rows are bucketed by `bucketOf` (default:
+ * calendar year). The target per bucket is `total / numBuckets`; under-filled
+ * buckets donate their slack to the others via a second pass. Sampling within a
+ * bucket and bucket-fill order are driven by the seeded PRNG, so re-runs with
+ * the same seed produce the same sample.
+ */
+export function stratifiedSample(
+  rows: readonly SampleRow[],
+  total: number,
+  rng: () => number,
+  bucketOf: (row: SampleRow) => string = (r) => String(new Date(r.created_at).getUTCFullYear()),
+): string[] {
+  if (total <= 0 || rows.length === 0) return [];
+
+  const byBucket = new Map<string, SampleRow[]>();
+  for (const row of rows) {
+    const key = bucketOf(row);
+    const list = byBucket.get(key) ?? [];
+    list.push(row);
+    byBucket.set(key, list);
+  }
+
+  // Shuffle within each bucket deterministically.
+  const buckets = [...byBucket.entries()].sort(([a], [b]) => a.localeCompare(b));
+  for (const [, list] of buckets) shuffleInPlace(list, rng);
+
+  const cap = Math.min(total, rows.length);
+  const perBucket = Math.max(1, Math.floor(cap / buckets.length));
+
+  // First pass: take up to perBucket from each bucket.
+  const selected: string[] = [];
+  const remaining = new Map<string, SampleRow[]>();
+  for (const [key, list] of buckets) {
+    const take = Math.min(perBucket, list.length);
+    for (let i = 0; i < take; i += 1) selected.push(list[i].id);
+    remaining.set(key, list.slice(take));
+  }
+
+  // Second pass: round-robin the leftover slots from buckets that still have rows.
+  const leftover = buckets.flatMap(([key]) => remaining.get(key) ?? []);
+  shuffleInPlace(leftover, rng);
+  for (const row of leftover) {
+    if (selected.length >= cap) break;
+    selected.push(row.id);
+  }
+
+  return selected.slice(0, cap);
+}
+
+function shuffleInPlace(arr: SampleRow[], rng: () => number): void {
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+// ---------- Verdict ----------
+
+/** Thresholds for the GO/NO-GO verdict — printed alongside the result. */
+export interface VerdictThresholds {
+  minDistinctYearMonths: number;
+  minRecencyStddevDays: number;
+  minImportanceStddev: number;
+  maxFractionAtSeed: number;
+  maxReshapeTau: number;
+}
+
+export const DEFAULT_THRESHOLDS: VerdictThresholds = {
+  minDistinctYearMonths: 12,
+  minRecencyStddevDays: 30,
+  minImportanceStddev: 0.05,
+  maxFractionAtSeed: 0.5,
+  maxReshapeTau: 0.9,
+};
+
+export interface VerdictInputs {
+  recency: RecencySummary;
+  importance: ImportanceSummary;
+  reshapeTau: number;
+  recallTable: Record<RankingVariant, number>;
+}
+
+export interface VerdictResult {
+  go: boolean;
+  recencyLive: boolean;
+  importanceLive: boolean;
+  reshapesRankings: boolean;
+  notSingleSignalConfound: boolean;
+  /** Names of the conditions that FAILED — empty on GO. */
+  failedConditions: string[];
+  thresholds: VerdictThresholds;
+}
+
+/**
+ * The GO/NO-GO verdict. GO iff the three core anti-LoCoMo conditions hold:
+ *   recency_live AND importance_live AND reshapes_rankings.
+ *
+ * `not_single_signal_confound` (composite ≥ every single-signal baseline) is
+ * SUPPORTING evidence reported in the result but does NOT gate the verdict —
+ * the core question is whether the metadata signals are alive and move order,
+ * not whether composite beats every trivial ranker on a tiny probe. Access being
+ * dead (zero on a fresh corpus) is EXPECTED and does not fail the verdict.
+ */
+export function evaluateVerdict(
+  inputs: VerdictInputs,
+  thresholds: VerdictThresholds = DEFAULT_THRESHOLDS,
+): VerdictResult {
+  const { recency, importance, reshapeTau } = inputs;
+
+  const recencyStddevDays = recency.numeric.stddev === null ? 0 : recency.numeric.stddev / (1000 * 60 * 60 * 24);
+  const recencyLive =
+    (recency.spanDays ?? 0) > 365 &&
+    recency.distinctYearMonths >= thresholds.minDistinctYearMonths &&
+    recencyStddevDays >= thresholds.minRecencyStddevDays;
+
+  const importanceStddev = importance.numeric.stddev ?? 0;
+  const importanceLive =
+    importanceStddev >= thresholds.minImportanceStddev && importance.fractionAtSeed < thresholds.maxFractionAtSeed;
+
+  const reshapesRankings = reshapeTau < thresholds.maxReshapeTau;
+
+  const composite = inputs.recallTable.composite;
+  const notSingleSignalConfound = SINGLE_SIGNAL_VARIANTS.every((v) => composite >= inputs.recallTable[v]);
+
+  const failedConditions: string[] = [];
+  if (!recencyLive) failedConditions.push('recency_live');
+  if (!importanceLive) failedConditions.push('importance_live');
+  if (!reshapesRankings) failedConditions.push('reshapes_rankings');
+
+  const go = recencyLive && importanceLive && reshapesRankings;
+
+  return {
+    go,
+    recencyLive,
+    importanceLive,
+    reshapesRankings,
+    notSingleSignalConfound,
+    failedConditions,
+    thresholds,
+  };
+}

--- a/scripts/memory-corpus/diagnose-lib.ts
+++ b/scripts/memory-corpus/diagnose-lib.ts
@@ -109,6 +109,7 @@ function candidateToRow(c: FixtureCandidate): MemoryRow {
     consolidated: 1,
     source: null,
     metadata: null,
+    segment_id: null,
   };
 }
 

--- a/scripts/show-system-prompt.ts
+++ b/scripts/show-system-prompt.ts
@@ -10,7 +10,7 @@ import 'dotenv/config';
 import { loadConfig } from '../src/config/index.js';
 import { toCallableName, extractRequiredParams } from '../src/sandbox/index.js';
 import { buildSystemPrompt } from '../src/session/prompts.js';
-import { claudeCodeAdapter } from '../src/docker/adapters/claude-code.js';
+import { createClaudeCodeAdapter } from '../src/docker/adapters/claude-code.js';
 import { extractAllowedDomains } from '../src/docker/orientation.js';
 import { CONTAINER_WORKSPACE_DIR, type OrientationContext } from '../src/docker/agent-adapter.js';
 import { discoverTools, buildServerListings } from './mcp-discovery.js';
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
     allowedDomains: extractAllowedDomains(config),
     networkMode: 'none',
   };
-  const dockerPrompt = claudeCodeAdapter.buildSystemPrompt(orientationContext);
+  const dockerPrompt = createClaudeCodeAdapter().buildSystemPrompt(orientationContext);
 
   // --- Print all ---
   const separator = '='.repeat(72);

--- a/test/build-corpus.test.ts
+++ b/test/build-corpus.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  assembleTranscript,
+  isEmptyConversation,
+  buildSource,
+  resolveAsOf,
+  buildProgressRecord,
+  buildEmptyProgressRecord,
+  computeResumeSet,
+  parseArgs,
+  DEFAULT_ARGS,
+  type ExportConversation,
+  type ProgressRecord,
+  type IngestResultLike,
+} from '../scripts/memory-corpus/corpus-lib.js';
+
+// ---------- Synthetic fixtures (NOT real export data) ----------
+
+function conv(overrides: Partial<ExportConversation> = {}): ExportConversation {
+  return {
+    uuid: 'conv-1',
+    created_at: '2023-05-01T12:00:00.000Z',
+    chat_messages: [
+      { uuid: 'm1', sender: 'human', text: 'I prefer dark mode.' },
+      { uuid: 'm2', sender: 'assistant', text: 'Noted, dark mode it is.' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('assembleTranscript', () => {
+  it('labels each line with the sender and joins with newlines', () => {
+    expect(assembleTranscript(conv())).toBe('human: I prefer dark mode.\nassistant: Noted, dark mode it is.');
+  });
+
+  it('drops messages whose text is empty or whitespace-only', () => {
+    const c = conv({
+      chat_messages: [
+        { uuid: 'm1', sender: 'human', text: 'keep me' },
+        { uuid: 'm2', sender: 'assistant', text: '' },
+        { uuid: 'm3', sender: 'human', text: '   ' },
+        { uuid: 'm4', sender: 'assistant', text: 'keep me too' },
+      ],
+    });
+    expect(assembleTranscript(c)).toBe('human: keep me\nassistant: keep me too');
+  });
+
+  it('uses `text`, never `content`', () => {
+    // A message carrying only structured `content` (no usable text) is dropped.
+    const c = conv({
+      chat_messages: [
+        { uuid: 'm1', sender: 'human', text: '', content: [{ type: 'text', text: 'from content' }] } as never,
+        { uuid: 'm2', sender: 'assistant', text: 'from text' },
+      ],
+    });
+    const transcript = assembleTranscript(c);
+    expect(transcript).toBe('assistant: from text');
+    expect(transcript).not.toContain('from content');
+  });
+});
+
+describe('isEmptyConversation', () => {
+  it('is false when at least one message has non-empty text', () => {
+    expect(isEmptyConversation(conv())).toBe(false);
+  });
+
+  it('is true when there are no messages', () => {
+    expect(isEmptyConversation(conv({ chat_messages: [] }))).toBe(true);
+  });
+
+  it('is true when all messages have empty/whitespace text', () => {
+    const c = conv({
+      chat_messages: [
+        { uuid: 'm1', sender: 'human', text: '' },
+        { uuid: 'm2', sender: 'assistant', text: '  ' },
+      ],
+    });
+    expect(isEmptyConversation(c)).toBe(true);
+  });
+});
+
+describe('buildSource', () => {
+  it('formats the provenance string as claude-export:<uuid>', () => {
+    expect(buildSource('3f2a-abc')).toBe('claude-export:3f2a-abc');
+  });
+});
+
+describe('resolveAsOf (created_at is the backdate source)', () => {
+  it('resolves an ISO 8601 created_at to its epoch-ms (not now)', () => {
+    // The driver passes resolveAsOf(conv.created_at) as as_of; this asserts the
+    // contract that created_at is the source-of-truth timestamp, not now.
+    const c = conv({ created_at: '2024-02-29T08:30:00.000Z' });
+    expect(resolveAsOf(c.created_at)).toBe(Date.UTC(2024, 1, 29, 8, 30, 0));
+  });
+
+  it('returns undefined for an unparseable or missing created_at (engine falls back to now)', () => {
+    expect(resolveAsOf('not a date')).toBeUndefined();
+    expect(resolveAsOf('')).toBeUndefined();
+    expect(resolveAsOf(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildProgressRecord', () => {
+  function result(overrides: Partial<IngestResultLike> = {}): IngestResultLike {
+    return { created: 5, merged: 2, facts: { length: 7 }, ...overrides };
+  }
+
+  it('records counts only (no fact text)', () => {
+    const record = buildProgressRecord('conv-9', result({ chunks: 3, failed_chunks: 0 }));
+    expect(record).toEqual({
+      uuid: 'conv-9',
+      status: 'ingested',
+      created: 5,
+      merged: 2,
+      facts: 7,
+      failed_chunks: 0,
+      chunks: 3,
+    });
+  });
+
+  it('marks status=partial when partial is set', () => {
+    const record = buildProgressRecord('c', result({ partial: true, failed_chunks: 1, chunks: 2 }));
+    expect(record.status).toBe('partial');
+    expect(record.failed_chunks).toBe(1);
+  });
+
+  it('marks status=skipped-failed when skipped is set', () => {
+    const record = buildProgressRecord('c', result({ skipped: true, created: 0, merged: 0, facts: { length: 0 } }));
+    expect(record.status).toBe('skipped-failed');
+  });
+
+  it('defaults chunks to 1 and failed_chunks to 0 when omitted', () => {
+    const record = buildProgressRecord('c', result());
+    expect(record.chunks).toBe(1);
+    expect(record.failed_chunks).toBe(0);
+  });
+
+  it('buildEmptyProgressRecord produces a zeroed skipped-empty record', () => {
+    expect(buildEmptyProgressRecord('e')).toEqual({
+      uuid: 'e',
+      status: 'skipped-empty',
+      created: 0,
+      merged: 0,
+      facts: 0,
+      failed_chunks: 0,
+      chunks: 0,
+    });
+  });
+});
+
+describe('computeResumeSet', () => {
+  const records: ProgressRecord[] = [
+    { uuid: 'done-ingested', status: 'ingested', created: 3, merged: 0, facts: 3, failed_chunks: 0, chunks: 1 },
+    { uuid: 'done-partial', status: 'partial', created: 1, merged: 0, facts: 1, failed_chunks: 1, chunks: 2 },
+    { uuid: 'done-empty', status: 'skipped-empty', created: 0, merged: 0, facts: 0, failed_chunks: 0, chunks: 0 },
+    { uuid: 'retry-failed', status: 'skipped-failed', created: 0, merged: 0, facts: 0, failed_chunks: 1, chunks: 1 },
+  ];
+
+  it('skips ingested, partial, and skipped-empty; retries skipped-failed', () => {
+    const skip = computeResumeSet(records);
+    expect(skip.has('done-ingested')).toBe(true);
+    expect(skip.has('done-partial')).toBe(true);
+    expect(skip.has('done-empty')).toBe(true);
+    expect(skip.has('retry-failed')).toBe(false);
+  });
+
+  it('treats a uuid as done if any of its records is done, even if a prior attempt failed', () => {
+    const withRetry: ProgressRecord[] = [
+      { uuid: 'x', status: 'skipped-failed', created: 0, merged: 0, facts: 0, failed_chunks: 1, chunks: 1 },
+      { uuid: 'x', status: 'ingested', created: 2, merged: 0, facts: 2, failed_chunks: 0, chunks: 1 },
+    ];
+    expect(computeResumeSet(withRetry).has('x')).toBe(true);
+  });
+
+  it('returns an empty set for no records', () => {
+    expect(computeResumeSet([]).size).toBe(0);
+  });
+});
+
+describe('parseArgs', () => {
+  it('applies defaults when no flags are given', () => {
+    const args = parseArgs([]);
+    expect(args.exportPath).toBe(DEFAULT_ARGS.exportPath);
+    expect(args.dbPath).toBe(DEFAULT_ARGS.dbPath);
+    expect(args.namespace).toBe(DEFAULT_ARGS.namespace);
+    expect(args.dryRun).toBe(false);
+    expect(args.resume).toBe(false);
+    expect(args.limit).toBeUndefined();
+    expect(args.conversation).toBeUndefined();
+  });
+
+  it('parses value flags', () => {
+    const args = parseArgs([
+      '--export',
+      '/tmp/e.json',
+      '--db',
+      '/tmp/m.memdb',
+      '--namespace',
+      'ns',
+      '--conversation',
+      'abc-123',
+    ]);
+    expect(args.exportPath).toBe('/tmp/e.json');
+    expect(args.dbPath).toBe('/tmp/m.memdb');
+    expect(args.namespace).toBe('ns');
+    expect(args.conversation).toBe('abc-123');
+  });
+
+  it('parses boolean flags', () => {
+    const args = parseArgs(['--dry-run', '--resume']);
+    expect(args.dryRun).toBe(true);
+    expect(args.resume).toBe(true);
+  });
+
+  it('parses --limit as a positive integer', () => {
+    expect(parseArgs(['--limit', '3']).limit).toBe(3);
+  });
+
+  it('rejects a non-positive or non-integer --limit', () => {
+    expect(() => parseArgs(['--limit', '0'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--limit', '-1'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--limit', 'abc'])).toThrow(/positive integer/);
+  });
+
+  it('throws when a value flag is missing its value', () => {
+    expect(() => parseArgs(['--db'])).toThrow(/requires a value/);
+    expect(() => parseArgs(['--db', '--resume'])).toThrow(/requires a value/);
+  });
+
+  it('throws on an unknown flag', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/Unknown flag/);
+  });
+
+  it('sets help for --help and -h', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+});

--- a/test/diagnose-corpus.test.ts
+++ b/test/diagnose-corpus.test.ts
@@ -1,0 +1,549 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  summarizeNumeric,
+  percentiles,
+  histogram,
+  summarizeRecency,
+  summarizeImportance,
+  yearMonth,
+  yearQuarter,
+  rankCandidates,
+  recallAtBudget,
+  recallTable,
+  meanRecallForVariant,
+  kendallTau,
+  meanCompositeVsFusionTau,
+  stratifiedSample,
+  mulberry32,
+  evaluateVerdict,
+  DEFAULT_THRESHOLDS,
+  type FixtureCandidate,
+  type FixtureQuery,
+  type SampleRow,
+} from '../scripts/memory-corpus/diagnose-lib.js';
+
+// ---------- Synthetic fixture helpers (NOT real corpus data) ----------
+
+const NOW = Date.UTC(2026, 0, 1); // fixed reference time for deterministic decay
+const DAY = 24 * 60 * 60 * 1000;
+const YEAR = 365 * DAY;
+
+function candidate(overrides: Partial<FixtureCandidate> = {}): FixtureCandidate {
+  return {
+    id: 'c0',
+    is_gold: false,
+    vector_distance: 0.4,
+    bm25_score: -3,
+    created_at: NOW - YEAR,
+    last_accessed_at: NOW - YEAR,
+    access_count: 0,
+    importance: 0.5,
+    content_length: 80,
+    ...overrides,
+  };
+}
+
+/**
+ * A LoCoMo-shaped degenerate query: all importance ≡ 0.5, all created_at
+ * identical, access ≡ 0. The only thing that differs between candidates is the
+ * retrieval signal (vector/bm25) — so composite and fusion-only MUST produce the
+ * same order (tau = 1, reshapes_rankings = false).
+ */
+function degenerateQuery(idx: number): FixtureQuery {
+  const created = Date.UTC(2024, 5, 15); // identical for every candidate
+  const candidates: FixtureCandidate[] = [0, 1, 2, 3, 4].map((i) => ({
+    id: `q${idx}-c${i}`,
+    is_gold: i === 0,
+    vector_distance: 0.2 + i * 0.1,
+    bm25_score: -10 + i * 2,
+    created_at: created,
+    last_accessed_at: created,
+    access_count: 0,
+    importance: 0.5,
+    content_length: 60,
+  }));
+  return { query_id: `q${idx}`, gold_id: `q${idx}-c0`, candidates };
+}
+
+/**
+ * A healthy query: importance and recency VARY in a way that should reorder the
+ * pool versus fusion-only. The gold candidate has a mediocre retrieval signal
+ * but high importance + strong recency, so composite should lift it above
+ * fusion-only neighbours — reshaping the ranking (tau < 1).
+ */
+function healthyQuery(idx: number): FixtureQuery {
+  const candidates: FixtureCandidate[] = [
+    // gold: near-top retrieval AND very recent + very important
+    {
+      id: `q${idx}-gold`,
+      is_gold: true,
+      vector_distance: 0.22,
+      bm25_score: -11,
+      created_at: NOW - 10 * DAY,
+      last_accessed_at: NOW - 10 * DAY,
+      access_count: 0,
+      importance: 0.95,
+      content_length: 70,
+    },
+    // BEST fusion but OLD + LOW importance — composite's metadata terms should
+    // drop it below gold, reshaping the order (the LIVE-lever signal).
+    {
+      id: `q${idx}-a`,
+      is_gold: false,
+      vector_distance: 0.2,
+      bm25_score: -12,
+      created_at: NOW - 4 * YEAR,
+      last_accessed_at: NOW - 4 * YEAR,
+      access_count: 0,
+      importance: 0.3,
+      content_length: 70,
+    },
+    {
+      id: `q${idx}-b`,
+      is_gold: false,
+      vector_distance: 0.5,
+      bm25_score: -6,
+      created_at: NOW - 2 * YEAR,
+      last_accessed_at: NOW - 2 * YEAR,
+      access_count: 0,
+      importance: 0.4,
+      content_length: 70,
+    },
+    {
+      id: `q${idx}-c`,
+      is_gold: false,
+      vector_distance: 0.6,
+      bm25_score: -3,
+      created_at: NOW - 3 * YEAR,
+      last_accessed_at: NOW - 3 * YEAR,
+      access_count: 0,
+      importance: 0.6,
+      content_length: 70,
+    },
+  ];
+  return { query_id: `q${idx}`, gold_id: `q${idx}-gold`, candidates };
+}
+
+// ---------- summarizeNumeric ----------
+
+describe('summarizeNumeric', () => {
+  it('returns all-null for an empty array', () => {
+    expect(summarizeNumeric([])).toEqual({ count: 0, min: null, max: null, mean: null, stddev: null });
+  });
+
+  it('computes min/max/mean/population-stddev', () => {
+    const s = summarizeNumeric([2, 4, 4, 4, 5, 5, 7, 9]);
+    expect(s.min).toBe(2);
+    expect(s.max).toBe(9);
+    expect(s.mean).toBe(5);
+    expect(s.stddev).toBeCloseTo(2, 6); // textbook population stddev = 2
+  });
+
+  it('reports zero stddev for constant input', () => {
+    expect(summarizeNumeric([0.5, 0.5, 0.5]).stddev).toBe(0);
+  });
+});
+
+describe('percentiles', () => {
+  it('interpolates linearly between ranks', () => {
+    const p = percentiles([0, 10, 20, 30, 40], [0, 0.5, 1]);
+    expect(p.p0).toBe(0);
+    expect(p.p50).toBe(20);
+    expect(p.p100).toBe(40);
+  });
+
+  it('returns null per fraction for empty input', () => {
+    expect(percentiles([], [0.5, 0.9])).toEqual({ p50: null, p90: null });
+  });
+});
+
+describe('histogram', () => {
+  it('buckets values into fixed-width bins', () => {
+    const h = histogram([0.0, 0.05, 0.12, 0.55, 0.95], 0.1, 0, 1);
+    expect(h['0.0']).toBe(2); // 0.0 and 0.05
+    expect(h['0.1']).toBe(1); // 0.12
+    expect(h['0.5']).toBe(1); // 0.55
+    expect(h['0.9']).toBe(1); // 0.95
+  });
+});
+
+// ---------- recency / importance summarizers ----------
+
+describe('yearMonth / yearQuarter', () => {
+  it('formats UTC year-month and quarter labels', () => {
+    const ts = Date.UTC(2024, 7, 9); // August 2024 ⇒ Q3
+    expect(yearMonth(ts)).toBe('2024-08');
+    expect(yearQuarter(ts)).toBe('2024-Q3');
+  });
+});
+
+describe('summarizeRecency', () => {
+  it('counts distinct year-months and computes a multi-year span', () => {
+    const ts = [Date.UTC(2023, 0, 1), Date.UTC(2023, 5, 1), Date.UTC(2024, 0, 1), Date.UTC(2025, 11, 1)];
+    const s = summarizeRecency(ts);
+    expect(s.distinctYearMonths).toBe(4);
+    expect(s.spanDays).not.toBeNull();
+    expect(s.spanDays as number).toBeGreaterThan(365 * 2);
+    expect(Object.keys(s.fractionByYear).sort()).toEqual(['2023', '2024', '2025']);
+    expect(s.fractionByYear['2023']).toBeCloseTo(0.5, 6);
+  });
+
+  it('collapses to a single year-month for identical timestamps (LoCoMo-shaped)', () => {
+    const same = Date.UTC(2024, 5, 15);
+    const s = summarizeRecency([same, same, same, same]);
+    expect(s.distinctYearMonths).toBe(1);
+    expect(s.spanDays).toBe(0);
+    expect(s.numeric.stddev).toBe(0);
+  });
+});
+
+describe('summarizeImportance', () => {
+  it('reports distinct values and the fraction exactly at the 0.5 seed', () => {
+    const s = summarizeImportance([0.5, 0.5, 0.7, 0.9]);
+    expect(s.distinctValues).toBe(3);
+    expect(s.fractionAtSeed).toBeCloseTo(0.5, 6);
+    expect(s.numeric.stddev as number).toBeGreaterThan(0);
+  });
+
+  it('flags a fully-flat (all-0.5) distribution', () => {
+    const s = summarizeImportance([0.5, 0.5, 0.5, 0.5]);
+    expect(s.distinctValues).toBe(1);
+    expect(s.fractionAtSeed).toBe(1);
+    expect(s.numeric.stddev).toBe(0);
+  });
+});
+
+// ---------- single-signal rankers ----------
+
+describe('rankCandidates single-signal variants', () => {
+  const q: FixtureQuery = {
+    query_id: 'q',
+    gold_id: 'hi-imp',
+    candidates: [
+      candidate({
+        id: 'old-recent',
+        created_at: NOW - 2 * YEAR,
+        importance: 0.3,
+        access_count: 1,
+        vector_distance: 0.5,
+        bm25_score: -2,
+      }),
+      candidate({
+        id: 'new-recent',
+        created_at: NOW - 1 * DAY,
+        importance: 0.4,
+        access_count: 0,
+        vector_distance: 0.6,
+        bm25_score: -1,
+      }),
+      candidate({
+        id: 'hi-imp',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.9,
+        access_count: 0,
+        vector_distance: 0.55,
+        bm25_score: -3,
+      }),
+      candidate({
+        id: 'hi-access',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.5,
+        access_count: 9,
+        vector_distance: 0.7,
+        bm25_score: -1,
+      }),
+      candidate({
+        id: 'close-vec',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.5,
+        access_count: 0,
+        vector_distance: 0.1,
+        bm25_score: -0.5,
+      }),
+      candidate({
+        id: 'top-bm25',
+        created_at: NOW - 1 * YEAR,
+        importance: 0.5,
+        access_count: 0,
+        vector_distance: 0.8,
+        bm25_score: -20,
+      }),
+    ],
+  };
+
+  it('recency-only ranks the newest first', () => {
+    expect(rankCandidates(q, 'recency-only', NOW)[0].id).toBe('new-recent');
+  });
+
+  it('importance-only ranks the most important first', () => {
+    expect(rankCandidates(q, 'importance-only', NOW)[0].id).toBe('hi-imp');
+  });
+
+  it('access-only ranks the most accessed first', () => {
+    expect(rankCandidates(q, 'access-only', NOW)[0].id).toBe('hi-access');
+  });
+
+  it('vector-only ranks the closest (smallest distance) first', () => {
+    expect(rankCandidates(q, 'vector-only', NOW)[0].id).toBe('close-vec');
+  });
+
+  it('bm25-only ranks the most-negative bm25 first', () => {
+    expect(rankCandidates(q, 'bm25-only', NOW)[0].id).toBe('top-bm25');
+  });
+
+  it('is deterministic (ties break by id)', () => {
+    const a = rankCandidates(q, 'importance-only', NOW).map((c) => c.id);
+    const b = rankCandidates(q, 'importance-only', NOW).map((c) => c.id);
+    expect(a).toEqual(b);
+  });
+});
+
+// ---------- recall@budget ----------
+
+describe('recallAtBudget', () => {
+  const q = healthyQuery(0);
+
+  it('reports gold present when the budget fits the gold-containing top set', () => {
+    const ranked = rankCandidates(q, 'composite', NOW);
+    // Budget large enough to pack everything ⇒ gold is present.
+    expect(recallAtBudget(q, ranked, 1000)).toBe(true);
+  });
+
+  it('reports gold absent when the budget is too small to reach gold', () => {
+    // Rank gold last, then a budget that fits only the first candidate ⇒ gold absent.
+    const ranked = [...q.candidates].sort((a, b) => (a.is_gold ? 1 : 0) - (b.is_gold ? 1 : 0));
+    // First candidate is 70 chars ≈ 18 tokens; budget 20 fits only one ⇒ gold (last) excluded.
+    expect(recallAtBudget(q, ranked, 20)).toBe(false);
+  });
+
+  it('packs with skip-not-break: a small later item still fits', () => {
+    const q2: FixtureQuery = {
+      query_id: 'q2',
+      gold_id: 'small-gold',
+      candidates: [
+        candidate({ id: 'big', is_gold: false, content_length: 400 }),
+        candidate({ id: 'small-gold', is_gold: true, content_length: 8 }),
+      ],
+    };
+    // budget 20 tokens: 'big' is ~100 tokens (skip), 'small-gold' is ~2 tokens (fits).
+    expect(recallAtBudget(q2, q2.candidates, 20)).toBe(true);
+  });
+});
+
+// ---------- Kendall-tau ----------
+
+describe('kendallTau', () => {
+  it('is +1 for identical orderings', () => {
+    expect(kendallTau(['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'd'])).toBe(1);
+  });
+
+  it('is -1 for fully reversed orderings', () => {
+    expect(kendallTau(['a', 'b', 'c', 'd'], ['d', 'c', 'b', 'a'])).toBe(-1);
+  });
+
+  it('is between -1 and 1 for a partial swap', () => {
+    const tau = kendallTau(['a', 'b', 'c', 'd'], ['a', 'c', 'b', 'd']);
+    expect(tau).toBeGreaterThan(-1);
+    expect(tau).toBeLessThan(1);
+  });
+
+  it('returns 1 for sets with fewer than two shared elements', () => {
+    expect(kendallTau(['a'], ['a'])).toBe(1);
+    expect(kendallTau([], [])).toBe(1);
+  });
+});
+
+describe('meanCompositeVsFusionTau', () => {
+  it('is exactly 1 for degenerate queries (metadata is flat, no reshaping)', () => {
+    const queries = [degenerateQuery(0), degenerateQuery(1), degenerateQuery(2)];
+    expect(meanCompositeVsFusionTau(queries, NOW)).toBeCloseTo(1, 6);
+  });
+
+  it('is below 1 for healthy queries (recency/importance reshape order)', () => {
+    const queries = [healthyQuery(0), healthyQuery(1), healthyQuery(2)];
+    expect(meanCompositeVsFusionTau(queries, NOW)).toBeLessThan(1);
+  });
+});
+
+// ---------- recall table ----------
+
+describe('recallTable', () => {
+  it('produces a recall value for every ranking variant', () => {
+    const queries = [healthyQuery(0), healthyQuery(1)];
+    const table = recallTable(queries, 300, NOW);
+    for (const v of [
+      'composite',
+      'fusion-only',
+      'recency-only',
+      'importance-only',
+      'access-only',
+      'bm25-only',
+      'vector-only',
+    ] as const) {
+      expect(table[v]).toBeGreaterThanOrEqual(0);
+      expect(table[v]).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('composite recalls the recency/importance-favored gold the single retrieval signals miss at tight budget', () => {
+    // At a tight budget the gold (weak vector/bm25) is only recalled when the
+    // metadata terms lift it — composite should beat fusion/vector/bm25-only.
+    const queries = [healthyQuery(0), healthyQuery(1), healthyQuery(2)];
+    const budget = 20; // ~18 tokens per 70-char fact ⇒ only one candidate fits
+    expect(meanRecallForVariant(queries, 'composite', budget, NOW)).toBe(1);
+    expect(meanRecallForVariant(queries, 'fusion-only', budget, NOW)).toBeLessThan(1);
+  });
+});
+
+// ---------- stratified sampler ----------
+
+describe('stratifiedSample', () => {
+  function rowsAcrossYears(): SampleRow[] {
+    const rows: SampleRow[] = [];
+    for (const year of [2023, 2024, 2025, 2026]) {
+      for (let i = 0; i < 20; i += 1) {
+        rows.push({ id: `${year}-${i}`, created_at: Date.UTC(year, i % 12, 1) });
+      }
+    }
+    return rows;
+  }
+
+  it('covers every recency bucket (no year left unrepresented)', () => {
+    const rows = rowsAcrossYears();
+    const sample = stratifiedSample(rows, 12, mulberry32(42));
+    const years = new Set(sample.map((id) => id.split('-')[0]));
+    expect(years).toEqual(new Set(['2023', '2024', '2025', '2026']));
+  });
+
+  it('is deterministic for a fixed seed', () => {
+    const rows = rowsAcrossYears();
+    const a = stratifiedSample(rows, 12, mulberry32(7));
+    const b = stratifiedSample(rows, 12, mulberry32(7));
+    expect(a).toEqual(b);
+  });
+
+  it('produces a different sample for a different seed', () => {
+    const rows = rowsAcrossYears();
+    const a = stratifiedSample(rows, 12, mulberry32(7));
+    const b = stratifiedSample(rows, 12, mulberry32(99));
+    expect(a).not.toEqual(b);
+  });
+
+  it('never exceeds the requested total or the available rows', () => {
+    const rows = rowsAcrossYears();
+    expect(stratifiedSample(rows, 12, mulberry32(1)).length).toBe(12);
+    expect(stratifiedSample(rows, 10000, mulberry32(1)).length).toBe(rows.length);
+  });
+
+  it('returns empty for total <= 0 or no rows', () => {
+    expect(stratifiedSample(rowsAcrossYears(), 0, mulberry32(1))).toEqual([]);
+    expect(stratifiedSample([], 5, mulberry32(1))).toEqual([]);
+  });
+});
+
+// ---------- VERDICT: the anti-vacuity proof ----------
+
+describe('evaluateVerdict — degenerate (LoCoMo-like) corpus → NO-GO', () => {
+  // All importance 0.5, all created_at identical, access 0. The diagnostic must
+  // FAIL this — it is exactly the corpus shape that made the metadata terms dead
+  // weight in the LoCoMo benchmark.
+  const sameTs = Date.UTC(2024, 5, 15);
+  const flatCreatedAt = Array.from({ length: 200 }, () => sameTs);
+  const flatImportance = Array.from({ length: 200 }, () => 0.5);
+  const queries = [degenerateQuery(0), degenerateQuery(1), degenerateQuery(2)];
+
+  const verdict = evaluateVerdict({
+    recency: summarizeRecency(flatCreatedAt),
+    importance: summarizeImportance(flatImportance),
+    reshapeTau: meanCompositeVsFusionTau(queries, NOW),
+    recallTable: recallTable(queries, 300, NOW),
+  });
+
+  it('returns NO-GO', () => {
+    expect(verdict.go).toBe(false);
+  });
+
+  it('fails importance_live (flat importance ≡ 0.5)', () => {
+    expect(verdict.importanceLive).toBe(false);
+    expect(verdict.failedConditions).toContain('importance_live');
+  });
+
+  it('fails reshapes_rankings (tau ≈ 1: metadata moves nothing)', () => {
+    expect(verdict.reshapesRankings).toBe(false);
+    expect(verdict.failedConditions).toContain('reshapes_rankings');
+  });
+
+  it('fails recency_live (identical created_at ⇒ no span, one year-month)', () => {
+    expect(verdict.recencyLive).toBe(false);
+    expect(verdict.failedConditions).toContain('recency_live');
+  });
+});
+
+describe('evaluateVerdict — healthy corpus → GO', () => {
+  // Multi-year recency + varied importance that reshapes rankings.
+  function healthyCreatedAt(): number[] {
+    const ts: number[] = [];
+    for (let year = 2023; year <= 2026; year += 1) {
+      for (let month = 0; month < 12; month += 1) {
+        ts.push(Date.UTC(year, month, 10));
+        ts.push(Date.UTC(year, month, 20));
+      }
+    }
+    return ts;
+  }
+  function variedImportance(): number[] {
+    const vals: number[] = [];
+    const levels = [0.6, 0.7, 0.8, 0.9, 0.55, 0.65];
+    for (let i = 0; i < 200; i += 1) vals.push(levels[i % levels.length]);
+    return vals;
+  }
+  const queries = [healthyQuery(0), healthyQuery(1), healthyQuery(2)];
+
+  const verdict = evaluateVerdict({
+    recency: summarizeRecency(healthyCreatedAt()),
+    importance: summarizeImportance(variedImportance()),
+    reshapeTau: meanCompositeVsFusionTau(queries, NOW),
+    recallTable: recallTable(queries, 300, NOW),
+  });
+
+  it('returns GO', () => {
+    expect(verdict.go).toBe(true);
+    expect(verdict.failedConditions).toEqual([]);
+  });
+
+  it('marks all three core conditions live', () => {
+    expect(verdict.recencyLive).toBe(true);
+    expect(verdict.importanceLive).toBe(true);
+    expect(verdict.reshapesRankings).toBe(true);
+  });
+
+  it('prints the thresholds it used', () => {
+    expect(verdict.thresholds).toEqual(DEFAULT_THRESHOLDS);
+  });
+});
+
+describe('evaluateVerdict — dead access alone does NOT fail the verdict', () => {
+  // A healthy corpus where access is zero everywhere (fresh, never queried).
+  // access is a LATENT signal; the verdict must still be GO.
+  function healthyCreatedAt(): number[] {
+    const ts: number[] = [];
+    for (let year = 2023; year <= 2026; year += 1) {
+      for (let month = 0; month < 12; month += 1) ts.push(Date.UTC(year, month, 15));
+    }
+    return ts;
+  }
+  const importance = Array.from({ length: 48 }, (_, i) => 0.5 + (i % 5) * 0.1);
+  const queries = [healthyQuery(0), healthyQuery(1)]; // access_count is 0 in all healthy candidates
+
+  const verdict = evaluateVerdict({
+    recency: summarizeRecency(healthyCreatedAt()),
+    importance: summarizeImportance(importance),
+    reshapeTau: meanCompositeVsFusionTau(queries, NOW),
+    recallTable: recallTable(queries, 300, NOW),
+  });
+
+  it('is still GO even though access-only recall is the floor', () => {
+    expect(verdict.go).toBe(true);
+  });
+});

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["scripts/**/*.ts", "test/build-corpus.test.ts", "test/diagnose-corpus.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

A substantial upgrade to the bundled memory MCP server (`packages/memory-mcp-server/`): an LLM **decomposition ingest** path, the tooling to build + validate a **representative** corpus, and **parent-context retrieval** ("index fine, return coarse") so detail-bearing records aren't lost to decomposition. The candidate ranker (fusion/composite/rerank) is **byte-for-byte unchanged** throughout.

7 commits, +9.6k. Research-grounded design docs under `docs/designs/`.

## Contents

**1. `memory_ingest` tool** — one Haiku call per chunk decomposes a blob into atomic-fact memories written through the existing store→dedup→consolidation path (compound content embeds to a muddy centroid and hurts recall). Insert-time fidelity the tool owns: order-independent merge timestamps, per-fact importance from extraction, `on_extraction_failure: degrade|skip|error` with observable partial-chunk, `as_of` backdating, `dry_run`, durability-filtered prompts, PII-safe logging. A valid empty extraction (`[]`) is a clean "nothing durable" result, not a failure.

**2. Corpus-build driver + representativeness diagnostic** (`scripts/memory-corpus/`) — ingests a conversation export into a gitignored DB via the production ingest path (real per-conversation recency via `as_of`, fail-loud, deterministic maintenance), then a diagnostic (distributional liveness + self-supervised recall probe + control baselines + Kendall-τ) emits an explicit **GO/NO-GO**. On a real 3,920-fact corpus: **GO** (importance live, ~22-mo recency, τ=0.58, no single-signal confound). This replaces the unrepresentative LoCoMo benchmark whose flat metadata an evolve run had overfit.

**3. Parent-context retrieval** — a new `segments` table holds the source chunk **off the index** (never embedded, never in vec/FTS — so the ranker can't regress); each atomic fact carries a `segment_id`. On recall, `expand:'auto'` (default) detects a shared parent and returns a **query-ranked passage** of the source via a **hybrid** budget policy (reserve one passage for guaranteed depth, top facts kept for breadth — so it never evicts breadth *or* silently drops the passage). New `memory_expand` tool for the agentic follow-up; `expanded`/`expanded_segment_ids` surfaced via MCP `structuredContent`.

**4. Schema & robustness** — canonical schema (`SCHEMA_VERSION 4`) with stale-DB **drop-and-recreate** self-heal (numeric version compare; **fail-closed** on a newer on-disk schema). Back-compat-free per directive.

## Validation

On the real corpus, the motivating query ("key terms of the Bandalert operating agreement") returns the full breadth **plus** the un-decomposed execution detail under the hybrid policy — fixing the decomposition loss that was the original failure. (Honest caveat: a *specific* never-indexed clause still depends on findability — that's the deferred Phase 2 / contextualized-embedding work.)

## Review history baked in

This branch already incorporates a Copilot review pass, a `/simplify` pass, and a full feature-review (F1–F7): the AUGMENT→hybrid expansion fix, MCP structured output, a `typecheck:scripts` gate, numeric schema-version compare, and the content-cap fix.

## Privacy

The conversation export, corpus DB, fixtures, and reports are private and **gitignored**; every persisted artifact is content-free (ids + numeric signals only).

## Tests

361 root + 279 package tests; `typecheck:scripts`, package + root `tsc`, eslint, prettier — all green. Key behaviors are mutation-verified (the hybrid-expansion breadth/depth guard fails under the naive policies).

## Evolve-ready

Once merged, the `dogfood/memory-fusion` evolve harness can rebase onto master and point at this representative corpus (the diagnostic already emits a content-free candidate-pool fixture) instead of LoCoMo.