### PR TITLE
fix(docker): positive cert serials + stabilize flaky integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,11 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             if npm ci --foreground-scripts; then exit 0; fi
-            echo "::warning::npm ci attempt $attempt failed; cleaning and retrying in 15s"
-            rm -rf node_modules
-            sleep 15
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::npm ci attempt $attempt failed; cleaning and retrying in 15s"
+              rm -rf node_modules
+              sleep 15
+            fi
           done
           echo "::error::npm ci failed after 3 attempts"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,21 @@ jobs:
       # the Actions UI is then the measurement. (No node_modules/prebuild cache
       # here on purpose — npm ci stays deterministic; if the Node-22 job ever
       # gets painful, a prebuild cache is a possible future optimization.)
-      - run: npm ci --foreground-scripts
+      #
+      # Retried: some deps run postinstall scripts that download native binaries
+      # from a CDN (e.g. onnxruntime-node via @huggingface/transformers), which
+      # intermittently ETIMEDOUT/ENETUNREACH on runners and fails `npm ci`. Retry
+      # the whole install a couple times before giving up.
+      - name: Install dependencies (retry on transient network failure)
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci --foreground-scripts; then exit 0; fi
+            echo "::warning::npm ci attempt $attempt failed; cleaning and retrying in 15s"
+            rm -rf node_modules
+            sleep 15
+          done
+          echo "::error::npm ci failed after 3 attempts"
+          exit 1
       - name: Report Node ABI and isolated-vm build source
         run: |
           node -e "console.log('ABI', process.versions.modules)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - **Node.js 26 support** — bumped the V8 sandbox dependency `isolated-vm` to 7.0.0 (via an npm `override`, since it is transitive through `@utcp/code-mode`) so Code Mode initializes on Node 26; `isolated-vm` 6.x has no Node 26 prebuild and fails to compile against Node 26's V8. Supported lines are now the even-numbered major lines **22, 24, and 26**: Node 24 and 26 install prebuilt native binaries, while Node 22 compiles `isolated-vm` from source at install (no prebuilt binary ships for it, so a C/C++ toolchain is required). Odd non-LTS lines (23, 25) run within `engines` (`>=22.0.0 <27`) but are untested — `ironcurtain doctor` reports them as a warning, not an `ok`. CI runs Node 24 and 26 on every PR and adds a Node 22 source-compile job on pushes to master (#356, #358).
 
+### Fixes
+
+- **MITM proxy certificate generation on Node 22 / OpenSSL 3.0** — `randomSerialNumber()` produced a 16-byte serial with no DER sign padding, so ~50% of generated certificates had a leading byte ≥ `0x80` and were encoded as a *negative* ASN.1 INTEGER. Strict OpenSSL builds (Node 22 / OpenSSL 3.0.x) reject these at cert-load with `asn1 encoding routines::illegal padding`, so MITM cert generation (CA and every leaf cert) failed intermittently on Node 22; Node 26's OpenSSL 3.6 tolerated it. Serials are now always positive DER INTEGERs.
+
 ## [0.12.0] - 2026-06-26
 
 ### Features

