### PR TITLE
feat(web-ui): add workflow statistics to the dashboard

### DIFF
--- a/packages/web-ui/e2e/dashboard.spec.ts
+++ b/packages/web-ui/e2e/dashboard.spec.ts
@@ -34,3 +34,58 @@ test.describe('Dashboard', () => {
     });
   });
 });
+
+test.describe('Dashboard — Workflow Activity', () => {
+  test.beforeEach(async ({ page, request }) => {
+    await resetMockServer(request);
+    await connectWithToken(page);
+  });
+
+  test('renders the workflow activity section with four KPI tiles', async ({ page }) => {
+    const section = page.getByTestId('workflow-activity');
+    await expect(section).toBeVisible();
+    await expect(page.getByTestId('wf-stat-active')).toBeVisible();
+    await expect(page.getByTestId('wf-stat-gates')).toBeVisible();
+    await expect(page.getByTestId('wf-stat-completed')).toBeVisible();
+    await expect(page.getByTestId('wf-stat-issues')).toBeVisible();
+  });
+
+  test('KPI tiles reflect the mock workflow data', async ({ page }) => {
+    // Mock seeds 2 active live workflows (1 running + 1 waiting_human) and one
+    // pending gate; listResumable returns 3 completed and 3 problem runs
+    // (failed + aborted + interrupted).
+    await expect(page.getByTestId('wf-stat-active').locator('.font-mono.font-bold')).toHaveText('2');
+    await expect(page.getByTestId('wf-stat-gates').locator('.font-mono.font-bold')).toHaveText('1');
+    await expect(page.getByTestId('wf-stat-completed').locator('.font-mono.font-bold')).toHaveText('3');
+    await expect(page.getByTestId('wf-stat-issues').locator('.font-mono.font-bold')).toHaveText('3');
+  });
+
+  test('renders the phase distribution bar with the total run count', async ({ page }) => {
+    await expect(page.getByTestId('wf-distribution')).toBeVisible();
+    // 1 running + 2 waiting_human + 3 completed + 1 failed + 1 aborted + 1 interrupted = 9.
+    await expect(page.getByTestId('workflow-activity')).toContainText('9 runs');
+  });
+
+  test('clicking an active workflow row opens that workflow in the Workflows view', async ({ page }) => {
+    const table = page.getByTestId('dashboard-active-workflows');
+    await expect(table).toBeVisible();
+    await table.locator('tbody tr').first().click();
+    // The Workflows view renders the selected workflow's detail (Back affordance).
+    await expect(page.getByRole('button', { name: /Back/ })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('sidebar-nav').getByRole('button', { name: 'Workflows' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  test('"View all" navigates to the Workflows view', async ({ page }) => {
+    await page.getByTestId('wf-view-all').click();
+    // A seeded pending gate may auto-open a workflow's detail, so assert the
+    // reliable signal: the Workflows nav item becomes the current page.
+    await expect(page.getByTestId('sidebar-nav').getByRole('button', { name: 'Workflows' })).toHaveAttribute(
+      'aria-current',
+      'page',
+      { timeout: 10_000 },
+    );
+  });
+});

--- a/packages/web-ui/src/routes/Dashboard.svelte
+++ b/packages/web-ui/src/routes/Dashboard.svelte
@@ -208,7 +208,7 @@
             <div class="text-3xl font-bold font-mono tracking-tight {kpis.issues > 0 ? 'text-destructive' : ''}">
               {kpis.issues}
             </div>
-            <div class="text-[11px] text-muted-foreground mt-1">failed / aborted</div>
+            <div class="text-[11px] text-muted-foreground mt-1">problem runs</div>
           </div>
         </div>
 

--- a/packages/web-ui/src/routes/Dashboard.svelte
+++ b/packages/web-ui/src/routes/Dashboard.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
-  import { appState } from '../lib/stores.svelte.js';
+  import { appState, connectionGeneration, listResumableWorkflows } from '../lib/stores.svelte.js';
   import { Card } from '$lib/components/ui/card/index.js';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '$lib/components/ui/table/index.js';
+  import { phaseBadgeVariant } from '$lib/utils.js';
+  import { mergePastRuns, terminalSummariesAsPastRuns, formatRelativeTime, phaseLabel } from './workflows-helpers.js';
+  import { computeWorkflowKpis, buildPhaseDistribution, sumWorkflowTokens, formatTokens } from './dashboard-helpers.js';
+  import type { PastRunDto, WorkflowPhase } from '$lib/types.js';
 
   import ChatCircle from 'phosphor-svelte/lib/ChatCircle';
   import Warning from 'phosphor-svelte/lib/Warning';
   import Clock from 'phosphor-svelte/lib/Clock';
   import Lightning from 'phosphor-svelte/lib/Lightning';
   import ShieldCheck from 'phosphor-svelte/lib/ShieldCheck';
+  import TreeStructure from 'phosphor-svelte/lib/TreeStructure';
+  import Gavel from 'phosphor-svelte/lib/Gavel';
+  import CheckCircle from 'phosphor-svelte/lib/CheckCircle';
+  import WarningOctagon from 'phosphor-svelte/lib/WarningOctagon';
+  import CaretRight from 'phosphor-svelte/lib/CaretRight';
 
   function formatTime(iso: string): string {
     return new Date(iso).toLocaleTimeString();
@@ -16,6 +25,63 @@
 
   function formatCost(usd: number): string {
     return `$${usd.toFixed(2)}`;
+  }
+
+  // ── Workflow statistics ──────────────────────────────────────────────
+  // Past runs aren't held in the store; fetch them here and re-fetch on
+  // (re)connect. `connectionGeneration.value` is read so this effect re-runs
+  // after the store's post-connect refresh bumps it.
+  let pastRunsRaw = $state<PastRunDto[]>([]);
+
+  $effect(() => {
+    void connectionGeneration.value;
+    if (!appState.connected) return;
+    void loadPastRuns();
+  });
+
+  async function loadPastRuns(): Promise<void> {
+    try {
+      pastRunsRaw = await listResumableWorkflows();
+    } catch {
+      // Best-effort: the section degrades to live-only stats.
+    }
+  }
+
+  const liveWorkflows = $derived([...appState.workflows.values()]);
+  const activeWorkflows = $derived(
+    liveWorkflows.filter((wf) => wf.phase === 'running' || wf.phase === 'waiting_human'),
+  );
+  // Merge on-disk past runs with any in-memory terminal entries (in-memory wins).
+  const pastRuns = $derived(mergePastRuns(pastRunsRaw, terminalSummariesAsPastRuns(liveWorkflows)));
+
+  const kpis = $derived(computeWorkflowKpis(liveWorkflows, pastRuns, appState.pendingGates.size));
+  const distribution = $derived(buildPhaseDistribution(liveWorkflows, pastRuns));
+  // Non-empty segments drive both the bar and the legend, so compute them once.
+  const visibleSegments = $derived(distribution.segments.filter((seg) => seg.count > 0));
+  const totalTokens = $derived(sumWorkflowTokens(liveWorkflows, pastRuns));
+  const hasWorkflowData = $derived(liveWorkflows.length > 0 || pastRuns.length > 0 || appState.pendingGates.size > 0);
+
+  // Phase → bar/legend swatch. Distinct, theme-driven colors so the six phases
+  // stay legible in every theme. `waiting_human` is a lighter shade of the
+  // warning hue so it separates from `running` in the Iron theme, where
+  // --primary and --warning resolve to the same amber.
+  const PHASE_BAR_CLASS: Record<WorkflowPhase, string> = {
+    running: 'bg-primary',
+    waiting_human: 'bg-warning/55',
+    completed: 'bg-success',
+    failed: 'bg-destructive',
+    aborted: 'bg-muted-foreground/60',
+    interrupted: 'bg-foreground/40',
+  };
+
+  function goToWorkflows(): void {
+    appState.selectedWorkflowId = null;
+    appState.currentView = 'workflows';
+  }
+
+  function openWorkflow(workflowId: string): void {
+    appState.selectedWorkflowId = workflowId;
+    appState.currentView = 'workflows';
   }
 </script>
 
@@ -77,6 +143,144 @@
       <div class="text-[11px] text-muted-foreground mt-1">in progress</div>
     </Card>
   </div>
+
+  {#if hasWorkflowData}
+    <section class="space-y-3 animate-fade-in" data-testid="workflow-activity">
+      <div class="flex items-center justify-between">
+        <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Workflow Activity</h3>
+        <button
+          type="button"
+          onclick={goToWorkflows}
+          data-testid="wf-view-all"
+          class="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View all
+          <CaretRight size={12} weight="bold" />
+        </button>
+      </div>
+
+      <Card class="overflow-hidden">
+        <!-- KPI band: gap-px over a border-colored backdrop draws crisp hairline
+             dividers that survive the 2-col (mobile) -> 4-col (desktop) reflow. -->
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-px bg-border">
+          <div class="bg-card p-4" data-testid="wf-stat-active">
+            <div class="flex items-center justify-between mb-3">
+              <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Active</span>
+              <TreeStructure size={16} class="text-muted-foreground/50" weight="duotone" />
+            </div>
+            <div class="text-3xl font-bold font-mono tracking-tight">{kpis.active}</div>
+            <div class="text-[11px] text-muted-foreground mt-1">running / gated</div>
+          </div>
+
+          <div class="bg-card p-4" data-testid="wf-stat-gates">
+            <div class="flex items-center justify-between mb-3">
+              <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Awaiting</span>
+              <Gavel
+                size={16}
+                class={kpis.awaitingGate > 0 ? 'text-warning' : 'text-muted-foreground/50'}
+                weight="duotone"
+              />
+            </div>
+            <div class="text-3xl font-bold font-mono tracking-tight {kpis.awaitingGate > 0 ? 'text-warning' : ''}">
+              {kpis.awaitingGate}
+            </div>
+            <div class="text-[11px] text-muted-foreground mt-1">human gates</div>
+          </div>
+
+          <div class="bg-card p-4" data-testid="wf-stat-completed">
+            <div class="flex items-center justify-between mb-3">
+              <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Completed</span>
+              <CheckCircle size={16} class="text-success/60" weight="duotone" />
+            </div>
+            <div class="text-3xl font-bold font-mono tracking-tight">{kpis.completed}</div>
+            <div class="text-[11px] text-muted-foreground mt-1">past runs</div>
+          </div>
+
+          <div class="bg-card p-4" data-testid="wf-stat-issues">
+            <div class="flex items-center justify-between mb-3">
+              <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Issues</span>
+              <WarningOctagon
+                size={16}
+                class={kpis.issues > 0 ? 'text-destructive' : 'text-muted-foreground/50'}
+                weight="duotone"
+              />
+            </div>
+            <div class="text-3xl font-bold font-mono tracking-tight {kpis.issues > 0 ? 'text-destructive' : ''}">
+              {kpis.issues}
+            </div>
+            <div class="text-[11px] text-muted-foreground mt-1">failed / aborted</div>
+          </div>
+        </div>
+
+        {#if distribution.total > 0}
+          <div class="border-t border-border px-4 py-3.5 space-y-2.5">
+            <div class="flex items-center justify-between">
+              <span class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Phase distribution</span>
+              <span class="text-[11px] font-mono text-muted-foreground">
+                {distribution.total} run{distribution.total === 1 ? '' : 's'} · {formatTokens(totalTokens)} tokens
+              </span>
+            </div>
+            <div class="flex h-2 w-full overflow-hidden rounded-full bg-muted" data-testid="wf-distribution">
+              {#each visibleSegments as seg (seg.phase)}
+                <div
+                  class="h-full {PHASE_BAR_CLASS[seg.phase]}"
+                  style="width: {seg.pct}%"
+                  title="{phaseLabel(seg.phase)}: {seg.count}"
+                ></div>
+              {/each}
+            </div>
+            <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+              {#each visibleSegments as seg (seg.phase)}
+                <div class="flex items-center gap-1.5">
+                  <span class="w-2 h-2 rounded-full shrink-0 {PHASE_BAR_CLASS[seg.phase]}"></span>
+                  <span class="text-[11px] text-muted-foreground capitalize">{phaseLabel(seg.phase)}</span>
+                  <span class="text-[11px] font-mono text-foreground/70">{seg.count}</span>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      </Card>
+
+      {#if activeWorkflows.length > 0}
+        <div data-testid="dashboard-active-workflows">
+          <Table>
+            <TableHeader>
+              <TableHead>Workflow</TableHead>
+              <TableHead>Phase</TableHead>
+              <TableHead>State</TableHead>
+              <TableHead>Round</TableHead>
+              <TableHead>Started</TableHead>
+            </TableHeader>
+            <TableBody>
+              {#each activeWorkflows as wf (wf.workflowId)}
+                <TableRow clickable onclick={() => openWorkflow(wf.workflowId)}>
+                  <TableCell class="font-mono font-medium text-primary text-xs">{wf.name}</TableCell>
+                  <TableCell>
+                    <Badge variant={phaseBadgeVariant(wf.phase)}>
+                      {#if wf.phase === 'running'}
+                        <span class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse"></span>
+                      {:else if wf.phase === 'waiting_human'}
+                        <span class="w-1.5 h-1.5 rounded-full bg-warning"></span>
+                      {/if}
+                      {phaseLabel(wf.phase)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell class="font-mono text-xs text-muted-foreground">{wf.currentState}</TableCell>
+                  <TableCell class="font-mono text-muted-foreground tabular-nums">
+                    {wf.maxRounds > 0 ? `${wf.round}/${wf.maxRounds}` : '--'}
+                  </TableCell>
+                  <TableCell class="text-muted-foreground whitespace-nowrap">
+                    <span title={new Date(wf.startedAt).toLocaleString()}>{formatRelativeTime(wf.startedAt)}</span>
+                  </TableCell>
+                </TableRow>
+              {/each}
+            </TableBody>
+          </Table>
+        </div>
+      {/if}
+    </section>
+  {/if}
 
   {#if appState.sessions.size > 0}
     <div class="animate-fade-in">
@@ -164,7 +368,7 @@
     </div>
   {/if}
 
-  {#if appState.sessions.size === 0 && appState.jobs.length === 0}
+  {#if appState.sessions.size === 0 && appState.jobs.length === 0 && !hasWorkflowData}
     <Card class="p-12 text-center">
       <ShieldCheck size={40} class="mx-auto text-muted-foreground/30 mb-4" />
       <p class="text-muted-foreground">No active sessions or jobs</p>

--- a/packages/web-ui/src/routes/WorkflowDetail.svelte
+++ b/packages/web-ui/src/routes/WorkflowDetail.svelte
@@ -13,6 +13,7 @@
   } from '$lib/stores.svelte.js';
   import { RpcError } from '$lib/ws-client.js';
   import { phaseBadgeVariant } from '$lib/utils.js';
+  import { phaseLabel } from './workflows-helpers.js';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { Button } from '$lib/components/ui/button/index.js';
   import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
@@ -239,7 +240,7 @@
   <div class="flex items-center gap-3">
     <Button variant="ghost" size="sm" onclick={onback}>&larr; Back</Button>
     <h2 class="text-xl font-semibold tracking-tight">{summary.name}</h2>
-    <Badge variant={phaseBadgeVariant(summary.phase)}>{summary.phase.replace('_', ' ')}</Badge>
+    <Badge variant={phaseBadgeVariant(summary.phase)}>{phaseLabel(summary.phase)}</Badge>
     {#if detail?.hasReadme}
       <Button
         variant="outline"

--- a/packages/web-ui/src/routes/Workflows.svelte
+++ b/packages/web-ui/src/routes/Workflows.svelte
@@ -26,6 +26,7 @@
     buildSummaryPlaceholder,
     synthesizeSummaryFromPastRun,
     synthesizeSummaryFromId,
+    phaseLabel,
     type PastRunFilter,
   } from './workflows-helpers.js';
   import { Button } from '$lib/components/ui/button/index.js';
@@ -536,7 +537,7 @@
                 <TableCell class="font-medium font-mono text-xs">{wf.name}</TableCell>
                 <TableCell>
                   <span class="inline-flex items-center gap-1.5">
-                    <Badge variant={phaseBadgeVariant(wf.phase)}>{wf.phase.replace('_', ' ')}</Badge>
+                    <Badge variant={phaseBadgeVariant(wf.phase)}>{phaseLabel(wf.phase)}</Badge>
                     {#if wf.phase === 'failed' && wf.error}
                       <Badge variant="destructive" class="cursor-help" title={wf.error}>!</Badge>
                     {/if}
@@ -619,7 +620,7 @@
                   <TableRow>
                     <TableCell>
                       <span class="inline-flex items-center gap-1.5">
-                        <Badge variant={phaseBadgeVariant(row.phase)}>{row.phase.replace('_', ' ')}</Badge>
+                        <Badge variant={phaseBadgeVariant(row.phase)}>{phaseLabel(row.phase)}</Badge>
                         {#if row.phase === 'failed' && row.error}
                           <Badge variant="destructive" class="cursor-help" title={row.error}>!</Badge>
                         {/if}

--- a/packages/web-ui/src/routes/dashboard-helpers.test.ts
+++ b/packages/web-ui/src/routes/dashboard-helpers.test.ts
@@ -146,6 +146,11 @@ describe('formatTokens', () => {
     expect(formatTokens(2_100_000)).toBe('2.1M');
   });
 
+  it('promotes the rounding boundary to "M" instead of emitting "1000k"', () => {
+    expect(formatTokens(999_499)).toBe('999k');
+    expect(formatTokens(999_999)).toBe('1.0M');
+  });
+
   it('guards against negative / non-finite input', () => {
     expect(formatTokens(-5)).toBe('0');
     expect(formatTokens(Number.NaN)).toBe('0');

--- a/packages/web-ui/src/routes/dashboard-helpers.test.ts
+++ b/packages/web-ui/src/routes/dashboard-helpers.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeWorkflowKpis,
+  buildPhaseDistribution,
+  sumWorkflowTokens,
+  formatTokens,
+  DISTRIBUTION_PHASES,
+} from './dashboard-helpers.js';
+import type { PastRunDto, WorkflowSummaryDto, LiveWorkflowPhase, PastRunPhase } from '$lib/types.js';
+
+function makeSummary(
+  overrides: Partial<WorkflowSummaryDto> & Pick<WorkflowSummaryDto, 'workflowId'>,
+): WorkflowSummaryDto {
+  return {
+    name: overrides.workflowId,
+    phase: 'running' as LiveWorkflowPhase,
+    currentState: 'state',
+    startedAt: '2026-04-22T10:00:00.000Z',
+    taskDescription: 'live task',
+    round: 1,
+    maxRounds: 3,
+    totalTokens: 0,
+    ...overrides,
+  };
+}
+
+function makePastRun(overrides: Partial<PastRunDto> & Pick<PastRunDto, 'workflowId'>): PastRunDto {
+  return {
+    name: overrides.workflowId,
+    phase: 'completed' as PastRunPhase,
+    currentState: 'done',
+    taskDescription: 'a task',
+    round: 1,
+    maxRounds: 3,
+    totalTokens: 0,
+    timestamp: '2026-04-22T10:00:00.000Z',
+    lastState: 'done',
+    ...overrides,
+  };
+}
+
+describe('computeWorkflowKpis', () => {
+  it('counts only running / waiting_human live workflows as active', () => {
+    const live = [
+      makeSummary({ workflowId: 'a', phase: 'running' }),
+      makeSummary({ workflowId: 'b', phase: 'waiting_human' }),
+      // A terminal live entry must not be counted as active.
+      makeSummary({ workflowId: 'c', phase: 'completed' }),
+    ];
+    const kpis = computeWorkflowKpis(live, [], 0);
+    expect(kpis.active).toBe(2);
+  });
+
+  it('passes through the supplied awaiting-gate count', () => {
+    expect(computeWorkflowKpis([], [], 3).awaitingGate).toBe(3);
+  });
+
+  it('splits past runs into completed vs issues (failed/aborted/interrupted)', () => {
+    const past = [
+      makePastRun({ workflowId: '1', phase: 'completed' }),
+      makePastRun({ workflowId: '2', phase: 'completed' }),
+      makePastRun({ workflowId: '3', phase: 'failed' }),
+      makePastRun({ workflowId: '4', phase: 'aborted' }),
+      makePastRun({ workflowId: '5', phase: 'interrupted' }),
+      // waiting_human is neither completed nor an "issue" outcome.
+      makePastRun({ workflowId: '6', phase: 'waiting_human' }),
+    ];
+    const kpis = computeWorkflowKpis([], past, 0);
+    expect(kpis.completed).toBe(2);
+    expect(kpis.issues).toBe(3);
+  });
+
+  it('returns all zeros for empty inputs', () => {
+    expect(computeWorkflowKpis([], [], 0)).toEqual({ active: 0, awaitingGate: 0, completed: 0, issues: 0 });
+  });
+});
+
+describe('buildPhaseDistribution', () => {
+  it('tallies live active + past phases and computes percentages summing to 100', () => {
+    const live = [
+      makeSummary({ workflowId: 'a', phase: 'running' }),
+      makeSummary({ workflowId: 'b', phase: 'waiting_human' }),
+    ];
+    const past = [
+      makePastRun({ workflowId: '1', phase: 'waiting_human' }),
+      makePastRun({ workflowId: '2', phase: 'completed' }),
+      makePastRun({ workflowId: '3', phase: 'completed' }),
+      makePastRun({ workflowId: '4', phase: 'failed' }),
+      makePastRun({ workflowId: '5', phase: 'aborted' }),
+      makePastRun({ workflowId: '6', phase: 'interrupted' }),
+    ];
+    const { segments, total } = buildPhaseDistribution(live, past);
+    expect(total).toBe(8);
+
+    const byPhase = Object.fromEntries(segments.map((s) => [s.phase, s.count]));
+    expect(byPhase.running).toBe(1);
+    expect(byPhase.waiting_human).toBe(2);
+    expect(byPhase.completed).toBe(2);
+    expect(byPhase.failed).toBe(1);
+    expect(byPhase.aborted).toBe(1);
+    expect(byPhase.interrupted).toBe(1);
+
+    const pctSum = segments.reduce((acc, s) => acc + s.pct, 0);
+    expect(pctSum).toBeCloseTo(100, 6);
+  });
+
+  it('returns a segment per distribution phase, in order, even when empty', () => {
+    const { segments, total } = buildPhaseDistribution([], []);
+    expect(total).toBe(0);
+    expect(segments.map((s) => s.phase)).toEqual([...DISTRIBUTION_PHASES]);
+    expect(segments.every((s) => s.count === 0 && s.pct === 0)).toBe(true);
+  });
+
+  it('ignores terminal live entries (only running/waiting_human contribute from live)', () => {
+    const live = [makeSummary({ workflowId: 'x', phase: 'completed' })];
+    const { total } = buildPhaseDistribution(live, []);
+    expect(total).toBe(0);
+  });
+});
+
+describe('sumWorkflowTokens', () => {
+  it('sums tokens across live and past, coalescing missing values to 0', () => {
+    const live = [
+      makeSummary({ workflowId: 'a', totalTokens: 1000 }),
+      // Simulate the slim live summary the daemon/mock may omit totalTokens on.
+      makeSummary({ workflowId: 'b', totalTokens: undefined as unknown as number }),
+    ];
+    const past = [
+      makePastRun({ workflowId: '1', totalTokens: 48200 }),
+      makePastRun({ workflowId: '2', totalTokens: 300 }),
+    ];
+    expect(sumWorkflowTokens(live, past)).toBe(49500);
+  });
+
+  it('returns 0 for empty inputs', () => {
+    expect(sumWorkflowTokens([], [])).toBe(0);
+  });
+});
+
+describe('formatTokens', () => {
+  it('formats small, thousand, and million ranges', () => {
+    expect(formatTokens(0)).toBe('0');
+    expect(formatTokens(942)).toBe('942');
+    expect(formatTokens(4521)).toBe('4.5k');
+    expect(formatTokens(173_400)).toBe('173k');
+    expect(formatTokens(2_100_000)).toBe('2.1M');
+  });
+
+  it('guards against negative / non-finite input', () => {
+    expect(formatTokens(-5)).toBe('0');
+    expect(formatTokens(Number.NaN)).toBe('0');
+  });
+});

--- a/packages/web-ui/src/routes/dashboard-helpers.ts
+++ b/packages/web-ui/src/routes/dashboard-helpers.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure helpers for the Dashboard's "Workflow Activity" section.
+ *
+ * Side-effect-free so the stat aggregation can be unit-tested without
+ * rendering the Svelte component. The component is responsible for fetching
+ * the live + past-run data and mapping phases to presentation (colors, icons).
+ */
+
+import type { PastRunDto, WorkflowPhase, WorkflowSummaryDto } from '$lib/types.js';
+import { PHASE } from '$lib/types.js';
+
+/** Live phases that count as "active" on the dashboard (running or paused at a gate). */
+const ACTIVE_LIVE_PHASES: ReadonlySet<WorkflowPhase> = new Set<WorkflowPhase>([PHASE.RUNNING, PHASE.WAITING_HUMAN]);
+
+/** Past-run phases that count as a problem outcome ("issues" KPI). */
+const ISSUE_PHASES: ReadonlySet<WorkflowPhase> = new Set<WorkflowPhase>([
+  PHASE.FAILED,
+  PHASE.ABORTED,
+  PHASE.INTERRUPTED,
+]);
+
+/**
+ * Ordered phases for the distribution bar and its legend. Order is fixed so the
+ * bar reads predictably (in-flight → success → problems) regardless of how the
+ * underlying counts arrive.
+ */
+export const DISTRIBUTION_PHASES: readonly WorkflowPhase[] = [
+  PHASE.RUNNING,
+  PHASE.WAITING_HUMAN,
+  PHASE.COMPLETED,
+  PHASE.FAILED,
+  PHASE.ABORTED,
+  PHASE.INTERRUPTED,
+];
+
+/** Headline counts shown as the four KPI tiles. */
+export interface WorkflowKpis {
+  /** Live runs that are running or waiting at a gate. */
+  readonly active: number;
+  /** Human gates currently awaiting a decision (live). */
+  readonly awaitingGate: number;
+  /** Past runs that reached the completed phase. */
+  readonly completed: number;
+  /** Past runs that ended in failure / abort / interruption. */
+  readonly issues: number;
+}
+
+/**
+ * Compute the KPI tile values.
+ *
+ * `active` is filtered here (not assumed pre-filtered) so callers can pass the
+ * full live workflow list. `awaitingGate` is supplied directly because the gate
+ * set lives outside the workflow list (in `appState.pendingGates`).
+ */
+export function computeWorkflowKpis(
+  liveWorkflows: readonly WorkflowSummaryDto[],
+  pastRuns: readonly PastRunDto[],
+  awaitingGate: number,
+): WorkflowKpis {
+  let completed = 0;
+  let issues = 0;
+  for (const run of pastRuns) {
+    if (run.phase === PHASE.COMPLETED) completed += 1;
+    else if (ISSUE_PHASES.has(run.phase)) issues += 1;
+  }
+  return {
+    active: liveWorkflows.filter((wf) => ACTIVE_LIVE_PHASES.has(wf.phase)).length,
+    awaitingGate,
+    completed,
+    issues,
+  };
+}
+
+/** A single segment of the phase-distribution bar. */
+export interface PhaseSegment {
+  readonly phase: WorkflowPhase;
+  readonly count: number;
+  /** Width percentage 0..100; non-zero segments sum to ~100. */
+  readonly pct: number;
+}
+
+export interface PhaseDistribution {
+  readonly segments: readonly PhaseSegment[];
+  readonly total: number;
+}
+
+/**
+ * Tally every known workflow by phase and project it onto the ordered segment
+ * list. Live workflows contribute their `running` / `waiting_human` phase; past
+ * runs contribute their terminal (or paused) phase. Phases outside
+ * {@link DISTRIBUTION_PHASES} are ignored.
+ */
+export function buildPhaseDistribution(
+  liveWorkflows: readonly WorkflowSummaryDto[],
+  pastRuns: readonly PastRunDto[],
+): PhaseDistribution {
+  const counts = new Map<WorkflowPhase, number>();
+  const bump = (phase: WorkflowPhase): void => {
+    counts.set(phase, (counts.get(phase) ?? 0) + 1);
+  };
+
+  for (const wf of liveWorkflows) {
+    if (ACTIVE_LIVE_PHASES.has(wf.phase)) bump(wf.phase);
+  }
+  for (const run of pastRuns) bump(run.phase);
+
+  let total = 0;
+  for (const phase of DISTRIBUTION_PHASES) total += counts.get(phase) ?? 0;
+
+  const segments: PhaseSegment[] = DISTRIBUTION_PHASES.map((phase) => {
+    const count = counts.get(phase) ?? 0;
+    return { phase, count, pct: total > 0 ? (count / total) * 100 : 0 };
+  });
+
+  return { segments, total };
+}
+
+/** Sum total tokens consumed across all live + past workflows (missing values coalesce to 0). */
+export function sumWorkflowTokens(
+  liveWorkflows: readonly WorkflowSummaryDto[],
+  pastRuns: readonly PastRunDto[],
+): number {
+  let total = 0;
+  for (const wf of liveWorkflows) total += wf.totalTokens ?? 0;
+  for (const run of pastRuns) total += run.totalTokens ?? 0;
+  return total;
+}
+
+/** Format a token count compactly: 942 → "942", 4 521 → "4.5k", 173 400 → "173k", 2 100 000 → "2.1M". */
+export function formatTokens(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0';
+  if (n < 1000) return String(Math.round(n));
+  if (n < 1_000_000) {
+    const k = n / 1000;
+    return `${k < 10 ? k.toFixed(1) : Math.round(k)}k`;
+  }
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/packages/web-ui/src/routes/dashboard-helpers.ts
+++ b/packages/web-ui/src/routes/dashboard-helpers.ts
@@ -130,7 +130,8 @@ export function sumWorkflowTokens(
 export function formatTokens(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return '0';
   if (n < 1000) return String(Math.round(n));
-  if (n < 1_000_000) {
+  // 999_500..999_999 would round to "1000k"; promote those to the "M" branch.
+  if (n < 999_500) {
     const k = n / 1000;
     return `${k < 10 ? k.toFixed(1) : Math.round(k)}k`;
   }

--- a/packages/web-ui/src/routes/workflows-helpers.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.ts
@@ -137,7 +137,7 @@ export function truncate(text: string, max = 80): string {
 
 /** Human-readable phase label, e.g. `waiting_human` -> `waiting human`. */
 export function phaseLabel(phase: string): string {
-  return phase.replace('_', ' ');
+  return phase.replace(/_/g, ' ');
 }
 
 /**

--- a/packages/web-ui/src/routes/workflows-helpers.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.ts
@@ -135,6 +135,11 @@ export function truncate(text: string, max = 80): string {
   return text.slice(0, max) + '…';
 }
 
+/** Human-readable phase label, e.g. `waiting_human` -> `waiting human`. */
+export function phaseLabel(phase: string): string {
+  return phase.replace('_', ' ');
+}
+
 /**
  * Phases that allow a Resume action from the Past-runs table.
  *


### PR DESCRIPTION
## Summary

Adds a **Workflow Activity** section to the daemon web-UI dashboard, surfacing live and historical workflow stats that previously only lived on the Workflows page.

- **Four KPI tiles** — active runs (running/gated), gates awaiting a human decision, completed past runs, and problem outcomes (failed/aborted/interrupted). The gate and issue tiles tint amber/red when non-zero.
- **Phase-distribution bar** — a theme-driven stacked bar + legend over all known runs, with the total run count and aggregate token usage (e.g. `9 runs · 173k tokens`).
- **Active-workflows table** — clickable rows that deep-link into the Workflows detail view, plus a **View all →** affordance.

The section only renders when there is workflow data, and is folded into the dashboard's global empty-state condition.

## Implementation notes

- Stat aggregation lives in pure, unit-tested helpers (`dashboard-helpers.ts`): `computeWorkflowKpis`, `buildPhaseDistribution`, `sumWorkflowTokens`, `formatTokens`.
- Data comes from existing store state (`workflows.list`, `pendingGates`) plus a `workflows.listResumable` fetch gated on connection — **no mock-server / daemon protocol changes were needed**.
- Reuses the existing `mergePastRuns` / `terminalSummariesAsPastRuns` / `formatRelativeTime` / `phaseBadgeVariant` helpers.
- Extracts a shared `phaseLabel()` into `workflows-helpers.ts`, replacing the inline `phase.replace('_', ' ')` calls in Dashboard, Workflows, and WorkflowDetail.
- In the Iron theme `--primary` and `--warning` resolve to the same amber, so the `waiting_human` swatch uses a lighter shade to stay distinct from `running` in the distribution bar.

## Testing

- `npm run check` — 0 errors · ESLint clean · Prettier clean
- Unit: **372 passed** (incl. 11 new helper tests)
- e2e: **73 passed** (incl. 5 new dashboard workflow-activity specs driven by the mock WS server)
- Visually verified in Iron, Daylight, and Midnight themes.