### PR TITLE
feat(registry-proxy): add cargo (crates.io) to the MITM package proxy

### DIFF
--- a/src/docker/CLAUDE.md
+++ b/src/docker/CLAUDE.md
@@ -40,7 +40,7 @@ Lifecycle is driven through `DockerInfrastructure.beginCaptureSession()` / `endC
 
 - `proxy-tools.ts` - Hardcoded MCP tool definitions, annotations, and policy rules for domain management. Injected into the ToolCallCoordinator during construction for policy evaluation and audit logging.
 - `code-mode-proxy.ts` - MCP server exposing a single `execute_code` tool backed by the UTCP Code Mode sandbox. Docker agents send TypeScript via this tool, sharing the same V8 execution engine as builtin Code Mode sessions. Implements the `DockerProxy` interface. `DockerProxy.getPolicySwapTarget()` returns a narrow `PolicySwapTarget` handle (only `startControlServer`) that the workflow orchestrator uses to attach a control server to the live coordinator; single-session callers never use it.
-- `registry-proxy.ts` - URL parsing, metadata filtering, and tarball backstop for npm, PyPI, and Debian package registries. Built-in registry configs for each.
+- `registry-proxy.ts` - URL parsing, metadata filtering, and tarball backstop for npm, PyPI, Debian, and cargo (crates.io) package registries. Built-in registry configs for each.
 - `package-types.ts` - Shared types for the package installation proxy (`RegistryConfig`, `PackageIdentity`, `PackageValidator`, etc.).
 - `package-validator.ts` - Package validation against allowlist/denylist/age-gate rules. First-match semantics: denylist > allowlist > age gate > default allow.
 
@@ -85,4 +85,4 @@ The `proxy` virtual MCP server (`proxy-tools.ts`) exposes `add_proxy_domain`, `r
 
 Real credentials (API keys or OAuth tokens) never enter the container. The agent receives a fake sentinel key; the MITM proxy validates it and swaps for the real credential on the host side. OAuth is auto-detected from `~/.claude/.credentials.json` and preferred over API keys; override with `IRONCURTAIN_DOCKER_AUTH=apikey`. Endpoint filtering ensures only specific API paths are accessible (e.g., `POST /v1/messages`).
 
