### PR TITLE
feat(config): OpenRouter model-name autocomplete + validation (web UI + CLI)

### DIFF
--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -560,6 +560,52 @@ let modelProviders: MockModelProviders = {
 
 const ORIGINAL_MODEL_PROVIDERS: MockModelProviders = structuredClone(modelProviders);
 
+// ---------------------------------------------------------------------------
+// OpenRouter model catalog (config.listOpenrouterModels).
+//
+// A realistic slug set for offline autocomplete/validation dev + demo. It MUST
+// include every slug referenced by the canned profiles above (z-ai/glm-5.2,
+// moonshot/kimi-k3) plus every DEFAULT_MODEL_MAP target, so opening/saving the
+// seeded profiles never hard-blocks.
+//
+// The reported `source` defaults to 'live' so the HARD-BLOCK path is demoable
+// offline (type a garbage slug -> see it blocked). Set the env var
+// MOCK_OPENROUTER_SOURCE=bundled to reach the warn-degrade path (unknown slugs
+// allowed), or =cache/=live for the authoritative path — all without a real daemon.
+// ---------------------------------------------------------------------------
+
+const MOCK_SLUGS: readonly string[] = [
+  'anthropic/claude-3.5-haiku',
+  'anthropic/claude-3.5-sonnet',
+  'anthropic/claude-3.7-sonnet',
+  'anthropic/claude-opus-4.1',
+  'anthropic/claude-sonnet-4.5',
+  'deepseek/deepseek-chat',
+  'deepseek/deepseek-r1',
+  'deepseek/deepseek-v3',
+  'google/gemini-2.0-flash',
+  'google/gemini-2.5-flash',
+  'google/gemini-2.5-pro',
+  'moonshot/kimi-k3',
+  'moonshotai/kimi-k2',
+  'openai/gpt-4.1',
+  'openai/gpt-4o',
+  'openai/gpt-4o-mini',
+  'openai/gpt-5',
+  'openai/o3',
+  'openai/o4-mini',
+  'x-ai/grok-4',
+  'z-ai/glm-4.5',
+  'z-ai/glm-4.6',
+  'z-ai/glm-5.2',
+];
+
+function resolveMockOpenrouterSource(): 'live' | 'cache' | 'bundled' {
+  const v = process.env.MOCK_OPENROUTER_SOURCE;
+  if (v === 'bundled' || v === 'cache' || v === 'live') return v;
+  return 'live';
+}
+
 /** Mirrors maskApiKey in config-command.ts / config-dispatch.ts (`sk-...xyz` / 'none'). */
 function maskApiKey(key: string | undefined): string {
   if (!key) return 'none';
@@ -1870,6 +1916,12 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
       broadcast('config.changed', {});
       return buildModelProvidersDto();
     }
+
+    // Ungated read of the OpenRouter catalog. Source is env-toggled (see
+    // MOCK_OPENROUTER_SOURCE near MOCK_SLUGS) so both validation modes are
+    // reachable offline; defaults to 'live' (hard-block path).
+    case 'config.listOpenrouterModels':
+      return { models: MOCK_SLUGS, source: resolveMockOpenrouterSource() };
 
     // Workflow methods
     case 'workflows.listDefinitions':

--- a/packages/web-ui/src/lib/components/features/model-combobox.svelte
+++ b/packages/web-ui/src/lib/components/features/model-combobox.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import { tick } from 'svelte';
+  import { Spinner } from '$lib/components/ui/spinner/index.js';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+
+  // Presentational OpenRouter slug picker. Free-typing is ALWAYS allowed — the
+  // dropdown only assists; the authoritative hard-block lives at save time in the
+  // route. This component holds NO store/RPC dependency (features layer rule); the
+  // route owns the fetch and feeds `models`/`source`/`loading`/`error` down.
+  let {
+    value = $bindable(''),
+    models,
+    source,
+    loading,
+    error,
+    invalid = false,
+    placeholder,
+    testid,
+  }: {
+    value?: string;
+    models: readonly string[];
+    source: 'live' | 'cache' | 'bundled';
+    loading: boolean;
+    error: boolean;
+    invalid?: boolean;
+    placeholder?: string;
+    testid: string;
+  } = $props();
+
+  // Cap rendered rows for DOM cost; the popover height caps visually (~8 rows) and
+  // scrolls beyond that.
+  const MAX_OPTIONS = 50;
+
+  let inputEl = $state<HTMLInputElement>();
+  let popoverEl = $state<HTMLDivElement>();
+  let open = $state(false);
+  let activeIndex = $state(-1);
+  let pos = $state({ top: 0, left: 0, width: 0 });
+
+  // ARIA ids are per-instance (derived from the unique testid) so multiple
+  // comboboxes never share an id; the data-testids stay fixed per the contract.
+  const listboxId = $derived(`${testid}-listbox`);
+  const optionId = (i: number): string => `${testid}-option-${i}`;
+
+  const filtered = $derived.by(() => {
+    const q = value.trim().toLowerCase();
+    const matches = q.length === 0 ? models : models.filter((m) => m.toLowerCase().includes(q));
+    return matches.slice(0, MAX_OPTIONS);
+  });
+
+  const activeDescendant = $derived(open && activeIndex >= 0 ? optionId(activeIndex) : undefined);
+
+  function updatePosition(): void {
+    if (!inputEl) return;
+    const r = inputEl.getBoundingClientRect();
+    pos = { top: r.bottom + 4, left: r.left, width: r.width };
+  }
+
+  function openPopover(): void {
+    open = true;
+    updatePosition();
+  }
+
+  function closePopover(): void {
+    open = false;
+    activeIndex = -1;
+  }
+
+  function commit(slug: string): void {
+    // Focus stays on the input throughout (Enter never blurs; option mousedown is
+    // prevented), so we must NOT re-focus here — that would re-fire onfocus and
+    // reopen the popover we just closed.
+    value = slug;
+    closePopover();
+  }
+
+  function scrollActiveIntoView(): void {
+    void tick().then(() => {
+      if (activeIndex < 0) return;
+      // getElementById (no CSS.escape / no CSS global dependency) — the popover is
+      // portaled to <body>, so a document-level lookup finds the active option.
+      // scrollIntoView is absent under jsdom, so feature-detect before calling.
+      const el = document.getElementById(optionId(activeIndex));
+      if (el && typeof el.scrollIntoView === 'function') el.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  function moveActive(delta: number): void {
+    const n = filtered.length;
+    if (n === 0) {
+      activeIndex = -1;
+      return;
+    }
+    const base = activeIndex < 0 ? (delta > 0 ? -1 : 0) : activeIndex;
+    activeIndex = (base + delta + n) % n;
+    scrollActiveIntoView();
+  }
+
+  function onInput(): void {
+    // `value` is already updated via bind:value; typing (re)opens and resets the
+    // active option so a bare Enter commits the typed text, not a stale highlight.
+    if (!open) open = true;
+    activeIndex = -1;
+    updatePosition();
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        if (!open) openPopover();
+        else moveActive(1);
+        return;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (!open) openPopover();
+        else moveActive(-1);
+        return;
+      case 'Enter':
+        if (!open) return;
+        e.preventDefault();
+        if (activeIndex >= 0 && activeIndex < filtered.length) commit(filtered[activeIndex]);
+        else closePopover(); // keep the typed value as-is
+        return;
+      case 'Escape':
+        if (!open) return;
+        // Swallow so the enclosing Modal does not also close on this Escape.
+        e.stopPropagation();
+        closePopover();
+        return;
+      case 'Tab':
+        // Commit typed text and close; let focus move naturally.
+        if (open) closePopover();
+        return;
+    }
+  }
+
+  // Teleport the popover to <body> so the max-h-[70vh] overflow-y-auto editor
+  // modal cannot clip a bottom-row dropdown. Positioned fixed against the input
+  // rect, kept in sync on scroll/resize; closed on outside pointer-down.
+  function portal(node: HTMLElement): { destroy: () => void } {
+    document.body.appendChild(node);
+    return {
+      destroy: () => node.remove(),
+    };
+  }
+
+  $effect(() => {
+    if (!open) return;
+    updatePosition();
+    const reposition = (): void => updatePosition();
+    const onDocPointerDown = (e: MouseEvent): void => {
+      const t = e.target as Node | null;
+      if (t && (inputEl?.contains(t) || popoverEl?.contains(t))) return;
+      closePopover();
+    };
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    document.addEventListener('mousedown', onDocPointerDown, true);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+      document.removeEventListener('mousedown', onDocPointerDown, true);
+    };
+  });
+</script>
+
+<div class="relative">
+  <input
+    bind:this={inputEl}
+    bind:value
+    {placeholder}
+    data-testid={testid}
+    role="combobox"
+    aria-expanded={open}
+    aria-controls={open ? listboxId : undefined}
+    aria-autocomplete="list"
+    aria-activedescendant={activeDescendant}
+    aria-invalid={invalid ? true : undefined}
+    autocomplete="off"
+    class={cn(
+      'w-full px-3 py-2.5 bg-background border rounded-lg text-sm transition-all',
+      'focus:outline-none focus:ring-2 placeholder:text-muted-foreground/50 disabled:opacity-50',
+      invalid
+        ? 'border-destructive ring-2 ring-destructive/40 focus:ring-destructive/40 focus:border-destructive'
+        : 'border-border focus:ring-ring/40 focus:border-ring',
+      loading ? 'pr-8' : '',
+    )}
+    oninput={onInput}
+    onfocus={openPopover}
+    onkeydown={onKeydown}
+  />
+  {#if loading}
+    <span class="absolute right-2.5 top-1/2 -translate-y-1/2 pointer-events-none">
+      <Spinner size="xs" />
+    </span>
+  {/if}
+</div>
+
+{#if error}
+  <p class="mt-1 text-[11px] text-muted-foreground">Couldn't load model list — validation is best-effort.</p>
+{:else if source === 'bundled' && !loading}
+  <div class="mt-1">
+    <Badge variant="warning" data-testid="model-combobox-source" title="unverified slugs allowed">
+      Partial list (offline)
+    </Badge>
+  </div>
+{/if}
+
+{#if open}
+  <div
+    use:portal
+    bind:this={popoverEl}
+    class="fixed z-[60] rounded-lg border border-border bg-card shadow-xl overflow-hidden animate-fade-in"
+    style="top: {pos.top}px; left: {pos.left}px; width: {pos.width}px;"
+  >
+    {#if loading}
+      <div class="px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
+        <Spinner size="xs" /> Loading models…
+      </div>
+    {:else if filtered.length === 0}
+      <div class="px-3 py-2 text-sm text-muted-foreground">
+        {#if value.trim().length > 0}
+          No matching models — press Enter to use “{value.trim()}” as-is
+        {:else}
+          No models available
+        {/if}
+      </div>
+    {:else}
+      <ul id={listboxId} role="listbox" data-testid="model-combobox-listbox" class="max-h-64 overflow-y-auto py-1">
+        {#each filtered as slug, i (slug)}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <li
+            id={optionId(i)}
+            role="option"
+            aria-selected={i === activeIndex}
+            data-testid={`model-combobox-option-${i}`}
+            class={cn(
+              'px-3 py-1.5 text-sm cursor-pointer font-mono',
+              i === activeIndex ? 'bg-primary/15 text-primary' : 'text-foreground hover:bg-muted',
+            )}
+            onmousedown={(e) => e.preventDefault()}
+            onclick={() => commit(slug)}
+          >
+            {slug}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+{/if}

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -32,6 +32,7 @@ import type {
   MessageLogResponseDto,
   GetModelProvidersDto,
   SetModelProvidersDto,
+  OpenrouterModelsDto,
 } from './types.js';
 import { PHASE } from './types.js';
 import { createWsClient, type PreflightResult, type WsClient } from './ws-client.js';
@@ -706,6 +707,19 @@ export async function setModelProviders(input: SetModelProvidersDto): Promise<Ge
     ...(input.default !== undefined ? { default: input.default } : {}),
     profiles: input.profiles,
   });
+}
+
+/**
+ * Fetch the OpenRouter model-slug catalog for autocomplete/validation. `source`
+ * tells the caller whether the list is authoritative (`live`/`cache` → hard-block
+ * unknown slugs) or the offline floor (`bundled` → warn-only). Ungated read.
+ * Pass `forceRefresh` to bypass the daemon's 6h cache (the editor's Refresh button).
+ */
+export async function listOpenrouterModels(forceRefresh = false): Promise<OpenrouterModelsDto> {
+  return getWsClient().request<OpenrouterModelsDto>(
+    'config.listOpenrouterModels',
+    forceRefresh ? { forceRefresh: true } : {},
+  );
 }
 
 export async function connectWithToken(token: string): Promise<void> {

--- a/packages/web-ui/src/lib/types.ts
+++ b/packages/web-ui/src/lib/types.ts
@@ -553,6 +553,16 @@ export interface SetModelProvidersDto {
   readonly profiles: Readonly<Record<string, ProfileDto>>;
 }
 
+/**
+ * Response from `config.listOpenrouterModels`. `source` drives validation
+ * strictness: `live`/`cache` hard-block unknown slugs; `bundled` (the offline
+ * floor) is warn-only.
+ */
+export interface OpenrouterModelsDto {
+  readonly models: readonly string[];
+  readonly source: 'live' | 'cache' | 'bundled';
+}
+
 // ---------------------------------------------------------------------------
 // Persona streamed-compile types (Phase 1b). Mirror src/web-ui/web-ui-types.ts.
 // ---------------------------------------------------------------------------

--- a/packages/web-ui/src/routes/Settings.svelte
+++ b/packages/web-ui/src/routes/Settings.svelte
@@ -3,6 +3,7 @@
   import {
     getModelProviders,
     setModelProviders,
+    listOpenrouterModels,
     appState,
     connectionGeneration,
     configChangedGeneration,
@@ -15,16 +16,23 @@
   import { Input } from '$lib/components/ui/input/index.js';
   import { Modal } from '$lib/components/ui/modal/index.js';
   import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '$lib/components/ui/table/index.js';
+  import ModelCombobox from '$lib/components/features/model-combobox.svelte';
   import Plus from 'phosphor-svelte/lib/Plus';
   import Trash from 'phosphor-svelte/lib/Trash';
+  import ArrowsClockwise from 'phosphor-svelte/lib/ArrowsClockwise';
   import {
     NATIVE_NAME,
     DOCKER_AGENTS,
+    type DockerAgent,
     type EditableProfile,
     blankOpenrouterProfile,
     toEditable,
     editableToDto,
     isDuplicateProfileName,
+    validateSlugs,
+    blockMessage,
+    warningMessage,
+    persistedSlugSet,
   } from './settings-helpers.js';
 
   // Whether the daemon permits config mutation. When false every mutation control
@@ -44,6 +52,21 @@
   let editing = $state<{ name: string; original: string | null; profile: EditableProfile } | null>(null);
   let saving = $state(false);
   let saveError = $state<{ code: string; message: string } | null>(null);
+
+  // OpenRouter model catalog for slug autocomplete + save-time validation.
+  // `modelsSource` defaults to 'bundled' (warn-only) until loadModels() resolves,
+  // so an in-flight save can never spuriously hard-block.
+  let models = $state<string[]>([]);
+  let modelsSource = $state<'live' | 'cache' | 'bundled'>('bundled');
+  let modelsLoading = $state(false);
+  let modelsError = $state(false);
+  let modelsLoaded = $state(false);
+
+  // Fields the last blocked save flagged (drives each combobox's `invalid` ring).
+  let invalidModelRows = $state<ReadonlySet<number>>(new Set());
+  let invalidAgents = $state<ReadonlySet<DockerAgent>>(new Set());
+  // Non-blocking note surfaced after a warn-degrade save (modal already closed).
+  let savedWarning = $state('');
 
   // Delete confirmation.
   let deleteTarget = $state<string | null>(null);
@@ -117,22 +140,61 @@
     return `${mapPart} · key: ${p.apiKey ?? 'none'}`;
   }
 
+  // Fetch the OpenRouter catalog lazily when the editor opens. Best-effort: a
+  // failure degrades to the bundled (warn-only) mode, never throws. Loads once
+  // per page session (the daemon caches with a 6h TTL); a prior failure retries,
+  // and the editor's Refresh button forces a re-fetch (`opts.force`).
+  async function loadModels(opts?: { force?: boolean }): Promise<void> {
+    const force = opts?.force ?? false;
+    if (modelsLoading) return;
+    if (modelsLoaded && !modelsError && !force) return;
+    modelsLoading = true;
+    modelsError = false;
+    try {
+      const dto = await listOpenrouterModels(force);
+      models = [...dto.models];
+      modelsSource = dto.source;
+      modelsLoaded = true;
+    } catch {
+      modelsError = true;
+    }
+    modelsLoading = false;
+  }
+
+  // Clears per-edit UX state (blocked-field marks + the last warn note) so a
+  // freshly opened editor starts clean.
+  function resetEditFeedback(): void {
+    saveError = null;
+    invalidModelRows = new Set();
+    invalidAgents = new Set();
+    savedWarning = '';
+  }
+
   // ── Add / edit dialog ────────────────────────────────────────────────────
   function openAdd(): void {
     editing = { name: '', original: null, profile: blankOpenrouterProfile() };
-    saveError = null;
+    resetEditFeedback();
+    void loadModels();
   }
 
   function openEdit(name: string): void {
     const p = registry?.profiles[name];
     if (!p || p.type !== 'openrouter') return;
     editing = { name, original: name, profile: toEditable(p) };
-    saveError = null;
+    resetEditFeedback();
+    void loadModels();
   }
 
   function closeEdit(): void {
     editing = null;
     saveError = null;
+  }
+
+  /** The originally-persisted openrouter DTO for `original` (undefined for add). */
+  function registryProfileDto(original: string | null): OpenrouterProfileDto | undefined {
+    if (!original) return undefined;
+    const p = registry?.profiles[original];
+    return p && p.type === 'openrouter' ? p : undefined;
   }
 
   function addMapRow(): void {
@@ -186,6 +248,29 @@
       saveError = { code: 'INVALID_PARAMS', message: `A profile named "${name}" already exists.` };
       return;
     }
+
+    // Client-side slug guardrail (a UX aid, not a security boundary — the backend
+    // persists whatever it is given). Grandfather slugs already persisted for this
+    // profile so a routine edit never traps an untouched, possibly-delisted slug.
+    const grandfathered = persistedSlugSet(registryProfileDto(editing.original));
+    const validation = validateSlugs(editing.profile, { slugs: new Set(models), source: modelsSource }, grandfathered);
+    if (validation.blocked.length > 0) {
+      saveError = { code: 'INVALID_PARAMS', message: blockMessage(validation.blocked) };
+      const rows = new Set<number>();
+      const agents = new Set<DockerAgent>();
+      for (const issue of validation.blocked) {
+        if (issue.field === 'model' && issue.index !== undefined) rows.add(issue.index);
+        else if (issue.field === 'peragent' && issue.agent) agents.add(issue.agent);
+      }
+      invalidModelRows = rows;
+      invalidAgents = agents;
+      return;
+    }
+    // Under the bundled fallback, unknown slugs only warn — surface after saving.
+    const pendingWarning = warningMessage(validation.warnings);
+    invalidModelRows = new Set();
+    invalidAgents = new Set();
+
     saving = true;
     saveError = null;
     try {
@@ -195,6 +280,7 @@
       const nextDefault = defaultName;
       applyRegistry(await setModelProviders({ default: nextDefault, profiles }));
       editing = null;
+      savedWarning = pendingWarning;
     } catch (err) {
       saveError = rpcError(err);
     }
@@ -288,6 +374,14 @@
           <span class="font-mono text-xs" data-testid="settings-error-code">{saveError.code}</span>
           <span class="block mt-1">{errorAffordance(saveError.code)}</span>
         </span>
+      </Alert>
+    </div>
+  {/if}
+
+  {#if savedWarning}
+    <div data-testid="slug-warning">
+      <Alert variant="default" dismissible ondismiss={() => (savedWarning = '')}>
+        <span class="block text-sm">{savedWarning}</span>
       </Alert>
     </div>
   {/if}
@@ -403,7 +497,19 @@
       </div>
 
       <div>
-        <p class="text-xs text-muted-foreground mb-1">Model map</p>
+        <div class="flex items-center justify-between mb-1">
+          <p class="text-xs text-muted-foreground">Model map</p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onclick={() => loadModels({ force: true })}
+            disabled={modelsLoading}
+            data-testid="model-refresh"
+          >
+            <ArrowsClockwise size={13} class="mr-1" />
+            {modelsLoading ? 'Refreshing…' : 'Refresh models'}
+          </Button>
+        </div>
         <label class="flex items-start gap-2 text-sm mb-2">
           <input
             type="checkbox"
@@ -424,18 +530,27 @@
         {#if !editing.profile.usesDefaultMap}
           <p class="text-[11px] text-muted-foreground mb-1">Custom rules (glob → slug, first match wins)</p>
           {#each editing.profile.modelMap as _row, i (i)}
-            <div class="flex items-center gap-2 mb-2">
-              <Input
-                bind:value={editing.profile.modelMap[i].match}
-                placeholder="*sonnet*"
-                data-testid={`map-match-${i}`}
-              />
+            <div class="flex items-start gap-2 mb-2">
+              <div class="flex-1">
+                <Input
+                  bind:value={editing.profile.modelMap[i].match}
+                  placeholder="*sonnet*"
+                  data-testid={`map-match-${i}`}
+                />
+              </div>
               <span class="text-muted-foreground">→</span>
-              <Input
-                bind:value={editing.profile.modelMap[i].model}
-                placeholder="z-ai/glm-5.2"
-                data-testid={`map-model-${i}`}
-              />
+              <div class="flex-1">
+                <ModelCombobox
+                  bind:value={editing.profile.modelMap[i].model}
+                  {models}
+                  source={modelsSource}
+                  loading={modelsLoading}
+                  error={modelsError}
+                  invalid={invalidModelRows.has(i)}
+                  placeholder="z-ai/glm-5.2"
+                  testid={`map-model-${i}`}
+                />
+              </div>
               <Button variant="ghost" size="sm" onclick={() => removeMapRow(i)} data-testid={`map-remove-${i}`}>
                 <Trash size={14} />
               </Button>
@@ -454,13 +569,20 @@
         <p class="text-xs text-muted-foreground mb-1">Per-agent model override (wins over the map)</p>
         <div class="space-y-2">
           {#each DOCKER_AGENTS as agent (agent)}
-            <div class="flex items-center gap-2">
-              <span class="text-xs font-mono w-24 shrink-0">{agent}</span>
-              <Input
-                bind:value={editing.profile.perAgent[agent]}
-                placeholder="(unset)"
-                data-testid={`peragent-${agent}`}
-              />
+            <div class="flex items-start gap-2">
+              <span class="text-xs font-mono w-24 shrink-0 mt-2.5">{agent}</span>
+              <div class="flex-1">
+                <ModelCombobox
+                  bind:value={editing.profile.perAgent[agent]}
+                  {models}
+                  source={modelsSource}
+                  loading={modelsLoading}
+                  error={modelsError}
+                  invalid={invalidAgents.has(agent)}
+                  placeholder="(unset)"
+                  testid={`peragent-${agent}`}
+                />
+              </div>
             </div>
           {/each}
         </div>
@@ -505,7 +627,9 @@
         <div data-testid="editor-error">
           <Alert variant="destructive">
             <span class="font-mono text-xs">{saveError.code}</span>
-            <span class="block mt-1">{errorAffordance(saveError.code)}</span>
+            <span class="block mt-1">
+              {saveError.code === 'INVALID_PARAMS' ? saveError.message : errorAffordance(saveError.code)}
+            </span>
           </Alert>
         </div>
       {/if}

--- a/packages/web-ui/src/routes/Settings.test.ts
+++ b/packages/web-ui/src/routes/Settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
-import type { GetModelProvidersDto, SetModelProvidersDto } from '$lib/types.js';
+import type { GetModelProvidersDto, SetModelProvidersDto, OpenrouterModelsDto } from '$lib/types.js';
 
 // ---------------------------------------------------------------------------
 // Mock the store — declared before importing the component (mirrors
@@ -11,6 +11,18 @@ import type { GetModelProvidersDto, SetModelProvidersDto } from '$lib/types.js';
 
 const mockGet = vi.fn<() => Promise<GetModelProvidersDto>>();
 const mockSet = vi.fn<(input: SetModelProvidersDto) => Promise<GetModelProvidersDto>>();
+const mockList = vi.fn<() => Promise<OpenrouterModelsDto>>();
+
+// A realistic catalog covering every fixture slug (incl. z-ai/glm-5.2) plus a
+// few glm variants for the filter/keyboard test. Used as the SAFE default so the
+// pre-existing save tests never hard-block on an in-flight/known slug.
+const CATALOG_SLUGS = [
+  'anthropic/claude-3.7-sonnet',
+  'moonshotai/kimi-k2',
+  'openai/gpt-5',
+  'z-ai/glm-4.6',
+  'z-ai/glm-5.2',
+];
 
 const appStateMock: { daemonStatus: { allowPolicyMutation: boolean } | null } = {
   daemonStatus: { allowPolicyMutation: true },
@@ -21,6 +33,7 @@ const configChangedGenerationMock = { value: 0 };
 vi.mock('$lib/stores.svelte.js', () => ({
   getModelProviders: (...args: unknown[]) => mockGet(...(args as [])),
   setModelProviders: (...args: unknown[]) => mockSet(...(args as [SetModelProvidersDto])),
+  listOpenrouterModels: (...args: unknown[]) => mockList(...(args as [])),
   get appState() {
     return appStateMock;
   },
@@ -58,11 +71,15 @@ describe('Settings', () => {
   beforeEach(() => {
     mockGet.mockReset();
     mockSet.mockReset();
+    mockList.mockReset();
     appStateMock.daemonStatus = { allowPolicyMutation: true };
     connectionGenerationMock.value = 0;
     configChangedGenerationMock.value = 0;
     mockGet.mockResolvedValue(makeRegistry());
     mockSet.mockImplementation((input) => Promise.resolve(makeRegistry({ default: input.default ?? 'native' })));
+    // SAFE default: bundled (warn-only) AND a list covering every fixture slug —
+    // so opening/saving existing profiles never spuriously hard-blocks.
+    mockList.mockResolvedValue({ models: CATALOG_SLUGS, source: 'bundled' });
   });
 
   it('renders the profile list with native first and non-deletable', async () => {
@@ -242,5 +259,133 @@ describe('Settings', () => {
     // No RPC issued; an inline error is shown.
     expect(mockSet).not.toHaveBeenCalled();
     await vi.waitFor(() => expect(screen.getByTestId('editor-error')).toBeTruthy());
+  });
+
+  // ── Model autocomplete + save-time slug validation (Unit B) ───────────────
+
+  it('opens the model dropdown on focus, filters as you type, and commits with the keyboard', async () => {
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('edit-profile-glm')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('edit-profile-glm'));
+
+    const model0 = screen.getByTestId('map-model-0') as HTMLInputElement;
+    await fireEvent.focus(model0);
+    // Popover (portaled to <body>) opens with options.
+    await vi.waitFor(() => expect(screen.getByTestId('model-combobox-listbox')).toBeTruthy());
+
+    // Typing filters to glm slugs (case-insensitive substring).
+    await fireEvent.input(model0, { target: { value: 'glm' } });
+    await vi.waitFor(() => {
+      const opts = screen.getAllByTestId(/^model-combobox-option-/);
+      expect(opts.length).toBeGreaterThan(0);
+      for (const o of opts) expect(o.textContent).toContain('glm');
+    });
+
+    // ArrowDown highlights the first option; Enter commits it into map-model-0.
+    await fireEvent.keyDown(model0, { key: 'ArrowDown' });
+    await fireEvent.keyDown(model0, { key: 'Enter' });
+    expect(model0.value).toContain('glm');
+    expect(CATALOG_SLUGS).toContain(model0.value);
+    // Popover closed after commit.
+    expect(screen.queryByTestId('model-combobox-listbox')).toBeNull();
+  });
+
+  it('hard-blocks an unknown slug under an authoritative (live) source', async () => {
+    // Live catalog that EXCLUDES the garbage slug the user types.
+    mockList.mockResolvedValue({ models: CATALOG_SLUGS, source: 'live' });
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('add-profile-button')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('add-profile-button'));
+    await fireEvent.input(screen.getByTestId('profile-name'), { target: { value: 'kimi' } });
+
+    // Wait for the live list to load: the "Partial list (offline)" badge (shown
+    // only for the bundled default) disappears once source flips to live.
+    await vi.waitFor(() => expect(screen.queryAllByTestId('model-combobox-source').length).toBe(0));
+
+    await fireEvent.input(screen.getByTestId('peragent-goose'), { target: { value: 'garbage/model' } });
+    await fireEvent.click(screen.getByTestId('save-profile-button'));
+
+    // Save aborted: no RPC, error names the slug, and the field is marked invalid.
+    expect(mockSet).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(screen.getByTestId('editor-error')).toBeTruthy());
+    expect(screen.getByTestId('editor-error').textContent).toContain('garbage/model');
+    expect(screen.getByTestId('peragent-goose').getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('warn-degrades (saves) an unknown slug under the bundled fallback', async () => {
+    // Default mock is bundled; the garbage slug is unknown but only warns.
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('add-profile-button')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('add-profile-button'));
+    await fireEvent.input(screen.getByTestId('profile-name'), { target: { value: 'kimi' } });
+    await fireEvent.input(screen.getByTestId('peragent-goose'), { target: { value: 'garbage/model' } });
+    await fireEvent.click(screen.getByTestId('save-profile-button'));
+
+    // Persisted despite the unknown slug; a non-blocking warning note is shown.
+    await vi.waitFor(() => expect(mockSet).toHaveBeenCalledOnce());
+    const kimi = mockSet.mock.calls[0][0].profiles.kimi;
+    if (kimi.type !== 'openrouter') throw new Error('unreachable');
+    expect(kimi.perAgent).toEqual({ goose: 'garbage/model' });
+    await vi.waitFor(() => expect(screen.getByTestId('slug-warning')).toBeTruthy());
+    expect(screen.getByTestId('slug-warning').textContent).toContain('garbage/model');
+  });
+
+  it('saves a bundled-legit slug typed by hand with no warning', async () => {
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('add-profile-button')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('add-profile-button'));
+    await fireEvent.input(screen.getByTestId('profile-name'), { target: { value: 'kimi' } });
+    await fireEvent.input(screen.getByTestId('peragent-goose'), { target: { value: 'z-ai/glm-4.6' } });
+    await fireEvent.click(screen.getByTestId('save-profile-button'));
+
+    await vi.waitFor(() => expect(mockSet).toHaveBeenCalledOnce());
+    expect(screen.queryByTestId('slug-warning')).toBeNull();
+  });
+
+  it('grandfathers an untouched persisted slug even under a live source (key-rotation)', async () => {
+    // glm's persisted slug z-ai/glm-5.2 is NOT in this live list, but it was
+    // already saved — editing only the API key must not trap it.
+    mockList.mockResolvedValue({ models: ['anthropic/claude-3.7-sonnet'], source: 'live' });
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('edit-profile-glm')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('edit-profile-glm'));
+    await vi.waitFor(() => expect(screen.queryAllByTestId('model-combobox-source').length).toBe(0));
+    // Rotate the key only; leave the (now-delisted) slug untouched.
+    await fireEvent.input(screen.getByTestId('profile-apikey'), { target: { value: 'sk-or-v1-ROTATED' } });
+    await fireEvent.click(screen.getByTestId('save-profile-button'));
+
+    await vi.waitFor(() => expect(mockSet).toHaveBeenCalledOnce());
+    const glm = mockSet.mock.calls[0][0].profiles.glm;
+    if (glm.type !== 'openrouter') throw new Error('unreachable');
+    expect(glm.apiKey).toBe('sk-or-v1-ROTATED');
+    expect(glm.modelMap).toEqual([{ match: '*sonnet*', model: 'z-ai/glm-5.2' }]);
+  });
+
+  it('shows the "Partial list (offline)" badge for bundled and hides it for live', async () => {
+    // Bundled (default) → badge present on the editor's slug fields.
+    const { unmount } = render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('edit-profile-glm')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('edit-profile-glm'));
+    await vi.waitFor(() => expect(screen.getAllByTestId('model-combobox-source').length).toBeGreaterThan(0));
+    unmount();
+
+    // Live → no bundled badge.
+    mockList.mockResolvedValue({ models: CATALOG_SLUGS, source: 'live' });
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('edit-profile-glm')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('edit-profile-glm'));
+    await vi.waitFor(() => expect(screen.queryAllByTestId('model-combobox-source').length).toBe(0));
+  });
+
+  it('the Refresh button forces a catalog re-fetch with forceRefresh=true', async () => {
+    render(Settings);
+    await vi.waitFor(() => expect(screen.getByTestId('edit-profile-glm')).toBeTruthy());
+    await fireEvent.click(screen.getByTestId('edit-profile-glm'));
+    // Let the on-open load settle (the Refresh button re-enables once modelsLoading clears).
+    await vi.waitFor(() => expect((screen.getByTestId('model-refresh') as HTMLButtonElement).disabled).toBe(false));
+    mockList.mockClear();
+    await fireEvent.click(screen.getByTestId('model-refresh'));
+    // Re-fetches even though the catalog already loaded this session, and with force=true.
+    await vi.waitFor(() => expect(mockList).toHaveBeenCalledWith(true));
   });
 });

--- a/packages/web-ui/src/routes/settings-helpers.test.ts
+++ b/packages/web-ui/src/routes/settings-helpers.test.ts
@@ -6,6 +6,13 @@ import {
   parseList,
   blankOpenrouterProfile,
   isDuplicateProfileName,
+  sourceEnforces,
+  persistedSlugSet,
+  validateSlugs,
+  blockMessage,
+  warningMessage,
+  type EditableProfile,
+  type KnownModels,
 } from './settings-helpers.js';
 
 // ---------------------------------------------------------------------------
@@ -135,6 +142,141 @@ describe('parseList', () => {
   it('splits, trims, and drops empties', () => {
     expect(parseList('z-ai,  deepinfra , ,')).toEqual(['z-ai', 'deepinfra']);
     expect(parseList('')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slug validation (OpenRouter model autocomplete).
+// ---------------------------------------------------------------------------
+
+describe('sourceEnforces', () => {
+  it('blocks on authoritative sources and warns on the bundled floor', () => {
+    expect(sourceEnforces('live')).toBe(true);
+    expect(sourceEnforces('cache')).toBe(true);
+    expect(sourceEnforces('bundled')).toBe(false);
+  });
+});
+
+describe('persistedSlugSet', () => {
+  it('returns an empty set for a brand-new (undefined) profile', () => {
+    expect(persistedSlugSet(undefined).size).toBe(0);
+  });
+
+  it('collects every persisted modelMap + perAgent slug, trimmed and de-duped', () => {
+    const dto: OpenrouterProfileDto = {
+      type: 'openrouter',
+      modelMap: [
+        { match: '*sonnet*', model: 'z-ai/glm-5.2' },
+        { match: '*opus*', model: 'z-ai/glm-5.2' },
+      ],
+      perAgent: { 'claude-code': 'openai/gpt-x', goose: undefined, codex: '  moonshot/kimi-k3  ' },
+    };
+    expect(persistedSlugSet(dto)).toEqual(new Set(['z-ai/glm-5.2', 'openai/gpt-x', 'moonshot/kimi-k3']));
+  });
+});
+
+/** A minimal editable profile with a custom map (usesDefaultMap = false). */
+function editableWith(over: Partial<EditableProfile> = {}): EditableProfile {
+  return {
+    apiKey: 'sk-x',
+    modelMap: [],
+    perAgent: { 'claude-code': '', goose: '', codex: '' },
+    providerOrder: '',
+    providerOnly: '',
+    allowFallbacks: true,
+    sessionAffinity: true,
+    usesDefaultMap: false,
+    ...over,
+  };
+}
+
+const KNOWN = 'z-ai/glm-5.2';
+const known = (source: KnownModels['source']): KnownModels => ({ slugs: new Set([KNOWN]), source });
+const NONE: ReadonlySet<string> = new Set();
+
+describe('validateSlugs', () => {
+  it('blocks an unknown modelMap slug under an authoritative (live) source', () => {
+    const p = editableWith({ modelMap: [{ match: '*', model: 'foo/bar' }] });
+    const v = validateSlugs(p, known('live'), NONE);
+    expect(v.blocked).toEqual([{ field: 'model', index: 0, slug: 'foo/bar' }]);
+    expect(v.warnings).toEqual([]);
+  });
+
+  it('only warns on an unknown slug under the bundled fallback', () => {
+    const p = editableWith({ modelMap: [{ match: '*', model: 'foo/bar' }] });
+    const v = validateSlugs(p, known('bundled'), NONE);
+    expect(v.blocked).toEqual([]);
+    expect(v.warnings).toEqual([{ field: 'model', index: 0, slug: 'foo/bar' }]);
+  });
+
+  it('treats a known slug as clean', () => {
+    const p = editableWith({ modelMap: [{ match: '*', model: KNOWN }] });
+    expect(validateSlugs(p, known('live'), NONE)).toEqual({ blocked: [], warnings: [] });
+  });
+
+  it('ignores empty slugs (never validated)', () => {
+    const p = editableWith({
+      modelMap: [{ match: '*', model: '   ' }],
+      perAgent: { 'claude-code': '', goose: '', codex: '' },
+    });
+    expect(validateSlugs(p, known('live'), NONE)).toEqual({ blocked: [], warnings: [] });
+  });
+
+  it('grandfathers a persisted slug under an authoritative source (key-rotation case)', () => {
+    // The persisted slug is absent from the (delisted) live catalog, but was
+    // already saved — editing only the API key must never trap it.
+    const p = editableWith({ modelMap: [{ match: '*sonnet*', model: 'z-ai/legacy-glm' }] });
+    const grandfathered = new Set(['z-ai/legacy-glm']);
+    const v = validateSlugs(p, known('live'), grandfathered);
+    expect(v.blocked).toEqual([]);
+    expect(v.warnings).toEqual([]);
+  });
+
+  it('trims before the membership check (a trailing-space known slug is clean)', () => {
+    const p = editableWith({ modelMap: [{ match: '*', model: `${KNOWN}  ` }] });
+    expect(validateSlugs(p, known('live'), NONE)).toEqual({ blocked: [], warnings: [] });
+  });
+
+  it('validates per-agent slugs and locates them by agent', () => {
+    const p = editableWith({ perAgent: { 'claude-code': '', goose: 'bad/one', codex: KNOWN } });
+    const v = validateSlugs(p, known('live'), NONE);
+    expect(v.blocked).toEqual([{ field: 'peragent', agent: 'goose', slug: 'bad/one' }]);
+  });
+
+  it('skips modelMap entirely when the profile tracks the default map', () => {
+    // Stale rows can linger behind the "use default map" toggle; they are omitted
+    // on save, so they must not block.
+    const p = editableWith({ usesDefaultMap: true, modelMap: [{ match: '*', model: 'foo/bar' }] });
+    expect(validateSlugs(p, known('live'), NONE)).toEqual({ blocked: [], warnings: [] });
+  });
+
+  it('skips a modelMap row with no match (editableToDto would discard it)', () => {
+    const p = editableWith({ modelMap: [{ match: '', model: 'foo/bar' }] });
+    expect(validateSlugs(p, known('live'), NONE)).toEqual({ blocked: [], warnings: [] });
+  });
+});
+
+describe('blockMessage', () => {
+  it('names each bad slug and where it lives', () => {
+    const msg = blockMessage([
+      { field: 'model', index: 1, slug: 'foo/bar' },
+      { field: 'peragent', agent: 'codex', slug: 'x/y' },
+    ]);
+    expect(msg).toContain('Model map row 2: `foo/bar`');
+    expect(msg).toContain('codex override: `x/y`');
+    expect(msg).toContain('is not a known OpenRouter model');
+  });
+});
+
+describe('warningMessage', () => {
+  it('is empty when there are no warnings', () => {
+    expect(warningMessage([])).toBe('');
+  });
+
+  it('lists the unverified slugs', () => {
+    const msg = warningMessage([{ field: 'peragent', agent: 'goose', slug: 'a/b' }]);
+    expect(msg).toContain('goose override: `a/b`');
+    expect(msg.toLowerCase()).toContain('offline');
   });
 });
 

--- a/packages/web-ui/src/routes/settings-helpers.ts
+++ b/packages/web-ui/src/routes/settings-helpers.ts
@@ -148,3 +148,124 @@ export function editableToDto(p: EditableProfile): OpenrouterProfileDto {
   dto.sessionAffinity = p.sessionAffinity;
   return dto;
 }
+
+// ---------------------------------------------------------------------------
+// Slug validation (OpenRouter model autocomplete).
+//
+// A pure, DOM-free guardrail run in `saveEdit` before persisting. The block-vs
+// -warn decision keys ONLY on the catalog `source` (mirrors the backend's
+// `catalogEnforces`): authoritative lists (`live`/`cache`) hard-block unknown
+// slugs; the offline `bundled` floor is warn-only. Grandfathering exempts any
+// slug that was already persisted for this profile, so routine edits (e.g. an
+// API-key rotation) never trap an untouched — possibly since-delisted — slug.
+// ---------------------------------------------------------------------------
+
+export type ModelCatalogSource = 'live' | 'cache' | 'bundled';
+
+/** The loaded catalog the editor validates against. */
+export interface KnownModels {
+  readonly slugs: ReadonlySet<string>;
+  readonly source: ModelCatalogSource;
+}
+
+/** One unrecognized slug, located back to the field that produced it. */
+export interface SlugIssue {
+  readonly field: 'model' | 'peragent';
+  /** modelMap row index (only for `field: 'model'`). */
+  readonly index?: number;
+  /** per-agent key (only for `field: 'peragent'`). */
+  readonly agent?: DockerAgent;
+  readonly slug: string;
+}
+
+/** Split of unrecognized slugs into hard-blocks and non-blocking warnings. */
+export interface SlugValidation {
+  readonly blocked: SlugIssue[];
+  readonly warnings: SlugIssue[];
+}
+
+/**
+ * The single source of truth for the block-vs-warn decision. Mirrors the
+ * backend catalog's `catalogEnforces`: authoritative sources enforce (block);
+ * the known-incomplete `bundled` fallback only warns.
+ */
+export function sourceEnforces(source: ModelCatalogSource): boolean {
+  return source !== 'bundled';
+}
+
+/**
+ * The set of slugs already persisted for a profile (all `modelMap[].model` and
+ * all `perAgent` values, trimmed). Membership in this set exempts a current slug
+ * from blocking — the robust, per-profile way to grandfather values the user did
+ * not introduce this session (no per-row identity tracking needed).
+ */
+export function persistedSlugSet(dto: OpenrouterProfileDto | undefined): ReadonlySet<string> {
+  const slugs = new Set<string>();
+  if (!dto) return slugs;
+  for (const row of dto.modelMap ?? []) {
+    const slug = row.model.trim();
+    if (slug.length > 0) slugs.add(slug);
+  }
+  for (const agent of DOCKER_AGENTS) {
+    const slug = (dto.perAgent?.[agent] ?? '').trim();
+    if (slug.length > 0) slugs.add(slug);
+  }
+  return slugs;
+}
+
+/**
+ * Validates the editable profile's slug-target fields against a known catalog.
+ *
+ * Each `modelMap[].model` (only for rows that would actually persist — see
+ * `editableToDto`) and each `perAgent` slug is trimmed, then: empty → ignored;
+ * in `known.slugs` or `grandfathered` → clean; otherwise blocked (authoritative
+ * source) or warned (bundled). modelMap is skipped entirely when the profile
+ * tracks the default map, since those rows are omitted on save.
+ */
+export function validateSlugs(
+  p: EditableProfile,
+  known: KnownModels,
+  grandfathered: ReadonlySet<string>,
+): SlugValidation {
+  const blocked: SlugIssue[] = [];
+  const warnings: SlugIssue[] = [];
+  const enforce = sourceEnforces(known.source);
+
+  const classify = (raw: string, locate: (slug: string) => SlugIssue): void => {
+    const slug = raw.trim();
+    if (slug.length === 0) return;
+    if (known.slugs.has(slug) || grandfathered.has(slug)) return;
+    (enforce ? blocked : warnings).push(locate(slug));
+  };
+
+  if (!p.usesDefaultMap) {
+    p.modelMap.forEach((row, index) => {
+      // A row with no `match` is filtered out by editableToDto, so it never
+      // persists — validating its model would false-block a discarded row.
+      if (row.match.trim().length === 0) return;
+      classify(row.model, (slug) => ({ field: 'model', index, slug }));
+    });
+  }
+  for (const agent of DOCKER_AGENTS) {
+    classify(p.perAgent[agent], (slug) => ({ field: 'peragent', agent, slug }));
+  }
+  return { blocked, warnings };
+}
+
+/** Human-readable location for a slug issue, e.g. "Model map row 2: `foo/bar`". */
+function describeIssue(issue: SlugIssue): string {
+  const where = issue.field === 'model' ? `Model map row ${(issue.index ?? 0) + 1}` : `${issue.agent} override`;
+  return `${where}: \`${issue.slug}\``;
+}
+
+/** Save-blocking message naming each unknown slug and where it lives. */
+export function blockMessage(blocked: SlugIssue[]): string {
+  return blocked.map((issue) => `${describeIssue(issue)} is not a known OpenRouter model`).join('; ');
+}
+
+/** Non-blocking note for slugs unverifiable against the offline `bundled` floor. */
+export function warningMessage(warnings: SlugIssue[]): string {
+  if (warnings.length === 0) return '';
+  const list = warnings.map(describeIssue).join('; ');
+  return `Saved. The following could not be verified against the offline model list — ${list}.`;
+}

--- a/src/config/config-command.ts
+++ b/src/config/config-command.ts
@@ -37,6 +37,12 @@ import {
   type ContainerRuntimeSetting,
 } from './user-config.js';
 import { getUserConfigPath } from './paths.js';
+import {
+  listOpenrouterModels,
+  catalogEnforces,
+  type ModelCatalogResult,
+  type ModelCatalogSource,
+} from './openrouter-catalog.js';
 import type { MCPServerConfig } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -1055,6 +1061,90 @@ async function editProfileField(
   return undefined;
 }
 
+// ─── Slug autocomplete (OpenRouter model catalog) ────────────
+
+/** One selectable slug in a model-slug autocomplete. */
+export type SlugOption = { value: string; label: string };
+
+/**
+ * Builds the option list for a model-slug autocomplete from the resolved catalog.
+ *
+ * - Every catalog slug becomes a `{ value, label }` option.
+ * - `allowNone` prepends a `(none)` sentinel (value `''`) FIRST — the only way a
+ *   selection-only prompt can clear a per-agent override.
+ * - A non-empty `current` absent from the catalog is appended as a grandfather
+ *   option, so editing a legacy/delisted slug never traps the user.
+ *
+ * There is intentionally NO refresh sentinel: `ironcurtain config` is short-lived
+ * and fetches the catalog once, so re-running it IS the refresh path.
+ */
+export function buildSlugOptions(
+  catalog: ModelCatalogResult,
+  current: string,
+  opts: { allowNone: boolean },
+): SlugOption[] {
+  const options: SlugOption[] = catalog.models.map((slug) => ({ value: slug, label: slug }));
+  if (opts.allowNone) {
+    options.unshift({ value: '', label: '(none — use model map)' });
+  }
+  if (current !== '' && !catalog.models.includes(current)) {
+    options.push({ value: current, label: `${current}  (current, unverified)` });
+  }
+  return options;
+}
+
+/** Autocomplete (hard-block) for an authoritative catalog; free text for the bundled floor. */
+export function slugPromptMode(source: ModelCatalogSource): 'autocomplete' | 'freetext' {
+  return catalogEnforces(source) ? 'autocomplete' : 'freetext';
+}
+
+/**
+ * Prompts for one OpenRouter model slug. Fetches the catalog lazily (module-cached)
+ * so apiKey / provider-preference-only edits never pay the network cost.
+ *
+ * Authoritative catalog (`live`/`cache`): a selection-only `autocomplete` whose
+ * options ARE the allowlist — a structural hard-block — with `validate` as
+ * belt-and-suspenders. For an UNSET field the `(none)` sentinel is first, so a
+ * no-op Enter keeps it unset — clack auto-preselects the first option and collapses
+ * a falsy `initialValue` to undefined; a non-empty `current` is passed as
+ * `initialValue` so editing an existing slug starts on it.
+ *
+ * Bundled floor (offline): the list is known-incomplete, so free-text entry with a
+ * one-line warning — the value is accepted as-is.
+ *
+ * Returns the chosen slug (`''` clears when `allowNone`), or `undefined` on cancel.
+ */
+async function promptSlug(message: string, opts: { current: string; allowNone: boolean }): Promise<string | undefined> {
+  const { current, allowNone } = opts;
+  const catalog = await listOpenrouterModels();
+
+  if (slugPromptMode(catalog.source) === 'autocomplete') {
+    // Allowlist = catalog slugs, plus `current` (grandfather a legacy/delisted slug)
+    // and '' ONLY when the field is clearable (per-agent). A required field
+    // (map-row model, allowNone:false) never admits an empty submit.
+    const allowlist = new Set<string>([...catalog.models, ...(current ? [current] : []), ...(allowNone ? [''] : [])]);
+    const picked = await p.autocomplete<string>({
+      message,
+      options: buildSlugOptions(catalog, current, { allowNone }),
+      initialValue: current || '',
+      initialUserInput: current || undefined,
+      maxItems: 8,
+      validate: (v) => (typeof v === 'string' && !allowlist.has(v) ? `Unknown model: ${v}` : undefined),
+    });
+    if (isCancelled(picked)) return undefined;
+    return picked as string;
+  }
+
+  p.note("Model catalog unavailable — slug can't be verified; entered value accepted as-is.");
+  const typed = await p.text({
+    message,
+    placeholder: current || DEFAULT_GLM_SLUG,
+    validate: allowNone ? () => undefined : (val) => (!val ? 'Target slug is required' : undefined),
+  });
+  if (isCancelled(typed)) return undefined;
+  return typed as string;
+}
+
 async function editModelMap(profile: PendingOpenrouterProfile): Promise<PendingOpenrouterProfile | undefined> {
   const rows = [...(profile.modelMap ?? [])];
   p.note(
@@ -1084,13 +1174,12 @@ async function editModelMap(profile: PendingOpenrouterProfile): Promise<PendingO
         validate: (val) => (!val ? 'Match glob is required' : undefined),
       });
       if (isCancelled(match)) continue;
-      const model = await p.text({
-        message: 'Target OpenRouter slug (e.g. z-ai/glm-5.2):',
-        placeholder: DEFAULT_GLM_SLUG,
-        validate: (val) => (!val ? 'Target slug is required' : undefined),
+      const model = await promptSlug('Target OpenRouter slug (e.g. z-ai/glm-5.2):', {
+        current: '',
+        allowNone: false,
       });
-      if (isCancelled(model)) continue;
-      rows.push({ match: match as string, model: model as string });
+      if (model === undefined) continue;
+      rows.push({ match: match as string, model });
     } else if (typeof action === 'string' && action.startsWith('row:')) {
       const index = Number(action.slice('row:'.length));
       rows.splice(index, 1);
@@ -1118,13 +1207,12 @@ async function editPerAgent(profile: PendingOpenrouterProfile): Promise<PendingO
     if (isCancelled(selected) || selected === 'back') break;
 
     const agent = selected as DockerAgent;
-    const slug = await p.text({
-      message: `${DOCKER_AGENT_LABELS[agent]} model slug (blank to clear):`,
-      placeholder: perAgent[agent] ?? DEFAULT_GLM_SLUG,
-      validate: () => undefined,
+    const slug = await promptSlug(`${DOCKER_AGENT_LABELS[agent]} model slug (blank to clear):`, {
+      current: perAgent[agent] ?? '',
+      allowNone: true,
     });
-    if (isCancelled(slug)) continue;
-    if (slug) perAgent[agent] = slug as string;
+    if (slug === undefined) continue;
+    if (slug) perAgent[agent] = slug;
     else perAgent = omitKey(perAgent, agent);
   }
 

--- a/src/config/config-command.ts
+++ b/src/config/config-command.ts
@@ -1139,10 +1139,13 @@ async function promptSlug(message: string, opts: { current: string; allowNone: b
   const typed = await p.text({
     message,
     placeholder: current || DEFAULT_GLM_SLUG,
-    validate: allowNone ? () => undefined : (val) => (!val ? 'Target slug is required' : undefined),
+    validate: allowNone ? () => undefined : (val) => (!val || !val.trim() ? 'Target slug is required' : undefined),
   });
   if (isCancelled(typed)) return undefined;
-  return typed as string;
+  // Trim: a free-typed slug is persisted as-is, and " " would pass the schema's
+  // min(1) yet break routing (and defeat "blank to clear" for per-agent). The web
+  // path already trims (editableToDto / validateSlugs); keep the CLI consistent.
+  return (typed as string).trim();
 }
 
 async function editModelMap(profile: PendingOpenrouterProfile): Promise<PendingOpenrouterProfile | undefined> {

--- a/src/config/openrouter-catalog.ts
+++ b/src/config/openrouter-catalog.ts
@@ -1,0 +1,134 @@
+/**
+ * OpenRouter model-catalog resolver.
+ *
+ * Resolves the set of valid OpenRouter model slugs from the PUBLIC
+ * `GET /api/v1/models` endpoint, with a bundled floor for offline degradation.
+ * The result carries a `source` that drives client-side validation strictness:
+ * an authoritative (`live` / `cache`) list hard-blocks unknown slugs, while the
+ * known-incomplete `bundled` floor only warns (see `catalogEnforces`).
+ *
+ * This module NEVER throws — every failure path degrades to a usable result.
+ *
+ * Layering: this is the FIRST network I/O in `src/config/`. It is acceptable
+ * because this leaf is imported only by the config editor (`config-command.ts`)
+ * and the daemon dispatch (`config-dispatch.ts`) — NOT on `loadConfig()`'s path.
+ * Keep it that way: nothing on the config-load path may import this.
+ */
+
+import { OPENROUTER_API_V1 } from './user-config.js';
+import { OPENROUTER_FALLBACK_SLUGS } from './openrouter-models-fallback.js';
+
+export type ModelCatalogSource = 'live' | 'cache' | 'bundled';
+
+export interface ModelCatalogResult {
+  /** Sorted, de-duped OpenRouter slugs (the `.id` of each `/models` entry). */
+  readonly models: readonly string[];
+  readonly source: ModelCatalogSource;
+  /** Epoch ms of the underlying fetch; 0 for the pure-bundled floor. */
+  readonly fetchedAt: number;
+}
+
+/** The public `/models` endpoint. No key is ever sent — it needs none. */
+const MODELS_ENDPOINT = `${OPENROUTER_API_V1}/models`;
+
+/** In-memory catalog TTL (6h). Model lists change rarely. */
+const CATALOG_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** Single-attempt fetch budget. A hung network must not stall the editor. */
+const FETCH_TIMEOUT_MS = 4000;
+
+/** Cache singleton — only ever holds a real (live-origin) result. */
+interface CacheEntry {
+  readonly result: ModelCatalogResult;
+  readonly expiresAt: number;
+}
+let cache: CacheEntry | undefined;
+
+/**
+ * The rule-table predicate: true when this source is authoritative and thus
+ * blocks unknown slugs; false for the known-incomplete `bundled` floor.
+ *
+ * The web UI mirrors this as `sourceEnforces` in
+ * `packages/web-ui/src/routes/settings-helpers.ts` — it cannot import this module
+ * across the package boundary, so keep the two one-liners in sync.
+ */
+export function catalogEnforces(source: ModelCatalogSource): boolean {
+  return source !== 'bundled';
+}
+
+/** Test-only: clear the module cache so each case starts isolated. */
+export function __resetCatalogCacheForTests(): void {
+  cache = undefined;
+}
+
+/**
+ * Resolves the OpenRouter model catalog. NEVER throws — always degrades:
+ *   fetch ok             -> { source: 'live' }   (and populates the cache)
+ *   within TTL           -> { source: 'cache' }
+ *   fetch fails, prior   -> { source: 'cache' }  (serve the stale-but-real list)
+ *   fetch fails, no prior-> { source: 'bundled' }
+ * `forceRefresh: true` bypasses the TTL.
+ */
+export async function listOpenrouterModels(opts?: { forceRefresh?: boolean }): Promise<ModelCatalogResult> {
+  const now = Date.now();
+
+  if (!opts?.forceRefresh && cache !== undefined && now < cache.expiresAt) {
+    return { ...cache.result, source: 'cache' };
+  }
+
+  const models = await fetchModelSlugs();
+  if (models !== undefined) {
+    const result: ModelCatalogResult = { models, source: 'live', fetchedAt: now };
+    cache = { result, expiresAt: now + CATALOG_TTL_MS };
+    return result;
+  }
+
+  // Fetch failed. A prior real result still enforces (it was live once); tag it
+  // `cache` while preserving its original fetch time.
+  if (cache !== undefined) {
+    return { ...cache.result, source: 'cache' };
+  }
+
+  return { models: OPENROUTER_FALLBACK_SLUGS, source: 'bundled', fetchedAt: 0 };
+}
+
+/**
+ * Single public GET with a hard timeout. Returns the parsed slug list, or
+ * `undefined` on any failure (non-2xx, malformed body, empty data, thrown/abort).
+ * No `Authorization` header — the endpoint is public and a key must never leak.
+ */
+async function fetchModelSlugs(): Promise<readonly string[] | undefined> {
+  try {
+    const res = await fetch(MODELS_ENDPOINT, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!res.ok) return undefined;
+    const body: unknown = await res.json();
+    return parseModelSlugs(body);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Defensive parse of the `{ data: [{ id }] }` envelope. Keeps only string `.id`s,
+ * sorts + de-dupes. Non-object / non-array-`data` / empty-after-filter -> failure.
+ */
+function parseModelSlugs(body: unknown): readonly string[] | undefined {
+  if (typeof body !== 'object' || body === null) return undefined;
+  const data = (body as { data?: unknown }).data;
+  if (!Array.isArray(data)) return undefined;
+
+  const ids: string[] = [];
+  for (const entry of data) {
+    const id = extractId(entry);
+    if (id !== undefined) ids.push(id);
+  }
+  if (ids.length === 0) return undefined;
+  return Array.from(new Set(ids)).sort();
+}
+
+/** Extracts a string `.id` from one catalog entry, or `undefined`. */
+function extractId(entry: unknown): string | undefined {
+  if (typeof entry !== 'object' || entry === null) return undefined;
+  const id = (entry as { id?: unknown }).id;
+  return typeof id === 'string' ? id : undefined;
+}

--- a/src/config/openrouter-models-fallback.ts
+++ b/src/config/openrouter-models-fallback.ts
@@ -1,0 +1,48 @@
+/**
+ * Bundled OpenRouter model-slug floor.
+ *
+ * A deliberately small, hand-maintained list — a FLOOR, not a mirror of the live
+ * catalog. Its only jobs are (1) keep the model picker non-empty when OpenRouter
+ * is unreachable and (2) never block the shipped defaults. It is allowed to be
+ * stale precisely because a `bundled` source resolves to warn-only validation
+ * (see `catalogEnforces` in `openrouter-catalog.ts`).
+ *
+ * INVARIANT: must contain `DEFAULT_GLM_SLUG` and every `DEFAULT_MODEL_MAP` target
+ * (both from `user-config.ts`) so a freshly-shipped default profile is always
+ * saveable offline. Kept pre-sorted + de-duped so the catalog can serve it by
+ * reference without re-processing.
+ */
+export const OPENROUTER_FALLBACK_SLUGS: readonly string[] = [
+  'anthropic/claude-3-haiku',
+  'anthropic/claude-3.5-haiku',
+  'anthropic/claude-3.5-sonnet',
+  'anthropic/claude-3.7-sonnet',
+  'anthropic/claude-opus-4',
+  'anthropic/claude-opus-4.1',
+  'anthropic/claude-sonnet-4',
+  'anthropic/claude-sonnet-4.5',
+  'deepseek/deepseek-chat',
+  'deepseek/deepseek-r1',
+  'deepseek/deepseek-r1-0528',
+  'deepseek/deepseek-v3',
+  'google/gemini-2.0-flash',
+  'google/gemini-2.5-flash',
+  'google/gemini-2.5-flash-lite',
+  'google/gemini-2.5-pro',
+  'meta-llama/llama-3.3-70b-instruct',
+  'mistralai/mistral-large',
+  'moonshotai/kimi-k2',
+  'moonshotai/kimi-k2-0905',
+  'openai/gpt-4.1',
+  'openai/gpt-4.1-mini',
+  'openai/gpt-4o',
+  'openai/gpt-4o-mini',
+  'openai/gpt-5',
+  'openai/o3',
+  'openai/o4-mini',
+  'qwen/qwen3-235b-a22b',
+  'x-ai/grok-4',
+  'z-ai/glm-4.5',
+  'z-ai/glm-4.6',
+  'z-ai/glm-5.2',
+];

--- a/src/web-ui/dispatch/config-dispatch.ts
+++ b/src/web-ui/dispatch/config-dispatch.ts
@@ -16,7 +16,13 @@ import { z } from 'zod';
 
 import { validateParams } from './types.js';
 import type { WorkflowDispatchContext } from './workflow-dispatch.js';
-import { type GetModelProvidersDto, type ProfileDto, RpcError, MethodNotFoundError } from '../web-ui-types.js';
+import {
+  type GetModelProvidersDto,
+  type OpenrouterModelsDto,
+  type ProfileDto,
+  RpcError,
+  MethodNotFoundError,
+} from '../web-ui-types.js';
 import {
   loadUserConfig,
   saveUserConfig,
@@ -28,6 +34,7 @@ import {
   type ResolvedModelProvidersConfig,
   type ResolvedOpenRouterProfile,
 } from '../../config/user-config.js';
+import { listOpenrouterModels } from '../../config/openrouter-catalog.js';
 
 // The mask FORMAT that `maskApiKey` produces is the DTO contract (§12.6): the
 // `resolveApiKey` round-trip below compares an incoming wire value against
@@ -80,11 +87,12 @@ const setModelProvidersSchema = z.object({
 
 const getModelProvidersSchema = z.object({});
 
+const listOpenrouterModelsSchema = z.object({ forceRefresh: z.boolean().optional() });
+
 // ---------------------------------------------------------------------------
 // Dispatch
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function configDispatch(
   ctx: WorkflowDispatchContext,
   method: string,
@@ -100,6 +108,13 @@ export async function configDispatch(
       requirePolicyMutation(ctx);
       const input = validateParams(setModelProvidersSchema, params);
       return setModelProviders(ctx, input);
+    }
+
+    // Ungated read of the PUBLIC OpenRouter catalog (mirrors getModelProviders).
+    case 'config.listOpenrouterModels': {
+      const input = validateParams(listOpenrouterModelsSchema, params);
+      const result = await listOpenrouterModels({ forceRefresh: input.forceRefresh });
+      return { models: result.models, source: result.source } satisfies OpenrouterModelsDto;
     }
 
     default:

--- a/src/web-ui/web-ui-types.ts
+++ b/src/web-ui/web-ui-types.ts
@@ -82,7 +82,10 @@ export type MethodName =
   // Config (modelProviders registry). Read is ungated; the mutation is gated
   // on the daemon's `--allow-policy-mutation` kill switch (POLICY_MUTATION_FORBIDDEN).
   | 'config.getModelProviders'
-  | 'config.setModelProviders';
+  | 'config.setModelProviders'
+  // OpenRouter model-slug catalog for autocomplete/validation. Ungated read of
+  // PUBLIC data (mirrors `config.getModelProviders`); no secret, no mutation.
+  | 'config.listOpenrouterModels';
 
 /** Browser -> Daemon request frame. */
 export interface RequestFrame {
@@ -622,6 +625,17 @@ export interface GetModelProvidersDto {
 export interface SetModelProvidersDto {
   readonly default?: string;
   readonly profiles: Readonly<Record<string, ProfileDto>>;
+}
+
+/**
+ * Response from `config.listOpenrouterModels`. `source` drives client-side
+ * validation strictness: `live`/`cache` are authoritative (hard-block unknown
+ * slugs), `bundled` is the known-incomplete offline floor (warn-only). See
+ * `catalogEnforces` in `src/config/openrouter-catalog.ts`.
+ */
+export interface OpenrouterModelsDto {
+  readonly models: readonly string[];
+  readonly source: 'live' | 'cache' | 'bundled';
 }
 
 // ---------------------------------------------------------------------------

--- a/test/config-command.test.ts
+++ b/test/config-command.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   select: vi.fn(),
   confirm: vi.fn(),
   text: vi.fn(),
+  autocomplete: vi.fn(),
   intro: vi.fn(),
   outro: vi.fn(),
   note: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('@clack/prompts', () => ({
   select: (...args: unknown[]) => mocks.select(...args),
   confirm: (...args: unknown[]) => mocks.confirm(...args),
   text: (...args: unknown[]) => mocks.text(...args),
+  autocomplete: (...args: unknown[]) => mocks.autocomplete(...args),
   intro: (...args: unknown[]) => mocks.intro(...args),
   outro: (...args: unknown[]) => mocks.outro(...args),
   note: (...args: unknown[]) => mocks.note(...args),
@@ -30,6 +32,17 @@ vi.mock('@clack/prompts', () => ({
   isCancel: (...args: unknown[]) => mocks.isCancel(...args),
   log: mocks.log,
 }));
+
+// Stub the network fetch in the catalog leaf so interactive-flow tests never hit
+// openrouter.ai. A plain (non-vi.fn) function is immune to clear/restoreAllMocks.
+// `catalogEnforces` stays REAL so slugPromptMode's truth table exercises production logic.
+vi.mock('../src/config/openrouter-catalog.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/config/openrouter-catalog.js')>();
+  return {
+    ...actual,
+    listOpenrouterModels: () => Promise.resolve({ models: [], source: 'bundled' as const, fetchedAt: 0 }),
+  };
+});
 
 // Now import the module under test
 import {
@@ -39,7 +52,10 @@ import {
   formatTokens,
   formatSeconds,
   formatCost,
+  buildSlugOptions,
+  slugPromptMode,
 } from '../src/config/config-command.js';
+import type { ModelCatalogResult, ModelCatalogSource } from '../src/config/openrouter-catalog.js';
 import type { ResolvedUserConfig, UserConfig } from '../src/config/user-config.js';
 import { USER_CONFIG_DEFAULTS, loadUserConfig, maskApiKey } from '../src/config/user-config.js';
 
@@ -601,5 +617,80 @@ describe('formatters', () => {
     expect(formatCost(null)).toBe('disabled');
     expect(formatCost(5)).toBe('$5.00');
     expect(formatCost(0.5)).toBe('$0.50');
+  });
+});
+
+describe('buildSlugOptions', () => {
+  const models = ['anthropic/claude-opus-4', 'z-ai/glm-5.2', 'openai/gpt-4o'];
+  const cat = (source: ModelCatalogSource, slugs: string[] = models): ModelCatalogResult => ({
+    models: slugs,
+    source,
+    fetchedAt: source === 'bundled' ? 0 : 1,
+  });
+
+  it('prepends the (none) sentinel FIRST when allowNone is true', () => {
+    const opts = buildSlugOptions(cat('live'), '', { allowNone: true });
+    expect(opts[0]).toEqual({ value: '', label: '(none — use model map)' });
+    // the catalog slugs follow, in catalog order
+    expect(opts.slice(1).map((o) => o.value)).toEqual(models);
+  });
+
+  it('omits the (none) sentinel when allowNone is false (map-row model is required)', () => {
+    const opts = buildSlugOptions(cat('live'), '', { allowNone: false });
+    expect(opts.some((o) => o.value === '')).toBe(false);
+    expect(opts.map((o) => o.value)).toEqual(models);
+  });
+
+  it('appends a grandfather option when current is non-empty and absent from the catalog', () => {
+    const opts = buildSlugOptions(cat('live'), 'legacy/delisted-model', { allowNone: false });
+    expect(opts[opts.length - 1]).toEqual({
+      value: 'legacy/delisted-model',
+      label: 'legacy/delisted-model  (current, unverified)',
+    });
+    expect(opts).toHaveLength(models.length + 1);
+  });
+
+  it('does NOT add a grandfather option when current is already in the catalog', () => {
+    const opts = buildSlugOptions(cat('live'), 'z-ai/glm-5.2', { allowNone: false });
+    expect(opts).toHaveLength(models.length);
+    expect(opts.filter((o) => o.value === 'z-ai/glm-5.2')).toHaveLength(1);
+  });
+
+  it('does NOT add a grandfather option when current is empty', () => {
+    const opts = buildSlugOptions(cat('live'), '', { allowNone: false });
+    expect(opts).toHaveLength(models.length);
+  });
+
+  it('places (none) first AND the grandfather last (perAgent editing a delisted slug)', () => {
+    const opts = buildSlugOptions(cat('cache'), 'legacy/delisted', { allowNone: true });
+    expect(opts[0].value).toBe('');
+    expect(opts[opts.length - 1]).toEqual({
+      value: 'legacy/delisted',
+      label: 'legacy/delisted  (current, unverified)',
+    });
+    expect(opts).toHaveLength(models.length + 2); // (none) + catalog + grandfather
+  });
+
+  it('never injects a __refresh__ sentinel (CHANGE 2)', () => {
+    const variants = [
+      buildSlugOptions(cat('live'), 'legacy/x', { allowNone: true }),
+      buildSlugOptions(cat('live'), '', { allowNone: false }),
+      buildSlugOptions(cat('cache'), 'z-ai/glm-5.2', { allowNone: true }),
+    ];
+    for (const opts of variants) {
+      expect(opts.some((o) => o.value === '__refresh__')).toBe(false);
+      expect(opts.some((o) => o.label.includes('Refresh'))).toBe(false);
+    }
+  });
+});
+
+describe('slugPromptMode', () => {
+  it('is autocomplete for authoritative sources (live/cache hard-block)', () => {
+    expect(slugPromptMode('live')).toBe('autocomplete');
+    expect(slugPromptMode('cache')).toBe('autocomplete');
+  });
+
+  it('is freetext for the bundled floor (warn-only)', () => {
+    expect(slugPromptMode('bundled')).toBe('freetext');
   });
 });

--- a/test/openrouter-catalog.test.ts
+++ b/test/openrouter-catalog.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  listOpenrouterModels,
+  catalogEnforces,
+  __resetCatalogCacheForTests,
+} from '../src/config/openrouter-catalog.js';
+import { OPENROUTER_FALLBACK_SLUGS } from '../src/config/openrouter-models-fallback.js';
+import { DEFAULT_GLM_SLUG, DEFAULT_MODEL_MAP } from '../src/config/user-config.js';
+
+// ---------------------------------------------------------------------------
+// listOpenrouterModels — fetch / cache / fallback behavior
+// ---------------------------------------------------------------------------
+
+describe('listOpenrouterModels', () => {
+  const mockFetch = vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>();
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch;
+    __resetCatalogCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mockFetch.mockReset();
+  });
+
+  /** A 200 response carrying the given `/models`-shaped JSON body. */
+  function okResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  it('returns source "live" with sorted, de-duped, string-only slugs on success', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        data: [
+          { id: 'z-ai/glm-5.2' },
+          { id: 'anthropic/claude-opus-4' },
+          { id: 'z-ai/glm-5.2' }, // duplicate → collapsed
+          { id: 42 }, // non-string id → dropped
+          { name: 'no-id-here' }, // missing id → dropped
+          { id: 'openai/gpt-5' },
+        ],
+      }),
+    );
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('live');
+    expect(result.models).toEqual(['anthropic/claude-opus-4', 'openai/gpt-5', 'z-ai/glm-5.2']);
+    expect(result.fetchedAt).toBeGreaterThan(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the cached list as source "cache" within TTL without re-fetching', async () => {
+    mockFetch.mockResolvedValue(okResponse({ data: [{ id: 'openai/gpt-5' }] }));
+
+    const first = await listOpenrouterModels();
+    const second = await listOpenrouterModels();
+
+    expect(first.source).toBe('live');
+    expect(second.source).toBe('cache');
+    expect(second.models).toEqual(['openai/gpt-5']);
+    // fetchedAt is preserved from the underlying (live) fetch.
+    expect(second.fetchedAt).toBe(first.fetchedAt);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses the TTL cache when forceRefresh is true', async () => {
+    // A fresh Response per call — a single Response body can only be read once.
+    mockFetch.mockImplementation(async () => okResponse({ data: [{ id: 'openai/gpt-5' }] }));
+
+    await listOpenrouterModels();
+    const refreshed = await listOpenrouterModels({ forceRefresh: true });
+
+    expect(refreshed.source).toBe('live');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the stale-but-real list as source "cache" when a later fetch fails', async () => {
+    mockFetch.mockResolvedValueOnce(okResponse({ data: [{ id: 'openai/gpt-5' }] }));
+    await listOpenrouterModels(); // populates the cache with a real result
+
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    const result = await listOpenrouterModels({ forceRefresh: true });
+
+    expect(result.source).toBe('cache');
+    expect(result.models).toEqual(['openai/gpt-5']);
+  });
+
+  it('falls back to the bundled floor when the fetch fails and there is no prior result', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('bundled');
+    expect(result.models).toBe(OPENROUTER_FALLBACK_SLUGS);
+    expect(result.fetchedAt).toBe(0);
+  });
+
+  it('degrades to bundled on a non-2xx response', async () => {
+    mockFetch.mockResolvedValue(new Response('nope', { status: 500 }));
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('bundled');
+    expect(result.models).toBe(OPENROUTER_FALLBACK_SLUGS);
+  });
+
+  it('degrades to bundled on malformed (non-JSON) body', async () => {
+    mockFetch.mockResolvedValue(new Response('<html>not json</html>', { status: 200 }));
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('bundled');
+  });
+
+  it('degrades to bundled when `data` is not an array', async () => {
+    mockFetch.mockResolvedValue(okResponse({ data: 'not-an-array' }));
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('bundled');
+  });
+
+  it('degrades to bundled when `data` is empty (no usable slugs)', async () => {
+    mockFetch.mockResolvedValue(okResponse({ data: [] }));
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('bundled');
+  });
+
+  it('degrades when the fetch aborts on timeout', async () => {
+    // AbortSignal.timeout(...) rejects with a TimeoutError DOMException; simulate it.
+    mockFetch.mockRejectedValue(new DOMException('The operation timed out', 'TimeoutError'));
+
+    const result = await listOpenrouterModels();
+
+    expect(result.source).toBe('bundled');
+  });
+
+  it('never sends an Authorization header (the endpoint is public)', async () => {
+    mockFetch.mockResolvedValue(okResponse({ data: [{ id: 'openai/gpt-5' }] }));
+
+    await listOpenrouterModels();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const init = mockFetch.mock.calls[0]?.[1];
+    // No headers object at all → no key can leak.
+    expect(init?.headers).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// catalogEnforces — the shared block-vs-warn decision
+// ---------------------------------------------------------------------------
+
+describe('catalogEnforces', () => {
+  it('enforces (blocks) for authoritative sources', () => {
+    expect(catalogEnforces('live')).toBe(true);
+    expect(catalogEnforces('cache')).toBe(true);
+  });
+
+  it('does not enforce (warn-only) for the bundled floor', () => {
+    expect(catalogEnforces('bundled')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundled floor invariants — the fallback must never block a shipped default,
+// or an offline user editing a default-tracking profile could not save it.
+// ---------------------------------------------------------------------------
+
+describe('OPENROUTER_FALLBACK_SLUGS invariants', () => {
+  it('includes the default GLM slug', () => {
+    expect(OPENROUTER_FALLBACK_SLUGS).toContain(DEFAULT_GLM_SLUG);
+  });
+
+  it('includes every DEFAULT_MODEL_MAP target slug', () => {
+    for (const rule of DEFAULT_MODEL_MAP) {
+      expect(OPENROUTER_FALLBACK_SLUGS).toContain(rule.model);
+    }
+  });
+
+  it('is sorted and de-duped (served by reference as the bundled result)', () => {
+    const arr = [...OPENROUTER_FALLBACK_SLUGS];
+    expect(arr).toEqual([...new Set(arr)]);
+    expect(arr).toEqual([...arr].sort());
+  });
+});


### PR DESCRIPTION
## Summary

Adds model-name **autocomplete + hard-block validation** for OpenRouter provider profiles, in both the **web UI** Settings view and the **`ironcurtain config`** CLI TUI. As a user types a model name they get a dropdown of matching OpenRouter slugs to choose from, and an unknown slug is rejected on save.

## How it works

- **Shared catalog** (`src/config/openrouter-catalog.ts`): anonymous fetch of the public `GET /api/v1/models`, 6h in-memory cache, bundled fallback floor, and a `source` tag (`live|cache|bundled`). Never throws — every failure path degrades.
- **Enforcement keys on `source`, not the frontend**: `live`/`cache` (authoritative) hard-block unknown slugs; the known-incomplete `bundled` floor degrades to warn-only. The one shared decision (`catalogEnforces` and its web mirror `sourceEnforces`) is unit-tested on both sides.
- **Web UI**: a portalled WAI-ARIA `ModelCombobox` (free-typing always allowed; loading/error/offline/empty/invalid states), save-time hard-block with **grandfathering** of untouched persisted slugs (so rotating an API key never traps you out of saving), warn-only on the bundled floor, and a **Refresh** button.
- **CLI**: `@clack` `autocomplete` (selection-only structural hard-block) when authoritative, free-text + one-line warning when offline; the catalog is fetched lazily and module-cached (no cost on key-only edits).
- **Server-side stays non-enforcing** (trusted-host model; the slug is only ever a JSON body field, never a shell/path value). Client-side validation is a UX guardrail.
- **Mock WS server** gets first-class support — realistic `MOCK_SLUGS`, default `source=live` so the hard-block path is demoable offline, and a `MOCK_OPENROUTER_SOURCE` env toggle for the warn path.

Autocomplete applies to slug-target fields only (`modelMap[].model` + per-agent overrides); the `modelMap` match glob is unchanged.

## Process

Built via a supervised **design → adversarial review → implement (3 units in parallel) → adversarial implementation review** flow. All 6 implementation-review findings were applied: web Refresh button, lazy CLI catalog fetch, `allowNone`-aware validate allowlist, `catalogEnforces`↔`sourceEnforces` cross-reference, and fallback-slug invariant tests.

## Testing

- `npm run build` ✅ · `npm run lint` ✅ · `npm run format:check` ✅ · `npm run check:cycles` ✅
- Full suite: **5459 root + 447 web-ui tests pass, 0 failures** — incl. new catalog fetch/cache/fallback + no-key-header tests, the validation rule-table with grandfathering, CLI option-builder helpers, and Settings DOM tests for hard-block / warn-degrade / grandfather / refresh / source badge.
