### PR TITLE
fix(test): neutralize teardown TCP-server leaks behind the macOS CI flake

### DIFF
--- a/src/web-ui/web-ui-server.ts
+++ b/src/web-ui/web-ui-server.ts
@@ -249,6 +249,13 @@ export class WebUiServer {
       const server = this.httpServer;
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
+        // `http.Server.close()` stops listening but WAITS for live connections
+        // to end on their own — it does not destroy them. Any lingering
+        // WS/keep-alive socket would otherwise keep both the server and its
+        // socket handles open, which keeps the process (and, under tests, the
+        // vitest forks worker) alive. Force-destroy them so close() resolves
+        // promptly. (`closeAllConnections` is Node >= 18.2; we run 24/26.)
+        server.closeAllConnections();
       });
       this.httpServer = null;
     }

--- a/test/setup/handle-leak-guard.ts
+++ b/test/setup/handle-leak-guard.ts
@@ -1,0 +1,106 @@
+/**
+ * Handle-leak guard — a test-only teardown safety net.
+ *
+ * Root-causes the recurring macOS-only CI flake where every test passes but the
+ * run fails with `Worker exited unexpectedly` / `close timed out after
+ * 30000ms` / `something prevents Vite server from exiting`. The cause is a
+ * teardown leak: several test files leave a listening TCP server (an
+ * `http`/`net.Server`) open after their own cleanup has run. Because vitest's
+ * `forks` pool reuses worker processes across files, those native handles
+ * accumulate; at end-of-run vitest force-terminates workers whose event loops
+ * won't drain. On the slow, contended macOS runners that force-termination
+ * exceeds the teardown budget → the flake. A listening server never
+ * self-closes, so it is held for the entire window — which is why simply
+ * widening `teardownTimeout` never fixed it (you cannot out-wait a permanent
+ * handle).
+ *
+ * This guard runs LAST in every file's teardown (setup-file hooks register
+ * before the test file body, so their `afterAll` runs AFTER the file's own
+ * `afterEach`/`afterAll`). If a file left any listening server open, it:
+ *   - destroys the server's live connections and closes it, so the worker's
+ *     event loop can drain and the run exits cleanly, and
+ *   - `unref()`s any lingering timer on that same (already-misbehaving) file so
+ *     a stray interval cannot independently hold the loop open.
+ * It then writes a `[leak-guard]` line to stderr naming the file so the real
+ * per-test cleanup can be added. See the `project-vitest-worker-exit-flake`
+ * note. (stderr, not `console.warn`, because vitest's console capture swallows
+ * hook-level `console` output on a passing run.)
+ *
+ * Safety: it only ever acts AFTER a file's own tests and teardown have run, and
+ * only on files that actually leaked a server. vitest's worker RPC uses stdio
+ * pipes (not a `net.Server` and not a keep-alive timer), so nothing
+ * framework-owned is touched. Well-behaved files are a pure no-op.
+ */
+import { afterAll, expect } from 'vitest';
+
+interface ClosableServer {
+  close(): void;
+  closeAllConnections?(): void;
+}
+
+function activeHandles(): unknown[] {
+  return (process as unknown as { _getActiveHandles?: () => unknown[] })._getActiveHandles?.() ?? [];
+}
+
+/** Realm-agnostic constructor name for an arbitrary active handle (or undefined). */
+function ctorName(handle: unknown): string | undefined {
+  if (typeof handle !== 'object' || handle === null) return undefined;
+  return (handle as { constructor?: { name?: string } }).constructor?.name;
+}
+
+/**
+ * A leaked listening `net`/`http`/`tls.Server`. Identified by constructor name
+ * rather than `instanceof` because vitest's forks isolation can hand the setup
+ * file a different `node:net` module identity than the test used, which breaks
+ * `instanceof` across the boundary. All three server classes expose `.close()`;
+ * the name check plus a `.close` typeof guard is realm-agnostic and precise
+ * (`ws`'s `WebSocketServer` has a different constructor name and is skipped —
+ * its underlying `http.Server` is the handle we actually close).
+ */
+function isListeningServer(handle: unknown): handle is ClosableServer {
+  return ctorName(handle) === 'Server' && typeof (handle as { close?: unknown }).close === 'function';
+}
+
+function currentTestFile(): string {
+  try {
+    return (expect.getState().testPath ?? 'unknown').replace(/.*\/(test|src)\//, '$1/');
+  } catch {
+    return 'unknown';
+  }
+}
+
+afterAll(() => {
+  const handles = activeHandles();
+  const leakedServers = handles.filter(isListeningServer);
+  // Only intervene when a listening server actually leaked — the persistent,
+  // never-self-closing handle behind the flake. Leave well-behaved files (whose
+  // only active handle is vitest's own worker RPC pipe + baseline timer) alone.
+  if (leakedServers.length === 0) return;
+
+  for (const server of leakedServers) {
+    try {
+      server.closeAllConnections?.();
+      server.close();
+    } catch {
+      // already closing / closed — nothing to do
+    }
+  }
+
+  let unrefdTimers = 0;
+  for (const handle of handles) {
+    if (ctorName(handle) === 'Timeout') {
+      try {
+        (handle as { unref?: () => void }).unref?.();
+        unrefdTimers += 1;
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  process.stderr.write(
+    `[leak-guard] ${currentTestFile()}: closed ${leakedServers.length} leaked server(s)` +
+      `${unrefdTimers ? `, unref'd ${unrefdTimers} timer(s)` : ''} at teardown ` +
+      `(run stays green; add explicit cleanup — see test/setup/handle-leak-guard.ts).\n`,
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,12 +6,16 @@ export default defineConfig({
     testTimeout: 30_000,
     // Match CI's default pool explicitly so local and CI runs behave the same.
     pool: 'forks',
-    // Mitigation (not a root-cause fix): the MCP SDK's StdioClientTransport.close()
-    // does not await the child's 'close' after SIGKILL, so under a loaded runner a
-    // spawned MCP server can still be exiting when teardown completes, briefly
-    // holding its stdio pipe FDs open. That intermittently tripped the default 10s
-    // teardown limit ("close timed out after 10000ms … Worker exited unexpectedly")
-    // even though all tests passed. Give slow child-reaping more slack.
+    // Teardown safety net for the macOS "Worker exited unexpectedly" /
+    // "prevents Vite server from exiting" flake. Root cause: some test files
+    // leave a listening TCP server open after their own cleanup; the forks pool
+    // reuses workers, so those handles accumulate and keep a worker's event loop
+    // alive, which the slow macOS runners can't drain within the teardown
+    // budget. handle-leak-guard runs LAST in each file's teardown and
+    // force-closes any leaked server. See project-vitest-worker-exit-flake.
+    setupFiles: ['./test/setup/handle-leak-guard.ts'],
+    // Keep extra teardown slack as belt-and-suspenders (the leak fix above is
+    // the real mitigation, not this timeout).
     teardownTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

Fixes the recurring **macOS-only** CI flake: every test passes, then the run fails with `Worker exited unexpectedly` / `close timed out after 30000ms` / `something prevents Vite server from exiting`, with exactly one of `macos-24`/`macos-26` failing per run (alternating on identical code).

**Root cause (investigated + verified):** a teardown open-handle leak. **~17 test files leave a listening TCP server open after their own cleanup has run.** vitest's `forks` pool reuses worker processes across files, so those native handles **accumulate** and keep a worker's event loop alive; at end-of-run vitest force-terminates workers whose loops won't drain. On the slow, contended macOS runners (~2.5× slower than Linux/local) that force-termination exceeds the teardown budget → the flake. A listening server **never self-closes**, so it is held for the entire 30s window (confirmed in the CI timestamps) — which is why the previous mitigations never worked: **you can't out-wait a permanent handle.**

The earlier theory (unreaped MCP stdio children, per the old `vitest.config.ts` comment / PR #353) is **disproven**: the `npx @modelcontextprotocol/server-filesystem` grandchild self-exits in ~500ms on stdin EOF. The real leak is unclosed **servers**, not children.

## Changes

- **`test/setup/handle-leak-guard.ts`** (new, wired via `setupFiles`) — a teardown safety net that runs *last* in each file (setup-file hooks register first → their `afterAll` runs after the file's own cleanup). If a file left any listening server open, it destroys the server's live connections, closes it, and `unref()`s stray timers, then logs a `[leak-guard]` line naming the file so the real per-test cleanup can follow. Well-behaved files are a pure no-op. Uses a realm-agnostic `constructor.name === 'Server'` check because vitest's forks isolation breaks `instanceof` across the setup-file/test boundary.
- **`WebUiServer.stop()`** — `httpServer.closeAllConnections()` so live WS/keep-alive sockets are destroyed instead of lingering as handles (correct shutdown hygiene; `close()` alone only *waits* for connections).
- **`vitest.config.ts`** — wire the guard; replace the stale `teardownTimeout` comment (which documented the disproven MCP-stdio theory).

## Why a safety net (and follow-up)

The leak is systemic — 17 files, ~35 servers — so the guard is the durable, comprehensive fix. The per-file cleanup (track and close every server in each file's `afterEach`/`afterAll`) is a good mechanical follow-up; the `[leak-guard]` stderr lines are the checklist. Until then the net keeps the run green **and** surfaces the debt (no silent masking).

## Security Impact

- [ ] Changes the policy evaluation logic or rule format
- [ ] Modifies the sandbox boundary or V8 isolate setup
- [ ] Adds or changes MCP server spawning, IPC, or credential handling
- [ ] Introduces new tool argument roles or path resolution logic
- [x] None of the above — test-harness + web-ui server shutdown only.

## Test plan

- [x] Full suite green locally (`npx vitest run`): **252 files / 5513 tests pass**, 0 failed, **0 flake markers**; guard neutralizes leaks in 17 files.
- [x] `npm run lint`, `npx tsc --noEmit`, `npm run check:cycles`, `prettier --check` all clean on the changed files.
- [x] Confirmed the guard detects and closes the leaked servers (e.g. `daemon-client.test.ts` → 8) via the `[leak-guard]` diagnostics.