### PR TITLE
Use runtime capability for workflow snapshots

### DIFF
--- a/src/docker/apple-container-manager.ts
+++ b/src/docker/apple-container-manager.ts
@@ -278,6 +278,8 @@ export function createAppleContainerManager(
   };
 
   return {
+    supportsImageSnapshots: false,
+
     async preflight(image: string): Promise<void> {
       const status = await availabilityProbe(execFileFn);
       if (!status.available) {

--- a/src/docker/apple-container-manager.ts
+++ b/src/docker/apple-container-manager.ts
@@ -423,9 +423,8 @@ export function createAppleContainerManager(
     },
 
     // Workflow snapshot/image management (commit, removeImage, listImages,
-    // inspectImage) is Docker-only. The orchestrator's snapshot paths call
-    // createDockerManager() directly, so these are never reached on the
-    // apple-container backend; reject loudly rather than degrade silently.
+    // inspectImage) is runtime-capability gated. Reject loudly if these methods
+    // are reached on the apple-container backend instead of degrading silently.
     commit: (): Promise<string> => unsupported('image commit (workflow snapshots)'),
     removeImage: (): Promise<boolean> => unsupported('image removal'),
     listImages: (): Promise<readonly DockerImageInfo[]> => unsupported('image listing'),

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -339,6 +339,8 @@ export function createDockerManager(
   const runStreamed = makeRunStreamed('docker', streamOpts, progressSinkFactory);
 
   return {
+    supportsImageSnapshots: true,
+
     async preflight(image: string): Promise<void> {
       const status = await dockerAvailabilityProbe();
       if (!status.available) {

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -174,6 +174,9 @@ export interface DockerImageInfo {
  * agent containers.
  */
 export interface ContainerRuntime {
+  /** True when this runtime can commit containers to images and manage snapshot images. */
+  readonly supportsImageSnapshots: boolean;
+
   /** Check that the runtime is available and the image exists. */
   preflight(image: string): Promise<void>;
 

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -1292,8 +1292,10 @@ export class WorkflowOrchestrator implements WorkflowController {
   }
 
   private async dockerForSnapshotCleanup(instance: WorkflowInstance): Promise<ContainerRuntime | undefined> {
-    if (instance.bundlesByScope.size > 0) {
-      return [...instance.bundlesByScope.values()][0].docker;
+    for (const infra of instance.bundlesByScope.values()) {
+      if (infra.docker.supportsImageSnapshots) {
+        return infra.docker;
+      }
     }
     if (!commandExists('docker')) return undefined;
     const { createDockerManager } = await import('../docker/docker-manager.js');

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -132,6 +132,7 @@ import {
   isWorkflowTransientFailureError,
 } from './errors.js';
 import { commitContainerSnapshot, removeContainerSnapshotImages } from './container-snapshots.js';
+import { commandExists } from '../trusted-process/container-command.js';
 
 const execFileAsync = promisify(execFileCb);
 
@@ -1265,11 +1266,9 @@ export class WorkflowOrchestrator implements WorkflowController {
 
     const snapshots: Record<string, ContainerSnapshotRef> = {};
     for (const [scope, infra] of entries) {
-      // Container snapshots require Docker's commit/image APIs, which the Apple
-      // `container` runtime does not provide. Skip cleanly (the workflow stops
-      // without a resumable container snapshot) rather than attempting a commit
-      // that the runtime would reject.
-      if (infra.runtimeKind !== 'docker') {
+      // Container snapshots require image commit/management APIs. Key off the
+      // runtime capability so new runtimes do not need orchestrator changes.
+      if (!infra.docker.supportsImageSnapshots) {
         writeStderr(
           `[workflow] Container snapshots are not supported on the "${infra.runtimeKind}" runtime; ` +
             `stopping ${instance.id} scope "${scope}" without a snapshot.`,
@@ -1292,10 +1291,11 @@ export class WorkflowOrchestrator implements WorkflowController {
     return Object.keys(snapshots).length > 0 ? snapshots : undefined;
   }
 
-  private async dockerForSnapshotCleanup(instance: WorkflowInstance): Promise<ContainerRuntime> {
+  private async dockerForSnapshotCleanup(instance: WorkflowInstance): Promise<ContainerRuntime | undefined> {
     if (instance.bundlesByScope.size > 0) {
       return [...instance.bundlesByScope.values()][0].docker;
     }
+    if (!commandExists('docker')) return undefined;
     const { createDockerManager } = await import('../docker/docker-manager.js');
     return createDockerManager();
   }

--- a/test/helpers/docker-mocks.ts
+++ b/test/helpers/docker-mocks.ts
@@ -79,6 +79,8 @@ export function createMockDocker(options: CreateMockDockerOptions = {}): Contain
   let commitSeq = 0;
 
   return {
+    supportsImageSnapshots: true,
+
     async preflight() {},
     async create(config: DockerContainerConfig) {
       tracker?.createCalls.push(config);

--- a/test/workflow/orchestrator-shared-container.test.ts
+++ b/test/workflow/orchestrator-shared-container.test.ts
@@ -483,6 +483,42 @@ describe('WorkflowOrchestrator shared-container mode', () => {
     }
   });
 
+  it('gates snapshotting on the runtime image-snapshot capability', async () => {
+    const docker = {
+      ...createMockDocker(),
+      supportsImageSnapshots: false,
+      commit: vi.fn(async () => {
+        throw new Error('snapshot should not be attempted');
+      }),
+    };
+    const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+    type SnapshotHarness = {
+      snapshotResumableScopes(instance: unknown): Promise<Readonly<Record<string, unknown>> | undefined>;
+    };
+    const instance = {
+      id: 'workflow-capability-gate',
+      definition: {
+        ...dockerWorkflowDef,
+        settings: { mode: 'docker', dockerAgent: 'claude-code', sharedContainer: true, snapshotOnStop: true },
+      },
+      bundlesByScope: new Map([
+        [
+          'primary',
+          {
+            ...makeStubInfrastructure('workflow-capability-gate', 'primary' as BundleId),
+            docker,
+            containerId: 'container-primary',
+          },
+        ],
+      ]),
+    };
+
+    const snapshots = await (orchestrator as unknown as SnapshotHarness).snapshotResumableScopes(instance);
+
+    expect(snapshots).toBeUndefined();
+    expect(docker.commit).not.toHaveBeenCalled();
+  });
+
   it('supersedes (removes) the previous snapshot digest on a resume-then-stop', async () => {
     const snapshotDef: WorkflowDefinition = {
       name: 'docker-snapshot-supersede',

--- a/test/workflow/orchestrator-shared-container.test.ts
+++ b/test/workflow/orchestrator-shared-container.test.ts
@@ -519,6 +519,34 @@ describe('WorkflowOrchestrator shared-container mode', () => {
     expect(docker.commit).not.toHaveBeenCalled();
   });
 
+  it('uses a snapshot-capable runtime for snapshot cleanup', async () => {
+    const unsupportedRuntime = {
+      ...createMockDocker(),
+      supportsImageSnapshots: false,
+      removeImage: vi.fn(async () => {
+        throw new Error('unsupported runtime should not clean snapshots');
+      }),
+    };
+    const snapshotRuntime = {
+      ...createMockDocker(),
+      removeImage: vi.fn(async () => true),
+    };
+    const orchestrator = new WorkflowOrchestrator(createDeps(tmpDir));
+    type CleanupHarness = {
+      dockerForSnapshotCleanup(instance: unknown): Promise<unknown>;
+    };
+    const instance = {
+      bundlesByScope: new Map([
+        ['apple', { docker: unsupportedRuntime }],
+        ['docker', { docker: snapshotRuntime }],
+      ]),
+    };
+
+    const cleanupRuntime = await (orchestrator as unknown as CleanupHarness).dockerForSnapshotCleanup(instance);
+
+    expect(cleanupRuntime).toBe(snapshotRuntime);
+  });
+
   it('supersedes (removes) the previous snapshot digest on a resume-then-stop', async () => {
     const snapshotDef: WorkflowDefinition = {
       name: 'docker-snapshot-supersede',


### PR DESCRIPTION
## Summary

- Add a `supportsImageSnapshots` capability to `ContainerRuntime`.
- Set Docker to support image snapshots and Apple `container` to opt out explicitly.
- Gate workflow snapshot commits on the runtime capability instead of the `runtimeKind` string.
- Skip fallback Docker snapshot cleanup manager creation when the Docker CLI is unavailable.

Closes #330.

## Security Impact

- [ ] Changes the policy evaluation logic or rule format
- [ ] Modifies the sandbox boundary or V8 isolate setup
- [ ] Adds or changes MCP server spawning, IPC, or credential handling
- [ ] Introduces new tool argument roles or path resolution logic
- [x] None of the above

## Test plan

- [ ] Existing tests pass (`npm test`) - not run locally; targeted checks below.
- [x] Added new tests for the change
- [x] Manual testing (describe below)

Checked locally:

- `npm run build -w @provos/memory-mcp-server`
- `npm exec prettier -- --check src/docker/types.ts src/docker/docker-manager.ts src/docker/apple-container-manager.ts src/workflow/orchestrator.ts test/helpers/docker-mocks.ts test/workflow/orchestrator-shared-container.test.ts`
- `npm exec eslint -- src/docker/types.ts src/docker/docker-manager.ts src/docker/apple-container-manager.ts src/workflow/orchestrator.ts test/helpers/docker-mocks.ts test/workflow/orchestrator-shared-container.test.ts`
- `npm exec tsc -- --noEmit`
- `npm exec vitest -- run test/workflow/orchestrator-shared-container.test.ts -t "gates snapshotting"`
- `npm exec vitest -- run test/workflow/container-snapshots.test.ts`
- `npm run lint`
- `npm run check:cycles`
- `npm run build`