### PR TITLE
fix(docker): detect exhausted writable storage

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -422,6 +422,14 @@ exit $STATUS
         const hardFailure = stdout.trim().length === 0;
         return { text: `Agent exited with code ${exitCode}.\n\nOutput:\n${stdout}`, hardFailure };
       }
+      if (stdout.trim().length === 0) {
+        return {
+          text:
+            'Claude Code exited without producing output. Check the session log for startup failures ' +
+            '(for example, exhausted Docker storage).',
+          hardFailure: true,
+        };
+      }
       return parseClaudeCodeJson(stdout);
     },
 

--- a/src/docker/docker-agent-session.ts
+++ b/src/docker/docker-agent-session.ts
@@ -279,8 +279,14 @@ export class DockerAgentSession implements Session {
   }
 
   async sendMessage(userMessage: string): Promise<string> {
-    const { text } = await this.sendMessageDetailed(userMessage);
-    return text;
+    const result = await this.sendMessageDetailed(userMessage);
+    // Non-workflow transports use the string-only Session API and cannot see
+    // the hardFailure flag. Rotate here so their next user turn never resumes
+    // a conversation whose failed CLI invocation produced no transcript.
+    // Workflow callers use sendMessageDetailed() and own their retry/rotation
+    // policy explicitly, so they do not pass through this branch.
+    if (result.hardFailure) this.rotateAgentConversationId();
+    return result.text;
   }
 
   async sendMessageDetailed(userMessage: string): Promise<AgentTurnResult> {
@@ -364,7 +370,7 @@ export class DockerAgentSession implements Session {
       // matches `extractResponse`'s hard-failure definition (stdout.trim()
       // empty); hard failures still route through rotateAgentConversationId()
       // at the orchestrator layer.
-      if (exitCode === 0 || stdout.trim().length > 0) {
+      if (stdout.trim().length > 0) {
         this.firstTurnComplete = true;
       }
 

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -1425,6 +1425,10 @@ async function createSessionContainersAttempt(
     await core.docker.start(mainContainerId);
     logger.info(`Container started: ${mainContainerId.substring(0, 12)}`);
 
+    if (core.runtimeKind === 'docker') {
+      await checkDockerContainerWritableStorage(core.docker, mainContainerId);
+    }
+
     // tcp-hostonly: write the apt proxy config inside the container (the
     // Docker topologies bind-mount it; see execAptProxyUrl above).
     if (execAptProxyUrl !== undefined) {
@@ -1517,6 +1521,31 @@ export async function checkInternalNetworkConnectivity(
         `the sidecar could not reach the host proxy.`,
     );
   }
+}
+
+/**
+ * Verifies that Docker's writable layer has space before an agent starts.
+ * Docker Desktop can keep creating/starting containers after its VM disk is
+ * full, while writes inside the container fail with ENOSPC. Claude Code then
+ * exits 0 with no output after its initialization timeout, which otherwise
+ * looks like a networking failure.
+ */
+export async function checkDockerContainerWritableStorage(
+  docker: ContainerRuntime,
+  containerId: string,
+): Promise<void> {
+  const result = await docker.exec(
+    containerId,
+    ['/bin/sh', '-c', 'probe="${HOME:-/home/codespace}/.ironcurtain-write-probe-$$"; mkdir "$probe" && rmdir "$probe"'],
+    5_000,
+  );
+  if (result.exitCode === 0) return;
+
+  const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.exitCode}`;
+  throw new Error(
+    `Docker container writable storage check failed: ${detail}. ` +
+      'Docker storage may be full; inspect it with `docker system df` and reclaim unused data or increase the disk limit.',
+  );
 }
 
 /**

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -1542,10 +1542,10 @@ export async function checkDockerContainerWritableStorage(
   if (result.exitCode === 0) return;
 
   const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.exitCode}`;
-  throw new Error(
-    `Docker container writable storage check failed: ${detail}. ` +
-      'Docker storage may be full; inspect it with `docker system df` and reclaim unused data or increase the disk limit.',
-  );
+  const guidance = /ENOSPC|no space left on device/i.test(detail)
+    ? 'Docker storage may be full; inspect it with `docker system df` and reclaim unused data or increase the disk limit.'
+    : 'Inspect the container state, Docker daemon logs, and filesystem permissions.';
+  throw new Error(`Docker container writable storage check failed: ${detail}. ${guidance}`);
 }
 
 /**

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -240,6 +240,7 @@ async function runPtySessionAttempt(
   const {
     prepareDockerInfrastructure,
     writeAptProxyConfigViaExec,
+    checkDockerContainerWritableStorage,
     checkHostOnlyConnectivity,
     checkInternalNetworkConnectivity,
   } = await import('./docker-infrastructure.js');
@@ -717,6 +718,10 @@ async function runPtySessionAttempt(
 
     await docker.start(containerId);
     logger.info(`PTY container started: ${containerId.substring(0, 12)}`);
+
+    if (infra.runtimeKind === 'docker') {
+      await checkDockerContainerWritableStorage(docker, containerId);
+    }
 
     // apple-container (uds and the retained tcp-hostonly): write the apt
     // proxy config inside the container via exec instead of a bind mount.

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -248,6 +248,13 @@ describe('Claude Code Adapter', () => {
     expect(response.quotaExhausted).toBeUndefined();
   });
 
+  it('does not silently accept a zero-byte successful process exit', () => {
+    const response = claudeCodeAdapter.extractResponse(0, '');
+    expect(response.hardFailure).toBe(true);
+    expect(response.text).toContain('exited without producing output');
+    expect(response.text).toContain('Docker storage');
+  });
+
   it('surfaces transientFailure when usage.output_tokens=0 AND stop_reason=null (degenerate stall envelope)', () => {
     // Mirrors the captured envelope from a sustained LiteLLM/Z.AI outage:
     // CLI exits 0, JSON parses, `result` non-empty (preamble), but the

--- a/test/docker-agent-session-retry.test.ts
+++ b/test/docker-agent-session-retry.test.ts
@@ -221,6 +221,44 @@ describe('DockerAgentSession retry path', () => {
     expect(flagValue(calls[1], '--resume')).toBeUndefined();
   });
 
+  it('exit 0 with empty stdout does not mark the conversation resumable', async () => {
+    const { exec, calls } = scriptedExec([
+      { exitCode: 0, stdout: '', stderr: '' },
+      { exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' },
+    ]);
+    const deps = buildDeps(tempDir, exec);
+    session = new DockerAgentSession(deps);
+    await session.initialize();
+
+    const first = await session.sendMessageDetailed('attempt 1');
+    expect(first.hardFailure).toBe(true);
+    await session.sendMessageDetailed('attempt 2');
+
+    expect(flagValue(calls[0], '--session-id')).toBe(deps.agentConversationId);
+    expect(flagValue(calls[1], '--session-id')).toBe(deps.agentConversationId);
+    expect(flagValue(calls[1], '--resume')).toBeUndefined();
+  });
+
+  it('string-only sendMessage callers rotate after exit 0 with empty stdout', async () => {
+    const { exec, calls } = scriptedExec([
+      { exitCode: 0, stdout: '', stderr: '' },
+      { exitCode: 0, stdout: CLAUDE_JSON_OK, stderr: '' },
+    ]);
+    const deps = buildDeps(tempDir, exec);
+    session = new DockerAgentSession(deps);
+    await session.initialize();
+
+    expect(await session.sendMessage('attempt 1')).toContain('exited without producing output');
+    expect(await session.sendMessage('attempt 2')).toBe('all done');
+
+    const firstId = flagValue(calls[0], '--session-id');
+    const secondId = flagValue(calls[1], '--session-id');
+    expect(firstId).toBe(deps.agentConversationId);
+    expect(secondId).toBeDefined();
+    expect(secondId).not.toBe(firstId);
+    expect(flagValue(calls[1], '--resume')).toBeUndefined();
+  });
+
   it('after a partial-failure turn (exit!=0 with non-empty stdout), the next call uses --resume', async () => {
     // Regression: the Anthropic-API-400-mid-stream class produces exit=1 with
     // partial assistant text already on stdout AND a session JSONL on disk.

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -13,6 +13,7 @@ import {
   canRefreshOAuth,
   computeWorkflowDependencyHash,
   buildWorkflowExecCommand,
+  checkDockerContainerWritableStorage,
   ensureImage,
 } from '../src/docker/docker-infrastructure.js';
 import type { AgentAdapter, AgentId, ConversationStateConfig } from '../src/docker/agent-adapter.js';
@@ -868,9 +869,10 @@ describe('createSessionContainers', () => {
     expect(mainCreate.user).toBeUndefined();
     expect(mainCreate.env.IRONCURTAIN_AGENT_UID).toBeUndefined();
     expect(mainCreate.env.IRONCURTAIN_AGENT_GID).toBeUndefined();
-    expect(healthCommands).toHaveLength(2);
-    expect(healthCommands[0].join(' ')).toContain('IRONCURTAIN_HEALTH/1');
-    expect(healthCommands[1].join(' ')).toContain('http://ironcurtain.invalid/__ironcurtain/health');
+    expect(healthCommands).toHaveLength(3);
+    expect(healthCommands[0].join(' ')).toContain('.ironcurtain-write-probe');
+    expect(healthCommands[1].join(' ')).toContain('IRONCURTAIN_HEALTH/1');
+    expect(healthCommands[2].join(' ')).toContain('http://ironcurtain.invalid/__ironcurtain/health');
     expect(createdNetworks).toHaveLength(1);
     expect(createdNetworks[0].options).toMatchObject({
       internal: true,
@@ -906,7 +908,10 @@ describe('createSessionContainers', () => {
   // to defend against regressions from either end of the rollback path.
   it('throws when connectivity check fails and cleans up sidecar, network, and main container', async () => {
     const { docker, stoppedContainers, removedContainers, removedNetworks, createdNetworks } = makeMockDocker({
-      async exec() {
+      async exec(_containerId, command) {
+        if (command.some((arg) => arg.includes('.ironcurtain-write-probe'))) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
         // Simulate the connectivity check failing: container can't reach
         // host-side proxies through the socat sidecar.
         return { exitCode: 1, stdout: '', stderr: 'Connection refused' };
@@ -933,6 +938,18 @@ describe('createSessionContainers', () => {
     const attemptedSubnets = createdNetworks.map((entry) => entry.options?.subnet);
     expect(new Set(attemptedSubnets).size).toBe(4);
     expect(new Set(attemptedSubnets.map((subnet) => dockerAllocationPoolForSubnet(String(subnet)))).size).toBe(4);
+  });
+
+  it('reports exhausted Docker writable storage before starting the agent', async () => {
+    const docker = {
+      async exec() {
+        return { exitCode: 1, stdout: '', stderr: 'mkdir: No space left on device' };
+      },
+    } as unknown as ContainerRuntime;
+
+    await expect(checkDockerContainerWritableStorage(docker, 'container-id')).rejects.toThrow(
+      /Docker container writable storage check failed: mkdir: No space left on device.*docker system df/,
+    );
   });
 
   // --- tcp-hostonly topology (apple-container) ---

--- a/test/docker-infrastructure.test.ts
+++ b/test/docker-infrastructure.test.ts
@@ -952,6 +952,19 @@ describe('createSessionContainers', () => {
     );
   });
 
+  it('does not diagnose unrelated writable-storage probe failures as disk exhaustion', async () => {
+    const docker = {
+      async exec() {
+        return { exitCode: 1, stdout: '', stderr: 'mkdir: Permission denied' };
+      },
+    } as unknown as ContainerRuntime;
+
+    await expect(checkDockerContainerWritableStorage(docker, 'container-id')).rejects.toThrow(
+      /Permission denied.*Inspect the container state, Docker daemon logs, and filesystem permissions/,
+    );
+    await expect(checkDockerContainerWritableStorage(docker, 'container-id')).rejects.not.toThrow(/docker system df/);
+  });
+
   // --- tcp-hostonly topology (apple-container) ---
 
   const HOST_ONLY = { name: 'ironcurtain-hostonly-net', subnet: '192.168.205.0/24', gateway: '192.168.205.1' };


### PR DESCRIPTION
## Summary

- probe the Docker container writable layer before reporting Session ready
- apply the same fail-fast check to batch and PTY Docker sessions
- surface a clear hard failure when Claude Code exits successfully with zero output
- add regression coverage for ENOSPC and zero-byte agent exits

## Root cause

A forced-Docker run appeared to reproduce the prior network failure: Claude waited 30 seconds and returned empty output. The session used a collision-free 172.23 /29 network and the MITM sidecar forwarded successfully. Claude debug output showed repeated ENOSPC errors because the Docker Desktop VM disk was at 100 percent, preventing Claude startup and MCP launch.

The preflight now reports Docker storage exhaustion during initialization instead of presenting an empty successful session. IronCurtain does not automatically delete unrelated Docker data.

## Validation

- TypeScript typecheck passed
- targeted lint passed
- 156 affected tests passed, 2 skipped
- exact forced-Docker command succeeded after reclaiming Docker space
- no orphaned IronCurtain containers or networks remained