### PR TITLE
fix(mcp): guard stdio transports against unhandled EPIPE on shutdown

### DIFF
--- a/src/servers/fetch-server.ts
+++ b/src/servers/fetch-server.ts
@@ -20,6 +20,7 @@ import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
 import { VERSION } from '../version.js';
 import { createSearchProvider, formatSearchResults } from './search-providers.js';
+import { guardStdioStreamErrors } from '../utils/stdio-guard.js';
 
 const USER_AGENT = `IronCurtain/${VERSION} (AI Agent Runtime)`;
 const MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MB
@@ -424,5 +425,6 @@ async function handleWebSearch(
   }
 }
 
+guardStdioStreamErrors();
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/trusted-process/mcp-proxy-server.ts
+++ b/src/trusted-process/mcp-proxy-server.ts
@@ -32,6 +32,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { guardStdioStreamErrors } from '../utils/stdio-guard.js';
 import { UdsServerTransport } from './uds-server-transport.js';
 import { TcpServerTransport } from './tcp-server-transport.js';
 import { resolveContainerSpawnCommand } from './container-command.js';
@@ -824,6 +825,7 @@ async function main(): Promise<void> {
   } else if (transportConfig.kind === 'uds') {
     transport = new UdsServerTransport(transportConfig.socketPath);
   } else {
+    guardStdioStreamErrors();
     transport = new StdioServerTransport();
   }
   await server.connect(transport);

--- a/src/utils/stdio-guard.ts
+++ b/src/utils/stdio-guard.ts
@@ -1,0 +1,25 @@
+/**
+ * Attaches an `'error'` listener to a stdio stream (default `process.stdout`)
+ * that swallows benign pipe-closed errors (`EPIPE` / `ECONNRESET`).
+ *
+ * Stdio MCP servers (the SDK's `StdioServerTransport`) write responses to the
+ * process's stdout. When the peer closes the pipe during shutdown while a write
+ * is in flight, Node emits an `'error'` (`EPIPE`) on the stream — and a stream
+ * `'error'` with no listener is an *unhandled* error that crashes the whole
+ * process. Under vitest's worker pool this surfaces as an opaque "worker exited
+ * unexpectedly" with no error text. Swallowing only the benign shutdown codes
+ * keeps any real stdout error visible.
+ *
+ * Idempotent per stream: re-invocations are no-ops, so it is safe to call from
+ * multiple module entry points that share a process.
+ */
+const guarded = new WeakSet<NodeJS.WritableStream>();
+
+export function guardStdioStreamErrors(stream: NodeJS.WriteStream = process.stdout): void {
+  if (guarded.has(stream)) return;
+  guarded.add(stream);
+  stream.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE' || err.code === 'ECONNRESET') return;
+    process.stderr.write(`[stdio-guard] unexpected stdout error: ${err.message}\n`);
+  });
+}

--- a/test/stdio-guard.test.ts
+++ b/test/stdio-guard.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { guardStdioStreamErrors } from '../src/utils/stdio-guard.js';
+
+/**
+ * `guardStdioStreamErrors` prevents an unhandled stream `'error'` (a benign
+ * pipe-closed EPIPE/ECONNRESET during shutdown) from crashing the process —
+ * the root cause of an intermittent vitest worker-exit flake on stdio MCP
+ * servers. Unrelated errors must still surface (to stderr), never silently.
+ */
+describe('guardStdioStreamErrors', () => {
+  function fakeStream(): NodeJS.WriteStream {
+    return new EventEmitter() as unknown as NodeJS.WriteStream;
+  }
+
+  it('swallows EPIPE without throwing or writing to stderr', () => {
+    const stream = fakeStream();
+    guardStdioStreamErrors(stream);
+    const spy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    expect(() => stream.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('swallows ECONNRESET the same way', () => {
+    const stream = fakeStream();
+    guardStdioStreamErrors(stream);
+    const spy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    expect(() => stream.emit('error', Object.assign(new Error('reset'), { code: 'ECONNRESET' }))).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('surfaces an unexpected stdout error to stderr instead of crashing', () => {
+    const stream = fakeStream();
+    guardStdioStreamErrors(stream);
+    const spy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    expect(() => stream.emit('error', Object.assign(new Error('boom'), { code: 'ENOSPC' }))).not.toThrow();
+    expect(spy).toHaveBeenCalledOnce();
+    expect(String(spy.mock.calls[0]?.[0])).toContain('boom');
+    spy.mockRestore();
+  });
+
+  it('is idempotent per stream (one listener even if called repeatedly)', () => {
+    const stream = fakeStream();
+    guardStdioStreamErrors(stream);
+    guardStdioStreamErrors(stream);
+    guardStdioStreamErrors(stream);
+    expect((stream as unknown as EventEmitter).listenerCount('error')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Intermittent CI flake: a vitest worker exits unexpectedly with **no error text** (~1 in 4 platform runs, macOS-skewed), all tests passing — surfacing as a bare *"Worker exited unexpectedly"*. Seen most recently on master after #351 (re-run went green).

## Root cause

The MCP SDK's `StdioServerTransport.send` does `process.stdout.write()` with **no `'error'` listener**. When an MCP stdio pipe closes during integration-test teardown (`afterAll`/`proxy.stop()`) while a write is pending, Node emits an unhandled `'error'` (`EPIPE`) → the process crashes. Under vitest's **forks** pool only the worker fork dies and its stderr is lost, so the symptom is opaque (the `--pool=threads` run exposes the raw `write EPIPE` stack).

## Fix

`src/utils/stdio-guard.ts` — `guardStdioStreamErrors()`: one **idempotent** `'error'` listener that swallows only the benign shutdown codes (`EPIPE`/`ECONNRESET`) and surfaces any other stdout error to stderr. No global catch-all; nothing real is masked. Wired into both stdio MCP server entry points (`fetch-server.ts`, `mcp-proxy-server.ts`) right before they connect their `StdioServerTransport`.

## Validation

- **0/20** full-suite **forks** runs (CI config) showed a worker death — baseline was ~2/42 (≈4.8%). Suite green (242 files / 5221 tests) on every run, so the change breaks nothing.
- Unit test (`test/stdio-guard.test.ts`) covers swallow EPIPE/ECONNRESET, surface other errors, and idempotency.
- **Honest caveat:** 0/20 is positive but not statistically airtight for a ~5% flake (~37% of unfixed 20-run samples would also be clean). The fix lands on its own merits — an unhandled `EPIPE` crashing a process is a real bug — and master CI will accumulate further signal.

## Note (separate issue, not addressed here)

A distinct crash exists under `--pool=threads` only: `isolated-vm` (the V8 sandbox behind `@utcp/code-mode`) is not `worker_threads`-safe. It does **not** affect CI, which uses the forks pool. Flagging for awareness; out of scope for this PR.