### PR TITLE
fix(docker): recover orphaned macOS session networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- **MITM proxy certificate generation on Node 22 / OpenSSL 3.0** — `randomSerialNumber()` produced a 16-byte serial with no DER sign padding, so ~50% of generated certificates had a leading byte ≥ `0x80` and were encoded as a *negative* ASN.1 INTEGER. Strict OpenSSL builds (Node 22 / OpenSSL 3.0.x) reject these at cert-load with `asn1 encoding routines::illegal padding`, so MITM cert generation (CA and every leaf cert) failed intermittently on Node 22; Node 26's OpenSSL 3.6 tolerated it. Serials are now always positive DER INTEGERs.
+- **Crash-safe Docker network lifecycle on macOS** — Docker containers and per-bundle networks now carry owner leases and labels, and later sessions reconcile resources left by `SIGKILL` or host crashes. macOS Docker uses collision-checked `/29` allocations outside `192.168/16`, retries a different subnet when end-to-end MCP/MITM routing checks fail, and handles `SIGTERM`/`SIGHUP` during workflow shutdown. `ironcurtain gc` exposes the same reconciler as a dry-run or explicit cleanup command.
+- **MITM proxy certificate generation on Node 22 / OpenSSL 3.0** — `randomSerialNumber()` produced a 16-byte serial with no DER sign padding, so ~50% of generated certificates had a leading byte ≥ `0x80` and were encoded as a _negative_ ASN.1 INTEGER. Strict OpenSSL builds (Node 22 / OpenSSL 3.0.x) reject these at cert-load with `asn1 encoding routines::illegal padding`, so MITM cert generation (CA and every leaf cert) failed intermittently on Node 22; Node 26's OpenSSL 3.6 tolerated it. Serials are now always positive DER INTEGERs.
 
 ## [0.12.0] - 2026-06-26
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ const topLevelSpec: CommandSpec = {
     { name: 'workflow', description: 'Run multi-agent workflows (start, resume, inspect)' },
     { name: 'observe', description: 'Watch live LLM token output for running sessions' },
     { name: 'doctor', description: 'Diagnose installation, credentials, and MCP server health' },
+    { name: 'gc', description: 'Inspect or reclaim orphaned IronCurtain Docker resources' },
     { name: 'help', description: 'Show this help message' },
   ],
   options: [
@@ -206,6 +207,11 @@ switch (subcommand) {
   case 'doctor': {
     const { runDoctorCommand } = await import('./doctor/doctor-command.js');
     await runDoctorCommand(process.argv.slice(3));
+    break;
+  }
+  case 'gc': {
+    const { runDockerGcCommand } = await import('./docker/gc-command.js');
+    await runDockerGcCommand(process.argv.slice(3));
     break;
   }
   case 'setup-signal': {

--- a/src/docker/apple-container-manager.ts
+++ b/src/docker/apple-container-manager.ts
@@ -23,7 +23,13 @@
  */
 
 import { arch, platform, release } from 'node:os';
-import type { ContainerRuntime, DockerContainerConfig, DockerExecResult, DockerImageInfo } from './types.js';
+import type {
+  ContainerRuntime,
+  DockerContainerConfig,
+  DockerExecResult,
+  DockerImageInfo,
+  DockerNetworkCreateOptions,
+} from './types.js';
 import * as logger from '../logger.js';
 import type { DockerAvailability } from './docker-probe.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
@@ -463,12 +469,12 @@ export function createAppleContainerManager(
       }
     },
 
-    async createNetwork(
-      name: string,
-      options?: { internal?: boolean; subnet?: string; gateway?: string },
-    ): Promise<void> {
+    async createNetwork(name: string, options?: DockerNetworkCreateOptions): Promise<void> {
       if (options?.gateway) {
         throw new Error('apple-container networks do not support an explicit gateway; the runtime assigns it');
+      }
+      if (options?.labels && Object.keys(options.labels).length > 0) {
+        throw new Error('apple-container networks do not support labels');
       }
       try {
         const args = ['network', 'create'];

--- a/src/docker/container-lifecycle.ts
+++ b/src/docker/container-lifecycle.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ContainerRuntime } from './types.js';
+import * as logger from '../logger.js';
 
 /**
  * Stop and remove Docker containers and their per-session network in parallel.
@@ -42,8 +43,17 @@ export async function cleanupContainers(
 
   await Promise.all(cleanups);
 
+  for (const id of [opts.containerId, opts.sidecarContainerId]) {
+    if (id && (await docker.containerExists(id))) {
+      logger.warn(`cleanupContainers: container ${id} still exists after removal`);
+    }
+  }
+
   // Remove per-session internal network after both containers are gone
   if (opts.networkName !== null) {
     await docker.removeNetwork(opts.networkName).catch(() => {});
+    if (docker.networkExists && (await docker.networkExists(opts.networkName))) {
+      logger.warn(`cleanupContainers: network ${opts.networkName} still exists after removal`);
+    }
   }
 }

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -50,10 +50,11 @@ import { getInternalNetworkName } from './platform.js';
 import { cleanupContainers } from './container-lifecycle.js';
 import {
   createIronCurtainInternalNetwork,
-  dockerAllocationPoolForSubnet,
+  InternalNetworkConnectivityError,
   managedResourceLabels,
-  reconcileIronCurtainDockerResources,
+  reconcileIronCurtainDockerResourcesBestEffort,
   releaseManagedResourceLease,
+  withInternalNetworkAllocationRetry,
 } from './docker-resource-lifecycle.js';
 import { clampDockerResources } from './resource-limits.js';
 import { errorMessage } from '../utils/error-message.js';
@@ -61,6 +62,8 @@ import { createCachedStager } from '../skills/staging.js';
 import type { ResolvedSkill } from '../skills/types.js';
 import { withProvisionLock } from './provision-lock.js';
 import * as logger from '../logger.js';
+
+export { InternalNetworkConnectivityError };
 
 /**
  * Create a bundle-owned directory and enforce 0o700 permissions even if
@@ -1142,31 +1145,18 @@ export async function createSessionContainers(
   options?: CreateDockerInfrastructureOptions,
 ): Promise<ContainerResources> {
   if (core.runtimeKind === 'docker') {
-    await reconcileIronCurtainDockerResources(core.docker);
+    await reconcileIronCurtainDockerResourcesBestEffort(core.docker, 'session startup');
   }
 
-  const excludedSubnets = new Set<string>();
   const maxAttempts = core.topology === 'tcp-sidecar' ? 4 : 1;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const allocationState: { subnet?: string } = {};
-    try {
-      return await createSessionContainersAttempt(core, config, options, excludedSubnets, allocationState);
-    } catch (error) {
-      lastError = error;
-      if (!(error instanceof InternalNetworkConnectivityError) || !allocationState.subnet || attempt === maxAttempts) {
-        throw error;
-      }
-      const rejectedPool = dockerAllocationPoolForSubnet(allocationState.subnet);
-      excludedSubnets.add(rejectedPool);
-      logger.warn(
-        `Internal Docker network ${allocationState.subnet} failed its end-to-end checks; rejecting ${rejectedPool} and ` +
-          `retrying with another allocation (${attempt}/${maxAttempts})`,
-      );
-      await reconcileIronCurtainDockerResources(core.docker);
-    }
-  }
-  throw lastError;
+  return withInternalNetworkAllocationRetry(
+    {
+      maxAttempts,
+      description: 'Internal Docker network',
+      reconcile: () => reconcileIronCurtainDockerResourcesBestEffort(core.docker, 'internal network retry'),
+    },
+    (excludedSubnets, attempt) => createSessionContainersAttempt(core, config, options, excludedSubnets, attempt),
+  );
 }
 
 async function createSessionContainersAttempt(
@@ -1174,7 +1164,7 @@ async function createSessionContainersAttempt(
   config: IronCurtainConfig,
   options: CreateDockerInfrastructureOptions | undefined,
   excludedSubnets: ReadonlySet<string>,
-  allocationState: { subnet?: string },
+  attempt: number,
 ): Promise<ContainerResources> {
   const shortId = getBundleShortId(core.bundleId);
   const mainContainerName = `${CONTAINER_NAME_PREFIX}${shortId}`;
@@ -1193,6 +1183,7 @@ async function createSessionContainersAttempt(
   let mainContainerId: string | undefined;
   let sidecarContainerId: string | undefined;
   let internalNetwork: string | undefined;
+  let allocatedNetworkSubnet: string | undefined;
 
   try {
     const mainImage =
@@ -1260,11 +1251,12 @@ async function createSessionContainersAttempt(
       mounts.push({ source: aptProxyPath, target: '/etc/apt/apt.conf.d/90-ironcurtain-proxy', readonly: true });
 
       // Create a per-session --internal Docker network that blocks internet egress.
-      const networkName = getInternalNetworkName(shortId);
+      const baseNetworkName = getInternalNetworkName(shortId);
+      const networkName = attempt === 1 ? baseNetworkName : `${baseNetworkName}-a${attempt}`;
       const allocatedNetwork = await createIronCurtainInternalNetwork(core.docker, networkName, core.bundleId, {
         excludedSubnets,
       });
-      allocationState.subnet = allocatedNetwork.subnet;
+      allocatedNetworkSubnet = allocatedNetwork.subnet;
       internalNetwork = networkName;
       network = networkName;
       logger.info(`Allocated internal Docker network ${networkName} at ${allocatedNetwork.subnet}`);
@@ -1449,7 +1441,14 @@ async function createSessionContainersAttempt(
       if (core.mitmAddr.port === undefined) {
         throw new Error('tcp-sidecar bundle is missing its MITM proxy port');
       }
-      await checkInternalNetworkConnectivity(core.docker, mainContainerId, core.proxy.port, core.mitmAddr.port);
+      try {
+        await checkInternalNetworkConnectivity(core.docker, mainContainerId, core.proxy.port, core.mitmAddr.port);
+      } catch (error) {
+        if (error instanceof InternalNetworkConnectivityError) {
+          throw new InternalNetworkConnectivityError(error.message, allocatedNetworkSubnet);
+        }
+        throw error;
+      }
     }
 
     return {
@@ -1477,10 +1476,6 @@ async function createSessionContainersAttempt(
  * Probes whether the container can reach host-side proxies via the socat
  * sidecar on the internal Docker network. Throws a descriptive error if not.
  */
-export class InternalNetworkConnectivityError extends Error {
-  subnet?: string;
-}
-
 export async function checkInternalNetworkConnectivity(
   docker: ContainerRuntime,
   containerId: string,

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -48,6 +48,13 @@ import type { ProviderKeyMapping } from './mitm-proxy.js';
 import { parseUpstreamBaseUrl, type AgentKind, type ProviderConfig, type UpstreamTarget } from './provider-config.js';
 import { getInternalNetworkName } from './platform.js';
 import { cleanupContainers } from './container-lifecycle.js';
+import {
+  createIronCurtainInternalNetwork,
+  dockerAllocationPoolForSubnet,
+  managedResourceLabels,
+  reconcileIronCurtainDockerResources,
+  releaseManagedResourceLease,
+} from './docker-resource-lifecycle.js';
 import { clampDockerResources } from './resource-limits.js';
 import { errorMessage } from '../utils/error-message.js';
 import { createCachedStager } from '../skills/staging.js';
@@ -949,6 +956,7 @@ export async function destroyDockerInfrastructure(infra: DockerInfrastructure): 
     sidecarContainerId: infra.sidecarContainerId ?? null,
     networkName: infra.internalNetwork ?? null,
   });
+  if (infra.runtimeKind === 'docker') releaseManagedResourceLease(infra.bundleId);
 
   // Proxies are independent producers -- stop them in parallel. Each
   // per-promise catch logs so one failure doesn't mask the other, and
@@ -1009,11 +1017,18 @@ export async function destroyDockerInfrastructure(infra: DockerInfrastructure): 
  *
  * See `docs/designs/workflow-session-identity.md` §7.
  */
-export function buildBundleLabels(core: Pick<PreContainerInfrastructure, 'bundleId' | 'workflowId' | 'scope'>): {
+export function buildBundleLabels(
+  core: Pick<PreContainerInfrastructure, 'bundleId' | 'workflowId' | 'scope' | 'runtimeKind'>,
+): {
   bundleLabel: string;
   workflowLabel?: string;
   scopeLabel?: string;
+  labels?: Readonly<Record<string, string>>;
 } {
+  const managedLabels = core.runtimeKind === 'docker' ? managedResourceLabels(core.bundleId) : undefined;
+  const labels = managedLabels
+    ? Object.fromEntries(Object.entries(managedLabels).filter(([key]) => key !== 'ironcurtain.bundle'))
+    : undefined;
   if (core.workflowId !== undefined) {
     return {
       bundleLabel: core.bundleId,
@@ -1022,9 +1037,10 @@ export function buildBundleLabels(core: Pick<PreContainerInfrastructure, 'bundle
       // bundle; default-fall back to DEFAULT_CONTAINER_SCOPE so that a
       // workflow bundle always carries a scope label.
       scopeLabel: core.scope ?? DEFAULT_CONTAINER_SCOPE,
+      labels,
     };
   }
-  return { bundleLabel: core.bundleId };
+  return { bundleLabel: core.bundleId, labels };
 }
 
 /**
@@ -1125,6 +1141,41 @@ export async function createSessionContainers(
   config: IronCurtainConfig,
   options?: CreateDockerInfrastructureOptions,
 ): Promise<ContainerResources> {
+  if (core.runtimeKind === 'docker') {
+    await reconcileIronCurtainDockerResources(core.docker);
+  }
+
+  const excludedSubnets = new Set<string>();
+  const maxAttempts = core.topology === 'tcp-sidecar' ? 4 : 1;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const allocationState: { subnet?: string } = {};
+    try {
+      return await createSessionContainersAttempt(core, config, options, excludedSubnets, allocationState);
+    } catch (error) {
+      lastError = error;
+      if (!(error instanceof InternalNetworkConnectivityError) || !allocationState.subnet || attempt === maxAttempts) {
+        throw error;
+      }
+      const rejectedPool = dockerAllocationPoolForSubnet(allocationState.subnet);
+      excludedSubnets.add(rejectedPool);
+      logger.warn(
+        `Internal Docker network ${allocationState.subnet} failed its end-to-end checks; rejecting ${rejectedPool} and ` +
+          `retrying with another allocation (${attempt}/${maxAttempts})`,
+      );
+      await reconcileIronCurtainDockerResources(core.docker);
+    }
+  }
+  throw lastError;
+}
+
+async function createSessionContainersAttempt(
+  core: PreContainerInfrastructure,
+  config: IronCurtainConfig,
+  options: CreateDockerInfrastructureOptions | undefined,
+  excludedSubnets: ReadonlySet<string>,
+  allocationState: { subnet?: string },
+): Promise<ContainerResources> {
   const shortId = getBundleShortId(core.bundleId);
   const mainContainerName = `${CONTAINER_NAME_PREFIX}${shortId}`;
   // Labels applied to every IronCurtain-owned container (main + sidecar).
@@ -1210,9 +1261,13 @@ export async function createSessionContainers(
 
       // Create a per-session --internal Docker network that blocks internet egress.
       const networkName = getInternalNetworkName(shortId);
-      await core.docker.createNetwork(networkName, { internal: true });
+      const allocatedNetwork = await createIronCurtainInternalNetwork(core.docker, networkName, core.bundleId, {
+        excludedSubnets,
+      });
+      allocationState.subnet = allocatedNetwork.subnet;
       internalNetwork = networkName;
       network = networkName;
+      logger.info(`Allocated internal Docker network ${networkName} at ${allocatedNetwork.subnet}`);
 
       // Ensure the socat image is available
       const socatImage = 'alpine/socat';
@@ -1391,7 +1446,10 @@ export async function createSessionContainers(
     if (core.topology === 'tcp-hostonly' && core.hostOnlyNetwork !== undefined && core.proxy.port !== undefined) {
       await checkHostOnlyConnectivity(core.docker, mainContainerId, core.hostOnlyNetwork.gateway, core.proxy.port);
     } else if (core.useTcp && internalNetwork !== undefined && core.proxy.port !== undefined) {
-      await checkInternalNetworkConnectivity(core.docker, mainContainerId, core.proxy.port);
+      if (core.mitmAddr.port === undefined) {
+        throw new Error('tcp-sidecar bundle is missing its MITM proxy port');
+      }
+      await checkInternalNetworkConnectivity(core.docker, mainContainerId, core.proxy.port, core.mitmAddr.port);
     }
 
     return {
@@ -1410,6 +1468,7 @@ export async function createSessionContainers(
       sidecarContainerId: sidecarContainerId ?? null,
       networkName: internalNetwork ?? null,
     });
+    if (core.runtimeKind === 'docker') releaseManagedResourceLease(core.bundleId);
     throw err;
   }
 }
@@ -1418,23 +1477,49 @@ export async function createSessionContainers(
  * Probes whether the container can reach host-side proxies via the socat
  * sidecar on the internal Docker network. Throws a descriptive error if not.
  */
-async function checkInternalNetworkConnectivity(
+export class InternalNetworkConnectivityError extends Error {
+  subnet?: string;
+}
+
+export async function checkInternalNetworkConnectivity(
   docker: ContainerRuntime,
   containerId: string,
   mcpPort: number,
+  mitmPort: number,
 ): Promise<void> {
-  const result = await docker.exec(
+  const mcpResult = await docker.exec(
     containerId,
-    ['socat', '-u', '/dev/null', `TCP:${DOCKER_HOST_GATEWAY}:${mcpPort},connect-timeout=5`],
+    [
+      '/bin/sh',
+      '-c',
+      `printf 'IRONCURTAIN_HEALTH/1\\n' | socat -T5 - TCP:${DOCKER_HOST_GATEWAY}:${mcpPort},connect-timeout=5 | grep -q '^IRONCURTAIN_OK/1'`,
+    ],
     // Allow a small buffer above socat's 5s connect-timeout for docker exec/process startup overhead.
     6_000,
   );
+  if (mcpResult.exitCode !== 0) {
+    throw new InternalNetworkConnectivityError(
+      `Internal network connectivity check failed: MCP round-trip exited ${mcpResult.exitCode}; ` +
+        `the sidecar could not reach the host proxy.`,
+    );
+  }
 
-  if (result.exitCode !== 0) {
-    throw new Error(
-      `Internal network connectivity check failed (exit=${result.exitCode}). ` +
-        `The container cannot reach host-side proxies via the socat sidecar on the --internal Docker network. ` +
-        `Check that the sidecar container is running and connected to the internal network.`,
+  const healthRequest =
+    'GET http://ironcurtain.invalid/__ironcurtain/health HTTP/1.1\\r\\n' +
+    'Host: ironcurtain.invalid\\r\\nConnection: close\\r\\n\\r\\n';
+  const mitmResult = await docker.exec(
+    containerId,
+    [
+      '/bin/sh',
+      '-c',
+      `printf '${healthRequest}' | socat -T5 - TCP:${DOCKER_HOST_GATEWAY}:${mitmPort},connect-timeout=5 | grep -q 'IRONCURTAIN_OK/1'`,
+    ],
+    6_000,
+  );
+  if (mitmResult.exitCode !== 0) {
+    throw new InternalNetworkConnectivityError(
+      `Internal network connectivity check failed: MITM round-trip exited ${mitmResult.exitCode}; ` +
+        `the sidecar could not reach the host proxy.`,
     );
   }
 }

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -11,7 +11,15 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import type { ContainerRuntime, DockerContainerConfig, DockerExecResult, DockerImageInfo } from './types.js';
+import type {
+  ContainerRuntime,
+  DockerContainerConfig,
+  DockerContainerInfo,
+  DockerExecResult,
+  DockerImageInfo,
+  DockerNetworkCreateOptions,
+  DockerNetworkInfo,
+} from './types.js';
 import * as logger from '../logger.js';
 import { checkDockerAvailable, type DockerAvailability } from './docker-probe.js';
 import { isExecError, isExecTimeout } from '../utils/exec-error.js';
@@ -65,6 +73,13 @@ const STOP_TIMEOUT_SECONDS = 10;
 export const IRONCURTAIN_LABEL_BUNDLE = 'ironcurtain.bundle';
 export const IRONCURTAIN_LABEL_WORKFLOW = 'ironcurtain.workflow';
 export const IRONCURTAIN_LABEL_SCOPE = 'ironcurtain.scope';
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -229,6 +244,9 @@ export function buildCreateArgs(config: DockerContainerConfig): string[] {
   }
   if (config.scopeLabel !== undefined) {
     args.push('--label', `${IRONCURTAIN_LABEL_SCOPE}=${config.scopeLabel}`);
+  }
+  for (const [key, value] of Object.entries(config.labels ?? {})) {
+    args.push('--label', `${key}=${value}`);
   }
 
   if (config.resources?.memoryMb) {
@@ -635,21 +653,87 @@ export function createDockerManager(
       }
     },
 
-    async createNetwork(
-      name: string,
-      options?: { internal?: boolean; subnet?: string; gateway?: string },
-    ): Promise<void> {
+    async createNetwork(name: string, options?: DockerNetworkCreateOptions): Promise<void> {
       try {
         const args = ['network', 'create'];
         if (options?.internal) args.push('--internal');
         if (options?.subnet) args.push('--subnet', options.subnet);
         if (options?.gateway) args.push('--gateway', options.gateway);
+        for (const [key, value] of Object.entries(options?.labels ?? {})) {
+          args.push('--label', `${key}=${value}`);
+        }
         args.push(name);
         await exec('docker', args, { timeout: 10_000 });
       } catch (err: unknown) {
         if (isExecError(err) && err.stderr.includes('already exists')) return;
         throw err;
       }
+    },
+
+    async listNetworks(): Promise<readonly DockerNetworkInfo[]> {
+      const { stdout: idsOut } = await exec('docker', ['network', 'ls', '--no-trunc', '--quiet'], {
+        timeout: 10_000,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const ids = idsOut
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+      if (ids.length === 0) return [];
+      const { stdout } = await exec('docker', ['network', 'inspect', ...ids], {
+        timeout: 30_000,
+        maxBuffer: 50 * 1024 * 1024,
+      });
+      const parsed = JSON.parse(stdout) as unknown;
+      if (!Array.isArray(parsed)) throw new Error('Unexpected docker network inspect result: expected array');
+      return parsed.filter(isRecord).map((entry): DockerNetworkInfo => {
+        const ipam = isRecord(entry.IPAM) && Array.isArray(entry.IPAM.Config) ? entry.IPAM.Config : [];
+        const subnets = ipam
+          .filter(isRecord)
+          .map((config) => config.Subnet)
+          .filter((subnet): subnet is string => typeof subnet === 'string');
+        const containers = isRecord(entry.Containers) ? entry.Containers : {};
+        return {
+          id: typeof entry.Id === 'string' ? entry.Id : '',
+          name: typeof entry.Name === 'string' ? entry.Name : '',
+          created: typeof entry.Created === 'string' ? entry.Created : '',
+          labels: stringRecord(entry.Labels),
+          subnets,
+          containerIds: Object.keys(containers),
+        };
+      });
+    },
+
+    async listContainers(options?: { readonly labelFilter?: string }): Promise<readonly DockerContainerInfo[]> {
+      const args = ['container', 'ls', '--all', '--no-trunc', '--quiet'];
+      if (options?.labelFilter) args.push('--filter', `label=${options.labelFilter}`);
+      const { stdout: idsOut } = await exec('docker', args, {
+        timeout: 10_000,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const ids = idsOut
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+      if (ids.length === 0) return [];
+      const { stdout } = await exec('docker', ['container', 'inspect', ...ids], {
+        timeout: 30_000,
+        maxBuffer: 50 * 1024 * 1024,
+      });
+      const parsed = JSON.parse(stdout) as unknown;
+      if (!Array.isArray(parsed)) throw new Error('Unexpected docker container inspect result: expected array');
+      return parsed.filter(isRecord).map((entry): DockerContainerInfo => {
+        const config = isRecord(entry.Config) ? entry.Config : {};
+        const state = isRecord(entry.State) ? entry.State : {};
+        const rawName = typeof entry.Name === 'string' ? entry.Name : '';
+        return {
+          id: typeof entry.Id === 'string' ? entry.Id : '',
+          name: rawName.startsWith('/') ? rawName.slice(1) : rawName,
+          created: typeof entry.Created === 'string' ? entry.Created : '',
+          running: state.Running === true,
+          labels: stringRecord(config.Labels),
+        };
+      });
     },
 
     async removeNetwork(name: string): Promise<void> {
@@ -664,6 +748,15 @@ export function createDockerManager(
         if (isExecError(err) && /not found|no such network/i.test(err.stderr)) return;
         const detail = isExecError(err) ? err.stderr.trim() || err.message : String(err);
         logger.warn(`removeNetwork: failed to remove "${name}": ${detail}`);
+      }
+    },
+
+    async networkExists(name: string): Promise<boolean> {
+      try {
+        await exec('docker', ['network', 'inspect', name], { timeout: 5_000 });
+        return true;
+      } catch {
+        return false;
       }
     },
 

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -85,6 +85,35 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+async function inspectDockerObjects(
+  exec: ExecFileFn,
+  kind: 'network' | 'container',
+  ids: readonly string[],
+): Promise<readonly Record<string, unknown>[]> {
+  if (ids.length === 0) return [];
+  try {
+    const { stdout } = await exec('docker', [kind, 'inspect', ...ids], {
+      timeout: 30_000,
+      maxBuffer: 50 * 1024 * 1024,
+    });
+    const parsed = JSON.parse(stdout) as unknown;
+    if (!Array.isArray(parsed)) throw new Error(`Unexpected docker ${kind} inspect result: expected array`);
+    return parsed.filter(isRecord);
+  } catch (error) {
+    const disappeared = isExecError(error) && /not found|no such (?:network|container|object)/i.test(error.stderr);
+    if (!disappeared) throw error;
+    if (ids.length === 1) return [];
+
+    // A resource disappeared between `docker ... ls` and inspect. Split the
+    // failed batch to retain every object that still exists without masking
+    // unrelated daemon/permission failures.
+    const middle = Math.ceil(ids.length / 2);
+    const left = await inspectDockerObjects(exec, kind, ids.slice(0, middle));
+    const right = await inspectDockerObjects(exec, kind, ids.slice(middle));
+    return [...left, ...right];
+  }
+}
+
 function parseDockerImageInfo(raw: unknown): DockerImageInfo {
   if (!isRecord(raw)) {
     throw new Error('Unexpected docker image inspect result: expected object');
@@ -680,13 +709,8 @@ export function createDockerManager(
         .map((line) => line.trim())
         .filter(Boolean);
       if (ids.length === 0) return [];
-      const { stdout } = await exec('docker', ['network', 'inspect', ...ids], {
-        timeout: 30_000,
-        maxBuffer: 50 * 1024 * 1024,
-      });
-      const parsed = JSON.parse(stdout) as unknown;
-      if (!Array.isArray(parsed)) throw new Error('Unexpected docker network inspect result: expected array');
-      return parsed.filter(isRecord).map((entry): DockerNetworkInfo => {
+      const inspected = await inspectDockerObjects(exec, 'network', ids);
+      return inspected.map((entry): DockerNetworkInfo => {
         const ipam = isRecord(entry.IPAM) && Array.isArray(entry.IPAM.Config) ? entry.IPAM.Config : [];
         const subnets = ipam
           .filter(isRecord)
@@ -716,13 +740,8 @@ export function createDockerManager(
         .map((line) => line.trim())
         .filter(Boolean);
       if (ids.length === 0) return [];
-      const { stdout } = await exec('docker', ['container', 'inspect', ...ids], {
-        timeout: 30_000,
-        maxBuffer: 50 * 1024 * 1024,
-      });
-      const parsed = JSON.parse(stdout) as unknown;
-      if (!Array.isArray(parsed)) throw new Error('Unexpected docker container inspect result: expected array');
-      return parsed.filter(isRecord).map((entry): DockerContainerInfo => {
+      const inspected = await inspectDockerObjects(exec, 'container', ids);
+      return inspected.map((entry): DockerContainerInfo => {
         const config = isRecord(entry.Config) ? entry.Config : {};
         const state = isRecord(entry.State) ? entry.State : {};
         const rawName = typeof entry.Name === 'string' ? entry.Name : '';

--- a/src/docker/docker-resource-lifecycle.ts
+++ b/src/docker/docker-resource-lifecycle.ts
@@ -1,0 +1,419 @@
+/**
+ * Crash-safe ownership, reconciliation, and IPv4 allocation for Docker
+ * resources created by IronCurtain.
+ *
+ * Docker intentionally outlives its CLI clients. A killed IronCurtain process
+ * therefore leaves containers and networks behind unless a later process can
+ * prove ownership and reclaim them. Labels plus a host-side owner lease provide
+ * that proof without confusing a concurrently-starting empty network for an
+ * orphan.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { closeSync, mkdirSync, openSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { networkInterfaces } from 'node:os';
+import { resolve } from 'node:path';
+import { getIronCurtainHome } from '../config/paths.js';
+import * as logger from '../logger.js';
+import { isExecError } from '../utils/exec-error.js';
+import type { BundleId } from '../session/types.js';
+import type { ContainerRuntime, DockerNetworkInfo } from './types.js';
+
+export const IRONCURTAIN_MANAGED_LABEL = 'ironcurtain.managed';
+export const IRONCURTAIN_OWNER_PID_LABEL = 'ironcurtain.owner-pid';
+export const IRONCURTAIN_OWNER_TOKEN_LABEL = 'ironcurtain.owner-token';
+export const IRONCURTAIN_CREATED_AT_LABEL = 'ironcurtain.created-at';
+export const IRONCURTAIN_RESOURCE_SCHEMA_LABEL = 'ironcurtain.resource-schema';
+const IRONCURTAIN_BUNDLE_LABEL = 'ironcurtain.bundle';
+const RESOURCE_SCHEMA = '1';
+// Current bundle slugs are 12 hex digits; pre-identity-refactor names used a
+// raw UUID substring and therefore contain a hyphen after eight digits.
+const LEGACY_NETWORK_RE = /^ironcurtain-(?:[a-f0-9]{12}|[a-f0-9]{8}-[a-f0-9]{3})$/;
+const LEGACY_EMPTY_NETWORK_GRACE_MS = 2 * 60_000;
+
+interface OwnerLease {
+  readonly token: string;
+  readonly pid: number;
+  readonly path: string;
+}
+
+const ownerLeases = new Map<string, OwnerLease>();
+let exitHookInstalled = false;
+
+function leaseRoot(): string {
+  return resolve(getIronCurtainHome(), 'run', 'docker-owners');
+}
+
+function installExitHook(): void {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  process.once('exit', () => {
+    for (const lease of ownerLeases.values()) {
+      try {
+        unlinkSync(lease.path);
+      } catch {
+        // A crash reconciler may already have removed it.
+      }
+    }
+  });
+}
+
+function ownerLeaseKey(root: string, bundleId: string): string {
+  return `${root}\0${bundleId}`;
+}
+
+function getOwnerLease(bundleId: string): OwnerLease {
+  const root = leaseRoot();
+  const key = ownerLeaseKey(root, bundleId);
+  const existing = ownerLeases.get(key);
+  if (existing) return existing;
+
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  const token = randomUUID();
+  const path = resolve(root, `${token}.json`);
+  const lease = { token, pid: process.pid, path };
+  writeFileSync(path, JSON.stringify({ token, pid: process.pid, bundleId, createdAt: new Date().toISOString() }), {
+    mode: 0o600,
+    flag: 'wx',
+  });
+  ownerLeases.set(key, lease);
+  installExitHook();
+  return lease;
+}
+
+/** Labels stamped on every managed container and network. */
+export function managedResourceLabels(bundleId: BundleId | string): Record<string, string> {
+  const lease = getOwnerLease(bundleId);
+  return {
+    [IRONCURTAIN_MANAGED_LABEL]: 'true',
+    [IRONCURTAIN_BUNDLE_LABEL]: bundleId,
+    [IRONCURTAIN_OWNER_PID_LABEL]: String(lease.pid),
+    [IRONCURTAIN_OWNER_TOKEN_LABEL]: lease.token,
+    [IRONCURTAIN_CREATED_AT_LABEL]: new Date().toISOString(),
+    [IRONCURTAIN_RESOURCE_SCHEMA_LABEL]: RESOURCE_SCHEMA,
+  };
+}
+
+/** Marks a completed/failed bundle as no longer live so same-process GC can reclaim a failed teardown. */
+export function releaseManagedResourceLease(bundleId: BundleId | string): void {
+  const root = leaseRoot();
+  const key = ownerLeaseKey(root, bundleId);
+  const lease = ownerLeases.get(key);
+  if (!lease) return;
+  ownerLeases.delete(key);
+  try {
+    unlinkSync(lease.path);
+  } catch {
+    // Already reclaimed or removed during shutdown.
+  }
+}
+
+function defaultPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function ownerIsAlive(
+  labels: Readonly<Record<string, string>>,
+  pidAlive: (pid: number) => boolean,
+  root = leaseRoot(),
+): boolean {
+  const pid = Number(labels[IRONCURTAIN_OWNER_PID_LABEL]);
+  const token = labels[IRONCURTAIN_OWNER_TOKEN_LABEL];
+  if (!Number.isSafeInteger(pid) || pid <= 0 || !token || !pidAlive(pid)) return false;
+  try {
+    const lease = JSON.parse(readFileSync(resolve(root, `${token}.json`), 'utf8')) as {
+      token?: unknown;
+      pid?: unknown;
+    };
+    return lease.token === token && lease.pid === pid;
+  } catch {
+    return false;
+  }
+}
+
+interface ReconcileOptions {
+  readonly dryRun?: boolean;
+  readonly now?: Date;
+  readonly pidAlive?: (pid: number) => boolean;
+  readonly legacyGraceMs?: number;
+}
+
+export interface ReconcileResult {
+  readonly removedContainers: readonly string[];
+  readonly removedNetworks: readonly string[];
+  readonly retainedActiveResources: number;
+  readonly skippedUnsafeNetworks: readonly string[];
+}
+
+function resourceAgeMs(created: string, now: Date): number {
+  const timestamp = Date.parse(created);
+  return Number.isFinite(timestamp) ? Math.max(0, now.getTime() - timestamp) : Number.POSITIVE_INFINITY;
+}
+
+async function withReconcileLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  const root = leaseRoot();
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  const lockPath = resolve(root, 'reconcile.lock');
+  let fd: number | undefined;
+  try {
+    try {
+      fd = openSync(lockPath, 'wx', 0o600);
+      writeFileSync(fd, JSON.stringify({ pid: process.pid }));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      try {
+        const owner = JSON.parse(readFileSync(lockPath, 'utf8')) as { pid?: unknown };
+        if (typeof owner.pid === 'number' && defaultPidAlive(owner.pid)) return undefined;
+      } catch {
+        // Invalid/stale lock: replace it below.
+      }
+      rmSync(lockPath, { force: true });
+      fd = openSync(lockPath, 'wx', 0o600);
+      writeFileSync(fd, JSON.stringify({ pid: process.pid }));
+    }
+    return await fn();
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    if (fd !== undefined) rmSync(lockPath, { force: true });
+  }
+}
+
+/**
+ * Reclaims resources whose owner process is gone. Unlabeled legacy networks
+ * are reclaimed only when empty and old enough; attached legacy resources are
+ * deliberately left for an explicit operator action because ownership cannot
+ * be proven safely.
+ */
+export async function reconcileIronCurtainDockerResources(
+  docker: ContainerRuntime,
+  options: ReconcileOptions = {},
+): Promise<ReconcileResult> {
+  const empty: ReconcileResult = {
+    removedContainers: [],
+    removedNetworks: [],
+    retainedActiveResources: 0,
+    skippedUnsafeNetworks: [],
+  };
+  if (!docker.listNetworks || !docker.listContainers) return empty;
+
+  const result = await withReconcileLock(async (): Promise<ReconcileResult> => {
+    const pidAlive = options.pidAlive ?? defaultPidAlive;
+    const now = options.now ?? new Date();
+    const removedContainers: string[] = [];
+    const removedNetworks: string[] = [];
+    const skippedUnsafeNetworks: string[] = [];
+    const deadOwnerTokens = new Set<string>();
+    let retainedActiveResources = 0;
+
+    const managedContainers = await docker.listContainers?.({ labelFilter: `${IRONCURTAIN_MANAGED_LABEL}=true` });
+    for (const container of managedContainers ?? []) {
+      if (ownerIsAlive(container.labels, pidAlive)) {
+        retainedActiveResources++;
+        continue;
+      }
+      const ownerToken = container.labels[IRONCURTAIN_OWNER_TOKEN_LABEL];
+      if (ownerToken) deadOwnerTokens.add(ownerToken);
+      logger.warn(`[docker-gc] reclaiming orphaned container ${container.name}`);
+      if (!options.dryRun) {
+        await docker.remove(container.id);
+        if (await docker.containerExists(container.id)) {
+          logger.warn(`[docker-gc] container ${container.name} still exists after forced removal`);
+          continue;
+        }
+      }
+      removedContainers.push(container.name);
+    }
+
+    const removedContainerIds = new Set(
+      (managedContainers ?? [])
+        .filter((container) => removedContainers.includes(container.name))
+        .map((container) => container.id),
+    );
+    const networks = await docker.listNetworks?.();
+    for (const network of networks ?? []) {
+      const managed = network.labels[IRONCURTAIN_MANAGED_LABEL] === 'true';
+      const legacy = !managed && LEGACY_NETWORK_RE.test(network.name);
+      if (!managed && !legacy) continue;
+
+      if (managed && ownerIsAlive(network.labels, pidAlive)) {
+        retainedActiveResources++;
+        continue;
+      }
+      const ownerToken = network.labels[IRONCURTAIN_OWNER_TOKEN_LABEL];
+      if (managed && ownerToken) deadOwnerTokens.add(ownerToken);
+      if (legacy) {
+        const graceMs = options.legacyGraceMs ?? LEGACY_EMPTY_NETWORK_GRACE_MS;
+        if (network.containerIds.length > 0 || resourceAgeMs(network.created, now) < graceMs) {
+          skippedUnsafeNetworks.push(network.name);
+          continue;
+        }
+      }
+
+      const survivingAttachments = network.containerIds.filter((id) => !removedContainerIds.has(id));
+      if (survivingAttachments.length > 0) {
+        logger.warn(`[docker-gc] refusing to remove ${network.name}: it has non-orphan attachments`);
+        skippedUnsafeNetworks.push(network.name);
+        continue;
+      }
+      logger.warn(`[docker-gc] reclaiming orphaned network ${network.name}`);
+      if (!options.dryRun) {
+        await docker.removeNetwork(network.name);
+        if (docker.networkExists && (await docker.networkExists(network.name))) {
+          logger.warn(`[docker-gc] network ${network.name} still exists after removal`);
+          continue;
+        }
+      }
+      removedNetworks.push(network.name);
+    }
+
+    if (!options.dryRun) {
+      for (const token of deadOwnerTokens) rmSync(resolve(leaseRoot(), `${token}.json`), { force: true });
+    }
+
+    return { removedContainers, removedNetworks, retainedActiveResources, skippedUnsafeNetworks };
+  });
+  return result ?? empty;
+}
+
+interface Ipv4Cidr {
+  readonly network: number;
+  readonly prefix: number;
+}
+
+function ipv4ToNumber(address: string): number | undefined {
+  const octets = address.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return undefined;
+  }
+  return (((octets[0] << 24) >>> 0) + (octets[1] << 16) + (octets[2] << 8) + octets[3]) >>> 0;
+}
+
+function numberToIpv4(value: number): string {
+  return [value >>> 24, (value >>> 16) & 255, (value >>> 8) & 255, value & 255].join('.');
+}
+
+function parseIpv4Cidr(value: string): Ipv4Cidr | undefined {
+  const [address, rawPrefix] = value.split('/');
+  const prefix = Number(rawPrefix);
+  const ip = ipv4ToNumber(address);
+  if (ip === undefined || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) return undefined;
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return { network: (ip & mask) >>> 0, prefix };
+}
+
+function cidrsOverlap(left: Ipv4Cidr, right: Ipv4Cidr): boolean {
+  const prefix = Math.min(left.prefix, right.prefix);
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (left.network & mask) === (right.network & mask);
+}
+
+export function hostInterfaceIpv4Cidrs(): readonly string[] {
+  return Object.values(networkInterfaces())
+    .flatMap((entries) => entries ?? [])
+    .filter((entry) => entry.family === 'IPv4' && entry.cidr)
+    .map((entry) => entry.cidr as string);
+}
+
+const DOCKER_SUBNET_PREFIX = 29;
+const ADDRESS_POOLS = ['172.20.0.0/14', '172.24.0.0/14', '172.28.0.0/14', '10.240.0.0/12'] as const;
+
+/** Returns the allocator pool containing a selected /29. */
+export function dockerAllocationPoolForSubnet(subnet: string): string {
+  const candidate = parseIpv4Cidr(subnet);
+  if (!candidate) return subnet;
+  return (
+    ADDRESS_POOLS.find((pool) => {
+      const parsed = parseIpv4Cidr(pool);
+      return parsed !== undefined && cidrsOverlap(candidate, parsed);
+    }) ?? subnet
+  );
+}
+
+function* candidateSubnets(name: string): Generator<string> {
+  const seed = createHash('sha256').update(name).digest().readUInt32BE(0);
+  for (const poolValue of ADDRESS_POOLS) {
+    const pool = parseIpv4Cidr(poolValue);
+    if (!pool) continue;
+    const count = 2 ** (DOCKER_SUBNET_PREFIX - pool.prefix);
+    const offset = seed % count;
+    const blockSize = 2 ** (32 - DOCKER_SUBNET_PREFIX);
+    for (let index = 0; index < count; index++) {
+      const block = (pool.network + ((offset + index) % count) * blockSize) >>> 0;
+      yield `${numberToIpv4(block)}/${DOCKER_SUBNET_PREFIX}`;
+    }
+  }
+}
+
+function allocationConflict(error: unknown): boolean {
+  if (!isExecError(error)) return false;
+  return /overlap|address pool|fully subnetted|pool.*exhaust|no available network/i.test(error.stderr);
+}
+
+export interface AllocatedInternalNetwork {
+  readonly name: string;
+  readonly subnet: string;
+}
+
+/** Allocates a small internal subnet while never falling back into 192.168/16. */
+export async function createIronCurtainInternalNetwork(
+  docker: ContainerRuntime,
+  name: string,
+  bundleId: BundleId | string,
+  options: {
+    readonly excludedSubnets?: ReadonlySet<string>;
+    readonly hostCidrs?: readonly string[];
+  } = {},
+): Promise<AllocatedInternalNetwork> {
+  const networks = (await docker.listNetworks?.()) ?? [];
+  const sameNamedNetwork = networks.find((network) => network.name === name);
+  if (sameNamedNetwork) {
+    throw new Error(
+      `Docker network ${name} already exists (${sameNamedNetwork.subnets.join(', ') || 'unknown subnet'}). ` +
+        `Refusing to reuse it because its requested ownership/subnet cannot be verified.`,
+    );
+  }
+  const occupied = [
+    ...networks.flatMap((network: DockerNetworkInfo) => network.subnets),
+    ...(options.hostCidrs ?? hostInterfaceIpv4Cidrs()),
+  ]
+    .map(parseIpv4Cidr)
+    .filter((cidr): cidr is Ipv4Cidr => cidr !== undefined);
+  const excluded = [...(options.excludedSubnets ?? [])]
+    .map(parseIpv4Cidr)
+    .filter((cidr): cidr is Ipv4Cidr => cidr !== undefined);
+
+  let lastConflict: unknown;
+  for (const subnet of candidateSubnets(name)) {
+    const candidate = parseIpv4Cidr(subnet);
+    if (
+      !candidate ||
+      excluded.some((cidr) => cidrsOverlap(candidate, cidr)) ||
+      occupied.some((cidr) => cidrsOverlap(candidate, cidr))
+    ) {
+      continue;
+    }
+    try {
+      await docker.createNetwork(name, {
+        internal: true,
+        subnet,
+        labels: managedResourceLabels(bundleId),
+      });
+      return { name, subnet };
+    } catch (error) {
+      if (!allocationConflict(error)) throw error;
+      lastConflict = error;
+      occupied.push(candidate);
+    }
+  }
+
+  throw new Error(
+    `No collision-free IronCurtain Docker subnet is available for ${name}. ` +
+      `Reconciled the managed resources and searched /29 networks outside 192.168.0.0/16.`,
+    { cause: lastConflict },
+  );
+}

--- a/src/docker/docker-resource-lifecycle.ts
+++ b/src/docker/docker-resource-lifecycle.ts
@@ -10,8 +10,9 @@
  */
 
 import { createHash, randomUUID } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { closeSync, mkdirSync, openSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
-import { networkInterfaces } from 'node:os';
+import { networkInterfaces, platform } from 'node:os';
 import { resolve } from 'node:path';
 import { getIronCurtainHome } from '../config/paths.js';
 import * as logger from '../logger.js';
@@ -25,7 +26,7 @@ export const IRONCURTAIN_OWNER_TOKEN_LABEL = 'ironcurtain.owner-token';
 export const IRONCURTAIN_CREATED_AT_LABEL = 'ironcurtain.created-at';
 export const IRONCURTAIN_RESOURCE_SCHEMA_LABEL = 'ironcurtain.resource-schema';
 const IRONCURTAIN_BUNDLE_LABEL = 'ironcurtain.bundle';
-const RESOURCE_SCHEMA = '1';
+const RESOURCE_SCHEMA = '2';
 // Current bundle slugs are 12 hex digits; pre-identity-refactor names used a
 // raw UUID substring and therefore contain a hyphen after eight digits.
 const LEGACY_NETWORK_RE = /^ironcurtain-(?:[a-f0-9]{12}|[a-f0-9]{8}-[a-f0-9]{3})$/;
@@ -34,11 +35,56 @@ const LEGACY_EMPTY_NETWORK_GRACE_MS = 2 * 60_000;
 interface OwnerLease {
   readonly token: string;
   readonly pid: number;
+  readonly identity: ProcessIdentity;
   readonly path: string;
+}
+
+export interface ProcessIdentity {
+  /** Stable for a single host boot, preventing a pre-reboot lease from matching. */
+  readonly bootId: string;
+  /** OS-reported process start time, preventing a recycled PID from matching. */
+  readonly startedAt: string;
 }
 
 const ownerLeases = new Map<string, OwnerLease>();
 let exitHookInstalled = false;
+let cachedBootId: string | undefined;
+
+function currentBootId(): string {
+  if (cachedBootId) return cachedBootId;
+  try {
+    if (platform() === 'linux') {
+      cachedBootId = readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim();
+    } else if (platform() === 'darwin') {
+      const bootTime = execFileSync('sysctl', ['-n', 'kern.boottime'], {
+        encoding: 'utf8',
+        timeout: 1_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const match = bootTime.match(/sec\s*=\s*(\d+),\s*usec\s*=\s*(\d+)/);
+      if (match) cachedBootId = `darwin:${match[1]}.${match[2]}`;
+    }
+  } catch {
+    // Process start time remains sufficient to distinguish recycled PIDs.
+  }
+  cachedBootId ||= `${platform()}:unknown-boot`;
+  return cachedBootId;
+}
+
+function defaultProcessIdentity(pid: number): ProcessIdentity | undefined {
+  try {
+    const startedAt = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf8',
+      timeout: 1_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      env: { ...process.env, LC_ALL: 'C', TZ: 'UTC' },
+    }).trim();
+    if (!startedAt) return undefined;
+    return { bootId: currentBootId(), startedAt };
+  } catch {
+    return undefined;
+  }
+}
 
 function leaseRoot(): string {
   return resolve(getIronCurtainHome(), 'run', 'docker-owners');
@@ -71,11 +117,14 @@ function getOwnerLease(bundleId: string): OwnerLease {
   mkdirSync(root, { recursive: true, mode: 0o700 });
   const token = randomUUID();
   const path = resolve(root, `${token}.json`);
-  const lease = { token, pid: process.pid, path };
-  writeFileSync(path, JSON.stringify({ token, pid: process.pid, bundleId, createdAt: new Date().toISOString() }), {
-    mode: 0o600,
-    flag: 'wx',
-  });
+  const identity = defaultProcessIdentity(process.pid);
+  if (!identity) throw new Error(`Unable to determine the identity of owner process ${process.pid}`);
+  const lease = { token, pid: process.pid, identity, path };
+  writeFileSync(
+    path,
+    JSON.stringify({ token, pid: process.pid, identity, bundleId, createdAt: new Date().toISOString() }),
+    { mode: 0o600, flag: 'wx' },
+  );
   ownerLeases.set(key, lease);
   installExitHook();
   return lease;
@@ -120,6 +169,7 @@ function defaultPidAlive(pid: number): boolean {
 function ownerIsAlive(
   labels: Readonly<Record<string, string>>,
   pidAlive: (pid: number) => boolean,
+  processIdentity: (pid: number) => ProcessIdentity | undefined,
   root = leaseRoot(),
 ): boolean {
   const pid = Number(labels[IRONCURTAIN_OWNER_PID_LABEL]);
@@ -129,8 +179,22 @@ function ownerIsAlive(
     const lease = JSON.parse(readFileSync(resolve(root, `${token}.json`), 'utf8')) as {
       token?: unknown;
       pid?: unknown;
+      identity?: Partial<ProcessIdentity>;
     };
-    return lease.token === token && lease.pid === pid;
+    if (
+      lease.token !== token ||
+      lease.pid !== pid ||
+      typeof lease.identity?.bootId !== 'string' ||
+      typeof lease.identity.startedAt !== 'string'
+    ) {
+      return false;
+    }
+    const currentIdentity = processIdentity(pid);
+    return (
+      currentIdentity !== undefined &&
+      currentIdentity.bootId === lease.identity.bootId &&
+      currentIdentity.startedAt === lease.identity.startedAt
+    );
   } catch {
     return false;
   }
@@ -140,6 +204,7 @@ interface ReconcileOptions {
   readonly dryRun?: boolean;
   readonly now?: Date;
   readonly pidAlive?: (pid: number) => boolean;
+  readonly processIdentity?: (pid: number) => ProcessIdentity | undefined;
   readonly legacyGraceMs?: number;
 }
 
@@ -155,7 +220,10 @@ function resourceAgeMs(created: string, now: Date): number {
   return Number.isFinite(timestamp) ? Math.max(0, now.getTime() - timestamp) : Number.POSITIVE_INFINITY;
 }
 
-async function withReconcileLock<T>(fn: () => Promise<T>): Promise<T | undefined> {
+async function withReconcileLock<T>(
+  fn: () => Promise<T>,
+  processIdentity: (pid: number) => ProcessIdentity | undefined,
+): Promise<T | undefined> {
   const root = leaseRoot();
   mkdirSync(root, { recursive: true, mode: 0o700 });
   const lockPath = resolve(root, 'reconcile.lock');
@@ -163,18 +231,31 @@ async function withReconcileLock<T>(fn: () => Promise<T>): Promise<T | undefined
   try {
     try {
       fd = openSync(lockPath, 'wx', 0o600);
-      writeFileSync(fd, JSON.stringify({ pid: process.pid }));
+      writeFileSync(fd, JSON.stringify({ pid: process.pid, identity: processIdentity(process.pid) }));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
       try {
-        const owner = JSON.parse(readFileSync(lockPath, 'utf8')) as { pid?: unknown };
-        if (typeof owner.pid === 'number' && defaultPidAlive(owner.pid)) return undefined;
+        const owner = JSON.parse(readFileSync(lockPath, 'utf8')) as {
+          pid?: unknown;
+          identity?: Partial<ProcessIdentity>;
+        };
+        const currentIdentity = typeof owner.pid === 'number' ? processIdentity(owner.pid) : undefined;
+        if (
+          typeof owner.pid === 'number' &&
+          defaultPidAlive(owner.pid) &&
+          currentIdentity !== undefined &&
+          owner.identity !== undefined &&
+          currentIdentity.bootId === owner.identity.bootId &&
+          currentIdentity.startedAt === owner.identity.startedAt
+        ) {
+          return undefined;
+        }
       } catch {
         // Invalid/stale lock: replace it below.
       }
       rmSync(lockPath, { force: true });
       fd = openSync(lockPath, 'wx', 0o600);
-      writeFileSync(fd, JSON.stringify({ pid: process.pid }));
+      writeFileSync(fd, JSON.stringify({ pid: process.pid, identity: processIdentity(process.pid) }));
     }
     return await fn();
   } finally {
@@ -201,6 +282,12 @@ export async function reconcileIronCurtainDockerResources(
   };
   if (!docker.listNetworks || !docker.listContainers) return empty;
 
+  const identityProbe = options.processIdentity ?? defaultProcessIdentity;
+  const identityCache = new Map<number, ProcessIdentity | undefined>();
+  const processIdentity = (pid: number): ProcessIdentity | undefined => {
+    if (!identityCache.has(pid)) identityCache.set(pid, identityProbe(pid));
+    return identityCache.get(pid);
+  };
   const result = await withReconcileLock(async (): Promise<ReconcileResult> => {
     const pidAlive = options.pidAlive ?? defaultPidAlive;
     const now = options.now ?? new Date();
@@ -212,7 +299,7 @@ export async function reconcileIronCurtainDockerResources(
 
     const managedContainers = await docker.listContainers?.({ labelFilter: `${IRONCURTAIN_MANAGED_LABEL}=true` });
     for (const container of managedContainers ?? []) {
-      if (ownerIsAlive(container.labels, pidAlive)) {
+      if (ownerIsAlive(container.labels, pidAlive, processIdentity)) {
         retainedActiveResources++;
         continue;
       }
@@ -240,7 +327,7 @@ export async function reconcileIronCurtainDockerResources(
       const legacy = !managed && LEGACY_NETWORK_RE.test(network.name);
       if (!managed && !legacy) continue;
 
-      if (managed && ownerIsAlive(network.labels, pidAlive)) {
+      if (managed && ownerIsAlive(network.labels, pidAlive, processIdentity)) {
         retainedActiveResources++;
         continue;
       }
@@ -276,8 +363,22 @@ export async function reconcileIronCurtainDockerResources(
     }
 
     return { removedContainers, removedNetworks, retainedActiveResources, skippedUnsafeNetworks };
-  });
+  }, processIdentity);
   return result ?? empty;
+}
+
+/** Startup/retry reconciliation must never become a Docker session prerequisite. */
+export async function reconcileIronCurtainDockerResourcesBestEffort(
+  docker: ContainerRuntime,
+  context: string,
+): Promise<void> {
+  try {
+    await reconcileIronCurtainDockerResources(docker);
+  } catch (error) {
+    logger.warn(
+      `[docker-gc] ${context} reconciliation skipped: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 interface Ipv4Cidr {
@@ -332,6 +433,46 @@ export function dockerAllocationPoolForSubnet(subnet: string): string {
       return parsed !== undefined && cidrsOverlap(candidate, parsed);
     }) ?? subnet
   );
+}
+
+export class InternalNetworkConnectivityError extends Error {
+  constructor(
+    message: string,
+    readonly subnet?: string,
+  ) {
+    super(message);
+    this.name = 'InternalNetworkConnectivityError';
+  }
+}
+
+export async function withInternalNetworkAllocationRetry<T>(
+  options: {
+    readonly maxAttempts: number;
+    readonly description: string;
+    readonly reconcile?: () => Promise<void>;
+  },
+  runAttempt: (excludedSubnets: ReadonlySet<string>, attempt: number) => Promise<T>,
+): Promise<T> {
+  const excludedSubnets = new Set<string>();
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      return await runAttempt(excludedSubnets, attempt);
+    } catch (error) {
+      lastError = error;
+      if (!(error instanceof InternalNetworkConnectivityError) || !error.subnet || attempt === options.maxAttempts) {
+        throw error;
+      }
+      const rejectedPool = dockerAllocationPoolForSubnet(error.subnet);
+      excludedSubnets.add(rejectedPool);
+      logger.warn(
+        `${options.description} ${error.subnet} failed its end-to-end checks; rejecting ${rejectedPool} and ` +
+          `retrying with another allocation (${attempt}/${options.maxAttempts})`,
+      );
+      await options.reconcile?.();
+    }
+  }
+  throw lastError;
 }
 
 function* candidateSubnets(name: string): Generator<string> {

--- a/src/docker/gc-command.ts
+++ b/src/docker/gc-command.ts
@@ -1,0 +1,40 @@
+import { parseArgs } from 'node:util';
+import { createDockerManager } from './docker-manager.js';
+import { reconcileIronCurtainDockerResources } from './docker-resource-lifecycle.js';
+
+/** Explicit operator surface for inspecting or applying the startup reconciler. */
+export async function runDockerGcCommand(args: readonly string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: [...args],
+    options: {
+      'dry-run': { type: 'boolean' },
+      force: { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+  });
+  if (values.help) {
+    process.stdout.write(
+      'Usage: ironcurtain gc [--dry-run | --force]\n\n' +
+        'Lists crash-orphaned IronCurtain Docker resources by default.\n' +
+        'Use --force to remove resources whose owner process is no longer alive.\n',
+    );
+    return;
+  }
+  if (values.force && values['dry-run']) throw new Error('Choose either --dry-run or --force, not both');
+
+  const apply = values.force === true;
+  const result = await reconcileIronCurtainDockerResources(createDockerManager(), { dryRun: !apply });
+  const verb = apply ? 'Reclaimed' : 'Would reclaim';
+  process.stdout.write(
+    `${verb} ${result.removedContainers.length} container(s) and ${result.removedNetworks.length} network(s).\n`,
+  );
+  for (const name of result.removedContainers) process.stdout.write(`  container ${name}\n`);
+  for (const name of result.removedNetworks) process.stdout.write(`  network   ${name}\n`);
+  if (result.skippedUnsafeNetworks.length > 0) {
+    process.stdout.write(
+      `Skipped ${result.skippedUnsafeNetworks.length} legacy/attached network(s) with uncertain ownership.\n`,
+    );
+  }
+  if (!apply) process.stdout.write('Re-run with --force to apply this plan.\n');
+}

--- a/src/docker/mitm-proxy.ts
+++ b/src/docker/mitm-proxy.ts
@@ -1437,6 +1437,14 @@ export function createMitmProxy(options: MitmProxyOptions): MitmProxy {
   }
 
   outerServer.on('request', (req, res) => {
+    // Side-effect-free round-trip probe for the macOS Docker sidecar. This
+    // proves that traffic reached the host proxy, not merely the sidecar's
+    // listening socket. The reserved host is never forwarded upstream.
+    if (req.method === 'GET' && req.url === 'http://ironcurtain.invalid/__ironcurtain/health') {
+      res.writeHead(200, { 'Content-Type': 'text/plain', Connection: 'close' });
+      res.end('IRONCURTAIN_OK/1\n');
+      return;
+    }
     // Handle plain HTTP proxy requests. HTTP proxy clients send absolute URLs:
     // "GET http://host:port/path HTTP/1.1". We parse the absolute URL into
     // hostname, port, and origin-form path before dispatching.

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -35,7 +35,14 @@ import { buildDockerClaudeMd } from './claude-md-seed.js';
 import { getInternalNetworkName } from './platform.js';
 import { cleanupContainers } from './container-lifecycle.js';
 import { clampDockerResources } from './resource-limits.js';
-import { buildAgentUidRemap, buildUdsSocketMounts } from './docker-infrastructure.js';
+import { buildAgentUidRemap, buildUdsSocketMounts, InternalNetworkConnectivityError } from './docker-infrastructure.js';
+import {
+  createIronCurtainInternalNetwork,
+  dockerAllocationPoolForSubnet,
+  managedResourceLabels,
+  reconcileIronCurtainDockerResources,
+  releaseManagedResourceLease,
+} from './docker-resource-lifecycle.js';
 
 export interface PtySessionOptions {
   readonly config: IronCurtainConfig;
@@ -207,8 +214,31 @@ function writeSessionSnapshot(sessionDir: string, snapshot: SessionSnapshot): vo
  * Claude Code, attaches the terminal, and blocks until the session ends.
  */
 export async function runPtySession(options: PtySessionOptions): Promise<void> {
-  const { prepareDockerInfrastructure, writeAptProxyConfigViaExec, checkHostOnlyConnectivity } =
-    await import('./docker-infrastructure.js');
+  const excludedSubnets = new Set<string>();
+  const maxAttempts = 4;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await runPtySessionAttempt(options, excludedSubnets);
+      return;
+    } catch (error) {
+      if (!(error instanceof InternalNetworkConnectivityError) || !error.subnet || attempt === maxAttempts) throw error;
+      const rejectedPool = dockerAllocationPoolForSubnet(error.subnet);
+      excludedSubnets.add(rejectedPool);
+      logger.warn(
+        `PTY internal Docker network ${error.subnet} failed its end-to-end checks; rejecting ${rejectedPool} and ` +
+          `retrying with another allocation (${attempt}/${maxAttempts})`,
+      );
+    }
+  }
+}
+
+async function runPtySessionAttempt(options: PtySessionOptions, excludedSubnets: ReadonlySet<string>): Promise<void> {
+  const {
+    prepareDockerInfrastructure,
+    writeAptProxyConfigViaExec,
+    checkHostOnlyConnectivity,
+    checkInternalNetworkConnectivity,
+  } = await import('./docker-infrastructure.js');
 
   // When resuming, validate the snapshot and reuse the existing session directory
   const resumeSnapshot = options.resumeSessionId
@@ -291,6 +321,7 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
   let docker: Awaited<ReturnType<typeof prepareDockerInfrastructure>>['docker'] | null = null;
   let useTcp: boolean;
   let networkName: string | null = null;
+  let allocatedNetworkSubnet: string | undefined;
   // Flushes the trajectory-capture session (clean, non-poisoned session-end)
   // before infra teardown. Assigned inside the try once the bundle exists;
   // invoked in finally. Undefined when capture is disabled. PTY mode tears
@@ -432,6 +463,10 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     const shortId = getBundleShortId(bundleId);
     const { quote } = await import('shell-quote');
     const internalNetworkName = getInternalNetworkName(shortId);
+    const managedLabels = infra.runtimeKind === 'docker' ? managedResourceLabels(bundleId) : undefined;
+    const resourceLabels = managedLabels
+      ? Object.fromEntries(Object.entries(managedLabels).filter(([key]) => key !== 'ironcurtain.bundle'))
+      : undefined;
     let env: Record<string, string>;
     let network: string | null;
     let mounts: { source: string; target: string; readonly: boolean }[];
@@ -443,6 +478,10 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     // instead of bind-mounted — see writeAptProxyConfigViaExec.
     let execAptProxyUrl: string | undefined;
     const mainContainerName = `ironcurtain-pty-${shortId}`;
+
+    if (infra.runtimeKind === 'docker') {
+      await reconcileIronCurtainDockerResources(docker);
+    }
 
     // Remove stale main container from a crashed previous session (same session
     // ID means same deterministic name, which would conflict on docker create).
@@ -492,11 +531,13 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       const aptProxyPath = resolve(orientationDir, 'apt-proxy.conf');
       writeFileSync(aptProxyPath, `Acquire::http::Proxy "${proxyUrl}";\nAcquire::https::Proxy "${proxyUrl}";\n`);
 
-      await docker.createNetwork(internalNetworkName, {
-        internal: true,
+      const allocatedNetwork = await createIronCurtainInternalNetwork(docker, internalNetworkName, bundleId, {
+        excludedSubnets,
       });
+      allocatedNetworkSubnet = allocatedNetwork.subnet;
       network = internalNetworkName;
       networkName = internalNetworkName;
+      logger.info(`Allocated internal Docker network ${internalNetworkName} at ${allocatedNetwork.subnet}`);
 
       const socatImage = 'alpine/socat';
       if (!(await docker.imageExists(socatImage))) {
@@ -527,6 +568,7 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
         // PTY sessions are standalone (no workflow/scope), so only the
         // bundle label is emitted. See docs/designs/workflow-session-identity.md §7.
         bundleLabel: bundleId,
+        labels: resourceLabels,
         ports: [`127.0.0.1:${hostPtyPort}:${containerPtyPort}`],
         command: [
           '-c',
@@ -652,6 +694,7 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
       // PTY sessions are standalone (no workflow/scope), so only the
       // bundle label is emitted. See docs/designs/workflow-session-identity.md §7.
       bundleLabel: bundleId,
+      labels: resourceLabels,
       resources: { memoryMb: ptyResources.memoryMb, cpus: ptyResources.cpus },
       extraHosts,
       publishSockets,
@@ -678,6 +721,13 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
     // reachable, internet egress blocked) before attaching.
     if (infra.topology === 'tcp-hostonly' && infra.hostOnlyNetwork !== undefined && proxy.port !== undefined) {
       await checkHostOnlyConnectivity(docker, containerId, infra.hostOnlyNetwork.gateway, proxy.port);
+    } else if (infra.topology === 'tcp-sidecar' && proxy.port !== undefined && mitmAddr.port !== undefined) {
+      try {
+        await checkInternalNetworkConnectivity(docker, containerId, proxy.port, mitmAddr.port);
+      } catch (error) {
+        if (error instanceof InternalNetworkConnectivityError) error.subnet = allocatedNetworkSubnet;
+        throw error;
+      }
     }
 
     // Write session registration for the escalation listener
@@ -793,6 +843,7 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
         networkName,
       });
     }
+    releaseManagedResourceLease(effectiveSessionId);
 
     // Stop proxies
     await mitmProxy?.stop().catch(() => {});

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -35,13 +35,14 @@ import { buildDockerClaudeMd } from './claude-md-seed.js';
 import { getInternalNetworkName } from './platform.js';
 import { cleanupContainers } from './container-lifecycle.js';
 import { clampDockerResources } from './resource-limits.js';
-import { buildAgentUidRemap, buildUdsSocketMounts, InternalNetworkConnectivityError } from './docker-infrastructure.js';
+import { buildAgentUidRemap, buildUdsSocketMounts } from './docker-infrastructure.js';
 import {
   createIronCurtainInternalNetwork,
-  dockerAllocationPoolForSubnet,
+  InternalNetworkConnectivityError,
   managedResourceLabels,
-  reconcileIronCurtainDockerResources,
+  reconcileIronCurtainDockerResourcesBestEffort,
   releaseManagedResourceLease,
+  withInternalNetworkAllocationRetry,
 } from './docker-resource-lifecycle.js';
 
 export interface PtySessionOptions {
@@ -214,25 +215,28 @@ function writeSessionSnapshot(sessionDir: string, snapshot: SessionSnapshot): vo
  * Claude Code, attaches the terminal, and blocks until the session ends.
  */
 export async function runPtySession(options: PtySessionOptions): Promise<void> {
-  const excludedSubnets = new Set<string>();
-  const maxAttempts = 4;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      await runPtySessionAttempt(options, excludedSubnets);
-      return;
-    } catch (error) {
-      if (!(error instanceof InternalNetworkConnectivityError) || !error.subnet || attempt === maxAttempts) throw error;
-      const rejectedPool = dockerAllocationPoolForSubnet(error.subnet);
-      excludedSubnets.add(rejectedPool);
-      logger.warn(
-        `PTY internal Docker network ${error.subnet} failed its end-to-end checks; rejecting ${rejectedPool} and ` +
-          `retrying with another allocation (${attempt}/${maxAttempts})`,
-      );
-    }
-  }
+  let retryDocker: ContainerRuntime | undefined;
+  await withInternalNetworkAllocationRetry(
+    {
+      maxAttempts: 4,
+      description: 'PTY internal Docker network',
+      reconcile: async () => {
+        if (retryDocker) await reconcileIronCurtainDockerResourcesBestEffort(retryDocker, 'PTY internal network retry');
+      },
+    },
+    (excludedSubnets, attempt) =>
+      runPtySessionAttempt(options, excludedSubnets, attempt, (docker) => {
+        retryDocker = docker;
+      }),
+  );
 }
 
-async function runPtySessionAttempt(options: PtySessionOptions, excludedSubnets: ReadonlySet<string>): Promise<void> {
+async function runPtySessionAttempt(
+  options: PtySessionOptions,
+  excludedSubnets: ReadonlySet<string>,
+  attempt: number,
+  onDockerReady: (docker: ContainerRuntime) => void,
+): Promise<void> {
   const {
     prepareDockerInfrastructure,
     writeAptProxyConfigViaExec,
@@ -396,6 +400,7 @@ async function runPtySessionAttempt(options: PtySessionOptions, excludedSubnets:
     }
 
     ({ docker, proxy, mitmProxy, useTcp } = infra);
+    onDockerReady(docker);
     const {
       adapter,
       fakeKeys,
@@ -462,7 +467,8 @@ async function runPtySessionAttempt(options: PtySessionOptions, excludedSubnets:
     // Build container configuration
     const shortId = getBundleShortId(bundleId);
     const { quote } = await import('shell-quote');
-    const internalNetworkName = getInternalNetworkName(shortId);
+    const baseInternalNetworkName = getInternalNetworkName(shortId);
+    const internalNetworkName = attempt === 1 ? baseInternalNetworkName : `${baseInternalNetworkName}-a${attempt}`;
     const managedLabels = infra.runtimeKind === 'docker' ? managedResourceLabels(bundleId) : undefined;
     const resourceLabels = managedLabels
       ? Object.fromEntries(Object.entries(managedLabels).filter(([key]) => key !== 'ironcurtain.bundle'))
@@ -480,7 +486,7 @@ async function runPtySessionAttempt(options: PtySessionOptions, excludedSubnets:
     const mainContainerName = `ironcurtain-pty-${shortId}`;
 
     if (infra.runtimeKind === 'docker') {
-      await reconcileIronCurtainDockerResources(docker);
+      await reconcileIronCurtainDockerResourcesBestEffort(docker, 'PTY session startup');
     }
 
     // Remove stale main container from a crashed previous session (same session
@@ -725,7 +731,9 @@ async function runPtySessionAttempt(options: PtySessionOptions, excludedSubnets:
       try {
         await checkInternalNetworkConnectivity(docker, containerId, proxy.port, mitmAddr.port);
       } catch (error) {
-        if (error instanceof InternalNetworkConnectivityError) error.subnet = allocatedNetworkSubnet;
+        if (error instanceof InternalNetworkConnectivityError) {
+          throw new InternalNetworkConnectivityError(error.message, allocatedNetworkSubnet);
+        }
         throw error;
       }
     }

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -53,6 +53,9 @@ export interface DockerContainerConfig {
    */
   readonly scopeLabel?: string;
 
+  /** Additional runtime ownership/housekeeping labels. */
+  readonly labels?: Readonly<Record<string, string>>;
+
   /** Extra --add-host entries (e.g. ["host.docker.internal:172.30.0.3"]). When set, suppresses the default host-gateway mapping. */
   readonly extraHosts?: readonly string[];
 
@@ -176,6 +179,32 @@ export interface DockerImageInfo {
   readonly created: string;
 }
 
+/** Docker network state used by crash reconciliation and subnet allocation. */
+export interface DockerNetworkInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly created: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly subnets: readonly string[];
+  readonly containerIds: readonly string[];
+}
+
+/** Docker container state used by crash reconciliation. */
+export interface DockerContainerInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly created: string;
+  readonly running: boolean;
+  readonly labels: Readonly<Record<string, string>>;
+}
+
+export interface DockerNetworkCreateOptions {
+  readonly internal?: boolean;
+  readonly subnet?: string;
+  readonly gateway?: string;
+  readonly labels?: Readonly<Record<string, string>>;
+}
+
 /**
  * Manages container lifecycle for agent sessions.
  *
@@ -268,10 +297,19 @@ export interface ContainerRuntime {
   probeImageVersion?(image: string, command: readonly string[]): Promise<string | undefined>;
 
   /** Create a Docker network. No-op if it already exists. */
-  createNetwork(name: string, options?: { internal?: boolean; subnet?: string; gateway?: string }): Promise<void>;
+  createNetwork(name: string, options?: DockerNetworkCreateOptions): Promise<void>;
+
+  /** Enumerate Docker networks. Optional for non-Docker runtimes. */
+  listNetworks?(): Promise<readonly DockerNetworkInfo[]>;
+
+  /** Enumerate Docker containers, including stopped containers. Optional for non-Docker runtimes. */
+  listContainers?(options?: { readonly labelFilter?: string }): Promise<readonly DockerContainerInfo[]>;
 
   /** Remove a Docker network. Ignores errors (e.g., already removed). */
   removeNetwork(name: string): Promise<void>;
+
+  /** Check whether a named network still exists. Optional for non-Docker runtimes. */
+  networkExists?(name: string): Promise<boolean>;
 
   /** Pull a Docker image from a registry. */
   pullImage(image: string): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,10 @@ export async function main(args?: string[]): Promise<void> {
     process.stderr.write(chalk.dim('\nShutting down...\n'));
     transport.close();
     // Force exit if cleanup takes too long
-    const forceExitTimeout = setTimeout(() => process.exit(1), 5_000);
+    // Docker allows each stop operation ten seconds, followed by container
+    // removal and network removal. Keep the emergency deadline above that
+    // cleanup budget so the fallback does not itself orphan the network.
+    const forceExitTimeout = setTimeout(() => process.exit(1), 30_000);
     forceExitTimeout.unref();
     session
       .close()

--- a/src/trusted-process/tcp-server-transport.ts
+++ b/src/trusted-process/tcp-server-transport.ts
@@ -29,6 +29,8 @@ export interface TcpServerTransportOptions {
    * reach the unauthenticated MCP endpoint.
    */
   readonly allowRemoteAddress?: (remoteAddress: string | undefined) => boolean;
+  /** Maximum time an unclassified connection may wait to send its first bytes. */
+  readonly firstByteTimeoutMs?: number;
 }
 
 /** Side-effect-free liveness exchange used by the Docker sidecar startup gate. */
@@ -39,8 +41,10 @@ export class TcpServerTransport implements Transport {
   private readonly host: string;
   private readonly requestedPort: number;
   private readonly allowRemoteAddress?: (remoteAddress: string | undefined) => boolean;
+  private readonly firstByteTimeoutMs: number;
   private server: NetServer | null = null;
   private activeSocket: Socket | null = null;
+  private pendingSocket: Socket | null = null;
   private readBuffer = new ReadBuffer();
   private _port: number | null = null;
 
@@ -52,6 +56,7 @@ export class TcpServerTransport implements Transport {
     this.host = host;
     this.requestedPort = port;
     this.allowRemoteAddress = options?.allowRemoteAddress;
+    this.firstByteTimeoutMs = options?.firstByteTimeoutMs ?? 5_000;
   }
 
   /** The actual port the server is listening on. Only valid after start(). */
@@ -107,6 +112,8 @@ export class TcpServerTransport implements Transport {
   async close(): Promise<void> {
     this.activeSocket?.destroy();
     this.activeSocket = null;
+    this.pendingSocket?.destroy();
+    this.pendingSocket = null;
 
     const server = this.server;
     if (server) {
@@ -133,6 +140,12 @@ export class TcpServerTransport implements Transport {
 
     // Delay claiming the single MCP connection until the first bytes arrive.
     // A health probe is answered locally and never evicts the real client.
+    // Permit only one unclassified connection, and bound how long it can hold
+    // resources without identifying itself as MCP traffic or a health probe.
+    if (this.pendingSocket && !this.pendingSocket.destroyed) this.pendingSocket.destroy();
+    this.pendingSocket = socket;
+    const firstByteTimer = setTimeout(() => socket.destroy(), this.firstByteTimeoutMs);
+    firstByteTimer.unref();
     let pending = Buffer.alloc(0);
     const inspectFirstBytes = (chunk: Buffer): void => {
       pending = Buffer.concat([pending, chunk]);
@@ -141,6 +154,8 @@ export class TcpServerTransport implements Transport {
         return;
       }
       socket.off('data', inspectFirstBytes);
+      clearTimeout(firstByteTimer);
+      if (this.pendingSocket === socket) this.pendingSocket = null;
       if (text === TCP_TRANSPORT_HEALTH_REQUEST) {
         socket.end(TCP_TRANSPORT_HEALTH_RESPONSE);
         return;
@@ -160,6 +175,8 @@ export class TcpServerTransport implements Transport {
     socket.on('data', inspectFirstBytes);
 
     socket.on('close', () => {
+      clearTimeout(firstByteTimer);
+      if (this.pendingSocket === socket) this.pendingSocket = null;
       if (this.activeSocket === socket) {
         this.activeSocket = null;
       }

--- a/src/trusted-process/tcp-server-transport.ts
+++ b/src/trusted-process/tcp-server-transport.ts
@@ -31,6 +31,10 @@ export interface TcpServerTransportOptions {
   readonly allowRemoteAddress?: (remoteAddress: string | undefined) => boolean;
 }
 
+/** Side-effect-free liveness exchange used by the Docker sidecar startup gate. */
+export const TCP_TRANSPORT_HEALTH_REQUEST = 'IRONCURTAIN_HEALTH/1\n';
+export const TCP_TRANSPORT_HEALTH_RESPONSE = 'IRONCURTAIN_OK/1\n';
+
 export class TcpServerTransport implements Transport {
   private readonly host: string;
   private readonly requestedPort: number;
@@ -123,22 +127,37 @@ export class TcpServerTransport implements Transport {
       return;
     }
 
-    // Close any existing connection -- only one client expected
-    if (this.activeSocket && !this.activeSocket.destroyed) {
-      this.activeSocket.destroy();
-    }
-
-    this.activeSocket = socket;
-    this.readBuffer = new ReadBuffer();
-
-    socket.on('data', (chunk: Buffer) => {
-      this.readBuffer.append(chunk);
-      this.processReadBuffer();
-    });
-
     socket.on('error', (err) => {
       this.onerror?.(err);
     });
+
+    // Delay claiming the single MCP connection until the first bytes arrive.
+    // A health probe is answered locally and never evicts the real client.
+    let pending = Buffer.alloc(0);
+    const inspectFirstBytes = (chunk: Buffer): void => {
+      pending = Buffer.concat([pending, chunk]);
+      const text = pending.toString('utf8');
+      if (TCP_TRANSPORT_HEALTH_REQUEST.startsWith(text) && pending.length < TCP_TRANSPORT_HEALTH_REQUEST.length) {
+        return;
+      }
+      socket.off('data', inspectFirstBytes);
+      if (text === TCP_TRANSPORT_HEALTH_REQUEST) {
+        socket.end(TCP_TRANSPORT_HEALTH_RESPONSE);
+        return;
+      }
+
+      // Close any existing connection -- only one MCP client is expected.
+      if (this.activeSocket && !this.activeSocket.destroyed) this.activeSocket.destroy();
+      this.activeSocket = socket;
+      this.readBuffer = new ReadBuffer();
+      this.readBuffer.append(pending);
+      this.processReadBuffer();
+      socket.on('data', (data: Buffer) => {
+        this.readBuffer.append(data);
+        this.processReadBuffer();
+      });
+    };
+    socket.on('data', inspectFirstBytes);
 
     socket.on('close', () => {
       if (this.activeSocket === socket) {

--- a/src/workflow/shutdown-signals.ts
+++ b/src/workflow/shutdown-signals.ts
@@ -1,0 +1,54 @@
+import { constants } from 'node:os';
+
+const WORKFLOW_FORCE_EXIT_MS = 30_000;
+const SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const;
+
+export interface WorkflowShutdownSignalOptions {
+  readonly forceExitAfterMs?: number;
+  readonly onFirstSignal?: (signal: NodeJS.Signals) => void;
+  readonly forceExit?: (exitCode: number) => void;
+}
+
+function signalExitCode(signal: NodeJS.Signals): number {
+  return 128 + constants.signals[signal];
+}
+
+/** Installs bounded graceful shutdown and returns an exact unregister thunk. */
+export function installWorkflowShutdownSignals(
+  controller: AbortController,
+  options: WorkflowShutdownSignalOptions = {},
+): () => void {
+  const forceExit = options.forceExit ?? ((exitCode: number) => process.exit(exitCode));
+  let firstSignal: NodeJS.Signals | undefined;
+  let forceExitTimer: NodeJS.Timeout | undefined;
+
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    if (firstSignal) {
+      if (forceExitTimer) clearTimeout(forceExitTimer);
+      forceExit(signalExitCode(signal));
+      return;
+    }
+
+    firstSignal = signal;
+    options.onFirstSignal?.(signal);
+    controller.abort();
+    forceExitTimer = setTimeout(
+      () => forceExit(signalExitCode(signal)),
+      options.forceExitAfterMs ?? WORKFLOW_FORCE_EXIT_MS,
+    );
+    forceExitTimer.unref();
+  };
+
+  // Keep named wrappers so teardown removes precisely what was installed.
+  const handlers: Record<(typeof SIGNALS)[number], () => void> = {
+    SIGINT: () => handleSignal('SIGINT'),
+    SIGTERM: () => handleSignal('SIGTERM'),
+    SIGHUP: () => handleSignal('SIGHUP'),
+  };
+  for (const signal of SIGNALS) process.on(signal, handlers[signal]);
+
+  return () => {
+    if (forceExitTimer) clearTimeout(forceExitTimer);
+    for (const signal of SIGNALS) process.off(signal, handlers[signal]);
+  };
+}

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -48,6 +48,7 @@ import {
 import { runRunState } from './run-state-command.js';
 import { runDaemonGateCommand } from './daemon-gate-commands.js';
 import { sweepContainerSnapshots } from './container-snapshots.js';
+import { installWorkflowShutdownSignals } from './shutdown-signals.js';
 import {
   formatDiagnostic,
   printDiagnostics,
@@ -236,16 +237,9 @@ async function runStart(args: string[]): Promise<void> {
   orchestrator.onEvent(printLifecycleEvent);
 
   const controller = new AbortController();
-  let shutdownSignal: NodeJS.Signals | undefined;
-  const handleShutdownSignal = (signal: NodeJS.Signals): void => {
-    if (shutdownSignal) return;
-    shutdownSignal = signal;
-    writeStderr(`\n[workflow] Caught ${signal}, shutting down...`);
-    controller.abort();
-  };
-  process.on('SIGINT', handleShutdownSignal);
-  process.on('SIGTERM', handleShutdownSignal);
-  process.on('SIGHUP', handleShutdownSignal);
+  const uninstallShutdownSignals = installWorkflowShutdownSignals(controller, {
+    onFirstSignal: (signal) => writeStderr(`\n[workflow] Caught ${signal}, shutting down...`),
+  });
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -281,9 +275,7 @@ async function runStart(args: string[]): Promise<void> {
     // Joins any in-flight teardown (see WorkflowInstance.teardownPromise)
     // so the process.exit below never strands infrastructure.
     await orchestrator.shutdownAll().catch(() => {});
-    process.off('SIGINT', handleShutdownSignal);
-    process.off('SIGTERM', handleShutdownSignal);
-    process.off('SIGHUP', handleShutdownSignal);
+    uninstallShutdownSignals();
     writeStdout(`${DIM}Artifacts preserved at: ${baseDir}${RESET}`);
   }
   process.exit(exitCode);
@@ -365,16 +357,9 @@ async function runResume(args: string[]): Promise<void> {
   orchestrator.onEvent(printLifecycleEvent);
 
   const controller = new AbortController();
-  let shutdownSignal: NodeJS.Signals | undefined;
-  const handleShutdownSignal = (signal: NodeJS.Signals): void => {
-    if (shutdownSignal) return;
-    shutdownSignal = signal;
-    writeStderr(`\n[workflow] Caught ${signal}, shutting down...`);
-    controller.abort();
-  };
-  process.on('SIGINT', handleShutdownSignal);
-  process.on('SIGTERM', handleShutdownSignal);
-  process.on('SIGHUP', handleShutdownSignal);
+  const uninstallShutdownSignals = installWorkflowShutdownSignals(controller, {
+    onFirstSignal: (signal) => writeStderr(`\n[workflow] Caught ${signal}, shutting down...`),
+  });
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -400,9 +385,7 @@ async function runResume(args: string[]): Promise<void> {
   } finally {
     rl.close();
     await orchestrator.shutdownAll().catch(() => {});
-    process.off('SIGINT', handleShutdownSignal);
-    process.off('SIGTERM', handleShutdownSignal);
-    process.off('SIGHUP', handleShutdownSignal);
+    uninstallShutdownSignals();
     writeStdout(`${DIM}Artifacts preserved at: ${baseDir}${RESET}`);
   }
   process.exit(exitCode);

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -236,10 +236,16 @@ async function runStart(args: string[]): Promise<void> {
   orchestrator.onEvent(printLifecycleEvent);
 
   const controller = new AbortController();
-  process.on('SIGINT', () => {
-    writeStderr(`\n[workflow] Caught SIGINT, shutting down...`);
+  let shutdownSignal: NodeJS.Signals | undefined;
+  const handleShutdownSignal = (signal: NodeJS.Signals): void => {
+    if (shutdownSignal) return;
+    shutdownSignal = signal;
+    writeStderr(`\n[workflow] Caught ${signal}, shutting down...`);
     controller.abort();
-  });
+  };
+  process.on('SIGINT', handleShutdownSignal);
+  process.on('SIGTERM', handleShutdownSignal);
+  process.on('SIGHUP', handleShutdownSignal);
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -247,8 +253,9 @@ async function runStart(args: string[]): Promise<void> {
   // fully drains first. Calling process.exit() inside the try — as this code
   // used to — terminates the process synchronously and cuts off the async
   // teardown in the finally, orphaning each run's per-session --internal
-  // Docker network (which has no stale-reaper) until Docker's address pools
-  // are exhausted. The apple-container backend loses this race every time
+  // Docker network. Crash reconciliation now repairs that state on the next
+  // startup, but graceful exits must still drain teardown rather than relying
+  // on recovery. The apple-container backend loses this race every time
   // (slower VM shutdown), so the fix matters there in particular.
   // Definitely assigned before the post-finally `process.exit`: the only way
   // to skip that assignment is a throw, which propagates past it.
@@ -274,6 +281,9 @@ async function runStart(args: string[]): Promise<void> {
     // Joins any in-flight teardown (see WorkflowInstance.teardownPromise)
     // so the process.exit below never strands infrastructure.
     await orchestrator.shutdownAll().catch(() => {});
+    process.off('SIGINT', handleShutdownSignal);
+    process.off('SIGTERM', handleShutdownSignal);
+    process.off('SIGHUP', handleShutdownSignal);
     writeStdout(`${DIM}Artifacts preserved at: ${baseDir}${RESET}`);
   }
   process.exit(exitCode);
@@ -355,10 +365,16 @@ async function runResume(args: string[]): Promise<void> {
   orchestrator.onEvent(printLifecycleEvent);
 
   const controller = new AbortController();
-  process.on('SIGINT', () => {
-    writeStderr(`\n[workflow] Caught SIGINT, shutting down...`);
+  let shutdownSignal: NodeJS.Signals | undefined;
+  const handleShutdownSignal = (signal: NodeJS.Signals): void => {
+    if (shutdownSignal) return;
+    shutdownSignal = signal;
+    writeStderr(`\n[workflow] Caught ${signal}, shutting down...`);
     controller.abort();
-  });
+  };
+  process.on('SIGINT', handleShutdownSignal);
+  process.on('SIGTERM', handleShutdownSignal);
+  process.on('SIGHUP', handleShutdownSignal);
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -384,6 +400,9 @@ async function runResume(args: string[]): Promise<void> {
   } finally {
     rl.close();
     await orchestrator.shutdownAll().catch(() => {});
+    process.off('SIGINT', handleShutdownSignal);
+    process.off('SIGTERM', handleShutdownSignal);
+    process.off('SIGHUP', handleShutdownSignal);
     writeStdout(`${DIM}Artifacts preserved at: ${baseDir}${RESET}`);
   }
   process.exit(exitCode);

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -25,6 +25,7 @@ import { resolveActiveProfile } from '../src/config/user-config.js';
 import { generateFakeKey } from '../src/docker/fake-keys.js';
 import { makeOpenRouterProvider, makeOpenRouterRewriter } from '../src/docker/openrouter.js';
 import { getInternalNetworkName } from '../src/docker/platform.js';
+import { dockerAllocationPoolForSubnet } from '../src/docker/docker-resource-lifecycle.js';
 import { getBundleShortId, type BundleId } from '../src/session/types.js';
 
 // Container target the mock adapter advertises via `skills.containerPath`.
@@ -664,12 +665,17 @@ function makeMockCore(opts: MockCoreOptions): PreContainerInfrastructure {
 
 describe('createSessionContainers', () => {
   let tempDir: string;
+  let originalHome: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'create-session-containers-'));
+    originalHome = process.env.IRONCURTAIN_HOME;
+    process.env.IRONCURTAIN_HOME = join(tempDir, 'home');
   });
 
   afterEach(() => {
+    if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = originalHome;
     if (existsSync(tempDir)) {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -846,8 +852,10 @@ describe('createSessionContainers', () => {
     // break it; the agent container must run as the baked codespace user.
     // We construct a TCP-mode core but bypass the connectivity check by
     // returning exitCode 0 from the mocked exec.
-    const { docker, createCalls } = makeMockDocker({
-      async exec() {
+    const healthCommands: string[][] = [];
+    const { docker, createCalls, createdNetworks } = makeMockDocker({
+      async exec(_container, command) {
+        healthCommands.push([...command]);
         return { exitCode: 0, stdout: '', stderr: '' };
       },
     });
@@ -860,6 +868,15 @@ describe('createSessionContainers', () => {
     expect(mainCreate.user).toBeUndefined();
     expect(mainCreate.env.IRONCURTAIN_AGENT_UID).toBeUndefined();
     expect(mainCreate.env.IRONCURTAIN_AGENT_GID).toBeUndefined();
+    expect(healthCommands).toHaveLength(2);
+    expect(healthCommands[0].join(' ')).toContain('IRONCURTAIN_HEALTH/1');
+    expect(healthCommands[1].join(' ')).toContain('http://ironcurtain.invalid/__ironcurtain/health');
+    expect(createdNetworks).toHaveLength(1);
+    expect(createdNetworks[0].options).toMatchObject({
+      internal: true,
+      subnet: expect.stringMatching(/\/29$/),
+      labels: expect.objectContaining({ 'ironcurtain.managed': 'true' }),
+    });
   });
 
   it('mounts an empty skills directory when set (workflow-mode invariant)', async () => {
@@ -888,7 +905,7 @@ describe('createSessionContainers', () => {
   // both TCP-mode resources (sidecar + network) AND the main container
   // to defend against regressions from either end of the rollback path.
   it('throws when connectivity check fails and cleans up sidecar, network, and main container', async () => {
-    const { docker, stoppedContainers, removedContainers, removedNetworks } = makeMockDocker({
+    const { docker, stoppedContainers, removedContainers, removedNetworks, createdNetworks } = makeMockDocker({
       async exec() {
         // Simulate the connectivity check failing: container can't reach
         // host-side proxies through the socat sidecar.
@@ -912,6 +929,10 @@ describe('createSessionContainers', () => {
     // The per-session internal network must also be cleaned up.
     const expectedNetworkName = getInternalNetworkName(TEST_SHORT_ID);
     expect(removedNetworks).toContain(expectedNetworkName);
+    expect(createdNetworks).toHaveLength(4);
+    const attemptedSubnets = createdNetworks.map((entry) => entry.options?.subnet);
+    expect(new Set(attemptedSubnets).size).toBe(4);
+    expect(new Set(attemptedSubnets.map((subnet) => dockerAllocationPoolForSubnet(String(subnet)))).size).toBe(4);
   });
 
   // --- tcp-hostonly topology (apple-container) ---

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -648,6 +648,28 @@ describe('DockerManager', () => {
       ]);
     });
 
+    it('keeps networks that survive a concurrent ls/inspect deletion', async () => {
+      const surviving = {
+        Id: 'network-live',
+        Name: 'ironcurtain-live',
+        Created: '2026-01-01T00:00:00Z',
+        Labels: { 'ironcurtain.managed': 'true' },
+        IPAM: { Config: [{ Subnet: '172.20.0.0/29' }] },
+        Containers: {},
+      };
+      mock.setSequence([
+        { stdout: 'network-live\nnetwork-gone\n' },
+        { error: true, code: 1, stderr: 'Error response from daemon: network network-gone not found' },
+        { stdout: JSON.stringify([surviving]) },
+        { error: true, code: 1, stderr: 'Error response from daemon: network network-gone not found' },
+      ]);
+
+      const manager = createDockerManager(mock.mockExec);
+      await expect(manager.listNetworks?.()).resolves.toEqual([
+        expect.objectContaining({ id: 'network-live', name: 'ironcurtain-live' }),
+      ]);
+    });
+
     it('parses all-container inspect data and applies a label filter', async () => {
       mock.setSequence([
         { stdout: 'container-id\n' },
@@ -675,6 +697,27 @@ describe('DockerManager', () => {
         },
       ]);
       expect(mock.calls[0].args).toContain('label=ironcurtain.managed=true');
+    });
+
+    it('keeps containers that survive a concurrent ls/inspect deletion', async () => {
+      const surviving = {
+        Id: 'container-live',
+        Name: '/ironcurtain-live',
+        Created: '2026-01-01T00:00:00Z',
+        Config: { Labels: { 'ironcurtain.managed': 'true' } },
+        State: { Running: true },
+      };
+      mock.setSequence([
+        { stdout: 'container-live\ncontainer-gone\n' },
+        { error: true, code: 1, stderr: 'Error: No such container: container-gone' },
+        { stdout: JSON.stringify([surviving]) },
+        { error: true, code: 1, stderr: 'Error: No such container: container-gone' },
+      ]);
+
+      const manager = createDockerManager(mock.mockExec);
+      await expect(manager.listContainers?.()).resolves.toEqual([
+        expect.objectContaining({ id: 'container-live', name: 'ironcurtain-live' }),
+      ]);
     });
   });
 

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -283,6 +283,7 @@ describe('DockerManager', () => {
         bundleLabel: 'bundle-xyz',
         workflowLabel: 'workflow-42',
         scopeLabel: 'state-foo',
+        labels: { 'ironcurtain.managed': 'true', 'ironcurtain.owner-pid': '123' },
       };
       const args = buildCreateArgs(config);
 
@@ -290,6 +291,8 @@ describe('DockerManager', () => {
       expect(labelArgs).toContain('ironcurtain.bundle=bundle-xyz');
       expect(labelArgs).toContain('ironcurtain.workflow=workflow-42');
       expect(labelArgs).toContain('ironcurtain.scope=state-foo');
+      expect(labelArgs).toContain('ironcurtain.managed=true');
+      expect(labelArgs).toContain('ironcurtain.owner-pid=123');
     });
 
     it('uses extraHosts instead of default host-gateway when provided', () => {
@@ -580,7 +583,7 @@ describe('DockerManager', () => {
       await expect(manager.createNetwork('ironcurtain-abc')).resolves.toBeUndefined();
     });
 
-    it('passes --internal, --subnet, and --gateway options', async () => {
+    it('passes --internal, --subnet, --gateway, and ownership labels', async () => {
       mock.setResponse('');
       const manager = createDockerManager(mock.mockExec);
 
@@ -588,6 +591,7 @@ describe('DockerManager', () => {
         internal: true,
         subnet: '172.30.0.0/24',
         gateway: '172.30.0.1',
+        labels: { 'ironcurtain.managed': 'true' },
       });
 
       const args = mock.calls[0].args;
@@ -596,6 +600,8 @@ describe('DockerManager', () => {
       expect(args[args.indexOf('--subnet') + 1]).toBe('172.30.0.0/24');
       expect(args).toContain('--gateway');
       expect(args[args.indexOf('--gateway') + 1]).toBe('172.30.0.1');
+      expect(args).toContain('--label');
+      expect(args[args.indexOf('--label') + 1]).toBe('ironcurtain.managed=true');
       expect(args[args.length - 1]).toBe('ironcurtain-internal');
     });
 
@@ -609,6 +615,66 @@ describe('DockerManager', () => {
       expect(args).not.toContain('--internal');
       expect(args).not.toContain('--subnet');
       expect(args).not.toContain('--gateway');
+    });
+  });
+
+  describe('managed resource inventory', () => {
+    it('parses network inspect data for reconciliation and IPAM', async () => {
+      mock.setSequence([
+        { stdout: 'network-id\n' },
+        {
+          stdout: JSON.stringify([
+            {
+              Id: 'network-id',
+              Name: 'ironcurtain-abcdef123456',
+              Created: '2026-01-01T00:00:00Z',
+              Labels: { 'ironcurtain.managed': 'true' },
+              IPAM: { Config: [{ Subnet: '172.20.0.0/29', Gateway: '172.20.0.1' }] },
+              Containers: { 'container-id': { Name: 'agent' } },
+            },
+          ]),
+        },
+      ]);
+      const manager = createDockerManager(mock.mockExec);
+      await expect(manager.listNetworks?.()).resolves.toEqual([
+        {
+          id: 'network-id',
+          name: 'ironcurtain-abcdef123456',
+          created: '2026-01-01T00:00:00Z',
+          labels: { 'ironcurtain.managed': 'true' },
+          subnets: ['172.20.0.0/29'],
+          containerIds: ['container-id'],
+        },
+      ]);
+    });
+
+    it('parses all-container inspect data and applies a label filter', async () => {
+      mock.setSequence([
+        { stdout: 'container-id\n' },
+        {
+          stdout: JSON.stringify([
+            {
+              Id: 'container-id',
+              Name: '/ironcurtain-abcdef123456',
+              Created: '2026-01-01T00:00:00Z',
+              Config: { Labels: { 'ironcurtain.managed': 'true' } },
+              State: { Running: true },
+            },
+          ]),
+        },
+      ]);
+      const manager = createDockerManager(mock.mockExec);
+      const containers = await manager.listContainers?.({ labelFilter: 'ironcurtain.managed=true' });
+      expect(containers).toEqual([
+        {
+          id: 'container-id',
+          name: 'ironcurtain-abcdef123456',
+          created: '2026-01-01T00:00:00Z',
+          running: true,
+          labels: { 'ironcurtain.managed': 'true' },
+        },
+      ]);
+      expect(mock.calls[0].args).toContain('label=ironcurtain.managed=true');
     });
   });
 

--- a/test/docker-resource-lifecycle.integration.test.ts
+++ b/test/docker-resource-lifecycle.integration.test.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDockerManager } from '../src/docker/docker-manager.js';
+import {
+  createIronCurtainInternalNetwork,
+  reconcileIronCurtainDockerResources,
+  releaseManagedResourceLease,
+} from '../src/docker/docker-resource-lifecycle.js';
+
+const enabled = process.env.INTEGRATION_TEST === '1';
+
+describe.skipIf(!enabled)('Docker resource lifecycle integration', () => {
+  const docker = createDockerManager();
+  let networkName: string | undefined;
+  let child: ChildProcess | undefined;
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(resolve(tmpdir(), 'ironcurtain-docker-crash-'));
+    previousHome = process.env.IRONCURTAIN_HOME;
+    process.env.IRONCURTAIN_HOME = home;
+  });
+
+  afterEach(async () => {
+    child?.kill('SIGKILL');
+    if (networkName) await docker.removeNetwork(networkName);
+    if (previousHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('allocates a labeled /29 and reconciles it after its owner lease is released', async () => {
+    const bundleId = randomUUID();
+    networkName = `ironcurtain-${bundleId.replace(/-/g, '').slice(0, 12)}`;
+
+    const allocated = await createIronCurtainInternalNetwork(docker, networkName, bundleId);
+    expect(allocated.subnet).toMatch(/\/29$/);
+    expect(allocated.subnet).not.toMatch(/^192\.168\./);
+    await expect(docker.networkExists?.(networkName)).resolves.toBe(true);
+
+    releaseManagedResourceLease(bundleId);
+    const result = await reconcileIronCurtainDockerResources(docker);
+
+    expect(result.removedNetworks).toContain(networkName);
+    await expect(docker.networkExists?.(networkName)).resolves.toBe(false);
+    networkName = undefined;
+  });
+
+  it('reclaims a network after its real owner process is killed with SIGKILL', async () => {
+    const bundleId = randomUUID();
+    networkName = `ironcurtain-${bundleId.replace(/-/g, '').slice(0, 12)}`;
+    const fixture = resolve(import.meta.dirname, 'fixtures', 'docker-network-owner.ts');
+    child = spawn(process.execPath, ['--import', 'tsx', fixture, networkName, bundleId], {
+      env: { ...process.env, IRONCURTAIN_HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const allocation = await new Promise<{ subnet: string }>((resolveAllocation, reject) => {
+      let stdout = '';
+      let stderr = '';
+      child?.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+        const newline = stdout.indexOf('\n');
+        if (newline >= 0) resolveAllocation(JSON.parse(stdout.slice(0, newline)) as { subnet: string });
+      });
+      child?.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      child?.once('error', reject);
+      child?.once('exit', (code) => {
+        if (code !== null) reject(new Error(`owner exited before allocation (${code}): ${stderr}`));
+      });
+    });
+    expect(allocation.subnet).toMatch(/\/29$/);
+
+    const exited = new Promise<void>((resolveExit) => child?.once('exit', () => resolveExit()));
+    child.kill('SIGKILL');
+    await exited;
+    child = undefined;
+
+    const result = await reconcileIronCurtainDockerResources(docker);
+    expect(result.removedNetworks).toContain(networkName);
+    await expect(docker.networkExists?.(networkName)).resolves.toBe(false);
+    networkName = undefined;
+  });
+});

--- a/test/docker-resource-lifecycle.test.ts
+++ b/test/docker-resource-lifecycle.test.ts
@@ -1,15 +1,18 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createIronCurtainInternalNetwork,
+  InternalNetworkConnectivityError,
   IRONCURTAIN_MANAGED_LABEL,
   IRONCURTAIN_OWNER_PID_LABEL,
   IRONCURTAIN_OWNER_TOKEN_LABEL,
   managedResourceLabels,
   reconcileIronCurtainDockerResources,
+  reconcileIronCurtainDockerResourcesBestEffort,
   releaseManagedResourceLease,
+  withInternalNetworkAllocationRetry,
 } from '../src/docker/docker-resource-lifecycle.js';
 import type { ContainerRuntime, DockerContainerInfo, DockerNetworkInfo } from '../src/docker/types.js';
 
@@ -20,12 +23,8 @@ function runtimeWithInventory(input: {
 }): ContainerRuntime {
   return {
     supportsImageSnapshots: true,
-    async listContainers() {
-      return input.containers ?? [];
-    },
-    async listNetworks() {
-      return input.networks ?? [];
-    },
+    listContainers: vi.fn(async () => input.containers ?? []),
+    listNetworks: vi.fn(async () => input.networks ?? []),
     createNetwork: input.createNetwork ?? vi.fn(async () => {}),
     remove: vi.fn(async () => {}),
     removeNetwork: vi.fn(async () => {}),
@@ -104,6 +103,43 @@ describe('Docker resource crash reconciliation', () => {
     expect(result.removedNetworks).toEqual(['ironcurtain-1234567890ab']);
     expect(docker.remove).toHaveBeenCalledWith('container-id');
     expect(docker.removeNetwork).toHaveBeenCalledWith('ironcurtain-1234567890ab');
+  });
+
+  it('reclaims a lease when its PID was recycled by another process', async () => {
+    const labels = managedResourceLabels('bundle-recycled-pid');
+    const docker = runtimeWithInventory({ networks: [network({ labels })] });
+
+    const result = await reconcileIronCurtainDockerResources(docker, {
+      pidAlive: () => true,
+      processIdentity: () => ({ bootId: 'same-boot', startedAt: 'different-process-start' }),
+    });
+
+    expect(result.removedNetworks).toEqual(['ironcurtain-1234567890ab']);
+    expect(docker.removeNetwork).toHaveBeenCalledWith('ironcurtain-1234567890ab');
+  });
+
+  it('replaces a reconciliation lock held by a recycled PID', async () => {
+    const lockRoot = resolve(home, 'run', 'docker-owners');
+    mkdirSync(lockRoot, { recursive: true });
+    writeFileSync(
+      resolve(lockRoot, 'reconcile.lock'),
+      JSON.stringify({ pid: process.pid, identity: { bootId: 'old-boot', startedAt: 'old-process' } }),
+    );
+    const docker = runtimeWithInventory({});
+
+    await reconcileIronCurtainDockerResources(docker, {
+      processIdentity: () => ({ bootId: 'current-boot', startedAt: 'current-process' }),
+    });
+
+    expect(docker.listContainers).toHaveBeenCalledOnce();
+    expect(docker.listNetworks).toHaveBeenCalledOnce();
+  });
+
+  it('keeps startup reconciliation best-effort when Docker inventory fails', async () => {
+    const docker = runtimeWithInventory({});
+    vi.mocked(docker.listContainers!).mockRejectedValueOnce(new Error('concurrent inspect failure'));
+
+    await expect(reconcileIronCurtainDockerResourcesBestEffort(docker, 'test startup')).resolves.toBeUndefined();
   });
 
   it('reclaims a failed teardown in the same live process after its bundle lease is released', async () => {
@@ -191,5 +227,26 @@ describe('IronCurtain Docker subnet allocator', () => {
     expect(attempts).toHaveLength(2);
     expect(allocated.subnet).toBe(attempts[1]);
     expect(attempts[0]).not.toBe(attempts[1]);
+  });
+
+  it('shares failed-pool exclusion and reconciliation across allocation retries', async () => {
+    const docker = runtimeWithInventory({});
+    const reconcile = vi.fn(async () => {});
+    const attempts: ReadonlySet<string>[] = [];
+
+    const result = await withInternalNetworkAllocationRetry(
+      { maxAttempts: 2, description: 'Test network', reconcile },
+      async (excludedSubnets, attempt) => {
+        attempts.push(new Set(excludedSubnets));
+        if (attempt === 1) throw new InternalNetworkConnectivityError('unreachable', '172.20.1.0/29');
+        return 'allocated';
+      },
+    );
+
+    expect(result).toBe('allocated');
+    expect(attempts[0]).toEqual(new Set());
+    expect(attempts[1]).toEqual(new Set(['172.20.0.0/14']));
+    expect(reconcile).toHaveBeenCalledOnce();
+    expect(docker.removeNetwork).not.toHaveBeenCalled();
   });
 });

--- a/test/docker-resource-lifecycle.test.ts
+++ b/test/docker-resource-lifecycle.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createIronCurtainInternalNetwork,
+  IRONCURTAIN_MANAGED_LABEL,
+  IRONCURTAIN_OWNER_PID_LABEL,
+  IRONCURTAIN_OWNER_TOKEN_LABEL,
+  managedResourceLabels,
+  reconcileIronCurtainDockerResources,
+  releaseManagedResourceLease,
+} from '../src/docker/docker-resource-lifecycle.js';
+import type { ContainerRuntime, DockerContainerInfo, DockerNetworkInfo } from '../src/docker/types.js';
+
+function runtimeWithInventory(input: {
+  containers?: DockerContainerInfo[];
+  networks?: DockerNetworkInfo[];
+  createNetwork?: ContainerRuntime['createNetwork'];
+}): ContainerRuntime {
+  return {
+    supportsImageSnapshots: true,
+    async listContainers() {
+      return input.containers ?? [];
+    },
+    async listNetworks() {
+      return input.networks ?? [];
+    },
+    createNetwork: input.createNetwork ?? vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+    removeNetwork: vi.fn(async () => {}),
+    containerExists: vi.fn(async () => false),
+    networkExists: vi.fn(async () => false),
+  } as unknown as ContainerRuntime;
+}
+
+function network(overrides: Partial<DockerNetworkInfo> = {}): DockerNetworkInfo {
+  return {
+    id: 'network-id',
+    name: 'ironcurtain-1234567890ab',
+    created: '2020-01-01T00:00:00.000Z',
+    labels: {},
+    subnets: ['172.20.0.0/29'],
+    containerIds: [],
+    ...overrides,
+  };
+}
+
+function container(overrides: Partial<DockerContainerInfo> = {}): DockerContainerInfo {
+  return {
+    id: 'container-id',
+    name: 'ironcurtain-1234567890ab',
+    created: '2020-01-01T00:00:00.000Z',
+    running: true,
+    labels: {},
+    ...overrides,
+  };
+}
+
+describe('Docker resource crash reconciliation', () => {
+  let home: string;
+  const previousHome = process.env.IRONCURTAIN_HOME;
+
+  beforeEach(() => {
+    home = mkdtempSync(resolve(tmpdir(), 'ironcurtain-docker-gc-'));
+    process.env.IRONCURTAIN_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('preserves resources whose owner process and lease are live', async () => {
+    const labels = managedResourceLabels('bundle-live');
+    const docker = runtimeWithInventory({
+      containers: [container({ labels })],
+      networks: [network({ labels, containerIds: ['container-id'] })],
+    });
+
+    const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => true });
+
+    expect(result.retainedActiveResources).toBe(2);
+    expect(docker.remove).not.toHaveBeenCalled();
+    expect(docker.removeNetwork).not.toHaveBeenCalled();
+  });
+
+  it('force-removes managed containers and networks after owner death', async () => {
+    const labels = {
+      [IRONCURTAIN_MANAGED_LABEL]: 'true',
+      [IRONCURTAIN_OWNER_PID_LABEL]: '424242',
+      [IRONCURTAIN_OWNER_TOKEN_LABEL]: 'dead-owner',
+      'ironcurtain.bundle': 'bundle-dead',
+    };
+    const docker = runtimeWithInventory({
+      containers: [container({ labels })],
+      networks: [network({ labels, containerIds: ['container-id'] })],
+    });
+
+    const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => false });
+
+    expect(result.removedContainers).toEqual(['ironcurtain-1234567890ab']);
+    expect(result.removedNetworks).toEqual(['ironcurtain-1234567890ab']);
+    expect(docker.remove).toHaveBeenCalledWith('container-id');
+    expect(docker.removeNetwork).toHaveBeenCalledWith('ironcurtain-1234567890ab');
+  });
+
+  it('reclaims a failed teardown in the same live process after its bundle lease is released', async () => {
+    const labels = managedResourceLabels('bundle-released');
+    releaseManagedResourceLease('bundle-released');
+    const docker = runtimeWithInventory({ networks: [network({ labels })] });
+
+    const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => true });
+
+    expect(result.removedNetworks).toEqual(['ironcurtain-1234567890ab']);
+  });
+
+  it('migrates only empty, aged legacy networks', async () => {
+    const docker = runtimeWithInventory({ networks: [network()] });
+    const result = await reconcileIronCurtainDockerResources(docker, {
+      now: new Date('2020-01-01T00:10:00.000Z'),
+      legacyGraceMs: 60_000,
+    });
+    expect(result.removedNetworks).toEqual(['ironcurtain-1234567890ab']);
+  });
+
+  it('never removes a network with an attachment it cannot prove is orphaned', async () => {
+    const labels = {
+      [IRONCURTAIN_MANAGED_LABEL]: 'true',
+      [IRONCURTAIN_OWNER_PID_LABEL]: '424242',
+      [IRONCURTAIN_OWNER_TOKEN_LABEL]: 'dead-owner',
+      'ironcurtain.bundle': 'bundle-dead',
+    };
+    const docker = runtimeWithInventory({
+      networks: [network({ labels, containerIds: ['foreign-container'] })],
+    });
+
+    const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => false });
+
+    expect(result.skippedUnsafeNetworks).toEqual(['ironcurtain-1234567890ab']);
+    expect(docker.removeNetwork).not.toHaveBeenCalled();
+  });
+});
+
+describe('IronCurtain Docker subnet allocator', () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(resolve(tmpdir(), 'ironcurtain-docker-ipam-'));
+    process.env.IRONCURTAIN_HOME = home;
+  });
+  afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+  it('allocates a labeled /29 outside 192.168/16 and host interface routes', async () => {
+    const createNetwork = vi.fn(async () => {});
+    const docker = runtimeWithInventory({ createNetwork });
+    const allocated = await createIronCurtainInternalNetwork(docker, 'ironcurtain-abcdef123456', 'bundle-1', {
+      hostCidrs: ['172.20.0.0/14'],
+    });
+
+    expect(allocated.subnet).toMatch(/\/29$/);
+    expect(allocated.subnet).not.toMatch(/^192\.168\./);
+    expect(allocated.subnet).not.toMatch(/^172\.(2[0-3])\./);
+    expect(createNetwork).toHaveBeenCalledWith(
+      'ironcurtain-abcdef123456',
+      expect.objectContaining({
+        internal: true,
+        subnet: allocated.subnet,
+        labels: expect.objectContaining({ [IRONCURTAIN_MANAGED_LABEL]: 'true' }),
+      }),
+    );
+  });
+
+  it('walks to another /29 when Docker reports an overlap race', async () => {
+    const attempts: string[] = [];
+    const createNetwork = vi.fn(async (_name: string, options?: { subnet?: string }) => {
+      attempts.push(options?.subnet ?? '');
+      if (attempts.length === 1) {
+        throw Object.assign(new Error('overlap'), {
+          code: 1,
+          stdout: '',
+          stderr: 'Pool overlaps with other one on this address space',
+        });
+      }
+    });
+    const docker = runtimeWithInventory({ createNetwork });
+    const allocated = await createIronCurtainInternalNetwork(docker, 'ironcurtain-race000000', 'bundle-2', {
+      hostCidrs: [],
+    });
+
+    expect(attempts).toHaveLength(2);
+    expect(allocated.subnet).toBe(attempts[1]);
+    expect(attempts[0]).not.toBe(attempts[1]);
+  });
+});

--- a/test/fixtures/docker-network-owner.ts
+++ b/test/fixtures/docker-network-owner.ts
@@ -1,0 +1,9 @@
+import { createDockerManager } from '../../src/docker/docker-manager.js';
+import { createIronCurtainInternalNetwork } from '../../src/docker/docker-resource-lifecycle.js';
+
+const [networkName, bundleId] = process.argv.slice(2);
+if (!networkName || !bundleId) throw new Error('usage: docker-network-owner <network-name> <bundle-id>');
+
+const allocated = await createIronCurtainInternalNetwork(createDockerManager(), networkName, bundleId);
+process.stdout.write(`${JSON.stringify(allocated)}\n`);
+setInterval(() => {}, 60_000);

--- a/test/mitm-proxy.test.ts
+++ b/test/mitm-proxy.test.ts
@@ -751,6 +751,37 @@ describe('MitmProxy', () => {
     expect(existsSync(socketPath)).toBe(true);
   });
 
+  it('answers the reserved sidecar health request without upstream access', async () => {
+    proxy = createMitmProxy({
+      socketPath,
+      ca,
+      providers: [{ config: testProvider, fakeKey, realKey }],
+    });
+    await proxy.start();
+
+    const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+      const req = http.request(
+        {
+          socketPath,
+          method: 'GET',
+          path: 'http://ironcurtain.invalid/__ironcurtain/health',
+        },
+        (res) => {
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk: string) => {
+            body += chunk;
+          });
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(response).toEqual({ status: 200, body: 'IRONCURTAIN_OK/1\n' });
+  });
+
   it('returns 403 for CONNECT to denied host', async () => {
     proxy = createMitmProxy({
       socketPath,

--- a/test/tcp-server-transport.test.ts
+++ b/test/tcp-server-transport.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { connect as netConnect, type Socket } from 'node:net';
-import { TcpServerTransport } from '../src/trusted-process/tcp-server-transport.js';
+import {
+  TCP_TRANSPORT_HEALTH_REQUEST,
+  TCP_TRANSPORT_HEALTH_RESPONSE,
+  TcpServerTransport,
+} from '../src/trusted-process/tcp-server-transport.js';
 import { serializeMessage, deserializeMessage } from '@modelcontextprotocol/sdk/shared/stdio.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 
@@ -218,5 +222,33 @@ describe('TcpServerTransport', () => {
     });
 
     firstClient.destroy();
+  });
+
+  it('answers a side-effect-free health probe without evicting the MCP client', async () => {
+    transport = new TcpServerTransport('127.0.0.1', 0);
+    const { messages, waitForMessages } = createMessageCollector(transport);
+    await transport.start();
+
+    clientSocket = await connectToTcp('127.0.0.1', transport.port);
+    sendMessage(clientSocket, { jsonrpc: '2.0', id: 1, method: 'setup' });
+    await waitForMessages(1);
+
+    const probe = await connectToTcp('127.0.0.1', transport.port);
+    const response = new Promise<string>((resolve, reject) => {
+      let received = '';
+      probe.on('data', (chunk: Buffer) => {
+        received += chunk.toString();
+      });
+      probe.on('end', () => resolve(received));
+      probe.on('error', reject);
+    });
+    // Split the magic request to cover TCP fragmentation.
+    probe.write(TCP_TRANSPORT_HEALTH_REQUEST.slice(0, 8));
+    probe.write(TCP_TRANSPORT_HEALTH_REQUEST.slice(8));
+    expect(await response).toBe(TCP_TRANSPORT_HEALTH_RESPONSE);
+
+    sendMessage(clientSocket, { jsonrpc: '2.0', id: 2, method: 'still-alive' });
+    await waitForMessages(2);
+    expect(messages[1]).toMatchObject({ id: 2, method: 'still-alive' });
   });
 });

--- a/test/tcp-server-transport.test.ts
+++ b/test/tcp-server-transport.test.ts
@@ -224,6 +224,21 @@ describe('TcpServerTransport', () => {
     firstClient.destroy();
   });
 
+  it('bounds idle unclassified connections and replaces older pending clients', async () => {
+    transport = new TcpServerTransport('127.0.0.1', 0, { firstByteTimeoutMs: 50 });
+    await transport.start();
+
+    const firstPending = await connectToTcp('127.0.0.1', transport.port);
+    const firstClosed = new Promise<void>((resolve) => firstPending.once('close', () => resolve()));
+    clientSocket = await connectToTcp('127.0.0.1', transport.port);
+    await firstClosed;
+
+    const secondClosed = new Promise<void>((resolve) => clientSocket!.once('close', () => resolve()));
+    await secondClosed;
+    expect(firstPending.destroyed).toBe(true);
+    expect(clientSocket.destroyed).toBe(true);
+  });
+
   it('answers a side-effect-free health probe without evicting the MCP client', async () => {
     transport = new TcpServerTransport('127.0.0.1', 0);
     const { messages, waitForMessages } = createMessageCollector(transport);

--- a/test/workflow-shutdown-signals.test.ts
+++ b/test/workflow-shutdown-signals.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installWorkflowShutdownSignals } from '../src/workflow/shutdown-signals.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function installedHandler(signal: NodeJS.Signals, before: ReadonlySet<NodeJS.SignalsListener>): NodeJS.SignalsListener {
+  const handler = process.listeners(signal).find((listener) => !before.has(listener));
+  if (!handler) throw new Error(`No ${signal} handler was installed`);
+  return handler as NodeJS.SignalsListener;
+}
+
+describe('workflow shutdown signals', () => {
+  it('aborts gracefully, escalates a second signal, and removes exact wrappers', () => {
+    const before = new Set(process.listeners('SIGTERM'));
+    const controller = new AbortController();
+    const forceExit = vi.fn();
+    const onFirstSignal = vi.fn();
+    const uninstall = installWorkflowShutdownSignals(controller, { forceExit, onFirstSignal });
+    const handler = installedHandler('SIGTERM', before);
+
+    handler('SIGTERM');
+    expect(controller.signal.aborted).toBe(true);
+    expect(onFirstSignal).toHaveBeenCalledWith('SIGTERM');
+    expect(forceExit).not.toHaveBeenCalled();
+
+    handler('SIGTERM');
+    expect(forceExit).toHaveBeenCalledWith(143);
+
+    uninstall();
+    expect(new Set(process.listeners('SIGTERM'))).toEqual(before);
+  });
+
+  it('forces exit when graceful teardown exceeds its deadline', async () => {
+    vi.useFakeTimers();
+    const before = new Set(process.listeners('SIGHUP'));
+    const forceExit = vi.fn();
+    const uninstall = installWorkflowShutdownSignals(new AbortController(), {
+      forceExit,
+      forceExitAfterMs: 25,
+    });
+
+    installedHandler('SIGHUP', before)('SIGHUP');
+    await vi.advanceTimersByTimeAsync(25);
+    expect(forceExit).toHaveBeenCalledWith(129);
+
+    uninstall();
+  });
+});


### PR DESCRIPTION
## Summary

- label Docker containers and per-bundle networks with process ownership leases, then reconcile resources left by SIGKILL or host crashes before new sessions allocate infrastructure
- replace Docker default /16 allocation with collision-checked /29 networks outside 192.168/16, with whole-pool fallback after failed routing checks
- add side-effect-free end-to-end MCP and MITM health probes, retrying failed allocations in both batch and PTY paths
- handle SIGTERM and SIGHUP during workflow shutdown, extend the emergency cleanup deadline, and verify cleanup postconditions
- add ironcurtain gc --dry-run/--force plus conservative migration cleanup for empty legacy networks

## Security Impact

- [ ] Changes the policy evaluation logic or rule format
- [ ] Modifies the sandbox boundary or V8 isolate setup
- [x] Adds or changes MCP server spawning, IPC, or credential handling
- [ ] Introduces new tool argument roles or path resolution logic
- [ ] None of the above

The TCP MCP transport now recognizes one fixed health preface before claiming the active MCP socket. It returns a fixed response without invoking MCP, evicting an active client, forwarding traffic, or exposing credentials. The MITM proxy similarly handles one reserved health URL locally and never forwards it upstream.

## Test plan

- [ ] Existing tests pass (npm test)
- [x] Added new tests for the change
- [x] Manual testing

Verification completed:

- build, TypeScript, ESLint, formatting, diff checks, pre-commit hooks, and circular-dependency check pass
- focused Docker lifecycle, infrastructure, proxy, transport, and PTY suites pass
- real Docker lifecycle integration passes 2/2, including a child process that allocates a network, receives SIGKILL, and is reclaimed by the next reconciler
- Apple container manager and integration coverage passes 56/56 standalone
- root suite excluding the two environment-sensitive integrations passes 5,519 tests; web UI passes 468/468
- ironcurtain gc --dry-run verified against Docker Desktop and integration cleanup leaves no temporary IronCurtain networks

The unfiltered local npm test run is not checked because the existing real-PTY integration cannot posix_spawnp in this execution environment, and the Apple gateway reachability integration flakes under the full parallel suite. The Apple integration passes when run standalone.