### PR TITLE
test(memory): run vitest serially to avoid model-download race

### DIFF
--- a/packages/memory-mcp-server/vitest.config.ts
+++ b/packages/memory-mcp-server/vitest.config.ts
@@ -4,5 +4,12 @@ export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
     testTimeout: 30000,
+    // Run test files serially. Several suites load the real ONNX embedding /
+    // reranker models; with parallel files and a cold cache they race to
+    // populate the on-disk model cache, and a half-written model_quantized.onnx
+    // fails to load (seen in the release workflow as 26 ingest.test.ts errors).
+    // Serial execution lets the first model-using file warm the cache for the
+    // rest. This suite runs in the release workflow, so the slowdown is fine.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Problem

The manual run of the *Release memory-mcp-server* workflow failed at the **Test** step — 26 of 31 tests in `test/ingest.test.ts` errored, all from one root cause:

```
Error: Load model from .../@huggingface/transformers/.cache/Xenova/bge-base-en-v1.5/onnx/model_quantized.onnx
  ❯ new OnnxruntimeSessionHandler node_modules/onnxruntime-node/lib/backend.ts:16
```

`ingest.test.ts` uses the **real embedder**, and the package's vitest config runs test files in parallel. On a fresh CI runner the model cache is cold, so parallel files race to download the BGE model and one reads a half-written `model_quantized.onnx`. Tell-tale: `expand.test.ts` and the e2e suite (which also use the model) passed — they ran after the download finished — and the only ingest tests that passed are the ones that never touch the embedder (`dry_run`, `skip`, `error`, empty-extraction).

This suite runs **only** in the release workflow (root CI doesn't run the `memory-mcp-server` workspace), so the race was never seen until the first release run that included the newer real-embedder tests.

## Fix

Set `fileParallelism: false` in `packages/memory-mcp-server/vitest.config.ts`. Files run one at a time, so the first model-using file fully warms the on-disk cache before the next starts — no half-written reads. Per the maintainer's call, this is fine since the suite only runs on release.

## Verification

- Full package suite run serially with this config: **284 tests / 15 files pass** in ~25s (e2e included locally). No measurable slowdown.
- The parallel race itself is documented by the failed release run's log.