### PR TITLE
fix(mitm): fast-reject WSS upgrades on provider hosts so Codex falls back to HTTP

### DIFF
--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -714,6 +714,45 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
     }
   });
 
+  // Fast-reject WebSocket upgrades on TLS-intercepted provider hosts.
+  //
+  // Codex CLI ≥ 0.142 talks to its inference endpoint over
+  // `wss://chatgpt.com/backend-api/codex/responses` (HTTP `GET` with
+  // `Upgrade: websocket`) and only falls back to the legacy `POST` + SSE
+  // path when the WS connection fails at the TRANSPORT level. Without this
+  // listener Node delivers the upgrade request to the `'request'` handler
+  // below, which forwards it via `https.request()`; the upstream's `101
+  // Switching Protocols` is then dropped on the floor (Node fires only
+  // `'close'` on a client request with no `'upgrade'` listener), and the
+  // agent's WS client sits on an open socket until its ~15s connect
+  // timeout, retrying ~7× (~112s) before falling back.
+  //
+  // We deliberately DESTROY the socket rather than replying with an HTTP
+  // 4xx/5xx: tungstenite surfaces a non-101 HTTP response as a fatal
+  // handshake error to the Codex turn (observed: `turn.failed` with the
+  // body text), whereas a connection-level failure (reset / EOF before
+  // handshake) is treated as a retryable transport error and triggers the
+  // POST/SSE fallback — the same path the timeout used to reach, just in
+  // milliseconds instead of ~15s per attempt.
+  //
+  // This is intentionally a fast-fail, NOT a bridge: bridging WS for
+  // provider hosts would let inference traffic bypass the SSE trajectory
+  // capture / token-stream extraction paths. A proper key-swapping WS
+  // bridge (with WS-frame reassembly for capture) is a follow-up; until
+  // then the agent's HTTP fallback is the supported transport.
+  innerServer.on('upgrade', (req: http.IncomingMessage, socket: Socket) => {
+    const meta = socketMetadata.get(req.socket as tls.TLSSocket);
+    const targetHost = meta?.host ?? 'unknown';
+    logger.info(
+      `[mitm-proxy] REJECTED ${req.headers.upgrade ?? 'upgrade'} ${targetHost}${req.url ?? ''} ` +
+        '(WebSocket not bridged for MITM provider hosts; agent should fall back to HTTP)',
+    );
+    socket.on('error', () => {
+      /* swallow — socket is being torn down */
+    });
+    socket.destroy();
+  });
+
   // Lazy-loaded registry handler to avoid circular imports.
   // Cached after first import so subsequent calls are synchronous.
   let registryHandlerModule: typeof import('./registry-proxy.js') | undefined;


### PR DESCRIPTION
## Problem

`ironcurtain start --agent codex "Hi"` takes **~118s** while `--agent claude-code` takes ~2s.

## Root cause

Codex CLI 0.142+ switched its primary inference transport to **WebSocket** (`wss://chatgpt.com/backend-api/codex/responses`), falling back to `POST` + SSE only on transport-level connect failure.

The TLS-terminating inner HTTP server in `mitm-proxy.ts` had no `'upgrade'` listener, so the WS handshake (`GET` + `Upgrade: websocket`) was delivered to the `'request'` handler and forwarded upstream via `https.request()`. chatgpt.com replies `101 Switching Protocols`; Node drops that on a client request with no `'upgrade'` listener (fires only `'close'`, never `'response'`/`'error'`), so nothing was ever written back to the agent. Codex's tungstenite client sat on the open socket until its ~15s connect timeout, retried ~7×, then fell back to POST after **~112s**.

The earlier-reported `codex_apps` MCP 403 is unrelated — it fails in <3s and doesn't block the turn.

## Fix

Register an `'upgrade'` listener on the inner server that **destroys the socket** immediately. A connection-level failure triggers Codex's retry-then-POST fallback in ~7s of client backoff instead of ~112s.

Note: an HTTP 4xx response was tried first but Codex treats a non-101 HTTP handshake response as **fatal** (`turn.failed`, no fallback) — only transport-level errors trigger fallback. Hence `socket.destroy()`.

## Result

| | before | after |
|---|---|---|
| `codex exec` duration | 117.7s | 12.3s |
| WS attempts → POST fallback | 7 × ~15s timeout | 7 × instant reject + ~6.5s client backoff |

Verified with `IRONCURTAIN_MITM_ALLOW_ALL_HOSTS=0` (strict egress). All 171 mitm-proxy unit tests pass.

## Not in scope / follow-up

This is a fast-fail, not a bridge. A proper key-swapping WSS bridge for provider hosts — plus WS-frame reassembly so `--capture-traces` and the token-stream bus see Codex inference — would eliminate the remaining ~7s of client backoff.