### PR TITLE
fix(docker): run Claude Code subagents synchronously (fixes #367)

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -118,6 +118,11 @@ export function createClaudeCodeAdapter(userConfig?: ResolvedUserConfig): AgentA
       return CLAUDE_CODE_IMAGE;
     },
 
+    // Claude Code is installed unpinned in the image; log the resolved version
+    // at infra prep so a silent minor bump (which can change subagent semantics
+    // — issue #367) is visible.
+    versionProbe: ['claude', '--version'],
+
     // Generates MCP config file passed via --mcp-config on the command line.
     // socketPath is either a UDS path or a TCP host:port address.
     generateMcpConfig(socketPath: string): AgentConfigFile[] {
@@ -274,6 +279,18 @@ exit $STATUS
         CLAUDE_CODE_DISABLE_UPDATE_CHECK: '1',
         // Node.js does not use the system CA store -- must set this explicitly
         NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/ironcurtain-ca.crt',
+        // Force subagents (Agent/Task tool) and `run_in_background` to run in the
+        // FOREGROUND (synchronously), disabling auto-backgrounding. As of Claude
+        // Code v2.1.198 subagents run in the *background* by default: the tool
+        // returns immediately and the parent is "notified automatically when it
+        // completes" via a persistent supervisor that re-fires the session. We
+        // invoke `claude -p` as a one-shot subprocess with no such supervisor, so
+        // when a workflow agent (e.g. vuln-discovery `analyze`) fans out to
+        // parallel subagents, the turn never receives their completions and stalls
+        // ("Response stalled mid-stream" / no `agent_status` block). This env var
+        // restores the pre-2.1.198 synchronous behavior, which the FSM's
+        // one-turn=one-result model requires. See docs/en/env-vars.
+        CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1',
       };
 
       if (modelId) {

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -215,6 +215,15 @@ export interface AgentAdapter {
   getImage(): Promise<string>;
 
   /**
+   * Command that prints the installed agent CLI version, run against the built
+   * image via {@link ContainerRuntime.probeImageVersion} (e.g.
+   * `['claude', '--version']`). The agent CLI is installed UNPINNED in the image,
+   * so infra prep logs the resolved version to surface silent drift on rebuild
+   * (issue #367). Omit to skip version logging for this adapter.
+   */
+  readonly versionProbe?: readonly string[];
+
+  /**
    * Generates the MCP client configuration file that tells
    * the agent how to connect to IronCurtain's proxy.
    *

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -743,6 +743,9 @@ export async function prepareDockerInfrastructure(
     const agentImage = await adapter.getImage();
     const agentBuildHash = await ensureImage(agentImage, docker, ca);
     const image = agentImage;
+    // Surface the (unpinned) agent CLI version baked into the image so silent
+    // version drift on rebuild is visible in logs (issue #367).
+    await logResolvedAgentVersion(docker, agentImage, adapter.versionProbe);
     const workflowDependencyMounts = prepareWorkflowDependencyMounts(agentBuildHash, scriptsDir, getIronCurtainHome());
 
     const orientationDir = resolve(bundleDir, 'orientation');
@@ -1689,6 +1692,40 @@ async function buildImageFromCleanContext(
     await docker.buildImage(image, resolve(tmpContext, dockerfile), tmpContext, labels);
   } finally {
     rmSync(tmpContext, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Agent images whose baked CLI version has already been logged this process, so
+ * the diagnostic probe (a throwaway `docker run --version`) runs at most once
+ * per image rather than on every session/workflow-state.
+ */
+const loggedAgentVersions = new Set<string>();
+
+/**
+ * Best-effort: log the agent CLI version baked into `image`. The agent CLI is
+ * installed UNPINNED in the Docker image, so any change to a hashed build input
+ * (Dockerfile / *.sh) rebuilds the image and can silently pull a newer agent —
+ * see issue #367, where a Claude Code minor bump flipped subagents to run in the
+ * background, breaking the one-shot `claude -p` workflow model. Surfacing the
+ * resolved version makes that drift visible. Skipped when the adapter defines no
+ * probe or the runtime can't run an ephemeral container; never throws.
+ */
+async function logResolvedAgentVersion(
+  runtime: ContainerRuntime,
+  image: string,
+  versionProbe: readonly string[] | undefined,
+): Promise<void> {
+  if (!versionProbe || versionProbe.length === 0 || !runtime.probeImageVersion) return;
+  if (loggedAgentVersions.has(image)) return;
+  loggedAgentVersions.add(image);
+  try {
+    const version = await runtime.probeImageVersion(image, versionProbe);
+    if (version) {
+      logger.info(`[docker] ${image} agent version (unpinned): ${version}`);
+    }
+  } catch {
+    // Diagnostic only — never disturb infra prep.
   }
 }
 

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -744,8 +744,9 @@ export async function prepareDockerInfrastructure(
     const agentBuildHash = await ensureImage(agentImage, docker, ca);
     const image = agentImage;
     // Surface the (unpinned) agent CLI version baked into the image so silent
-    // version drift on rebuild is visible in logs (issue #367).
-    await logResolvedAgentVersion(docker, agentImage, adapter.versionProbe);
+    // version drift on rebuild is visible in logs (issue #367). Keyed by build
+    // hash so a same-process rebuild re-logs the possibly-changed version.
+    await logResolvedAgentVersion(docker, agentImage, agentBuildHash, adapter.versionProbe);
     const workflowDependencyMounts = prepareWorkflowDependencyMounts(agentBuildHash, scriptsDir, getIronCurtainHome());
 
     const orientationDir = resolve(bundleDir, 'orientation');
@@ -1696,9 +1697,13 @@ async function buildImageFromCleanContext(
 }
 
 /**
- * Agent images whose baked CLI version has already been logged this process, so
- * the diagnostic probe (a throwaway `docker run --version`) runs at most once
- * per image rather than on every session/workflow-state.
+ * `${image}@${buildHash}` keys whose baked CLI version has already been logged
+ * this process, so the diagnostic probe (a throwaway `docker run --version`)
+ * runs at most once per built image rather than on every session/workflow-state.
+ * Keyed by build hash — not the tag alone — so a same-process rebuild (which
+ * keeps the `:latest` tag but changes `ironcurtain.build-hash`) re-probes and
+ * re-logs the possibly-changed version, which is the whole point of surfacing
+ * drift.
  */
 const loggedAgentVersions = new Set<string>();
 
@@ -1714,11 +1719,13 @@ const loggedAgentVersions = new Set<string>();
 async function logResolvedAgentVersion(
   runtime: ContainerRuntime,
   image: string,
+  buildHash: string,
   versionProbe: readonly string[] | undefined,
 ): Promise<void> {
   if (!versionProbe || versionProbe.length === 0 || !runtime.probeImageVersion) return;
-  if (loggedAgentVersions.has(image)) return;
-  loggedAgentVersions.add(image);
+  const cacheKey = `${image}@${buildHash}`;
+  if (loggedAgentVersions.has(cacheKey)) return;
+  loggedAgentVersions.add(cacheKey);
   try {
     const version = await runtime.probeImageVersion(image, versionProbe);
     if (version) {

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -368,6 +368,21 @@ export function createDockerManager(
       await exec('docker', ['start', nameOrId], { timeout: 30_000 });
     },
 
+    async probeImageVersion(image: string, command: readonly string[]): Promise<string | undefined> {
+      const [entrypoint, ...rest] = command;
+      if (!entrypoint) return undefined;
+      try {
+        const { stdout } = await exec('docker', ['run', '--rm', '--entrypoint', entrypoint, image, ...rest], {
+          timeout: 20_000,
+        });
+        const version = stdout.trim();
+        return version.length > 0 ? version : undefined;
+      } catch {
+        // Best-effort diagnostic — never fail over a version probe.
+        return undefined;
+      }
+    },
+
     async exec(
       nameOrId: string,
       command: readonly string[],

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -372,9 +372,15 @@ export function createDockerManager(
       const [entrypoint, ...rest] = command;
       if (!entrypoint) return undefined;
       try {
-        const { stdout } = await exec('docker', ['run', '--rm', '--entrypoint', entrypoint, image, ...rest], {
-          timeout: 20_000,
-        });
+        // `--network none`: the probe executes the agent binary (e.g.
+        // `claude --version`), which may attempt update-check/telemetry egress.
+        // Agent containers run with no network; keep this diagnostic isolated too
+        // (a version string is baked in and needs no network).
+        const { stdout } = await exec(
+          'docker',
+          ['run', '--rm', '--network', 'none', '--entrypoint', entrypoint, image, ...rest],
+          { timeout: 20_000 },
+        );
         const version = stdout.trim();
         return version.length > 0 ? version : undefined;
       } catch {

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -258,8 +258,10 @@ export interface ContainerRuntime {
 
   /**
    * Probe the version string of an agent binary baked into an image by running
-   * a throwaway container (`run --rm --entrypoint <command[0]> <image>
-   * <command[1..]>`) and returning its trimmed stdout. Best-effort: returns
+   * a throwaway, network-isolated container (`run --rm --network none
+   * --entrypoint <command[0]> <image> <command[1..]>`) and returning its trimmed
+   * stdout. Network isolation is required — the probe executes an agent binary
+   * that may attempt update-check/telemetry egress. Best-effort: returns
    * undefined on any failure. Optional — runtimes that cannot cheaply run an
    * ephemeral container may omit it, in which case callers skip version logging.
    */

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -256,6 +256,15 @@ export interface ContainerRuntime {
   /** Read a label value from a Docker image. Returns undefined if image or label doesn't exist. */
   getImageLabel(image: string, label: string): Promise<string | undefined>;
 
+  /**
+   * Probe the version string of an agent binary baked into an image by running
+   * a throwaway container (`run --rm --entrypoint <command[0]> <image>
+   * <command[1..]>`) and returning its trimmed stdout. Best-effort: returns
+   * undefined on any failure. Optional — runtimes that cannot cheaply run an
+   * ephemeral container may omit it, in which case callers skip version logging.
+   */
+  probeImageVersion?(image: string, command: readonly string[]): Promise<string | undefined>;
+
   /** Create a Docker network. No-op if it already exists. */
   createNetwork(name: string, options?: { internal?: boolean; subnet?: string; gateway?: string }): Promise<void>;
 

--- a/test/docker/openrouter-agent-session.test.ts
+++ b/test/docker/openrouter-agent-session.test.ts
@@ -367,6 +367,9 @@ describe('OpenRouter OFF — native profile is byte-identical to today', () => {
     expect(env).toEqual({
       CLAUDE_CODE_DISABLE_UPDATE_CHECK: '1',
       NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/ironcurtain-ca.crt',
+      // Forces subagents synchronous (issue #367); set on every path — native
+      // and OpenRouter — not an OpenRouter-specific var.
+      CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1',
       IRONCURTAIN_API_KEY: 'sk-ant-api03-ironcurtain-FAKE',
     });
     // No OpenRouter vars leaked in.


### PR DESCRIPTION
## Summary

Fixes #367 — the `vuln-discovery` workflow's `analyze` state stalled indefinitely ("Response stalled mid-stream" / "Agent failed to provide agent_status block after retry") and aborted the workflow. Reproduced against `mackron/dr_libs`.

## Root cause (two layers)

1. **Why now — silent version drift.** Claude Code is installed *unpinned* in the agent image (`Dockerfile.claude-code`). `computeBuildHash` hashes every `.sh` file in `docker/`, so the unrelated `entrypoint-claude-code.sh` edit in #361 changed the build hash → the agent image rebuilt → `npm install -g @anthropic-ai/claude-code` pulled a newer Claude Code, crossing the **v2.1.198** boundary. #361's code is inert on the native request path; only the rebuild mattered — which is exactly why a bisect lands on it.

2. **Proximate — background subagents.** Claude Code **v2.1.198** flipped subagents (the `Agent`/`Task` tool) to run in the **background by default**: the tool returns immediately (*"Async agent launched… you'll be notified automatically when it completes"*) and results are delivered later by a persistent supervisor that re-fires the session. IronCurtain runs `claude -p` as a **one-shot subprocess** with no such supervisor, so when the complex `analyze` state fans out to parallel subagents, the turn never receives their completions and stalls. Confirmed from captured trajectories: the parent launched 3 async agents, tried to `sleep`-wait, was blocked by Claude Code's own rail (*"use Monitor with an until-loop…"*), and never synthesized an `agent_status` block.

## Fix

Set `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in the Claude Code adapter env (`buildEnv`). Per Anthropic's [env-vars docs](https://code.claude.com/docs/en/env-vars) this disables `run_in_background` on Bash + subagent tools and auto-backgrounding, so subagents run **foreground / synchronously** — the pre-2.1.198 behavior, which matches the workflow FSM's one-turn = one-result contract. Subagents still work; they block-and-return inline.

## Drift visibility (no pinning)

Per discussion we're **not** pinning Claude Code for now. Instead, to surface silent version drift on rebuild, infra prep now probes and logs the resolved agent CLI version — once per image per process — via a new optional `ContainerRuntime.probeImageVersion`:

```
[docker] ironcurtain-claude-code:latest agent version (unpinned): 2.1.201 (Claude Code)
```

## Verification

Reproduced and fixed end-to-end against `mackron/dr_libs` on the **same 2.1.201 image** (the env var is host-side, so no rebuild — a clean A/B):

| | `analyze` | subagents |
|---|---|---|
| **before** | hung indefinitely, workflow aborted | 3 **async** ("Async agent launched"), never reaped |
| **after** | **`completed: verdict=completed, artifacts=analysis`** → advanced to next round | 3 **synchronous**, all `end_turn`; parent received results inline |

## Tests

- 211 docker unit tests pass (`docker-infrastructure`, `docker-manager`, `docker-agent-adapter`, `docker-session`, `docker-session-factory`).
- `tsc --noEmit`, ESLint, Prettier all clean.