-Package installations are mediated by the registry proxy, which validates packages against allowlist/denylist rules and an age gate (quarantine period for new versions) before allowing downloads from npm, PyPI, or Debian repositories.
+Package installations are mediated by the registry proxy, which validates packages against allowlist/denylist rules and an age gate (quarantine period for new versions) before allowing downloads from npm, PyPI, Debian, or crates.io repositories.

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -561,10 +561,10 @@ export async function prepareDockerInfrastructure(
   let packageValidation: { validator: import('./package-types.js').PackageValidator; auditLogPath: string } | undefined;
 
   if (pkgConfig.enabled) {
-    const { npmRegistry, pypiRegistry, debianRegistry } = await import('./registry-proxy.js');
+    const { npmRegistry, pypiRegistry, debianRegistry, cargoRegistry } = await import('./registry-proxy.js');
     const { createPackageValidator } = await import('./package-validator.js');
 
-    registries = [npmRegistry, pypiRegistry, debianRegistry];
+    registries = [npmRegistry, pypiRegistry, debianRegistry, cargoRegistry];
     const validator = createPackageValidator({
       allowedPackages: pkgConfig.allowedPackages,
       deniedPackages: pkgConfig.deniedPackages,

--- a/src/docker/package-types.ts
+++ b/src/docker/package-types.ts
@@ -10,7 +10,7 @@
  * Each type determines how package names and versions are extracted
  * from HTTP request paths, and how metadata responses are filtered.
  */
-export type RegistryType = 'npm' | 'pypi' | 'debian';
+export type RegistryType = 'npm' | 'pypi' | 'debian' | 'cargo';
 
 /**
  * Configuration for a package registry host.

--- a/src/docker/registry-proxy.ts
+++ b/src/docker/registry-proxy.ts
@@ -46,15 +46,25 @@ export const debianRegistry: RegistryConfig = {
   mirrorHosts: ['security.debian.org'],
 };
 
+// crates.io topology. The three hosts need different handling:
+//   - index.crates.io  : sparse index (version resolution) — metadata filter
+//   - static.crates.io : pure .crate tarball CDN — fail-closed backstop,
+//                        exactly like PyPI's files.pythonhosted.org
+//   - crates.io        : web API host (search/owners/readme) that also
+//                        issues the legacy download redirect — pass-through
+//                        for non-download paths, backstop for downloads
+const CARGO_INDEX_HOST = 'index.crates.io';
+const CARGO_STATIC_HOST = 'static.crates.io';
+const CARGO_API_HOST = 'crates.io';
+
 export const cargoRegistry: RegistryConfig = {
   // Primary host is the sparse index — where cargo resolves versions.
-  host: 'index.crates.io',
+  host: CARGO_INDEX_HOST,
   displayName: 'crates.io',
   type: 'cargo',
-  // crates.io serves the API download redirect; static.crates.io serves
-  // the actual .crate tarballs (mirrors the PyPI files.pythonhosted.org
-  // pattern).
-  mirrorHosts: ['crates.io', 'static.crates.io'],
+  // Both download hosts must be in the allowlist so their CONNECTs are
+  // MITM-terminated; handleRegistryRequest then routes each by host.
+  mirrorHosts: [CARGO_API_HOST, CARGO_STATIC_HOST],
 };
 
 // ── PyPI sidecar suffixes (PEP 658 metadata, PEP 714 provenance) ────
@@ -360,7 +370,11 @@ export function parseCargoDownloadUrl(path: string): PackageIdentity | undefined
     const name = crateMatch[1];
     const filename = crateMatch[2];
     const prefix = `${name}-`;
-    if (!filename.startsWith(prefix)) return undefined;
+    // crates.io treats crate names case-insensitively; cargo emits the
+    // canonical case but compare case-insensitively so a mixed-case dir vs
+    // filename (e.g. /crates/Inflector/inflector-0.11.4.crate) still parses
+    // rather than being denied.
+    if (!filename.toLowerCase().startsWith(prefix.toLowerCase())) return undefined;
     const version = filename.slice(prefix.length);
     if (!version) return undefined;
     return { registry: 'cargo', name: normalizeCargoName(name), version };
@@ -660,10 +674,15 @@ export async function handleRegistryRequest(
       await handleDebianRequest(registry, path, clientReq, clientRes, host, port, options);
       break;
     case 'cargo':
-      if (registry.mirrorHosts?.includes(host)) {
-        // crates.io API + static.crates.io serve downloads. Anything we
-        // can't identify as a crate download (search, owners, readme)
-        // passes through.
+      if (host === CARGO_STATIC_HOST) {
+        // Pure tarball CDN — fail closed on any unrecognized path, exactly
+        // like PyPI's files.pythonhosted.org. Every request must validate as
+        // a crate download or be denied (handleTarballDownload 403s on an
+        // unparseable URL); there are no legitimate non-download requests.
+        await handleTarballDownload(registry, path, clientRes, host, port, options, 'cargo');
+      } else if (host === CARGO_API_HOST) {
+        // Web API host: validate the download redirect; pass non-download
+        // endpoints (search, owners, readme) through unmodified.
         if (parseCargoDownloadUrl(path)) {
           await handleTarballDownload(registry, path, clientRes, host, port, options, 'cargo');
         } else {

--- a/src/docker/registry-proxy.ts
+++ b/src/docker/registry-proxy.ts
@@ -46,6 +46,17 @@ export const debianRegistry: RegistryConfig = {
   mirrorHosts: ['security.debian.org'],
 };
 
+export const cargoRegistry: RegistryConfig = {
+  // Primary host is the sparse index — where cargo resolves versions.
+  host: 'index.crates.io',
+  displayName: 'crates.io',
+  type: 'cargo',
+  // crates.io serves the API download redirect; static.crates.io serves
+  // the actual .crate tarballs (mirrors the PyPI files.pythonhosted.org
+  // pattern).
+  mirrorHosts: ['crates.io', 'static.crates.io'],
+};
+
 // ── PyPI sidecar suffixes (PEP 658 metadata, PEP 714 provenance) ────
 
 const PYPI_SIDECAR_SUFFIXES = ['.metadata', '.provenance'];
@@ -266,6 +277,154 @@ export function parseDebianPackageUrl(path: string): PackageIdentity | undefined
   if (!filename || !filename.endsWith('.deb')) return undefined;
 
   return extractDebianPackageFromFilename(filename);
+}
+
+// ── Cargo / crates.io URL parsing ───────────────────────────────────
+
+/**
+ * Normalizes a crate name for index lookup and cache keying.
+ * crates.io treats names case-insensitively; the sparse index path
+ * is always lowercase.
+ */
+export function normalizeCargoName(name: string): string {
+  return name.toLowerCase();
+}
+
+/**
+ * Computes the sparse-index path for a crate name (without leading /).
+ *
+ * Per the Cargo registry protocol:
+ *   1 char  -> 1/{name}
+ *   2 chars -> 2/{name}
+ *   3 chars -> 3/{first}/{name}
+ *   4+      -> {first-two}/{next-two}/{name}
+ */
+export function cargoSparseIndexPath(name: string): string {
+  const lower = normalizeCargoName(name);
+  switch (lower.length) {
+    case 0:
+      return lower;
+    case 1:
+      return `1/${lower}`;
+    case 2:
+      return `2/${lower}`;
+    case 3:
+      return `3/${lower[0]}/${lower}`;
+    default:
+      return `${lower.slice(0, 2)}/${lower.slice(2, 4)}/${lower}`;
+  }
+}
+
+/** Valid crate name characters: ASCII alphanumerics, `-`, `_`. */
+const CARGO_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Parses a crates.io sparse-index URL path into a PackageIdentity.
+ * Returns undefined for /config.json and paths that don't conform to
+ * the sparse-index prefix layout.
+ */
+export function parseCargoSparseIndexUrl(path: string): PackageIdentity | undefined {
+  const cleanPath = path.split('?')[0].replace(/^\/+/, '');
+  if (cleanPath === 'config.json' || cleanPath === '') return undefined;
+
+  const segments = cleanPath.split('/');
+  const name = segments[segments.length - 1];
+  if (!name || !CARGO_NAME_RE.test(name)) return undefined;
+
+  // Verify the prefix matches the name (reject arbitrary paths).
+  if (cargoSparseIndexPath(name) !== cleanPath.toLowerCase()) return undefined;
+
+  return { registry: 'cargo', name: normalizeCargoName(name) };
+}
+
+/**
+ * Parses a crates.io download URL into a PackageIdentity.
+ *
+ * Patterns (across crates.io and static.crates.io):
+ *   /api/v1/crates/{name}/{version}/download
+ *   /crates/{name}/{version}/download
+ *   /crates/{name}/{name}-{version}.crate
+ */
+export function parseCargoDownloadUrl(path: string): PackageIdentity | undefined {
+  const cleanPath = path.split('?')[0];
+
+  // /api/v1/crates/{name}/{version}/download  or  /crates/{name}/{version}/download
+  const dlMatch = cleanPath.match(/^(?:\/api\/v1)?\/crates\/([A-Za-z0-9_-]+)\/([^/]+)\/download$/);
+  if (dlMatch) {
+    return { registry: 'cargo', name: normalizeCargoName(dlMatch[1]), version: dlMatch[2] };
+  }
+
+  // /crates/{name}/{name}-{version}.crate
+  const crateMatch = cleanPath.match(/^\/crates\/([A-Za-z0-9_-]+)\/([^/]+)\.crate$/);
+  if (crateMatch) {
+    const name = crateMatch[1];
+    const filename = crateMatch[2];
+    const prefix = `${name}-`;
+    if (!filename.startsWith(prefix)) return undefined;
+    const version = filename.slice(prefix.length);
+    if (!version) return undefined;
+    return { registry: 'cargo', name: normalizeCargoName(name), version };
+  }
+
+  return undefined;
+}
+
+/** One line of the crates.io sparse index (newline-delimited JSON). */
+interface CargoIndexLine {
+  readonly name: string;
+  readonly vers: string;
+  readonly yanked?: boolean;
+  /** Publish timestamp (RFC 3339), backfilled across all versions. */
+  readonly pubtime?: string;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Filters a crates.io sparse-index file (newline-delimited JSON) to
+ * remove disallowed versions. Each line is a self-contained JSON object
+ * carrying its own `pubtime`, so no side-channel timestamp fetch is
+ * needed (unlike PyPI).
+ */
+export function filterCargoSparseIndex(
+  ndjson: string,
+  validator: PackageValidator,
+  packageName: string,
+): { filtered: string; denied: Array<{ version: string; reason: string }>; allowedVersions: Set<string> } {
+  const denied: Array<{ version: string; reason: string }> = [];
+  const allowedVersions = new Set<string>();
+  const kept: string[] = [];
+
+  for (const rawLine of ndjson.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    let entry: CargoIndexLine;
+    try {
+      entry = JSON.parse(line) as CargoIndexLine;
+    } catch {
+      // Unparseable line — drop it (fail-closed).
+      continue;
+    }
+    if (!entry.vers) continue;
+
+    const rawDate = entry.pubtime ? new Date(entry.pubtime) : undefined;
+    const publishedAt = rawDate && Number.isFinite(rawDate.getTime()) ? rawDate : undefined;
+
+    const decision = validator.validate(
+      { registry: 'cargo', name: packageName, version: entry.vers },
+      publishedAt !== undefined ? { publishedAt } : undefined,
+    );
+
+    if (decision.status === 'allow') {
+      allowedVersions.add(entry.vers);
+      kept.push(line);
+    } else {
+      denied.push({ version: entry.vers, reason: decision.reason });
+    }
+  }
+
+  // Trailing newline keeps cargo's NDJSON parser happy on an empty result.
+  return { filtered: kept.join('\n') + '\n', denied, allowedVersions };
 }
 
 // ── Request classification ──────────────────────────────────────────
@@ -500,6 +659,23 @@ export async function handleRegistryRequest(
     case 'debian':
       await handleDebianRequest(registry, path, clientReq, clientRes, host, port, options);
       break;
+    case 'cargo':
+      if (registry.mirrorHosts?.includes(host)) {
+        // crates.io API + static.crates.io serve downloads. Anything we
+        // can't identify as a crate download (search, owners, readme)
+        // passes through.
+        if (parseCargoDownloadUrl(path)) {
+          await handleTarballDownload(registry, path, clientRes, host, port, options, 'cargo');
+        } else {
+          await forwardUpstream(clientReq, clientRes, host, port);
+        }
+      } else if (parseCargoSparseIndexUrl(path)) {
+        await handleCargoSparseIndex(registry, path, clientReq, clientRes, host, port, options);
+      } else {
+        // index.crates.io/config.json and anything unrecognized — pass through.
+        await forwardUpstream(clientReq, clientRes, host, port);
+      }
+      break;
     default: {
       const _exhaustive: never = registry.type;
       throw new Error(`Unknown registry type: ${String(_exhaustive)}`);
@@ -679,7 +855,7 @@ async function handleTarballDownload(
   options: RegistryHandlerOptions,
   registryType: RegistryType,
 ): Promise<void> {
-  const pkg = registryType === 'npm' ? parseNpmUrl(path) : parsePypiTarballUrl(path);
+  const pkg = parseTarballUrl(registryType, path);
   if (!pkg || !pkg.version) {
     // Can't parse -- fail-closed
     logger.info(`[registry-proxy] tarball backstop: can't parse URL, denying: ${path}`);
@@ -771,6 +947,94 @@ async function handleTarballDownload(
   }
 }
 
+/** Dispatches tarball-URL parsing by registry type. */
+function parseTarballUrl(registryType: RegistryType, path: string): PackageIdentity | undefined {
+  switch (registryType) {
+    case 'npm':
+      return parseNpmUrl(path);
+    case 'pypi':
+      return parsePypiTarballUrl(path);
+    case 'cargo':
+      return parseCargoDownloadUrl(path);
+    case 'debian':
+      return parseDebianPackageUrl(path);
+  }
+}
+
+async function handleCargoSparseIndex(
+  _registry: RegistryConfig,
+  path: string,
+  clientReq: http.IncomingMessage,
+  clientRes: http.ServerResponse,
+  host: string,
+  port: number,
+  options: RegistryHandlerOptions,
+): Promise<void> {
+  const pkg = parseCargoSparseIndexUrl(path);
+  if (!pkg) {
+    await forwardUpstream(clientReq, clientRes, host, port);
+    return;
+  }
+
+  try {
+    const ndjson = await fetchUpstreamText(host, port, path, 'text/plain');
+    if (ndjson === undefined) {
+      // Cargo treats 404/non-200 here as "crate not found" — preserve that.
+      clientRes.writeHead(404, { 'Content-Type': 'text/plain' });
+      clientRes.end('Not Found');
+      return;
+    }
+
+    const { filtered, denied, allowedVersions } = filterCargoSparseIndex(ndjson, options.validator, pkg.name);
+
+    setCachedVersions(options.cache, pkg, allowedVersions);
+
+    for (const d of denied) {
+      writeAuditEntry(options.auditLogPath, {
+        timestamp: new Date().toISOString(),
+        registry: pkg.registry,
+        packageName: pkg.name,
+        packageVersion: d.version,
+        decision: 'deny',
+        reason: d.reason,
+        source: 'metadata-filter',
+        requestPath: path,
+      });
+    }
+
+    if (allowedVersions.size > 0) {
+      writeAuditEntry(options.auditLogPath, {
+        timestamp: new Date().toISOString(),
+        registry: pkg.registry,
+        packageName: pkg.name,
+        packageVersion: `${allowedVersions.size} version(s)`,
+        decision: 'allow',
+        reason: 'Passed all validation checks',
+        source: 'metadata-filter',
+        requestPath: path,
+      });
+    }
+
+    if (denied.length > 0) {
+      logger.info(
+        `[registry-proxy] cargo ${pkg.name}: filtered ${denied.length} version(s), ${allowedVersions.size} allowed`,
+      );
+    }
+
+    clientRes.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Content-Length': Buffer.byteLength(filtered),
+    });
+    clientRes.end(filtered);
+  } catch (err) {
+    logger.info(
+      `[registry-proxy] cargo index error for ${pkg.name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    clientRes.writeHead(502, { 'Content-Type': 'text/plain' });
+    clientRes.end('Failed to process crate index');
+  }
+}
+
 async function handleDebianRequest(
   _registry: RegistryConfig,
   path: string,
@@ -844,6 +1108,24 @@ async function fetchAndValidateVersion(
     }
     const deniedEntry = denied.find((d) => d.version === pkg.version);
     return { status: 'deny', reason: deniedEntry?.reason ?? 'Version not found in package metadata' };
+  }
+
+  if (registry.type === 'cargo') {
+    // Sparse index carries pubtime per line — fetch it directly from
+    // index.crates.io regardless of which mirror the tarball request hit.
+    const indexPath = `/${cargoSparseIndexPath(pkg.name)}`;
+    const ndjson = await fetchUpstreamText(cargoRegistry.host, 443, indexPath, 'text/plain');
+    if (ndjson === undefined) {
+      return { status: 'deny', reason: 'Failed to fetch crate index from upstream' };
+    }
+    const { denied, allowedVersions } = filterCargoSparseIndex(ndjson, options.validator, pkg.name);
+    setCachedVersions(options.cache, pkg, allowedVersions);
+
+    if (pkg.version !== undefined && allowedVersions.has(pkg.version)) {
+      return { status: 'allow', reason: 'Version passed validation' };
+    }
+    const deniedEntry = denied.find((d) => d.version === pkg.version);
+    return { status: 'deny', reason: deniedEntry?.reason ?? 'Version not found in crate index' };
   }
 
   // PyPI: fetch JSON API for timestamps, validate ALL versions, populate cache

--- a/test/docker/registry-proxy.test.ts
+++ b/test/docker/registry-proxy.test.ts
@@ -885,6 +885,22 @@ describe('parseCargoDownloadUrl', () => {
   it('returns undefined when .crate filename does not match crate name', () => {
     expect(parseCargoDownloadUrl('/crates/serde/tokio-1.0.0.crate')).toBeUndefined();
   });
+
+  it('parses canonical mixed-case .crate filenames', () => {
+    expect(parseCargoDownloadUrl('/crates/Inflector/Inflector-0.11.4.crate')).toEqual({
+      registry: 'cargo',
+      name: 'inflector',
+      version: '0.11.4',
+    });
+  });
+
+  it('parses .crate when dir and filename case differ (case-insensitive prefix)', () => {
+    expect(parseCargoDownloadUrl('/crates/Inflector/inflector-0.11.4.crate')).toEqual({
+      registry: 'cargo',
+      name: 'inflector',
+      version: '0.11.4',
+    });
+  });
 });
 
 // ── Cargo sparse-index filtering ────────────────────────────────────
@@ -979,5 +995,19 @@ describe('handleRegistryRequest: cargo', () => {
 
     expect(res.statusCode).toBe(403);
     expect(res.body).toContain('tokio');
+  });
+
+  it('fails closed on an unrecognized path on static.crates.io (no pass-through)', async () => {
+    // static.crates.io is a pure tarball CDN — like files.pythonhosted.org it
+    // must never pass a request straight upstream. An unparseable path is
+    // denied rather than forwarded unvalidated.
+    const options: RegistryHandlerOptions = { validator: DENY_ALL_VALIDATOR, cache: new Map() };
+    const req = fakeReq('/some/unexpected/path');
+    const res = fakeRes();
+
+    await handleRegistryRequest(cargoRegistry, req, res, 'static.crates.io', 443, options);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain('Forbidden');
   });
 });

--- a/test/docker/registry-proxy.test.ts
+++ b/test/docker/registry-proxy.test.ts
@@ -19,6 +19,11 @@ import {
   handleRegistryRequest,
   npmRegistry,
   debianRegistry,
+  cargoRegistry,
+  cargoSparseIndexPath,
+  parseCargoSparseIndexUrl,
+  parseCargoDownloadUrl,
+  filterCargoSparseIndex,
   type NpmPackument,
   type RegistryHandlerOptions,
 } from '../../src/docker/registry-proxy.js';
@@ -755,5 +760,224 @@ describe('handleRegistryRequest: debian', () => {
     });
     // Debian packages bypass quarantine via epoch publishedAt
     expect(validatedMetadata?.publishedAt).toEqual(new Date(0));
+  });
+});
+
+// ── Cargo sparse-index path computation ─────────────────────────────
+
+describe('cargoSparseIndexPath', () => {
+  it('handles 1-char crate names', () => {
+    expect(cargoSparseIndexPath('a')).toBe('1/a');
+  });
+
+  it('handles 2-char crate names', () => {
+    expect(cargoSparseIndexPath('io')).toBe('2/io');
+  });
+
+  it('handles 3-char crate names', () => {
+    expect(cargoSparseIndexPath('rmp')).toBe('3/r/rmp');
+  });
+
+  it('handles 4+ char crate names', () => {
+    expect(cargoSparseIndexPath('serde')).toBe('se/rd/serde');
+    expect(cargoSparseIndexPath('tokio')).toBe('to/ki/tokio');
+  });
+
+  it('lowercases the name', () => {
+    expect(cargoSparseIndexPath('Serde')).toBe('se/rd/serde');
+  });
+});
+
+// ── Cargo sparse-index URL parsing ──────────────────────────────────
+
+describe('parseCargoSparseIndexUrl', () => {
+  it('parses 4+ char crate path', () => {
+    expect(parseCargoSparseIndexUrl('/se/rd/serde')).toEqual({ registry: 'cargo', name: 'serde' });
+  });
+
+  it('parses 3-char crate path', () => {
+    expect(parseCargoSparseIndexUrl('/3/r/rmp')).toEqual({ registry: 'cargo', name: 'rmp' });
+  });
+
+  it('parses 2-char crate path', () => {
+    expect(parseCargoSparseIndexUrl('/2/io')).toEqual({ registry: 'cargo', name: 'io' });
+  });
+
+  it('parses 1-char crate path', () => {
+    expect(parseCargoSparseIndexUrl('/1/a')).toEqual({ registry: 'cargo', name: 'a' });
+  });
+
+  it('returns undefined for /config.json', () => {
+    expect(parseCargoSparseIndexUrl('/config.json')).toBeUndefined();
+  });
+
+  it('returns undefined for root', () => {
+    expect(parseCargoSparseIndexUrl('/')).toBeUndefined();
+  });
+
+  it('returns undefined when prefix does not match name', () => {
+    // Wrong prefix for "serde" — should be /se/rd/serde
+    expect(parseCargoSparseIndexUrl('/ab/cd/serde')).toBeUndefined();
+  });
+
+  it('returns undefined for invalid crate-name characters', () => {
+    expect(parseCargoSparseIndexUrl('/se/rd/ser.de')).toBeUndefined();
+  });
+
+  it('strips query string', () => {
+    expect(parseCargoSparseIndexUrl('/se/rd/serde?foo=bar')).toEqual({ registry: 'cargo', name: 'serde' });
+  });
+});
+
+// ── Cargo download URL parsing ──────────────────────────────────────
+
+describe('parseCargoDownloadUrl', () => {
+  it('parses static.crates.io /crates/{name}/{version}/download', () => {
+    expect(parseCargoDownloadUrl('/crates/serde/1.0.193/download')).toEqual({
+      registry: 'cargo',
+      name: 'serde',
+      version: '1.0.193',
+    });
+  });
+
+  it('parses crates.io API /api/v1/crates/{name}/{version}/download', () => {
+    expect(parseCargoDownloadUrl('/api/v1/crates/tokio/1.35.1/download')).toEqual({
+      registry: 'cargo',
+      name: 'tokio',
+      version: '1.35.1',
+    });
+  });
+
+  it('parses /crates/{name}/{name}-{version}.crate', () => {
+    expect(parseCargoDownloadUrl('/crates/serde/serde-1.0.193.crate')).toEqual({
+      registry: 'cargo',
+      name: 'serde',
+      version: '1.0.193',
+    });
+  });
+
+  it('handles pre-release versions', () => {
+    expect(parseCargoDownloadUrl('/crates/tokio/1.0.0-rc.1/download')).toEqual({
+      registry: 'cargo',
+      name: 'tokio',
+      version: '1.0.0-rc.1',
+    });
+  });
+
+  it('handles underscores in crate names', () => {
+    expect(parseCargoDownloadUrl('/crates/serde_json/1.0.108/download')).toEqual({
+      registry: 'cargo',
+      name: 'serde_json',
+      version: '1.0.108',
+    });
+  });
+
+  it('lowercases the crate name', () => {
+    expect(parseCargoDownloadUrl('/crates/Inflector/0.11.4/download')?.name).toBe('inflector');
+  });
+
+  it('returns undefined for non-download paths', () => {
+    expect(parseCargoDownloadUrl('/api/v1/crates/serde')).toBeUndefined();
+    expect(parseCargoDownloadUrl('/api/v1/crates/serde/owners')).toBeUndefined();
+    expect(parseCargoDownloadUrl('/')).toBeUndefined();
+  });
+
+  it('returns undefined when .crate filename does not match crate name', () => {
+    expect(parseCargoDownloadUrl('/crates/serde/tokio-1.0.0.crate')).toBeUndefined();
+  });
+});
+
+// ── Cargo sparse-index filtering ────────────────────────────────────
+
+describe('filterCargoSparseIndex', () => {
+  const oldDate = '2023-01-01T00:00:00Z';
+  const newDate = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(); // 1 day ago
+
+  const ndjson =
+    [
+      JSON.stringify({ name: 'serde', vers: '1.0.100', cksum: 'a', yanked: false, pubtime: oldDate }),
+      JSON.stringify({ name: 'serde', vers: '1.0.193', cksum: 'b', yanked: false, pubtime: oldDate }),
+      JSON.stringify({ name: 'serde', vers: '1.0.999', cksum: 'c', yanked: false, pubtime: newDate }),
+    ].join('\n') + '\n';
+
+  it('filters out versions newer than quarantine period', () => {
+    const validator = createPackageValidator({ quarantineDays: 7 });
+    const { filtered, denied, allowedVersions } = filterCargoSparseIndex(ndjson, validator, 'serde');
+
+    expect(filtered).toContain('"vers":"1.0.100"');
+    expect(filtered).toContain('"vers":"1.0.193"');
+    expect(filtered).not.toContain('"vers":"1.0.999"');
+    expect(denied).toHaveLength(1);
+    expect(denied[0].version).toBe('1.0.999');
+    expect(allowedVersions).toEqual(new Set(['1.0.100', '1.0.193']));
+  });
+
+  it('outputs valid newline-delimited JSON', () => {
+    const validator = createPackageValidator({ quarantineDays: 0 });
+    const { filtered } = filterCargoSparseIndex(ndjson, validator, 'serde');
+
+    const lines = filtered.split('\n').filter((l) => l.trim());
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it('treats missing pubtime as fail-closed under quarantine', () => {
+    const noTime = JSON.stringify({ name: 'serde', vers: '2.0.0', cksum: 'd', yanked: false }) + '\n';
+    const validator = createPackageValidator({ quarantineDays: 7 });
+    const { allowedVersions, denied } = filterCargoSparseIndex(noTime, validator, 'serde');
+
+    expect(allowedVersions.size).toBe(0);
+    expect(denied[0].reason).toContain('fail-closed');
+  });
+
+  it('drops unparseable lines (fail-closed)', () => {
+    const garbage = '{"name":"serde","vers":"1.0.0","pubtime":"' + oldDate + '"}\nnot json\n';
+    const validator = createPackageValidator({ quarantineDays: 0 });
+    const { allowedVersions } = filterCargoSparseIndex(garbage, validator, 'serde');
+
+    expect(allowedVersions).toEqual(new Set(['1.0.0']));
+  });
+
+  it('removes all versions for denylisted crates', () => {
+    const validator = createPackageValidator({ deniedPackages: ['serde'] });
+    const { allowedVersions, denied } = filterCargoSparseIndex(ndjson, validator, 'serde');
+
+    expect(allowedVersions.size).toBe(0);
+    expect(denied).toHaveLength(3);
+  });
+});
+
+// ── Cargo handleRegistryRequest ─────────────────────────────────────
+
+describe('handleRegistryRequest: cargo', () => {
+  it('blocks .crate download not in allowed cache (tarball backstop)', async () => {
+    const cache: AllowedVersionCache = new Map();
+    setCachedVersions(cache, { registry: 'cargo', name: 'serde' }, new Set(['1.0.100']));
+
+    const options: RegistryHandlerOptions = { validator: DENY_ALL_VALIDATOR, cache };
+    const req = fakeReq('/crates/serde/1.0.999/download');
+    const res = fakeRes();
+
+    await handleRegistryRequest(cargoRegistry, req, res, 'static.crates.io', 443, options);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain('Forbidden');
+    expect(res.body).toContain('serde');
+  });
+
+  it('blocks API download path on crates.io', async () => {
+    const cache: AllowedVersionCache = new Map();
+    setCachedVersions(cache, { registry: 'cargo', name: 'tokio' }, new Set(['1.0.0']));
+
+    const options: RegistryHandlerOptions = { validator: DENY_ALL_VALIDATOR, cache };
+    const req = fakeReq('/api/v1/crates/tokio/1.35.1/download');
+    const res = fakeRes();
+
+    await handleRegistryRequest(cargoRegistry, req, res, 'crates.io', 443, options);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain('tokio');
   });
 });


### PR DESCRIPTION
## Summary

Adds a `cargo` `RegistryType` alongside npm/PyPI/Debian so crate downloads from the Rust toolchain (baked into the base image since #290) flow through the same allow/deny + age-gate validation and `package-audit.jsonl` logging as the other registries, instead of bypassing it via the fetch-tool domain allowlist.

Closes #331.

## Implementation

- **`cargoRegistry` config** — `index.crates.io` (sparse index) as the primary host; `crates.io` + `static.crates.io` as mirror hosts (mirrors the PyPI `files.pythonhosted.org` pattern).
- **Sparse-index handling** — `cargoSparseIndexPath()` / `parseCargoSparseIndexUrl()` implement the `1/`, `2/`, `3/{a}/`, `{ab}/{cd}/` prefix layout with prefix↔name verification so arbitrary paths don't masquerade as crate lookups. `/config.json` passes through.
- **Download URL parser** — `parseCargoDownloadUrl()` covers `/api/v1/crates/{name}/{version}/download`, `/crates/{name}/{version}/download`, and `/crates/{name}/{name}-{version}.crate`.
- **`filterCargoSparseIndex()`** — filters NDJSON lines using the embedded `pubtime` field (backfilled across all of crates.io history), so no side-channel API call is needed for timestamps. Missing/invalid `pubtime` fails closed, matching the npm packument behaviour.
- Wired into the `handleRegistryRequest` switch (mirror hosts → tarball backstop; index host → sparse-index filter), `fetchAndValidateVersion` cache-miss path, and the `DockerInfrastructure` registries list.
- Small refactor: `handleTarballDownload` now dispatches via `parseTarballUrl()` instead of the npm/pypi ternary.

## Tests

28 new tests in `test/docker/registry-proxy.test.ts` covering sparse-index path computation, URL parsing (both directions), NDJSON filtering (quarantine / denylist / fail-closed on missing `pubtime` / unparseable lines), and tarball-backstop denial on both `static.crates.io` and `crates.io`.

```
test/docker/registry-proxy.test.ts — 119 passed (119)
```