--- a/src/docker/ca.ts
+++ b/src/docker/ca.ts
@@ -99,6 +99,12 @@ function generateCA(certPath: string, keyPath: string): CertificateAuthority {
 
 /** Generates a random serial number as a hex string. */
 export function randomSerialNumber(): string {
-  const bytes = forge.random.getBytesSync(16);
-  return forge.util.bytesToHex(bytes);
+  const hex = forge.util.bytesToHex(forge.random.getBytesSync(16));
+  // node-forge encodes the serial's bytes verbatim with no sign pad; a leading
+  // byte >= 0x80 becomes a NEGATIVE DER INTEGER, which strict OpenSSL (Node 22 /
+  // OpenSSL 3.0.x) rejects at cert-load with "asn1 …::illegal padding". Clear the
+  // high bit for a positive serial, and avoid a 0x00 leading byte (redundant pad).
+  let first = parseInt(hex.slice(0, 2), 16) & 0x7f;
+  if (first === 0) first = 0x01;
+  return first.toString(16).padStart(2, '0') + hex.slice(2);
 }

--- a/src/signal/signal-bot-daemon.ts
+++ b/src/signal/signal-bot-daemon.ts
@@ -103,6 +103,7 @@ export class SignalBotDaemon {
   private baseUrl: string = '';
   private closed = false;
   private reconnectAttempts = 0;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
   private static readonly MAX_RECONNECT_DELAY_MS = 30_000;
   private static readonly BASE_RECONNECT_DELAY_MS = 1_000;
 
@@ -195,6 +196,10 @@ export class SignalBotDaemon {
   async shutdown(): Promise<void> {
     logger.info('[Signal Daemon] Shutting down...');
     this.closed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
     await this.sendSignalMessage('IronCurtain bot is shutting down. Goodbye.').catch(() => {});
 
     // Wait for any in-flight session operations (e.g., /new) to complete
@@ -292,13 +297,15 @@ export class SignalBotDaemon {
       SignalBotDaemon.MAX_RECONNECT_DELAY_MS,
     );
 
-    setTimeout(() => {
+    this.reconnectTimer = setTimeout(() => {
       if (!this.closed) {
         this.connectWebSocket().catch(() => {
           // Retry will be scheduled by the close handler
         });
       }
     }, delay);
+    // Don't let a pending reconnect timer keep the event loop alive after shutdown.
+    this.reconnectTimer.unref();
   }
 
   // --- Message routing ---

--- a/test/ca.test.ts
+++ b/test/ca.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import forge from 'node-forge';
-import { loadOrCreateCA } from '../src/docker/ca.js';
+import { loadOrCreateCA, randomSerialNumber } from '../src/docker/ca.js';
 
 describe('loadOrCreateCA', () => {
   let tempDir: string;
@@ -108,5 +108,27 @@ describe('loadOrCreateCA', () => {
     // Verify the leaf cert was signed by the CA
     const verified = caCert.verify(leafCert);
     expect(verified).toBe(true);
+  });
+});
+
+describe('randomSerialNumber', () => {
+  // node-forge encodes the serial's bytes verbatim as a DER INTEGER with no sign
+  // padding, so a leading byte >= 0x80 becomes a NEGATIVE integer that strict
+  // OpenSSL (Node 22 / OpenSSL 3.0.x) rejects at cert-load with "illegal padding".
+  // The leading byte must always encode a positive, minimally-encoded integer:
+  // >= 0x01 (non-zero, no redundant sign pad) and < 0x80 (positive).
+  it('always produces a positive, minimally-encoded leading byte', () => {
+    for (let i = 0; i < 500; i++) {
+      const serial = randomSerialNumber();
+      const first = parseInt(serial.slice(0, 2), 16);
+      expect(first).toBeGreaterThanOrEqual(0x01);
+      expect(first).toBeLessThan(0x80);
+    }
+  });
+
+  it('returns 32 hex chars (16 bytes) of even length', () => {
+    const serial = randomSerialNumber();
+    expect(serial).toHaveLength(32);
+    expect(serial).toMatch(/^[0-9a-f]+$/);
   });
 });

--- a/test/fetch-server.test.ts
+++ b/test/fetch-server.test.ts
@@ -125,7 +125,11 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await client.close();
-  httpServer.close();
+  // Force-close any lingering connections (e.g. the never-responding /slow
+  // request) so the server socket actually releases and doesn't keep the event
+  // loop alive past teardown.
+  httpServer.closeAllConnections();
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
 });
 
 /** Extracts the text content from an MCP tool call result. */

--- a/test/mux-escalation-manager.test.ts
+++ b/test/mux-escalation-manager.test.ts
@@ -30,6 +30,20 @@ vi.mock('../src/escalation/listener-lock.js', async (importOriginal) => {
   };
 });
 
+// The watcher polls on a 300ms interval, so a fixed sleep can lose the race under
+// a GC/scheduler stall. Poll the live `pendingCount` getter until it reaches the
+// expected value or a generous timeout elapses.
+async function waitForPendingCount(
+  manager: { readonly pendingCount: number },
+  expected: number,
+  timeoutMs = 5000,
+): Promise<void> {
+  const start = Date.now();
+  while (manager.pendingCount < expected && Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
 describe('MuxEscalationManager', () => {
   let tempDir: string;
 
@@ -149,7 +163,7 @@ describe('MuxEscalationManager', () => {
     });
 
     // Wait for the watcher to poll (default 300ms)
-    await new Promise((r) => setTimeout(r, 500));
+    await waitForPendingCount(manager, 1);
 
     expect(manager.pendingCount).toBe(1);
     manager.stop();
@@ -187,7 +201,7 @@ describe('MuxEscalationManager', () => {
     });
 
     // Wait for the watcher to poll (default 300ms)
-    await new Promise((r) => setTimeout(r, 500));
+    await waitForPendingCount(manager, 1);
 
     // Should only have 1 pending escalation, not 2
     expect(manager.pendingCount).toBe(1);

--- a/test/mux-escalation-manager.test.ts
+++ b/test/mux-escalation-manager.test.ts
@@ -39,7 +39,12 @@ async function waitForPendingCount(
   timeoutMs = 5000,
 ): Promise<void> {
   const start = Date.now();
-  while (manager.pendingCount < expected && Date.now() - start < timeoutMs) {
+  while (manager.pendingCount < expected) {
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for pendingCount to reach ${expected} (last seen: ${manager.pendingCount})`,
+      );
+    }
     await new Promise((r) => setTimeout(r, 25));
   }
 }

--- a/test/signal/setup-signal.test.ts
+++ b/test/signal/setup-signal.test.ts
@@ -151,7 +151,8 @@ interface SentMessage {
 class MockSignalApi {
   private server: http.Server;
   readonly sentMessages: SentMessage[] = [];
-  readonly port: number;
+  // Assigned by start() after the OS picks an ephemeral port (bind to 0).
+  port = 0;
   private identities: Array<{
     number: string;
     fingerprint: string;
@@ -163,8 +164,7 @@ class MockSignalApi {
   private registerShouldFail = false;
   private verifyShouldFail = false;
 
-  constructor(port: number) {
-    this.port = port;
+  constructor() {
     this.server = http.createServer((req, res) => {
       this.handleRequest(req, res);
     });
@@ -193,8 +193,14 @@ class MockSignalApi {
   }
 
   async start(): Promise<void> {
-    return new Promise((resolve) => {
-      this.server.listen(this.port, '127.0.0.1', () => resolve());
+    return new Promise((resolve, reject) => {
+      this.server.on('error', reject);
+      // Bind an ephemeral port (0) so parallel/retried runs never collide.
+      this.server.listen(0, '127.0.0.1', () => {
+        const addr = this.server.address();
+        this.port = typeof addr === 'object' && addr ? addr.port : 0;
+        resolve();
+      });
     });
   }
 
@@ -300,12 +306,11 @@ describe('validatePhoneNumber', () => {
 describe('registerNewNumber', () => {
   let api: MockSignalApi;
   let baseUrl: string;
-  const PORT = 19201;
 
   beforeAll(async () => {
-    api = new MockSignalApi(PORT);
+    api = new MockSignalApi();
     await api.start();
-    baseUrl = `http://127.0.0.1:${PORT}`;
+    baseUrl = `http://127.0.0.1:${api.port}`;
   });
 
   afterAll(async () => {
@@ -352,12 +357,11 @@ describe('registerNewNumber', () => {
 describe('verifyRecipientIdentity', () => {
   let api: MockSignalApi;
   let baseUrl: string;
-  const PORT = 19203;
 
   beforeAll(async () => {
-    api = new MockSignalApi(PORT);
+    api = new MockSignalApi();
     await api.start();
-    baseUrl = `http://127.0.0.1:${PORT}`;
+    baseUrl = `http://127.0.0.1:${api.port}`;
   });
 
   afterAll(async () => {
@@ -422,11 +426,12 @@ describe('verifyRecipientIdentity', () => {
 
 describe('runSignalSetup', () => {
   let api: MockSignalApi;
-  const PORT = 19204;
+  let port: number;
 
   beforeAll(async () => {
-    api = new MockSignalApi(PORT);
+    api = new MockSignalApi();
     await api.start();
+    port = api.port;
   });
 
   afterAll(async () => {
@@ -441,7 +446,7 @@ describe('runSignalSetup', () => {
     api.setRegisterShouldFail(false);
     api.setVerifyShouldFail(false);
 
-    sharedContainerManager.ensureRunning.mockResolvedValue(`http://127.0.0.1:${PORT}`);
+    sharedContainerManager.ensureRunning.mockResolvedValue(`http://127.0.0.1:${port}`);
     sharedContainerManager.isRunning.mockResolvedValue(true);
     sharedContainerManager.pullImage.mockResolvedValue(undefined);
     sharedContainerManager.waitForHealthy.mockResolvedValue(undefined);
@@ -481,7 +486,7 @@ describe('runSignalSetup', () => {
       recipientIdentityKey: '05oldkey1234567890abcdef',
       container: {
         image: 'bbernhard/signal-cli-rest-api:latest',
-        port: PORT,
+        port,
         dataDir: '/tmp/test-signal-data',
         containerName: 'ironcurtain-signal-test',
       },
@@ -516,11 +521,12 @@ describe('runSignalSetup', () => {
 
 describe('runReTrust', () => {
   let api: MockSignalApi;
-  const PORT = 19205;
+  let port: number;
 
   beforeAll(async () => {
-    api = new MockSignalApi(PORT);
+    api = new MockSignalApi();
     await api.start();
+    port = api.port;
   });
 
   afterAll(async () => {
@@ -540,14 +546,14 @@ describe('runReTrust', () => {
       recipientIdentityKey: '05oldkey1234567890abcdef',
       container: {
         image: 'bbernhard/signal-cli-rest-api:latest',
-        port: PORT,
+        port,
         dataDir: '/tmp/test-signal-data',
         containerName: 'ironcurtain-signal-test',
       },
     });
 
     sharedContainerManager.isRunning.mockResolvedValue(true);
-    sharedContainerManager.ensureRunning.mockResolvedValue(`http://127.0.0.1:${PORT}`);
+    sharedContainerManager.ensureRunning.mockResolvedValue(`http://127.0.0.1:${port}`);
   });
 
   it('re-verifies identity and saves new key', async () => {

--- a/test/signal/signal-bot-daemon.test.ts
+++ b/test/signal/signal-bot-daemon.test.ts
@@ -23,13 +23,12 @@ class MockSignalApi {
   private server: http.Server;
   private wss: WebSocketServer;
   readonly sentMessages: SentMessage[] = [];
-  readonly port: number;
+  // Assigned by start() after the OS picks an ephemeral port (bind to 0).
+  port = 0;
   private identities: Array<{ number: string; fingerprint: string }> = [];
   private identityEndpointDown = false;
 
-  constructor(port: number) {
-    this.port = port;
-
+  constructor() {
     this.server = http.createServer((req, res) => {
       this.handleRequest(req, res);
     });
@@ -80,8 +79,14 @@ class MockSignalApi {
   }
 
   async start(): Promise<void> {
-    return new Promise((resolve) => {
-      this.server.listen(this.port, '127.0.0.1', () => resolve());
+    return new Promise((resolve, reject) => {
+      this.server.on('error', reject);
+      // Bind an ephemeral port (0) so parallel/retried runs never collide.
+      this.server.listen(0, '127.0.0.1', () => {
+        const addr = this.server.address();
+        this.port = typeof addr === 'object' && addr ? addr.port : 0;
+        resolve();
+      });
     });
   }
 
@@ -465,11 +470,11 @@ describe('SignalBotDaemon', () => {
   let mockApi: MockSignalApi;
   let port: number;
 
-  // Use a random port to avoid conflicts
+  // Bind an ephemeral port to avoid conflicts; read it back after start().
   beforeEach(async () => {
-    port = 18100 + Math.floor(Math.random() * 900);
-    mockApi = new MockSignalApi(port);
+    mockApi = new MockSignalApi();
     await mockApi.start();
+    port = mockApi.port;
     // Set default identity for the configured recipient
     mockApi.setIdentities([{ number: '+15559876543', fingerprint: 'test-identity-key-abc123' }]);
   });
@@ -1408,6 +1413,10 @@ describe('SignalBotDaemon', () => {
     // Deny and verify correct routing
     mockApi.simulateIncomingMessage('+15559876543', 'deny');
     await waitForMessage(mockApi, (m) => m.includes('Clone blocked'));
+    // The "denied" confirmation is emitted on a separate async chain
+    // (resolveSessionEscalation().then()) from the session's "Clone blocked"
+    // response, so wait for it explicitly before asserting on it.
+    await waitForMessage(mockApi, (m) => m.includes('denied') && m.includes('[#2]'));
 
     messages = mockApi.messageTexts;
     // Deny confirmation should reference #2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['test/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
     testTimeout: 30_000,
+    // Match CI's default pool explicitly so local and CI runs behave the same.
+    pool: 'forks',
+    // Mitigation (not a root-cause fix): the MCP SDK's StdioClientTransport.close()
+    // does not await the child's 'close' after SIGKILL, so under a loaded runner a
+    // spawned MCP server can still be exiting when teardown completes, briefly
+    // holding its stdio pipe FDs open. That intermittently tripped the default 10s
+    // teardown limit ("close timed out after 10000ms … Worker exited unexpectedly")
+    // even though all tests passed. Give slow child-reaping more slack.
+    teardownTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

Stabilizes the integration suite by fixing the **root cause** of each CI flake surfaced while landing Node 26 support (#356/#358/#359). None were caused by those PRs — three investigation passes traced each to a real defect. One of them (the cert serial) is a genuine **production bug**, not just a test flake.

## The fixes, by flake

### 1. proxy-integration ASN.1 "illegal padding" → a real MITM cert bug on Node 22 *(production fix)*
`randomSerialNumber()` (`src/docker/ca.ts`) generated a 16-byte serial and handed it to node-forge with **no DER sign padding**. ~50% of the time the leading byte is ≥ `0x80`, so node-forge encodes a **negative** ASN.1 INTEGER. Strict OpenSSL builds (**Node 22 / OpenSSL 3.0.x**) reject such certs at load with `error:068000DD:asn1 encoding routines::illegal padding`; Node 26's OpenSSL 3.6 tolerates them. So MITM cert generation (the CA cert **and every leaf cert**) failed ~50% of the time on Node 22 — in production, not just tests.

**Fix:** force a positive, minimally-encoded leading byte (clear the high bit; avoid a `0x00` lead). Added a regression test.

Verified: 0/5000 serials have a high/zero leading byte; a real forge cert with the new serial parses as a **positive** serial via `crypto.X509Certificate` (no leading `-`).

### 2. onnxruntime-node install `ETIMEDOUT` → CI install retry
`npm ci` runs postinstall scripts that download native binaries from a CDN (`onnxruntime-node` via `@huggingface/transformers`), which intermittently times out on runners. **`ci.yml`** now retries `npm ci` up to 3× (clean `node_modules` between attempts) before failing.

### 3. "Worker exited unexpectedly / close timed out after 10000ms" → teardown mitigation
Investigation showed the #353 stdout guard is complete; the mechanism is the MCP SDK's `StdioClientTransport.close()` **not awaiting the child's exit after SIGKILL**, so a slow-reaping child briefly holds pipe FDs past the default 10s teardown. **`vitest.config.ts`** now sets `pool: 'forks'` explicitly and raises `teardownTimeout` to 30s — labeled in-code as a **mitigation**, not a root-cause fix (that lives in the SDK). Plus two cheap, correct hardening closes: `fetch-server.test.ts` (`closeAllConnections()` + awaited `close()`), and `signal-bot-daemon.ts` (`.unref()` + cancel the reconnect timer on shutdown).

### 4. signal-daemon assertion flake → the *twin* of #359 + suite audit
An audit found a second instance of the exact #359 deny-race — a **different** test in `signal-bot-daemon.test.ts` that awaited the session's "blocked" response then asserted on the separately-emitted "denied" confirmation without awaiting it. Fixed the same way. The audit also fixed:
- **`mux-escalation-manager.test.ts`**: a fixed `500ms` sleep racing a `300ms` poller → bounded poll-until-condition.
- **signal test mocks** (`signal-bot-daemon.test.ts`, `setup-signal.test.ts`): fixed/leak-prone listener ports → **ephemeral port 0** (no more `EADDRINUSE` hangs under parallelism/retries).

## Verification (local, Node 26)
- Affected tests green, and the timing-sensitive ones stress-run **3×** clean: ca (37), signal-bot-daemon + mux-escalation (78 ×3), setup-signal + fetch-server.
- `npm run build`, `format:check`, `lint`: clean.
- Cert fix proven at the byte level and end-to-end (positive serial parse).

_Note: the cert fix's effect is only observable on Node 22 (Node 26's OpenSSL accepts the old encoding), so CI here validates no regression; the Node 22 line runs on the master merge._
