### PR TITLE
feat(deps): support Node 26 via isolated-vm 7.0.0 override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,36 @@ jobs:
   ci:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        # Node 24 (abi137) and Node 26 (abi147) both have isolated-vm 7.0.0
+        # prebuilt binaries → fast install on every PR and every master push.
         os: [ubuntu-latest, macos-latest]
-        node-version: [22, 24]
+        node-version: [24, 26]
+        # Node 22 has NO isolated-vm 7.0.0 prebuild → it source-compiles via
+        # node-gyp during `npm ci` (~tens of seconds on CI). Run it on master
+        # pushes only, and ubuntu-only, to keep that cost off every PR and off
+        # the ~10x-pricier macOS runners. `push` here fires only on master (see
+        # trigger above), so github.event_name == 'push' means "a master push".
+        include: ${{ github.event_name == 'push' && fromJSON('[{"os":"ubuntu-latest","node-version":22}]') || fromJSON('[]') }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: npm ci
+      # --foreground-scripts surfaces the node-gyp compile output in the logs so
+      # the Node-22 isolated-vm source build is visible; the step's duration in
+      # the Actions UI is then the measurement. (No node_modules/prebuild cache
+      # here on purpose — npm ci stays deterministic; if the Node-22 job ever
+      # gets painful, a prebuild cache is a possible future optimization.)
+      - run: npm ci --foreground-scripts
+      - name: Report Node ABI and isolated-vm build source
+        run: |
+          node -e "console.log('ABI', process.versions.modules)"
+          test -f node_modules/isolated-vm/build/Release/isolated_vm.node \
+            && echo "isolated-vm: SOURCE-COMPILED (build/Release/isolated_vm.node present)" \
+            || echo "isolated-vm: PREBUILD (no build/Release/isolated_vm.node)"
       - run: npm run build --workspace=packages/memory-mcp-server
       - run: npm run format:check
       - run: npm run lint

--- a/.github/workflows/release-memory-mcp-server.yml
+++ b/.github/workflows/release-memory-mcp-server.yml
@@ -22,7 +22,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # Node 24 has an isolated-vm 7.0.0 prebuild; Node 22 does not (the root
+          # `npm ci` below would source-compile it via node-gyp on the release
+          # critical path). memory-mcp-server doesn't use isolated-vm, so the Node
+          # version only affects install/build speed here — pin a prebuilt line.
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,12 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # Node 24 has an isolated-vm 7.0.0 prebuild; Node 22 does not (it would
+          # source-compile via node-gyp on the publish critical path). The Node
+          # version only affects build/test speed here — the published npm
+          # artifact is IronCurtain's own JS and does not bundle isolated-vm
+          # (consumers install it themselves) — so pin a prebuilt line.
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Behavior changes
 
-- **Node.js 26 support** — bumped the V8 sandbox dependency `isolated-vm` to 7.0.0 (via an npm `override`, since it is transitive through `@utcp/code-mode`) so Code Mode initializes on Node 26; `isolated-vm` 6.x has no Node 26 prebuild and fails to compile against Node 26's V8. The supported range is now Node 22–26 (`engines` `>=22.0.0 <27`): Node 24 and 26 install prebuilt native binaries, while Node 22 compiles `isolated-vm` from source at install (no prebuilt binary ships for it, so a C/C++ toolchain is required). CI runs Node 24 and 26 on every PR and adds a Node 22 source-compile job on pushes to master.
+- **Node.js 26 support** — bumped the V8 sandbox dependency `isolated-vm` to 7.0.0 (via an npm `override`, since it is transitive through `@utcp/code-mode`) so Code Mode initializes on Node 26; `isolated-vm` 6.x has no Node 26 prebuild and fails to compile against Node 26's V8. The supported range is now Node 22–26 (`engines` `>=22.0.0 <27`): Node 24 and 26 install prebuilt native binaries, while Node 22 compiles `isolated-vm` from source at install (no prebuilt binary ships for it, so a C/C++ toolchain is required). CI runs Node 24 and 26 on every PR and adds a Node 22 source-compile job on pushes to master (#356).
 
 ## [0.12.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Behavior changes
+
+- **Node.js 26 support** — bumped the V8 sandbox dependency `isolated-vm` to 7.0.0 (via an npm `override`, since it is transitive through `@utcp/code-mode`) so Code Mode initializes on Node 26; `isolated-vm` 6.x has no Node 26 prebuild and fails to compile against Node 26's V8. The supported range is now Node 22–26 (`engines` `>=22.0.0 <27`): Node 24 and 26 install prebuilt native binaries, while Node 22 compiles `isolated-vm` from source at install (no prebuilt binary ships for it, so a C/C++ toolchain is required). CI runs Node 24 and 26 on every PR and adds a Node 22 source-compile job on pushes to master.
 
 ## [0.12.0] - 2026-06-26
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [SANDBOXING.md](SANDBOXING.md) for the full architecture with diagrams, laye
 
 ### Prerequisites
 
-- Node.js 22+ (required by `isolated-vm`; maximum Node 25)
+- Node.js 22–26 (required by `isolated-vm`; Node 24 and 26 use prebuilt binaries, Node 22 compiles from source at install and needs a C/C++ toolchain)
 - Docker — not required but **strongly recommended** for Docker Agent Mode, which provides the strongest isolation. On macOS 26+ (Apple silicon), [Apple `container`](https://github.com/apple/container) works as an alternative backend (VM per container; used automatically when its services are running — see `containerRuntime` in `ironcurtain config`)
 - An API key for at least one LLM provider (Anthropic, Google, or OpenAI)
 
@@ -344,7 +344,7 @@ See [docs/SECURITY_CONCERNS.md](docs/SECURITY_CONCERNS.md) for a detailed threat
 | **Missing API key**                     | Set the environment variable (`ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, or `OPENAI_API_KEY`) or add the corresponding key to `~/.ironcurtain/config.json`.                                                                                    |
 | **Sandbox unavailable**                 | OS-level sandboxing requires `bubblewrap` and `socat`. Install both, or set `"sandboxPolicy": "warn"` in your MCP server config for development.                                                                                                         |
 | **Budget exhausted**                    | Adjust limits in `~/.ironcurtain/config.json` under `resourceBudget`. Set any individual limit to `null` to disable it.                                                                                                                                  |
-| **Node version errors**                 | Node.js 22+ is required (`isolated-vm` needs `>=22.0.0`). Maximum supported is Node 25 (`<26`).                                                                                                                                                          |
+| **Node version errors**                 | Node.js 22–26 is required (`isolated-vm`, `>=22.0.0 <27`). Node 24 and 26 install prebuilt binaries; Node 22 compiles `isolated-vm` from source and needs a C/C++ toolchain.                                                                                                                                                          |
 | **Policy doesn't match intent**         | Review `compiled-policy.json` to see the generated rules. Run `ironcurtain customize-policy` to refine your constitution, then `ironcurtain compile-policy` to recompile. Specific wording produces better rules — vague phrasing leads to vague policy. |
 | **Auto-approve not triggering**         | The auto-approver only approves when the user's message explicitly authorizes the action (e.g., "push to origin" for `git_push`). Vague messages always escalate to human review. Verify `autoApprove.enabled` is `true` in `config.json`.               |
 | **PTY/mux terminal garbled after exit** | Run `reset` in that terminal to restore normal mode. This is needed when the process is killed ungracefully and raw mode is not restored.                                                                                                                |

--- a/docs/vuln-discovery-onboarding/README.md
+++ b/docs/vuln-discovery-onboarding/README.md
@@ -4,7 +4,7 @@ This guide walks a new user from a fresh checkout to a running `vuln-discovery` 
 
 ## Prerequisites
 
-- **Node.js 22, 23, or 24** (`isolated-vm` requires this; Node 25 segfaults and pre-flight will reject it)
+- **Node.js 22, 24, or 26** (`isolated-vm`; 24 and 26 use prebuilt binaries, Node 22 compiles from source). The pre-flight check validates your Node version and the sandbox before the workflow runs.
 - **Docker** running. The workflow uses Docker Agent Mode with `--network=none`, so Docker is required (not optional).
 - **LLM credentials.** Either:
   - `ANTHROPIC_API_KEY` exported in your shell or set in `~/.ironcurtain/config.json`, **or**

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=22.0.0 <26"
+        "node": ">=22.0.0 <27"
       },
       "optionalDependencies": {
         "node-pty": "^1.1.0",
@@ -6404,9 +6404,9 @@
       "license": "ISC"
     },
     "node_modules/isolated-vm": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
-      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-7.0.0.tgz",
+      "integrity": "sha512-TXlJp9kiSf4AEpkCgB4VIf2M+6MRW3SEzlZUXFmQ6QcRypOnENRvK6RoZuQt/dlLOnqyFGUoZELUfH4ucsG4iw==",
       "hasInstallScript": true,
       "license": "ISC",
       "peer": true,
@@ -6414,7 +6414,7 @@
         "node-gyp-build": "^4.8.4"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=26.0.0"
       }
     },
     "node_modules/istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=22.0.0 <26"
+    "node": ">=22.0.0 <27"
   },
   "bin": {
     "ironcurtain": "dist/cli.js"
@@ -112,7 +112,8 @@
     "terminal-kit": "^3.1.2"
   },
   "overrides": {
-    "minimatch": "^10.2.1"
+    "minimatch": "^10.2.1",
+    "isolated-vm": "7.0.0"
   },
   "lint-staged": {
     "!(packages/**)/*.ts": [

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -50,7 +50,7 @@ export interface CheckResult {
 
 /** Minimum and maximum supported Node.js major versions. */
 const NODE_MIN_MAJOR = 22;
-const NODE_MAX_MAJOR = 24;
+const NODE_MAX_MAJOR = 26;
 
 export function checkNodeVersion(versionString: string = process.versions.node): CheckResult {
   const match = /^(\d+)\./.exec(versionString);
@@ -68,7 +68,9 @@ export function checkNodeVersion(versionString: string = process.versions.node):
       name: 'Node.js',
       status: 'fail',
       message: `${versionString} (unsupported)`,
-      hint: `IronCurtain requires Node.js ${NODE_MIN_MAJOR}.x – ${NODE_MAX_MAJOR}.x.`,
+      hint:
+        `IronCurtain requires Node.js ${NODE_MIN_MAJOR}.x – ${NODE_MAX_MAJOR}.x. ` +
+        'Node 22 source-compiles the V8 sandbox (isolated-vm); 24 and 26 use prebuilt binaries.',
     };
   }
   return {

--- a/src/utils/preflight-checks.ts
+++ b/src/utils/preflight-checks.ts
@@ -172,9 +172,7 @@ function runSandboxViabilityCheck(): Promise<PreflightCheckResult> {
       if (signal) {
         message = `V8 sandbox crashed with signal ${signal}.`;
         if (signal === 'SIGSEGV' || signal === 'SIGILL') {
-          hint =
-            'This is often caused by an incompatible Node.js version (e.g., Node 25). ' +
-            'Please use Node.js 22, 23, or 24.';
+          hint = 'This is often caused by an unsupported Node.js version. Please use Node.js 22, 24, or 26.';
         }
       } else if (stderr.includes('NODE_MODULE_VERSION')) {
         message = 'Native module ABI mismatch detected.';

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -166,6 +166,7 @@ describe('checkNodeVersion', () => {
     expect(checkNodeVersion('22.13.0').status).toBe('ok');
     expect(checkNodeVersion('23.5.0').status).toBe('ok');
     expect(checkNodeVersion('24.0.0').status).toBe('ok');
+    expect(checkNodeVersion('26.0.0').status).toBe('ok');
   });
 
   it('fails for too-old major version', () => {
@@ -175,7 +176,7 @@ describe('checkNodeVersion', () => {
   });
 
   it('fails for too-new major version', () => {
-    const result = checkNodeVersion('25.0.0');
+    const result = checkNodeVersion('27.0.0');
     expect(result.status).toBe('fail');
   });
 


### PR DESCRIPTION
## Summary

IronCurtain's V8 sandbox (Code Mode) was broken on Node 26: `isolated-vm` 6.x ships no Node 26 (abi147) prebuilt binary **and** fails to compile against Node 26's V8 14.6 — the `GetAlignedPointerFromInternalField` signature gained a required `EmbedderDataTypeTag` argument, so 6.1.2's source no longer builds there. This forces `isolated-vm` to **7.0.0** via an npm `override` and widens the supported Node range to **22–26**.

`isolated-vm` is a transitive dependency (via `@utcp/code-mode`, which declares `^6.0.0`), so a direct bump wasn't possible — an `override` is the mechanism. It's safe because the 6.1.2 → 7.0.0 change is native-only: the JS API (`isolated-vm.d.ts`) is byte-identical, and code-mode only uses `Isolate`/`Context`/`Reference`.

## Prebuild coverage — the Node 22 caveat

No single `isolated-vm` version has prebuilts for all three even Node lines; the V8 14.6 API break forced a fork in the prebuild matrix:

| Node | ABI | 6.1.2 | 7.0.0 |
|------|-----|:-----:|:-----:|
| 22 | 127 | prebuild | **source-compile** |
| 24 | 137 | prebuild | prebuild |
| 26 | 147 | — | prebuild |

So on 7.0.0, Node 24/26 install a prebuilt binary, while **Node 22 compiles from source** at install (needs a C/C++ toolchain). Measured cost: ~20s serial on an M-series Mac; expect tens of seconds up to ~1–2 min on `ubuntu-latest`.

## Changes

- **`package.json`** — `overrides.isolated-vm = "7.0.0"`; `engines.node` `>=22.0.0 <26` → `>=22.0.0 <27`.
- **`src/doctor/checks.ts`** — `NODE_MAX_MAJOR` 24 → 26, with an accurate prebuild-vs-source hint.
- **`src/utils/preflight-checks.ts`** — corrected the stale "use Node 22, 23, or 24" segfault hint (predated 7.0.0).
- **CI (`ci.yml`)** — every PR runs `{ubuntu,macos} × {24,26}` (all prebuilt, fast); master pushes add a single `ubuntu × 22` source-compile job. `npm ci --foreground-scripts` plus a report step surface the Node ABI and whether isolated-vm was source-compiled or used a prebuild.
- **Release workflows** — `release.yml` and `release-memory-mcp-server.yml` pinned to Node 24, keeping releases off the source-compile path (the published artifacts don't bundle isolated-vm).
- **Docs** — README prerequisites + troubleshooting, vuln-discovery onboarding, CHANGELOG.

## Verification (local, Node 26.4.0)

- `doctor`: Node.js **and** V8 sandbox checks now green (both were failing).
- `format:check`, `lint`, `build`: clean.
- `sandbox.test.ts`: 16/16; `sandbox-integration.test.ts`: 53 pass / 1 skip (real MCP servers + real isolate execution).

## Notes

- `isolated-vm` 7.0.0 declares its own `engines.node: ">=26"`, so `npm ci` on the Node 22/24 jobs emits a benign `EBADENGINE` **warning** (not a failure — no `engine-strict` is set).
- This PR's CI run is itself the first exercise of the Node 26 line in GitHub Actions.
