### PR TITLE
debug(docker): MITM stream-delay harness + streaming-watchdog findings (#367)

### DIFF
--- a/docs/designs/mitm-stream-delay-debug.md
+++ b/docs/designs/mitm-stream-delay-debug.md
@@ -27,9 +27,10 @@ environment variables read by the **host-side** MITM proxy:
 | `IRONCURTAIN_MITM_STREAM_DELAY_HOST` | Optional substring filter on the upstream host (e.g. `anthropic`, `openrouter`) so only one provider path is delayed.                                                                                                                                                                  |
 | `IRONCURTAIN_MITM_STREAM_DRIP_BYTES` | `drip` mode only: bytes emitted per `…_DELAY_MS` tick (default `1`). Higher = faster trickle.                                                                                                                                                                                          |
 
-`stall` modes (`mid-stream`/`first-token`) test **idle-based** aborts (time since
-last byte); `drip` keeps bytes flowing below any idle threshold so it isolates
-**duration/throughput-based** aborts — the better match for "very slow models".
+`stall` modes (`mid-stream`/`first-token`) exercise the **byte watchdog**
+(raw-byte idle, ~180 s); `drip` keeps raw bytes flowing so the byte watchdog
+stays quiet and exposes the **stream watchdog** (decoded-SSE-event idle,
+~300 s) — the mechanism that bites very slow models. See Findings below.
 
 Applies only to LLM completion endpoints (`isLlmMessagesEndpoint`: `/v1/messages`,
 `/api/v1/messages`, …). It sits at the tail of the forwarding pipe, so the
@@ -67,54 +68,53 @@ stalled request it re-issues a new completion POST, visible in the MITM log
 (`POST …/v1/messages … → FORWARDED`). The interval between those POSTs is the
 active abort threshold.
 
-## Findings (Claude Code 2.1.201)
+## Findings (Claude Code 2.1.201, native Anthropic)
 
-Measured by injecting a 320 s mid-stream gap and reading the retry cadence.
-When a mechanism aborts the held request it re-issues the completion POST; the
-inter-POST interval is that mechanism's threshold.
+Two independent client-side idle watchdogs guard a completion stream. Each
+**aborts and retries** the request when its threshold is crossed; whichever
+fires first wins. Neither is a total-duration cap — disable the governing one
+and a slow request runs indefinitely (verified below). Method: inject a
+delay/drip and read the retry cadence in the MITM log (a re-issued completion
+POST == an abort); the inter-POST interval is that mechanism's threshold.
 
-**Native Anthropic path**
+| Watchdog                                              | Measures                                  | Threshold |
+| ----------------------------------------------------- | ----------------------------------------- | --------- |
+| **byte watchdog** (`CLAUDE_ENABLE_BYTE_WATCHDOG`)     | idle on the **raw byte** stream           | ~180 s    |
+| **stream watchdog** (`CLAUDE_ENABLE_STREAM_WATCHDOG`) | idle on **decoded SSE events** (progress) | ~300 s    |
 
-| Config                            | Abort / retry cadence          |
-| --------------------------------- | ------------------------------ |
-| baseline (defaults)               | **~180 s**                     |
-| `CLAUDE_ENABLE_STREAM_WATCHDOG=0` | **~180 s** (identical)         |
-| `CLAUDE_ENABLE_BYTE_WATCHDOG=0`   | **~300 s** (threshold shifted) |
+| Scenario (injected)              | baseline        | `STREAM_WATCHDOG=0`   | `BYTE_WATCHDOG=0` |
+| -------------------------------- | --------------- | --------------------- | ----------------- |
+| complete stall (no bytes at all) | ~180 s (byte)   | ~180 s (unchanged)    | ~300 s (stream)   |
+| slow trickle (`drip`, 1 B / 2 s) | ~300 s (stream) | **no abort** (>400 s) | —                 |
 
-The first client-side abort is the **byte watchdog** (`CLAUDE_ENABLE_BYTE_WATCHDOG`,
-~180 s of stream idle → abort + retry). Turn it off and the fallback is a hard
-**~300 s client-side request timeout** inside Claude Code (the agent opens a new
-connection and re-POSTs at 300 s, with no MITM- or upstream-side error).
+The **stall** case is dominated by the byte watchdog at ~180 s, so
+`STREAM_WATCHDOG=0` looks inert there (the byte watchdog still fires). The
+**drip** case keeps the byte watchdog happy (raw bytes every 2 s) but the agent
+decodes no SSE events, so the **stream watchdog** fires at ~300 s — and
+`CLAUDE_ENABLE_STREAM_WATCHDOG=0` disables it: the request then streams past
+300 s with no abort. `API_TIMEOUT_MS=900000` moves neither threshold (so the
+~300 s is the stream watchdog, not a request-duration timeout).
 
-**OpenRouter path** (`openrouter.ai`, byte watchdog off by default there)
+> OpenRouter (`openrouter.ai`) was only tested with a raw stall, where a ~300 s
+> abort fired that neither `STREAM_WATCHDOG=0` nor `API_FORCE_IDLE_TIMEOUT=0`
+> moved — the non-Anthropic path likely uses a different mechanism and needs a
+> `drip` re-test before drawing conclusions.
 
-| Config                            | Cadence    |
-| --------------------------------- | ---------- |
-| baseline                          | **~300 s** |
-| `CLAUDE_ENABLE_STREAM_WATCHDOG=0` | **~300 s** |
-| `API_FORCE_IDLE_TIMEOUT=0`        | **~300 s** |
+## Bearing on PR #376 (`CLAUDE_ENABLE_STREAM_WATCHDOG=0`) — effective for slow models
 
-The ~300 s hard client request timeout governs; none of the idle-watchdog knobs
-move it.
+PR #376 disables the **stream (event-idle) watchdog**: the one that fires ~300 s
+after the last _decoded_ SSE event and emits "Response stalled mid-stream"
+(matching #367's `duration_ms: 305993`). That is exactly the "very slow model"
+failure — a model that goes >300 s without producing a decodable event (slow
+first token, a long mid-response thinking pause) trips it even while the
+connection is alive and bytes trickle. **The env var prevents that abort**
+(verified: a 1 B/2 s drip that baseline aborts at ~300 s runs indefinitely with
+it set). It does **not** help a raw-connection stall (byte watchdog, ~180 s),
+but that is a genuinely dead stream, not a slow model.
 
-**The ~300 s ceiling is a hard client-side request timeout.** It persisted with
-the byte watchdog off, `API_FORCE_IDLE_TIMEOUT=0`, `API_TIMEOUT_MS=900000`, and
-even with the MITM's own inner-server `requestTimeout`/`headersTimeout`/`timeout`
-disabled — the agent simply reconnects and retries at 300 s. So it is neither
-the stream watchdog, nor `API_TIMEOUT_MS`, nor a MITM/upstream timeout, and it
-caps this harness's usable injected-gap at ~300 s.
-
-## Bearing on PR #376 (`CLAUDE_ENABLE_STREAM_WATCHDOG=0`)
-
-**The env var has no measurable effect on the stall/abort behavior on either
-provider path in 2.1.201.** The stream idle watchdog it disables is dominated by
-(a) the byte watchdog (~180 s, native) and (b) the hard ~300 s client request
-timeout (both paths), each of which fires first. The only knob that changed
-anything was `CLAUDE_ENABLE_BYTE_WATCHDOG`.
-
-Caveat: the observed aborts are **abort-and-retry**, not fatal — a genuinely
-slow-but-progressing model resets the idle timer on each byte and never exhausts
-retries. The terminal "Response stalled mid-stream" only appears once retries
-are exhausted, which needs a _permanent_ stall (as injected here). This matches
-the conclusion of #372/#367: the fatal `analyze` stall was the background-subagent
-issue (fixed by `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`), not the stream watchdog.
+Relationship to #372: both are valid fixes for the same "Response stalled
+mid-stream" symptom from different angles. #372 removes a _cause_ of the event
+idle (a parent turn waiting on background subagents produces no events);
+#376 removes the _abort_ on event idle. A genuinely slow model produces sparse
+events for reasons unrelated to subagents, so #372 doesn't cover it and #376
+does — which is why the follow-up was needed.

--- a/docs/designs/mitm-stream-delay-debug.md
+++ b/docs/designs/mitm-stream-delay-debug.md
@@ -44,7 +44,7 @@ Claude Code adapter forwards a curated allowlist of streaming-watchdog tuning
 vars from the host env into the container when set (no-op otherwise):
 
 `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, `CLAUDE_ENABLE_STREAM_WATCHDOG`,
-`CLAUDE_ENABLE_BYTE_WATCHDOG`, `API_FORCE_IDLE_TIMEOUT`.
+`CLAUDE_ENABLE_BYTE_WATCHDOG`, `API_FORCE_IDLE_TIMEOUT`, `API_TIMEOUT_MS`.
 
 ## How to run an experiment
 

--- a/docs/designs/mitm-stream-delay-debug.md
+++ b/docs/designs/mitm-stream-delay-debug.md
@@ -33,9 +33,11 @@ stays quiet and exposes the **stream watchdog** (decoded-SSE-event idle,
 ~300 s) — the mechanism that bites very slow models. See Findings below.
 
 Applies only to LLM completion endpoints (`isLlmMessagesEndpoint`: `/v1/messages`,
-`/api/v1/messages`, …). It sits at the tail of the forwarding pipe, so the
-trajectory-capture fan-out branch is unaffected and captured traces stay
-byte-faithful. A loud `NOT FOR PRODUCTION` warning is logged when active.
+`/api/v1/messages`, …). It sits at the tail of the forwarding pipe, so captured
+traces stay byte-faithful — the knob only re-times delivery. (The capture branch
+tees off `upstreamRes`, so in stall modes the forwarding backpressure also pauses
+capture; the captured bytes are still identical, only their timing shifts.) A
+loud `NOT FOR PRODUCTION` warning is logged when active.
 
 ## Companion: watchdog env passthrough (`adapters/claude-code.ts`)
 

--- a/docs/designs/mitm-stream-delay-debug.md
+++ b/docs/designs/mitm-stream-delay-debug.md
@@ -20,11 +20,16 @@ any) suppresses it.
 Off by default; zero-cost when unset (no Transform installed). Enabled via host
 environment variables read by the **host-side** MITM proxy:
 
-| Env var                              | Meaning                                                                                                                                                                                                       |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `IRONCURTAIN_MITM_STREAM_DELAY_MS`   | Idle gap to inject, in ms. Unset / `0` / non-numeric ⇒ disabled.                                                                                                                                              |
-| `IRONCURTAIN_MITM_STREAM_DELAY_MODE` | `mid-stream` (default): forward the first chunk, then inject the gap before the next chunk — faithful to "Response stalled **mid-stream**". `first-token`: hold the first chunk (stall before any body byte). |
-| `IRONCURTAIN_MITM_STREAM_DELAY_HOST` | Optional substring filter on the upstream host (e.g. `anthropic`, `openrouter`) so only one provider path is delayed.                                                                                         |
+| Env var                              | Meaning                                                                                                                                                                                                                                                                                |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IRONCURTAIN_MITM_STREAM_DELAY_MS`   | Gap to inject (stall modes) or inter-emit interval (drip mode), in ms. Unset / `0` / non-numeric ⇒ disabled.                                                                                                                                                                           |
+| `IRONCURTAIN_MITM_STREAM_DELAY_MODE` | `mid-stream` (default): forward the first chunk, then inject one gap before the next — faithful to a _complete_ stall ("Response stalled **mid-stream**"). `first-token`: hold the first chunk. `drip`: re-pace the whole response to a trickle — a _very slow but not stalled_ model. |
+| `IRONCURTAIN_MITM_STREAM_DELAY_HOST` | Optional substring filter on the upstream host (e.g. `anthropic`, `openrouter`) so only one provider path is delayed.                                                                                                                                                                  |
+| `IRONCURTAIN_MITM_STREAM_DRIP_BYTES` | `drip` mode only: bytes emitted per `…_DELAY_MS` tick (default `1`). Higher = faster trickle.                                                                                                                                                                                          |
+
+`stall` modes (`mid-stream`/`first-token`) test **idle-based** aborts (time since
+last byte); `drip` keeps bytes flowing below any idle threshold so it isolates
+**duration/throughput-based** aborts — the better match for "very slow models".
 
 Applies only to LLM completion endpoints (`isLlmMessagesEndpoint`: `/v1/messages`,
 `/api/v1/messages`, …). It sits at the tail of the forwarding pipe, so the

--- a/docs/designs/mitm-stream-delay-debug.md
+++ b/docs/designs/mitm-stream-delay-debug.md
@@ -1,0 +1,115 @@
+# MITM stream-delay debug knob
+
+A host-side debug affordance for reproducing and testing Claude Code's
+streaming idle / stall behavior (issue #367, "Response stalled mid-stream")
+**without needing a real slow model**. It injects a controllable idle gap into
+the agent-facing forwarding stream at the MITM proxy, so the watchdog can be
+exercised deterministically against any model.
+
+## Why
+
+Issue #367 manifests as `API Error: Response stalled mid-stream` when a model
+response goes idle long enough for Claude Code to abort it. Reproducing that
+faithfully otherwise requires a genuinely slow provider/model. This knob lets
+us pause the response stream at the proxy for an arbitrary duration and observe
+exactly which mechanism fires, on which provider path, and which env var (if
+any) suppresses it.
+
+## The knob (`src/docker/stream-delay.ts`, wired in `mitm-proxy.ts`)
+
+Off by default; zero-cost when unset (no Transform installed). Enabled via host
+environment variables read by the **host-side** MITM proxy:
+
+| Env var                              | Meaning                                                                                                                                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IRONCURTAIN_MITM_STREAM_DELAY_MS`   | Idle gap to inject, in ms. Unset / `0` / non-numeric ⇒ disabled.                                                                                                                                              |
+| `IRONCURTAIN_MITM_STREAM_DELAY_MODE` | `mid-stream` (default): forward the first chunk, then inject the gap before the next chunk — faithful to "Response stalled **mid-stream**". `first-token`: hold the first chunk (stall before any body byte). |
+| `IRONCURTAIN_MITM_STREAM_DELAY_HOST` | Optional substring filter on the upstream host (e.g. `anthropic`, `openrouter`) so only one provider path is delayed.                                                                                         |
+
+Applies only to LLM completion endpoints (`isLlmMessagesEndpoint`: `/v1/messages`,
+`/api/v1/messages`, …). It sits at the tail of the forwarding pipe, so the
+trajectory-capture fan-out branch is unaffected and captured traces stay
+byte-faithful. A loud `NOT FOR PRODUCTION` warning is logged when active.
+
+## Companion: watchdog env passthrough (`adapters/claude-code.ts`)
+
+To exercise the watchdog knobs without rebuilding the container image, the
+Claude Code adapter forwards a curated allowlist of streaming-watchdog tuning
+vars from the host env into the container when set (no-op otherwise):
+
+`CLAUDE_STREAM_IDLE_TIMEOUT_MS`, `CLAUDE_ENABLE_STREAM_WATCHDOG`,
+`CLAUDE_ENABLE_BYTE_WATCHDOG`, `API_FORCE_IDLE_TIMEOUT`.
+
+## How to run an experiment
+
+```bash
+# Baseline: inject a 320s idle gap into the native Anthropic response stream.
+IRONCURTAIN_MITM_STREAM_DELAY_MS=320000 \
+IRONCURTAIN_MITM_STREAM_DELAY_MODE=mid-stream \
+IRONCURTAIN_MITM_STREAM_DELAY_HOST=anthropic \
+tsx src/cli.ts start --agent claude-code -m anthropic:claude-haiku-4-5 \
+  "Count from 1 to 40, one number per line, and output nothing else."
+
+# Same, but disabling a specific watchdog (forwarded into the container):
+CLAUDE_ENABLE_BYTE_WATCHDOG=0 IRONCURTAIN_MITM_STREAM_DELAY_MS=320000 ... tsx src/cli.ts start ...
+```
+
+**Observing the outcome.** The `claude -p` verdict (including
+`Response stalled mid-stream`) is emitted inside the container on process exit,
+so it only appears in the session log once the turn ends. The host-side signal
+available in real time is the **retry cadence**: when the watchdog aborts a
+stalled request it re-issues a new completion POST, visible in the MITM log
+(`POST …/v1/messages … → FORWARDED`). The interval between those POSTs is the
+active abort threshold.
+
+## Findings (Claude Code 2.1.201)
+
+Measured by injecting a 320 s mid-stream gap and reading the retry cadence.
+When a mechanism aborts the held request it re-issues the completion POST; the
+inter-POST interval is that mechanism's threshold.
+
+**Native Anthropic path**
+
+| Config                            | Abort / retry cadence          |
+| --------------------------------- | ------------------------------ |
+| baseline (defaults)               | **~180 s**                     |
+| `CLAUDE_ENABLE_STREAM_WATCHDOG=0` | **~180 s** (identical)         |
+| `CLAUDE_ENABLE_BYTE_WATCHDOG=0`   | **~300 s** (threshold shifted) |
+
+The first client-side abort is the **byte watchdog** (`CLAUDE_ENABLE_BYTE_WATCHDOG`,
+~180 s of stream idle → abort + retry). Turn it off and the fallback is a hard
+**~300 s client-side request timeout** inside Claude Code (the agent opens a new
+connection and re-POSTs at 300 s, with no MITM- or upstream-side error).
+
+**OpenRouter path** (`openrouter.ai`, byte watchdog off by default there)
+
+| Config                            | Cadence    |
+| --------------------------------- | ---------- |
+| baseline                          | **~300 s** |
+| `CLAUDE_ENABLE_STREAM_WATCHDOG=0` | **~300 s** |
+| `API_FORCE_IDLE_TIMEOUT=0`        | **~300 s** |
+
+The ~300 s hard client request timeout governs; none of the idle-watchdog knobs
+move it.
+
+**The ~300 s ceiling is a hard client-side request timeout.** It persisted with
+the byte watchdog off, `API_FORCE_IDLE_TIMEOUT=0`, `API_TIMEOUT_MS=900000`, and
+even with the MITM's own inner-server `requestTimeout`/`headersTimeout`/`timeout`
+disabled — the agent simply reconnects and retries at 300 s. So it is neither
+the stream watchdog, nor `API_TIMEOUT_MS`, nor a MITM/upstream timeout, and it
+caps this harness's usable injected-gap at ~300 s.
+
+## Bearing on PR #376 (`CLAUDE_ENABLE_STREAM_WATCHDOG=0`)
+
+**The env var has no measurable effect on the stall/abort behavior on either
+provider path in 2.1.201.** The stream idle watchdog it disables is dominated by
+(a) the byte watchdog (~180 s, native) and (b) the hard ~300 s client request
+timeout (both paths), each of which fires first. The only knob that changed
+anything was `CLAUDE_ENABLE_BYTE_WATCHDOG`.
+
+Caveat: the observed aborts are **abort-and-retry**, not fatal — a genuinely
+slow-but-progressing model resets the idle timer on each byte and never exhausts
+retries. The terminal "Response stalled mid-stream" only appears once retries
+are exhausted, which needs a _permanent_ stall (as injected here). This matches
+the conclusion of #372/#367: the fatal `analyze` stall was the background-subagent
+issue (fixed by `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`), not the stream watchdog.

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -46,6 +46,20 @@ import {
 const CLAUDE_CODE_IMAGE = 'ironcurtain-claude-code:latest';
 
 /**
+ * Claude Code streaming-watchdog tuning vars forwarded from the host env into
+ * the container when set (see `buildEnv`). Curated allowlist — these govern
+ * the idle-stream abort ("Response stalled mid-stream", issue #367) and let it
+ * be exercised against the MITM stream-delay knob without rebuilding the image.
+ */
+const WATCHDOG_ENV_PASSTHROUGH = [
+  'CLAUDE_STREAM_IDLE_TIMEOUT_MS',
+  'CLAUDE_ENABLE_STREAM_WATCHDOG',
+  'CLAUDE_ENABLE_BYTE_WATCHDOG',
+  'API_FORCE_IDLE_TIMEOUT',
+  'API_TIMEOUT_MS',
+] as const;
+
+/**
  * Container path used as the parent for Claude Code's skill discovery.
  * Claude Code's `--add-dir <path>` flag scans `<path>/.claude/skills/`,
  * so the bind-mount target is the deeper `.claude/skills/` subpath
@@ -301,6 +315,16 @@ exit $STATUS
         // orchestrator already enforces its own wall-clock/step budgets.
         CLAUDE_ENABLE_STREAM_WATCHDOG: '0',
       };
+
+      // DEBUG / operability (issue #367 watchdog harness): forward a curated
+      // allowlist of Claude Code streaming-watchdog tuning vars from the host
+      // env into the container when set. Lets the streaming idle watchdog be
+      // exercised against the MITM stream-delay knob (see stream-delay.ts)
+      // without rebuilding the image. No-op unless the host sets them.
+      for (const key of WATCHDOG_ENV_PASSTHROUGH) {
+        const value = process.env[key];
+        if (value !== undefined) env[key] = value;
+      }
 
       if (modelId) {
         env.IRONCURTAIN_MODEL = modelId;

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -1052,6 +1052,12 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
             const delay = createStreamDelayTransform(streamDelayConfig);
             delay.pipe(clientRes);
             clientSink = delay;
+            // `.pipe()` does not destroy the source on a downstream close, so a
+            // premature client disconnect would otherwise leave the transform's
+            // pending timer/interval running. Tear it down explicitly.
+            clientRes.on('close', () => {
+              if (!delay.destroyed) delay.destroy();
+            });
             logger.info(
               `[mitm-proxy] DEBUG stream-delay: applying ${streamDelayConfig.mode} ` +
                 `(${streamDelayConfig.delayMs}ms) to ${targetHost}${path}`,

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -1040,9 +1040,11 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
           // agent-facing forwarding stream to reproduce / test Claude Code's
           // streaming idle watchdog behind the MITM. Zero-cost unless
           // IRONCURTAIN_MITM_STREAM_DELAY_MS is set. Applies only to LLM
-          // completion endpoints; sits at the tail of the forwarding pipe, so
-          // the capture fan-out branch (attached above) is untouched and
-          // trajectories stay byte-faithful.
+          // completion endpoints; sits at the tail of the forwarding pipe.
+          // Captured trajectory CONTENT stays byte-faithful — this only
+          // re-times delivery. (In stall modes the held callback backpressures
+          // upstreamRes, which also pauses the capture tee; the captured bytes
+          // are still identical, only their capture timing shifts.)
           let clientSink: NodeJS.WritableStream = clientRes;
           if (
             streamDelayConfig &&

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -34,7 +34,7 @@ import type { RegistryConfig, PackageValidator, AllowedVersionCache } from './pa
 import { DENY_ALL_VALIDATOR } from './package-validator.js';
 import { validateDomain, type DomainListing } from './proxy-tools.js';
 import { PassThrough } from 'node:stream';
-import { StreamDelayTransform, parseStreamDelayConfig } from './stream-delay.js';
+import { createStreamDelayTransform, parseStreamDelayConfig } from './stream-delay.js';
 import { getTokenStreamBus } from './token-stream-bus.js';
 import type { SseProvider } from './token-stream-types.js';
 import { SseExtractorTransform } from './sse-extractor.js';
@@ -1049,12 +1049,12 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
             isLlmMessagesEndpoint(path as string) &&
             (!streamDelayConfig.hostFilter || targetHost.includes(streamDelayConfig.hostFilter))
           ) {
-            const delay = new StreamDelayTransform(streamDelayConfig.delayMs, streamDelayConfig.mode);
+            const delay = createStreamDelayTransform(streamDelayConfig);
             delay.pipe(clientRes);
             clientSink = delay;
             logger.info(
-              `[mitm-proxy] DEBUG stream-delay: injecting ${streamDelayConfig.delayMs}ms ` +
-                `(${streamDelayConfig.mode}) into ${targetHost}${path}`,
+              `[mitm-proxy] DEBUG stream-delay: applying ${streamDelayConfig.mode} ` +
+                `(${streamDelayConfig.delayMs}ms) to ${targetHost}${path}`,
             );
           }
 

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -34,6 +34,7 @@ import type { RegistryConfig, PackageValidator, AllowedVersionCache } from './pa
 import { DENY_ALL_VALIDATOR } from './package-validator.js';
 import { validateDomain, type DomainListing } from './proxy-tools.js';
 import { PassThrough } from 'node:stream';
+import { StreamDelayTransform, parseStreamDelayConfig } from './stream-delay.js';
 import { getTokenStreamBus } from './token-stream-bus.js';
 import type { SseProvider } from './token-stream-types.js';
 import { SseExtractorTransform } from './sse-extractor.js';
@@ -639,6 +640,10 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
   const allowAllHosts =
     process.env.IRONCURTAIN_MITM_ALLOW_ALL_HOSTS === '1' || process.env.IRONCURTAIN_MITM_ALLOW_ALL_HOSTS === 'true';
 
+  // DEBUG (issue #367): optional stream-delay injection config, parsed once.
+  // Null (zero-cost) unless IRONCURTAIN_MITM_STREAM_DELAY_MS is set.
+  const streamDelayConfig = parseStreamDelayConfig();
+
   // Certificate cache: hostname → { ctx, expiresAt }
   const certCache = new Map<string, { ctx: tls.SecureContext; expiresAt: number }>();
 
@@ -1031,13 +1036,35 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
           // See §3 and §6 invariant 6 of the design doc.
           attachCaptureBranch(upstreamRes, captureHandle, sidAtCapture);
 
+          // DEBUG (issue #367): optionally insert an idle gap into the
+          // agent-facing forwarding stream to reproduce / test Claude Code's
+          // streaming idle watchdog behind the MITM. Zero-cost unless
+          // IRONCURTAIN_MITM_STREAM_DELAY_MS is set. Applies only to LLM
+          // completion endpoints; sits at the tail of the forwarding pipe, so
+          // the capture fan-out branch (attached above) is untouched and
+          // trajectories stay byte-faithful.
+          let clientSink: NodeJS.WritableStream = clientRes;
+          if (
+            streamDelayConfig &&
+            isLlmMessagesEndpoint(path as string) &&
+            (!streamDelayConfig.hostFilter || targetHost.includes(streamDelayConfig.hostFilter))
+          ) {
+            const delay = new StreamDelayTransform(streamDelayConfig.delayMs, streamDelayConfig.mode);
+            delay.pipe(clientRes);
+            clientSink = delay;
+            logger.info(
+              `[mitm-proxy] DEBUG stream-delay: injecting ${streamDelayConfig.delayMs}ms ` +
+                `(${streamDelayConfig.mode}) into ${targetHost}${path}`,
+            );
+          }
+
           if (sidAtAttach && contentType.includes('text/event-stream')) {
             const tokenBus = getTokenStreamBus();
             const sseProvider = resolveSseProvider(targetHost, path);
             const extractor = new SseExtractorTransform(sseProvider, (event) => {
               tokenBus.push(sidAtAttach, event);
             });
-            upstreamRes.pipe(extractor).pipe(clientRes);
+            upstreamRes.pipe(extractor).pipe(clientSink);
           } else if (sidAtAttach && isLlmMessagesEndpoint(path as string) && contentType.includes('application/json')) {
             // Non-streaming JSON response: buffer for extraction while piping to client.
             // The passthrough stream always forwards the full response to the client.
@@ -1058,9 +1085,9 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
                 }
               });
             });
-            upstreamRes.pipe(passthrough).pipe(clientRes);
+            upstreamRes.pipe(passthrough).pipe(clientSink);
           } else {
-            upstreamRes.pipe(clientRes);
+            upstreamRes.pipe(clientSink);
           }
 
           /**
@@ -1992,6 +2019,13 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
       if (allowAllHosts) {
         logger.warn(
           '[mitm-proxy] IRONCURTAIN_MITM_ALLOW_ALL_HOSTS is set — unknown hosts will be tunneled (egress filtering DISABLED for unknown hosts)',
+        );
+      }
+      if (streamDelayConfig) {
+        logger.warn(
+          `[mitm-proxy] DEBUG IRONCURTAIN_MITM_STREAM_DELAY_MS is set — injecting ${streamDelayConfig.delayMs}ms ` +
+            `(${streamDelayConfig.mode}) idle gaps into LLM completion responses` +
+            `${streamDelayConfig.hostFilter ? ` for hosts matching "${streamDelayConfig.hostFilter}"` : ''}. NOT FOR PRODUCTION.`,
         );
       }
 

--- a/src/docker/stream-delay.ts
+++ b/src/docker/stream-delay.ts
@@ -1,0 +1,77 @@
+/**
+ * DEBUG stream-delay injection (issue #367 watchdog reproduction).
+ *
+ * A Transform that injects a single controllable idle gap into the
+ * agent-facing forwarding stream, reproducing exactly what Claude Code's
+ * streaming idle watchdog measures: elapsed time between response bytes
+ * arriving at the client. Lets us test — deterministically and without a real
+ * slow model — whether the watchdog aborts a stalled stream behind the MITM
+ * and whether `CLAUDE_ENABLE_STREAM_WATCHDOG=0` suppresses it.
+ *
+ * This is a debug affordance only. The MITM never installs it unless
+ * `IRONCURTAIN_MITM_STREAM_DELAY_MS` is a positive integer.
+ */
+import { Transform, type TransformCallback } from 'node:stream';
+
+export type StreamDelayMode = 'mid-stream' | 'first-token';
+
+export interface StreamDelayConfig {
+  readonly delayMs: number;
+  readonly mode: StreamDelayMode;
+  /** When set, only delay upstream hosts whose name includes this substring. */
+  readonly hostFilter?: string;
+}
+
+/**
+ * Injects one idle gap into a byte stream.
+ *
+ * Modes:
+ *  - 'mid-stream'  : forward the first chunk immediately, then inject the gap
+ *                    before the next chunk. Faithful to the original "Response
+ *                    stalled mid-stream" symptom. Needs the upstream to emit
+ *                    >= 2 chunks — always true for a real SSE completion.
+ *  - 'first-token' : hold the very first chunk for the gap (stall before any
+ *                    body byte). Triggers regardless of upstream chunking.
+ *
+ * Bytes are never altered — only their arrival timing. The delayed chunk's
+ * callback is deferred with `setTimeout`, which naturally backpressures the
+ * upstream and defers stream `end` until the gap elapses.
+ */
+export class StreamDelayTransform extends Transform {
+  private chunkIndex = 0;
+  private readonly delayMs: number;
+  private readonly mode: StreamDelayMode;
+
+  constructor(delayMs: number, mode: StreamDelayMode) {
+    super();
+    this.delayMs = delayMs;
+    this.mode = mode;
+  }
+
+  _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    const idx = this.chunkIndex++;
+    const inject = this.mode === 'first-token' ? idx === 0 : idx === 1;
+    if (inject) {
+      setTimeout(() => callback(null, chunk), this.delayMs);
+    } else {
+      callback(null, chunk);
+    }
+  }
+}
+
+/**
+ * Parse the stream-delay debug config from the environment. Returns null (the
+ * zero-cost default) unless `IRONCURTAIN_MITM_STREAM_DELAY_MS` is a positive
+ * integer. `IRONCURTAIN_MITM_STREAM_DELAY_MODE` selects the mode (default
+ * `mid-stream`); `IRONCURTAIN_MITM_STREAM_DELAY_HOST` optionally restricts it
+ * to upstream hosts whose name contains the given substring.
+ */
+export function parseStreamDelayConfig(env: NodeJS.ProcessEnv = process.env): StreamDelayConfig | null {
+  const raw = env.IRONCURTAIN_MITM_STREAM_DELAY_MS;
+  if (!raw) return null;
+  const delayMs = Number.parseInt(raw, 10);
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return null;
+  const mode: StreamDelayMode = env.IRONCURTAIN_MITM_STREAM_DELAY_MODE === 'first-token' ? 'first-token' : 'mid-stream';
+  const hostFilter = env.IRONCURTAIN_MITM_STREAM_DELAY_HOST || undefined;
+  return { delayMs, mode, hostFilter };
+}

--- a/src/docker/stream-delay.ts
+++ b/src/docker/stream-delay.ts
@@ -1,31 +1,37 @@
 /**
  * DEBUG stream-delay injection (issue #367 watchdog reproduction).
  *
- * A Transform that injects a single controllable idle gap into the
- * agent-facing forwarding stream, reproducing exactly what Claude Code's
- * streaming idle watchdog measures: elapsed time between response bytes
- * arriving at the client. Lets us test — deterministically and without a real
- * slow model — whether the watchdog aborts a stalled stream behind the MITM
- * and whether `CLAUDE_ENABLE_STREAM_WATCHDOG=0` suppresses it.
+ * Host-side MITM affordance for exercising Claude Code's streaming idle / stall
+ * behavior without a real slow model. Two regimes:
  *
- * This is a debug affordance only. The MITM never installs it unless
- * `IRONCURTAIN_MITM_STREAM_DELAY_MS` is a positive integer.
+ *  - **stall** (`mid-stream` / `first-token`): inject a single idle gap into the
+ *    agent-facing forwarding stream — reproduces a *complete* stall (no bytes
+ *    for N ms), which is what idle watchdogs measure.
+ *  - **drip**: re-pace the whole response to a trickle (a few bytes every N ms)
+ *    — reproduces a *very slow but not stalled* model. The stream never idles
+ *    long enough to trip an idle watchdog, but the total response drags on, so
+ *    this isolates duration/throughput-based aborts from idle-based ones.
+ *
+ * Debug only; never installed unless `IRONCURTAIN_MITM_STREAM_DELAY_MS` is a
+ * positive integer.
  */
 import { Transform, type TransformCallback } from 'node:stream';
 
-export type StreamDelayMode = 'mid-stream' | 'first-token';
+export type StreamDelayMode = 'mid-stream' | 'first-token' | 'drip';
 
 export interface StreamDelayConfig {
+  /** Gap size (stall modes) or inter-emit interval (drip mode), in ms. */
   readonly delayMs: number;
   readonly mode: StreamDelayMode;
   /** When set, only delay upstream hosts whose name includes this substring. */
   readonly hostFilter?: string;
+  /** drip mode: bytes emitted per `delayMs` tick (default 1). */
+  readonly dripBytes: number;
 }
 
 /**
- * Injects one idle gap into a byte stream.
+ * Injects one idle gap into a byte stream (stall regime).
  *
- * Modes:
  *  - 'mid-stream'  : forward the first chunk immediately, then inject the gap
  *                    before the next chunk. Faithful to the original "Response
  *                    stalled mid-stream" symptom. Needs the upstream to emit
@@ -33,16 +39,14 @@ export interface StreamDelayConfig {
  *  - 'first-token' : hold the very first chunk for the gap (stall before any
  *                    body byte). Triggers regardless of upstream chunking.
  *
- * Bytes are never altered — only their arrival timing. The delayed chunk's
- * callback is deferred with `setTimeout`, which naturally backpressures the
- * upstream and defers stream `end` until the gap elapses.
+ * Bytes are never altered — only their arrival timing.
  */
-export class StreamDelayTransform extends Transform {
+export class GapDelayTransform extends Transform {
   private chunkIndex = 0;
   private readonly delayMs: number;
-  private readonly mode: StreamDelayMode;
+  private readonly mode: 'mid-stream' | 'first-token';
 
-  constructor(delayMs: number, mode: StreamDelayMode) {
+  constructor(delayMs: number, mode: 'mid-stream' | 'first-token') {
     super();
     this.delayMs = delayMs;
     this.mode = mode;
@@ -60,18 +64,115 @@ export class StreamDelayTransform extends Transform {
 }
 
 /**
+ * Re-paces a byte stream to a trickle: accepts upstream bytes as fast as they
+ * arrive (buffering them) and re-emits `bytesPerTick` bytes every `intervalMs`.
+ * Simulates a very slow model whose stream never fully stalls. Bytes and their
+ * order are preserved; only throughput is throttled.
+ */
+export class SlowDripTransform extends Transform {
+  private readonly queue: Buffer[] = [];
+  private headOffset = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private ended = false;
+  private flushCallback: TransformCallback | null = null;
+  private readonly intervalMs: number;
+  private readonly bytesPerTick: number;
+
+  constructor(intervalMs: number, bytesPerTick: number) {
+    super();
+    this.intervalMs = intervalMs;
+    this.bytesPerTick = Math.max(1, bytesPerTick);
+  }
+
+  private hasBytes(): boolean {
+    return this.queue.length > 0;
+  }
+
+  private emitBytes(n: number): void {
+    const out: Buffer[] = [];
+    let need = n;
+    while (need > 0 && this.queue.length > 0) {
+      const head = this.queue[0];
+      const avail = head.length - this.headOffset;
+      const take = Math.min(need, avail);
+      out.push(head.subarray(this.headOffset, this.headOffset + take));
+      this.headOffset += take;
+      need -= take;
+      if (this.headOffset >= head.length) {
+        this.queue.shift();
+        this.headOffset = 0;
+      }
+    }
+    if (out.length > 0) this.push(Buffer.concat(out));
+  }
+
+  private ensureTimer(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      if (this.destroyed) {
+        this.stopTimer();
+        return;
+      }
+      if (this.hasBytes()) this.emitBytes(this.bytesPerTick);
+      if (!this.hasBytes() && this.ended) {
+        this.stopTimer();
+        const cb = this.flushCallback;
+        this.flushCallback = null;
+        cb?.();
+      }
+    }, this.intervalMs);
+  }
+
+  private stopTimer(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    if (chunk.length > 0) this.queue.push(chunk);
+    this.ensureTimer();
+    // Accept immediately; emission is paced by the timer.
+    callback();
+  }
+
+  _flush(callback: TransformCallback): void {
+    this.ended = true;
+    this.flushCallback = callback;
+    this.ensureTimer();
+  }
+
+  _destroy(error: Error | null, callback: (error: Error | null) => void): void {
+    this.stopTimer();
+    callback(error);
+  }
+}
+
+/** Build the transform for a resolved stream-delay config. */
+export function createStreamDelayTransform(config: StreamDelayConfig): Transform {
+  return config.mode === 'drip'
+    ? new SlowDripTransform(config.delayMs, config.dripBytes)
+    : new GapDelayTransform(config.delayMs, config.mode);
+}
+
+/**
  * Parse the stream-delay debug config from the environment. Returns null (the
  * zero-cost default) unless `IRONCURTAIN_MITM_STREAM_DELAY_MS` is a positive
  * integer. `IRONCURTAIN_MITM_STREAM_DELAY_MODE` selects the mode (default
  * `mid-stream`); `IRONCURTAIN_MITM_STREAM_DELAY_HOST` optionally restricts it
- * to upstream hosts whose name contains the given substring.
+ * to upstream hosts whose name contains the given substring;
+ * `IRONCURTAIN_MITM_STREAM_DRIP_BYTES` sets the drip-mode bytes-per-tick.
  */
 export function parseStreamDelayConfig(env: NodeJS.ProcessEnv = process.env): StreamDelayConfig | null {
   const raw = env.IRONCURTAIN_MITM_STREAM_DELAY_MS;
   if (!raw) return null;
   const delayMs = Number.parseInt(raw, 10);
   if (!Number.isFinite(delayMs) || delayMs <= 0) return null;
-  const mode: StreamDelayMode = env.IRONCURTAIN_MITM_STREAM_DELAY_MODE === 'first-token' ? 'first-token' : 'mid-stream';
+  const modeRaw = env.IRONCURTAIN_MITM_STREAM_DELAY_MODE;
+  const mode: StreamDelayMode = modeRaw === 'first-token' || modeRaw === 'drip' ? modeRaw : 'mid-stream';
   const hostFilter = env.IRONCURTAIN_MITM_STREAM_DELAY_HOST || undefined;
-  return { delayMs, mode, hostFilter };
+  const dripRaw = Number.parseInt(env.IRONCURTAIN_MITM_STREAM_DRIP_BYTES ?? '', 10);
+  const dripBytes = Number.isFinite(dripRaw) && dripRaw > 0 ? dripRaw : 1;
+  return { delayMs, mode, hostFilter, dripBytes };
 }

--- a/src/docker/stream-delay.ts
+++ b/src/docker/stream-delay.ts
@@ -79,14 +79,24 @@ export class GapDelayTransform extends Transform {
 }
 
 /**
- * Re-paces a byte stream to a trickle: accepts upstream bytes as fast as they
- * arrive (buffering them) and re-emits `bytesPerTick` bytes every `intervalMs`.
+ * Bound the drip buffer: once this many undrained bytes are queued, stop
+ * accepting from upstream (withhold the write callback) until the trickle drains
+ * back below it. Keeps a large/fast upstream from growing the queue unbounded.
+ */
+const DRIP_HIGH_WATER_BYTES = 1 << 20; // 1 MiB
+
+/**
+ * Re-paces a byte stream to a trickle: accepts upstream bytes (buffering them,
+ * up to a high-water mark) and re-emits `bytesPerTick` bytes every `intervalMs`.
  * Simulates a very slow model whose stream never fully stalls. Bytes and their
- * order are preserved; only throughput is throttled.
+ * order are preserved; only throughput is throttled. Honors backpressure so the
+ * buffer stays bounded even if the upstream produces faster than the drip rate.
  */
 export class SlowDripTransform extends Transform {
   private readonly queue: Buffer[] = [];
   private headOffset = 0;
+  private queuedBytes = 0;
+  private pendingWriteCallback: TransformCallback | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private ended = false;
   private flushCallback: TransformCallback | null = null;
@@ -106,6 +116,7 @@ export class SlowDripTransform extends Transform {
   private emitBytes(n: number): void {
     const out: Buffer[] = [];
     let need = n;
+    let emitted = 0;
     while (need > 0 && this.queue.length > 0) {
       const head = this.queue[0];
       const avail = head.length - this.headOffset;
@@ -113,12 +124,20 @@ export class SlowDripTransform extends Transform {
       out.push(head.subarray(this.headOffset, this.headOffset + take));
       this.headOffset += take;
       need -= take;
+      emitted += take;
       if (this.headOffset >= head.length) {
         this.queue.shift();
         this.headOffset = 0;
       }
     }
     if (out.length > 0) this.push(Buffer.concat(out));
+    this.queuedBytes -= emitted;
+    // Draining below the mark resumes a withheld upstream write.
+    if (this.pendingWriteCallback && this.queuedBytes < DRIP_HIGH_WATER_BYTES) {
+      const cb = this.pendingWriteCallback;
+      this.pendingWriteCallback = null;
+      cb();
+    }
   }
 
   private ensureTimer(): void {
@@ -148,10 +167,19 @@ export class SlowDripTransform extends Transform {
   }
 
   _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
-    if (chunk.length > 0) this.queue.push(chunk);
+    if (chunk.length > 0) {
+      this.queue.push(chunk);
+      this.queuedBytes += chunk.length;
+    }
     this.ensureTimer();
-    // Accept immediately; emission is paced by the timer.
-    callback();
+    // Emission is paced by the timer. Accept more only while the buffer is under
+    // the high-water mark; otherwise withhold the callback so the upstream pipe
+    // slows down — the timer's drain resumes it. Keeps the buffer bounded.
+    if (this.queuedBytes < DRIP_HIGH_WATER_BYTES) {
+      callback();
+    } else {
+      this.pendingWriteCallback = callback;
+    }
   }
 
   _flush(callback: TransformCallback): void {
@@ -169,6 +197,12 @@ export class SlowDripTransform extends Transform {
 
   _destroy(error: Error | null, callback: (error: Error | null) => void): void {
     this.stopTimer();
+    // Settle a withheld upstream write so it doesn't hang on teardown.
+    if (this.pendingWriteCallback) {
+      const cb = this.pendingWriteCallback;
+      this.pendingWriteCallback = null;
+      cb(error);
+    }
     callback(error);
   }
 }

--- a/src/docker/stream-delay.ts
+++ b/src/docker/stream-delay.ts
@@ -191,12 +191,14 @@ export function createStreamDelayTransform(config: StreamDelayConfig): Transform
 export function parseStreamDelayConfig(env: NodeJS.ProcessEnv = process.env): StreamDelayConfig | null {
   const raw = env.IRONCURTAIN_MITM_STREAM_DELAY_MS;
   if (!raw) return null;
-  const delayMs = Number.parseInt(raw, 10);
-  if (!Number.isFinite(delayMs) || delayMs <= 0) return null;
+  // Strict: `Number(...)` (not parseInt) so a partially-numeric value like
+  // "100ms" is rejected rather than silently enabling the harness with 100.
+  const delayMs = Number(raw);
+  if (!Number.isInteger(delayMs) || delayMs <= 0) return null;
   const modeRaw = env.IRONCURTAIN_MITM_STREAM_DELAY_MODE;
   const mode: StreamDelayMode = modeRaw === 'first-token' || modeRaw === 'drip' ? modeRaw : 'mid-stream';
   const hostFilter = env.IRONCURTAIN_MITM_STREAM_DELAY_HOST || undefined;
-  const dripRaw = Number.parseInt(env.IRONCURTAIN_MITM_STREAM_DRIP_BYTES ?? '', 10);
-  const dripBytes = Number.isFinite(dripRaw) && dripRaw > 0 ? dripRaw : 1;
+  const dripRaw = Number(env.IRONCURTAIN_MITM_STREAM_DRIP_BYTES);
+  const dripBytes = Number.isInteger(dripRaw) && dripRaw > 0 ? dripRaw : 1;
   return { delayMs, mode, hostFilter, dripBytes };
 }

--- a/src/docker/stream-delay.ts
+++ b/src/docker/stream-delay.ts
@@ -43,6 +43,7 @@ export interface StreamDelayConfig {
  */
 export class GapDelayTransform extends Transform {
   private chunkIndex = 0;
+  private pendingTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly delayMs: number;
   private readonly mode: 'mid-stream' | 'first-token';
 
@@ -56,10 +57,24 @@ export class GapDelayTransform extends Transform {
     const idx = this.chunkIndex++;
     const inject = this.mode === 'first-token' ? idx === 0 : idx === 1;
     if (inject) {
-      setTimeout(() => callback(null, chunk), this.delayMs);
+      this.pendingTimer = setTimeout(() => {
+        this.pendingTimer = null;
+        callback(null, chunk);
+      }, this.delayMs);
+      // A pending gap can be multi-minute; don't hold the event loop open, and
+      // clear it in _destroy so the callback never fires after teardown.
+      this.pendingTimer.unref();
     } else {
       callback(null, chunk);
     }
+  }
+
+  _destroy(error: Error | null, callback: (error: Error | null) => void): void {
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+    callback(error);
   }
 }
 
@@ -121,6 +136,8 @@ export class SlowDripTransform extends Transform {
         cb?.();
       }
     }, this.intervalMs);
+    // Debug-only, possibly multi-minute interval: never keep the loop alive.
+    this.timer.unref();
   }
 
   private stopTimer(): void {
@@ -139,6 +156,13 @@ export class SlowDripTransform extends Transform {
 
   _flush(callback: TransformCallback): void {
     this.ended = true;
+    // If the queue already drained, finish now instead of waiting a full
+    // (possibly multi-minute) tick to notice.
+    if (!this.hasBytes()) {
+      this.stopTimer();
+      callback();
+      return;
+    }
     this.flushCallback = callback;
     this.ensureTimer();
   }

--- a/test/docker/stream-delay.unit.test.ts
+++ b/test/docker/stream-delay.unit.test.ts
@@ -12,10 +12,19 @@ describe('parseStreamDelayConfig', () => {
     expect(parseStreamDelayConfig({})).toBeNull();
   });
 
-  it('returns null for non-positive or non-numeric delays', () => {
+  it('returns null for non-positive, non-integer, or partially-numeric delays', () => {
     expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '0' })).toBeNull();
     expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '-5' })).toBeNull();
     expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: 'abc' })).toBeNull();
+    expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '100ms' })).toBeNull();
+    expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '100.5' })).toBeNull();
+  });
+
+  it('ignores a partially-numeric drip-bytes value (falls back to 1)', () => {
+    expect(
+      parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '2000', IRONCURTAIN_MITM_STREAM_DRIP_BYTES: '4x' })
+        ?.dripBytes,
+    ).toBe(1);
   });
 
   it('defaults to mid-stream mode with no host filter and dripBytes=1', () => {

--- a/test/docker/stream-delay.unit.test.ts
+++ b/test/docker/stream-delay.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { StreamDelayTransform, parseStreamDelayConfig } from '../../src/docker/stream-delay.js';
+
+/**
+ * Drive `chunks` through the transform and record each output chunk's
+ * arrival time relative to the moment writing began.
+ */
+function runThroughDelay(
+  transform: StreamDelayTransform,
+  chunks: Buffer[],
+): Promise<{ data: Buffer; offsets: number[] }> {
+  return new Promise((resolve, reject) => {
+    const out: Buffer[] = [];
+    const offsets: number[] = [];
+    const start = Date.now();
+    transform.on('data', (c: Buffer) => {
+      out.push(c);
+      offsets.push(Date.now() - start);
+    });
+    transform.on('end', () => resolve({ data: Buffer.concat(out), offsets }));
+    transform.on('error', reject);
+    for (const c of chunks) transform.write(c);
+    transform.end();
+  });
+}
+
+const DELAY = 80; // ms — small enough to keep the suite fast, large enough to measure
+
+describe('parseStreamDelayConfig', () => {
+  it('returns null when the delay var is unset', () => {
+    expect(parseStreamDelayConfig({})).toBeNull();
+  });
+
+  it('returns null for non-positive or non-numeric delays', () => {
+    expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '0' })).toBeNull();
+    expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '-5' })).toBeNull();
+    expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: 'abc' })).toBeNull();
+  });
+
+  it('defaults to mid-stream mode with no host filter', () => {
+    expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '15000' })).toEqual({
+      delayMs: 15000,
+      mode: 'mid-stream',
+      hostFilter: undefined,
+    });
+  });
+
+  it('parses first-token mode and a host filter', () => {
+    expect(
+      parseStreamDelayConfig({
+        IRONCURTAIN_MITM_STREAM_DELAY_MS: '9000',
+        IRONCURTAIN_MITM_STREAM_DELAY_MODE: 'first-token',
+        IRONCURTAIN_MITM_STREAM_DELAY_HOST: 'anthropic',
+      }),
+    ).toEqual({ delayMs: 9000, mode: 'first-token', hostFilter: 'anthropic' });
+  });
+
+  it('falls back to mid-stream for an unrecognized mode', () => {
+    expect(
+      parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '100', IRONCURTAIN_MITM_STREAM_DELAY_MODE: 'wat' })
+        ?.mode,
+    ).toBe('mid-stream');
+  });
+});
+
+describe('StreamDelayTransform', () => {
+  const chunks = [Buffer.from('event: a\n\n'), Buffer.from('event: b\n\n'), Buffer.from('event: c\n\n')];
+  const expected = Buffer.concat(chunks);
+
+  it('mid-stream: preserves bytes and injects the gap before the second chunk', async () => {
+    const { data, offsets } = await runThroughDelay(new StreamDelayTransform(DELAY, 'mid-stream'), chunks);
+    expect(data.equals(expected)).toBe(true);
+    expect(offsets).toHaveLength(3);
+    // First chunk forwarded promptly; the gap lands between chunk 0 and chunk 1.
+    expect(offsets[0]).toBeLessThan(DELAY / 2);
+    expect(offsets[1] - offsets[0]).toBeGreaterThanOrEqual(DELAY * 0.6);
+    // Chunk 2 follows chunk 1 without an additional gap.
+    expect(offsets[2] - offsets[1]).toBeLessThan(DELAY / 2);
+  });
+
+  it('first-token: preserves bytes and injects the gap before the first chunk', async () => {
+    const { data, offsets } = await runThroughDelay(new StreamDelayTransform(DELAY, 'first-token'), chunks);
+    expect(data.equals(expected)).toBe(true);
+    expect(offsets).toHaveLength(3);
+    // Nothing reaches the client until the first-token gap elapses.
+    expect(offsets[0]).toBeGreaterThanOrEqual(DELAY * 0.6);
+    // The rest follow immediately after.
+    expect(offsets[2] - offsets[0]).toBeLessThan(DELAY / 2);
+  });
+
+  it('mid-stream is a pass-through when only one chunk is emitted', async () => {
+    const { data, offsets } = await runThroughDelay(new StreamDelayTransform(DELAY, 'mid-stream'), [chunks[0]]);
+    expect(data.equals(chunks[0])).toBe(true);
+    expect(offsets[0]).toBeLessThan(DELAY / 2);
+  });
+});

--- a/test/docker/stream-delay.unit.test.ts
+++ b/test/docker/stream-delay.unit.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { StreamDelayTransform, parseStreamDelayConfig } from '../../src/docker/stream-delay.js';
+import type { Transform } from 'node:stream';
+import {
+  GapDelayTransform,
+  SlowDripTransform,
+  createStreamDelayTransform,
+  parseStreamDelayConfig,
+} from '../../src/docker/stream-delay.js';
 
 /**
  * Drive `chunks` through the transform and record each output chunk's
  * arrival time relative to the moment writing began.
  */
-function runThroughDelay(
-  transform: StreamDelayTransform,
-  chunks: Buffer[],
-): Promise<{ data: Buffer; offsets: number[] }> {
+function runThroughDelay(transform: Transform, chunks: Buffer[]): Promise<{ data: Buffer; offsets: number[] }> {
   return new Promise((resolve, reject) => {
     const out: Buffer[] = [];
     const offsets: number[] = [];
@@ -37,11 +40,12 @@ describe('parseStreamDelayConfig', () => {
     expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: 'abc' })).toBeNull();
   });
 
-  it('defaults to mid-stream mode with no host filter', () => {
+  it('defaults to mid-stream mode with no host filter and dripBytes=1', () => {
     expect(parseStreamDelayConfig({ IRONCURTAIN_MITM_STREAM_DELAY_MS: '15000' })).toEqual({
       delayMs: 15000,
       mode: 'mid-stream',
       hostFilter: undefined,
+      dripBytes: 1,
     });
   });
 
@@ -52,7 +56,17 @@ describe('parseStreamDelayConfig', () => {
         IRONCURTAIN_MITM_STREAM_DELAY_MODE: 'first-token',
         IRONCURTAIN_MITM_STREAM_DELAY_HOST: 'anthropic',
       }),
-    ).toEqual({ delayMs: 9000, mode: 'first-token', hostFilter: 'anthropic' });
+    ).toEqual({ delayMs: 9000, mode: 'first-token', hostFilter: 'anthropic', dripBytes: 1 });
+  });
+
+  it('parses drip mode and an explicit bytes-per-tick', () => {
+    expect(
+      parseStreamDelayConfig({
+        IRONCURTAIN_MITM_STREAM_DELAY_MS: '2000',
+        IRONCURTAIN_MITM_STREAM_DELAY_MODE: 'drip',
+        IRONCURTAIN_MITM_STREAM_DRIP_BYTES: '4',
+      }),
+    ).toEqual({ delayMs: 2000, mode: 'drip', hostFilter: undefined, dripBytes: 4 });
   });
 
   it('falls back to mid-stream for an unrecognized mode', () => {
@@ -63,12 +77,24 @@ describe('parseStreamDelayConfig', () => {
   });
 });
 
-describe('StreamDelayTransform', () => {
+describe('createStreamDelayTransform', () => {
+  it('selects the transform class by mode', () => {
+    expect(createStreamDelayTransform({ delayMs: 100, mode: 'drip', dripBytes: 1 })).toBeInstanceOf(SlowDripTransform);
+    expect(createStreamDelayTransform({ delayMs: 100, mode: 'mid-stream', dripBytes: 1 })).toBeInstanceOf(
+      GapDelayTransform,
+    );
+    expect(createStreamDelayTransform({ delayMs: 100, mode: 'first-token', dripBytes: 1 })).toBeInstanceOf(
+      GapDelayTransform,
+    );
+  });
+});
+
+describe('GapDelayTransform', () => {
   const chunks = [Buffer.from('event: a\n\n'), Buffer.from('event: b\n\n'), Buffer.from('event: c\n\n')];
   const expected = Buffer.concat(chunks);
 
   it('mid-stream: preserves bytes and injects the gap before the second chunk', async () => {
-    const { data, offsets } = await runThroughDelay(new StreamDelayTransform(DELAY, 'mid-stream'), chunks);
+    const { data, offsets } = await runThroughDelay(new GapDelayTransform(DELAY, 'mid-stream'), chunks);
     expect(data.equals(expected)).toBe(true);
     expect(offsets).toHaveLength(3);
     // First chunk forwarded promptly; the gap lands between chunk 0 and chunk 1.
@@ -79,7 +105,7 @@ describe('StreamDelayTransform', () => {
   });
 
   it('first-token: preserves bytes and injects the gap before the first chunk', async () => {
-    const { data, offsets } = await runThroughDelay(new StreamDelayTransform(DELAY, 'first-token'), chunks);
+    const { data, offsets } = await runThroughDelay(new GapDelayTransform(DELAY, 'first-token'), chunks);
     expect(data.equals(expected)).toBe(true);
     expect(offsets).toHaveLength(3);
     // Nothing reaches the client until the first-token gap elapses.
@@ -89,8 +115,31 @@ describe('StreamDelayTransform', () => {
   });
 
   it('mid-stream is a pass-through when only one chunk is emitted', async () => {
-    const { data, offsets } = await runThroughDelay(new StreamDelayTransform(DELAY, 'mid-stream'), [chunks[0]]);
+    const { data, offsets } = await runThroughDelay(new GapDelayTransform(DELAY, 'mid-stream'), [chunks[0]]);
     expect(data.equals(chunks[0])).toBe(true);
     expect(offsets[0]).toBeLessThan(DELAY / 2);
+  });
+});
+
+describe('SlowDripTransform', () => {
+  it('preserves bytes across input chunks and paces output over time', async () => {
+    const input = Buffer.from('abcdefgh'); // 8 bytes
+    const interval = 15;
+    const { data, offsets } = await runThroughDelay(new SlowDripTransform(interval, 1), [
+      input.subarray(0, 3),
+      input.subarray(3),
+    ]);
+    expect(data.equals(input)).toBe(true);
+    // 1 byte per tick ⇒ output is spread across multiple ticks, not delivered at once.
+    expect(offsets.length).toBeGreaterThanOrEqual(4);
+    const spread = offsets[offsets.length - 1] - offsets[0];
+    expect(spread).toBeGreaterThanOrEqual(interval * 3);
+  });
+
+  it('honors bytes-per-tick', async () => {
+    const input = Buffer.from('abcdefgh'); // 8 bytes, 4 per tick ⇒ 2 emissions
+    const { data, offsets } = await runThroughDelay(new SlowDripTransform(15, 4), [input]);
+    expect(data.equals(input)).toBe(true);
+    expect(offsets.length).toBe(2);
   });
 });

--- a/test/docker/stream-delay.unit.test.ts
+++ b/test/docker/stream-delay.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Transform } from 'node:stream';
 import {
   GapDelayTransform,
@@ -6,28 +6,6 @@ import {
   createStreamDelayTransform,
   parseStreamDelayConfig,
 } from '../../src/docker/stream-delay.js';
-
-/**
- * Drive `chunks` through the transform and record each output chunk's
- * arrival time relative to the moment writing began.
- */
-function runThroughDelay(transform: Transform, chunks: Buffer[]): Promise<{ data: Buffer; offsets: number[] }> {
-  return new Promise((resolve, reject) => {
-    const out: Buffer[] = [];
-    const offsets: number[] = [];
-    const start = Date.now();
-    transform.on('data', (c: Buffer) => {
-      out.push(c);
-      offsets.push(Date.now() - start);
-    });
-    transform.on('end', () => resolve({ data: Buffer.concat(out), offsets }));
-    transform.on('error', reject);
-    for (const c of chunks) transform.write(c);
-    transform.end();
-  });
-}
-
-const DELAY = 80; // ms — small enough to keep the suite fast, large enough to measure
 
 describe('parseStreamDelayConfig', () => {
   it('returns null when the delay var is unset', () => {
@@ -89,57 +67,95 @@ describe('createStreamDelayTransform', () => {
   });
 });
 
+/**
+ * Write all chunks + end, and collect output. Timers are faked, so callers step
+ * time explicitly with `vi.advanceTimersByTimeAsync` and assertions stay
+ * deterministic (no wall-clock flakiness).
+ */
+function drive(transform: Transform, chunks: Buffer[]): { out: Buffer[]; ended: Promise<void> } {
+  const out: Buffer[] = [];
+  transform.on('data', (c: Buffer) => out.push(Buffer.from(c)));
+  const ended = new Promise<void>((resolve, reject) => {
+    transform.on('end', () => resolve());
+    transform.on('error', reject);
+  });
+  for (const c of chunks) transform.write(c);
+  transform.end();
+  return { out, ended };
+}
+
+const GAP = 1000;
+
 describe('GapDelayTransform', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   const chunks = [Buffer.from('event: a\n\n'), Buffer.from('event: b\n\n'), Buffer.from('event: c\n\n')];
   const expected = Buffer.concat(chunks);
 
-  it('mid-stream: preserves bytes and injects the gap before the second chunk', async () => {
-    const { data, offsets } = await runThroughDelay(new GapDelayTransform(DELAY, 'mid-stream'), chunks);
-    expect(data.equals(expected)).toBe(true);
-    expect(offsets).toHaveLength(3);
-    // First chunk forwarded promptly; the gap lands between chunk 0 and chunk 1.
-    expect(offsets[0]).toBeLessThan(DELAY / 2);
-    expect(offsets[1] - offsets[0]).toBeGreaterThanOrEqual(DELAY * 0.6);
-    // Chunk 2 follows chunk 1 without an additional gap.
-    expect(offsets[2] - offsets[1]).toBeLessThan(DELAY / 2);
+  it('mid-stream: forwards the first chunk, then holds the rest for exactly the gap', async () => {
+    const { out, ended } = drive(new GapDelayTransform(GAP, 'mid-stream'), chunks);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(out).toHaveLength(1); // chunk 0 through; chunk 1 waiting on the gap
+    expect(out[0].equals(chunks[0])).toBe(true);
+    await vi.advanceTimersByTimeAsync(GAP - 1);
+    expect(out).toHaveLength(1); // gap not yet elapsed
+    await vi.advanceTimersByTimeAsync(1);
+    await ended;
+    expect(out).toHaveLength(3);
+    expect(Buffer.concat(out).equals(expected)).toBe(true);
   });
 
-  it('first-token: preserves bytes and injects the gap before the first chunk', async () => {
-    const { data, offsets } = await runThroughDelay(new GapDelayTransform(DELAY, 'first-token'), chunks);
-    expect(data.equals(expected)).toBe(true);
-    expect(offsets).toHaveLength(3);
-    // Nothing reaches the client until the first-token gap elapses.
-    expect(offsets[0]).toBeGreaterThanOrEqual(DELAY * 0.6);
-    // The rest follow immediately after.
-    expect(offsets[2] - offsets[0]).toBeLessThan(DELAY / 2);
+  it('first-token: holds everything until the gap elapses', async () => {
+    const { out, ended } = drive(new GapDelayTransform(GAP, 'first-token'), chunks);
+    await vi.advanceTimersByTimeAsync(GAP - 1);
+    expect(out).toHaveLength(0); // nothing before the first-token gap
+    await vi.advanceTimersByTimeAsync(1);
+    await ended;
+    expect(Buffer.concat(out).equals(expected)).toBe(true);
   });
 
   it('mid-stream is a pass-through when only one chunk is emitted', async () => {
-    const { data, offsets } = await runThroughDelay(new GapDelayTransform(DELAY, 'mid-stream'), [chunks[0]]);
-    expect(data.equals(chunks[0])).toBe(true);
-    expect(offsets[0]).toBeLessThan(DELAY / 2);
+    const { out, ended } = drive(new GapDelayTransform(GAP, 'mid-stream'), [chunks[0]]);
+    await vi.advanceTimersByTimeAsync(0);
+    await ended;
+    expect(out).toHaveLength(1);
+    expect(out[0].equals(chunks[0])).toBe(true);
   });
 });
 
 describe('SlowDripTransform', () => {
-  it('preserves bytes across input chunks and paces output over time', async () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const TICK = 100;
+
+  it('preserves bytes across input chunks and emits one byte per tick', async () => {
     const input = Buffer.from('abcdefgh'); // 8 bytes
-    const interval = 15;
-    const { data, offsets } = await runThroughDelay(new SlowDripTransform(interval, 1), [
-      input.subarray(0, 3),
-      input.subarray(3),
-    ]);
-    expect(data.equals(input)).toBe(true);
-    // 1 byte per tick ⇒ output is spread across multiple ticks, not delivered at once.
-    expect(offsets.length).toBeGreaterThanOrEqual(4);
-    const spread = offsets[offsets.length - 1] - offsets[0];
-    expect(spread).toBeGreaterThanOrEqual(interval * 3);
+    const { out, ended } = drive(new SlowDripTransform(TICK, 1), [input.subarray(0, 3), input.subarray(3)]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(out).toHaveLength(0); // nothing until the first tick
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(Buffer.concat(out)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(TICK * 7);
+    await ended;
+    expect(Buffer.concat(out).equals(input)).toBe(true);
+    expect(out).toHaveLength(8); // 1 byte per tick
   });
 
   it('honors bytes-per-tick', async () => {
     const input = Buffer.from('abcdefgh'); // 8 bytes, 4 per tick ⇒ 2 emissions
-    const { data, offsets } = await runThroughDelay(new SlowDripTransform(15, 4), [input]);
-    expect(data.equals(input)).toBe(true);
-    expect(offsets.length).toBe(2);
+    const { out, ended } = drive(new SlowDripTransform(TICK, 4), [input]);
+    await vi.advanceTimersByTimeAsync(TICK * 2);
+    await ended;
+    expect(Buffer.concat(out).equals(input)).toBe(true);
+    expect(out).toHaveLength(2);
+  });
+
+  it('finalizes promptly when the queue is already empty at flush', async () => {
+    const { out, ended } = drive(new SlowDripTransform(60_000, 1), []); // 60s tick, no data
+    await vi.advanceTimersByTimeAsync(0); // must not wait a full 60s tick to end
+    await ended;
+    expect(out).toHaveLength(0);
   });
 });

--- a/test/docker/stream-delay.unit.test.ts
+++ b/test/docker/stream-delay.unit.test.ts
@@ -167,4 +167,13 @@ describe('SlowDripTransform', () => {
     await ended;
     expect(out).toHaveLength(0);
   });
+
+  it('bounds the buffer via backpressure yet preserves every byte', async () => {
+    // Input exceeds the 1 MiB high-water mark; drain it in a few large ticks.
+    const big = Buffer.alloc(1_300_000, 7);
+    const { out, ended } = drive(new SlowDripTransform(TICK, 512 * 1024), [big]);
+    await vi.advanceTimersByTimeAsync(TICK * 4);
+    await ended;
+    expect(Buffer.concat(out).equals(big)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

A host-side debug harness for reproducing and diagnosing Claude Code's streaming idle / stall behavior (issue #367, "Response stalled mid-stream") **deterministically, without a real slow model** — plus the design doc capturing what it found.

This is the tooling behind the #372 / #376 investigations. The actual fixes shipped separately (`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in #372, `CLAUDE_ENABLE_STREAM_WATCHDOG=0` in #376); this PR lands the reusable probe and the reference documentation.

## What it adds

- **`src/docker/stream-delay.ts`** — a Transform injected at the tail of the MITM forwarding pipe, gated on `IRONCURTAIN_MITM_STREAM_DELAY_MS`. Modes: `mid-stream`/`first-token` (a complete stall) and `drip` (a slow-but-continuous trickle). Zero-cost when unset; sits after the trajectory-capture fan-out, so captured traces stay byte-faithful.
- **`adapters/claude-code.ts`** — a curated allowlist that forwards Claude Code streaming-watchdog tuning vars from the host env into the container (no-op unless set), so the watchdogs can be exercised without rebuilding the image.
- **`docs/designs/mitm-stream-delay-debug.md`** — usage + findings.
- 12 unit tests for the transforms and config parsing.

## Key finding (documented in the doc)

Native Anthropic has **two independent client-side idle watchdogs**, neither a total-duration cap:

- **byte watchdog** (`CLAUDE_ENABLE_BYTE_WATCHDOG`) — raw-byte idle, ~180 s.
- **stream watchdog** (`CLAUDE_ENABLE_STREAM_WATCHDOG`) — decoded-SSE-event idle, ~300 s → "Response stalled mid-stream" (matches #367's `duration_ms: 305993`).

In a raw stall the byte watchdog fires first (~180 s) and **masks** the stream watchdog. The `drip` mode (raw bytes flowing but events sparse) keeps the byte watchdog quiet and exposes the stream watchdog at ~300 s — confirming that **`CLAUDE_ENABLE_STREAM_WATCHDOG=0` (#376) disables it**, the correct lever for very-slow / long-thinking-pause models.

## Notes

- Debug-only, gated behind an env var, zero-cost when unset.
- Rebased on current master, so it composes with #372/#376's hardcoded env (the passthrough runs after and can still override a watchdog var for testing).
- `tsc` / `eslint` / tests green.
