### PR TITLE
test(signal): await 'denied' confirmation to fix deny-race flake

### DIFF
--- a/test/signal/signal-bot-daemon.test.ts
+++ b/test/signal/signal-bot-daemon.test.ts
@@ -1202,6 +1202,11 @@ describe('SignalBotDaemon', () => {
     // Step 6: Deny and verify it resolves on session #2
     mockApi.simulateIncomingMessage('+15559876543', 'deny');
     await waitForMessage(mockApi, (m) => m.includes('Clone operation was blocked'));
+    // The "Escalation denied." confirmation is emitted on a separate async chain
+    // (resolveSessionEscalation().then() in signal-bot-daemon.ts) and can lag the
+    // session's "blocked" response, so await it explicitly before asserting on it —
+    // otherwise `denyMsg` is intermittently undefined (macOS-runner-timing flake).
+    await waitForMessage(mockApi, (m) => m.includes('denied'));
 
     messages = mockApi.messageTexts;
     // The deny confirmation should reference session #2


### PR DESCRIPTION
## Summary

Fixes a pre-existing macOS CI flake in `test/signal/signal-bot-daemon.test.ts` — the test *"reproduces production scenario: session #1 escalation resolved, /new, message to #2 escalates with correct label."*

### Root cause

After `deny`, two **independent** async chains fire:
1. the session's agent emits `[#2] … Clone operation was blocked` (its response to the denied tool call), and
2. the daemon separately emits `[#2] Escalation denied.` via `resolveSessionEscalation().then()` (`signal-bot-daemon.ts:605`).

Step 6 awaited only chain (1) — the `"Clone operation was blocked"` message — then immediately did `messages.find(m => m.includes('denied'))` and asserted on it. Chain (2) can still be in flight at that point, so under macOS-runner timing pressure `denyMsg` was `undefined`, failing at `signal-bot-daemon.test.ts:1209`:

```
AssertionError: the given combination of arguments (undefined and string) is invalid…
❯ test/signal/signal-bot-daemon.test.ts:1209:21
```

It's environmental: it failed on a single `macos-latest` job while `ubuntu` and the other jobs passed the same test.

### Fix

Await the `"denied"` message explicitly before asserting on it — one added `await waitForMessage(...)`, plus a comment documenting the two-chain race. No production code changes.

## Verification

Ran `test/signal/signal-bot-daemon.test.ts` **3×** under the forks pool locally — 63/63 each time, no hang (the `denied` confirmation reliably arrives). eslint + prettier clean.

_Observed as an unrelated flake while landing #356/#358 (isolated-vm 7.0.0 / Node 26)._
