### PR TITLE
fix(claude-code): disable the streaming idle watchdog (issue #367)

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -291,6 +291,15 @@ exit $STATUS
         // restores the pre-2.1.198 synchronous behavior, which the FSM's
         // one-turn=one-result model requires. See docs/en/env-vars.
         CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1',
+        // Disable the streaming idle watchdog (on by default since Claude
+        // Code v2.1.196). Behind the MITM proxy, long tool-use turns and
+        // SSE re-buffering trip the watchdog's idle threshold, which
+        // aborts the request with "API Error: Response stalled
+        // mid-stream" — the actual root cause of issue #367 (PR #372's
+        // background-task fix alone did not resolve it). Turning the
+        // watchdog off restores the pre-2.1.196 behavior; the workflow
+        // orchestrator already enforces its own wall-clock/step budgets.
+        CLAUDE_ENABLE_STREAM_WATCHDOG: '0',
       };
 
       if (modelId) {

--- a/test/docker/openrouter-agent-session.test.ts
+++ b/test/docker/openrouter-agent-session.test.ts
@@ -370,6 +370,8 @@ describe('OpenRouter OFF — native profile is byte-identical to today', () => {
       // Forces subagents synchronous (issue #367); set on every path — native
       // and OpenRouter — not an OpenRouter-specific var.
       CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1',
+      // Disables the streaming idle watchdog (issue #367); set on every path.
+      CLAUDE_ENABLE_STREAM_WATCHDOG: '0',
       IRONCURTAIN_API_KEY: 'sk-ant-api03-ironcurtain-FAKE',
     });
     // No OpenRouter vars leaked in.


### PR DESCRIPTION
## Summary

Follow-up to #372 — that fix (`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`) did not resolve #367 on its own. The actual trigger is Claude Code **v2.1.196** turning the **streaming idle watchdog** on by default: behind IronCurtain's MITM proxy, long tool-use turns and SSE re-buffering trip the watchdog's idle threshold, which aborts the request with

> `API Error: Response stalled mid-stream. The response above may be incomplete.`

during the `vuln-discovery` `analyze` state.

## Fix

Set `CLAUDE_ENABLE_STREAM_WATCHDOG=0` in the Claude Code adapter's `buildEnv` (right after the existing `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`), restoring pre-2.1.196 behavior. The workflow orchestrator already enforces its own wall-clock / step / cost budgets (`ResourceBudgetTracker`), so no timeout coverage is lost.

## Changes

- `src/docker/adapters/claude-code.ts` — add `CLAUDE_ENABLE_STREAM_WATCHDOG: '0'` to the base env with an explanatory comment.
- `test/docker/openrouter-agent-session.test.ts` — add the var to the `buildEnv` exact-match assertion.

Fixes #367.
