### PR TITLE
feat(docker): detect OAuth credentials from the Anthropic CLI store

### DIFF
--- a/docs/designs/oauth-docker-support.md
+++ b/docs/designs/oauth-docker-support.md
@@ -86,9 +86,12 @@ function detectAuthMethod(config: IronCurtainConfig): AuthMethod;
 
 **Detection order (prefer OAuth):**
 1. Read `~/.claude/.credentials.json` → parse `claudeAiOauth` → if valid and not expired, return `oauth`
-2. On macOS, if credentials file is missing, try extracting from Keychain (see 4.5)
-3. Fall back to `ANTHROPIC_API_KEY` / `config.userConfig.anthropicApiKey` → return `apikey`
-4. Return `none`
+2. Read `~/.config/anthropic/credentials/default.json` (Anthropic CLI store; honors `ANTHROPIC_CONFIG_DIR` and `XDG_CONFIG_HOME`) → parse flat snake_case shape (`access_token`, `refresh_token`, `expires_at` in epoch seconds) → if valid and not expired, return `oauth`
+3. On macOS, if no credentials file is found, try extracting from Keychain (see 4.5)
+4. Fall back to `ANTHROPIC_API_KEY` / `config.userConfig.anthropicApiKey` → return `apikey`
+5. Return `none`
+
+Token refresh writes back to the file the credentials were detected in, preserving that file's native format — the `AuthMethod` file variant carries a `filePath` for this.
 
 **Override:** `IRONCURTAIN_DOCKER_AUTH=apikey` forces API key mode.
 

--- a/docs/designs/oauth-docker-support.md
+++ b/docs/designs/oauth-docker-support.md
@@ -8,6 +8,7 @@
 IronCurtain's Docker agent mode currently only supports API key authentication. Most Claude Code users authenticate via OAuth (Pro/Max/Teams/Enterprise subscriptions), not API keys. These users cannot use Docker agent mode today.
 
 We need to:
+
 1. Detect whether the host user has OAuth credentials
 2. Prefer OAuth over API keys when both are available
 3. Maintain the security invariant: real credentials never enter the container
@@ -17,12 +18,14 @@ We need to:
 Claude Code natively supports a `CLAUDE_CODE_OAUTH_TOKEN` environment variable as its **highest-priority** auth source. When set, Claude Code uses it as a bearer token directly — no credentials files needed.
 
 **Auth priority order in Claude Code:**
+
 1. `CLAUDE_CODE_OAUTH_TOKEN` env var (highest)
 2. `ANTHROPIC_API_KEY` env var
 3. `~/.claude/.credentials.json` file
 4. macOS Keychain
 
 Users can generate a long-lived OAuth token (~1 year validity) via:
+
 ```bash
 claude setup-token
 ```
@@ -85,19 +88,23 @@ function detectAuthMethod(config: IronCurtainConfig): AuthMethod;
 ```
 
 **Detection order (prefer OAuth):**
+
 1. Read `~/.claude/.credentials.json` → parse `claudeAiOauth` → if valid and not expired, return `oauth`
 2. Read `~/.config/anthropic/credentials/default.json` (Anthropic CLI store; honors `ANTHROPIC_CONFIG_DIR` and `XDG_CONFIG_HOME`) → parse flat snake_case shape (`access_token`, `refresh_token`, `expires_at` in epoch seconds) → if valid and not expired, return `oauth`
 3. On macOS, if no credentials file is found, try extracting from Keychain (see 4.5)
 4. Fall back to `ANTHROPIC_API_KEY` / `config.userConfig.anthropicApiKey` → return `apikey`
 5. Return `none`
 
-Token refresh writes back to the file the credentials were detected in, preserving that file's native format — the `AuthMethod` file variant carries a `filePath` for this.
+Each credential file is considered independently: an expired file whose refresh fails does **not** shadow a valid (or refreshable) lower-priority file — detection falls through to the next candidate.
+
+Token refresh writes back to the file the credentials were detected in, preserving that file's native format — the `AuthMethod` file variant carries a `filePath` for this. If the origin file vanished between detection and write-back, the format is decided by the target path (CLI store path → flat snake_case) so the wrong shape is never written into the Anthropic CLI's store.
 
 **Override:** `IRONCURTAIN_DOCKER_AUTH=apikey` forces API key mode.
 
 ### 4.2 OAuth credential structure on host
 
 **Linux** — `~/.claude/.credentials.json` (mode 0600):
+
 ```json
 {
   "claudeAiOauth": {
@@ -112,11 +119,13 @@ Token refresh writes back to the file the credentials were detected in, preservi
 ```
 
 **macOS** — stored in Keychain under:
+
 - Service: `"Claude Code-credentials"` (write path) / `"Claude Code"` (read path)
 - Account: `$USER`
 - Value: same JSON structure as above
 
 Extraction command:
+
 ```bash
 security find-generic-password -s "Claude Code-credentials" -w
 # or
@@ -205,10 +214,10 @@ function extractFromKeychain(): OAuthCredentials | null {
   // Try both service names (Claude Code has a known bug where write/read use different names)
   for (const service of ['Claude Code-credentials', 'Claude Code']) {
     try {
-      const result = execSync(
-        `security find-generic-password -s "${service}" -w`,
-        { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-      );
+      const result = execSync(`security find-generic-password -s "${service}" -w`, {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
       const parsed = JSON.parse(result.trim());
       if (parsed.claudeAiOauth?.accessToken) {
         return parsed.claudeAiOauth;
@@ -222,6 +231,7 @@ function extractFromKeychain(): OAuthCredentials | null {
 ```
 
 **Keychain access caveats:**
+
 - Prompts the user for Keychain password if locked (acceptable UX for a one-time session start)
 - SSH sessions may need `security unlock-keychain` first
 - If Keychain access fails, fall back to API key with a helpful message
@@ -333,22 +343,23 @@ Refresh token rotation means concurrent refreshes (IronCurtain + host Claude Cod
 
 ## 6. Edge Cases
 
-| Scenario | Behavior |
-|---|---|
-| Expired access token, valid refresh token | Refresh at session start; proceed with new token |
-| Expired access + expired refresh token | Fall back to API key; if none, error with "run `claude login`" |
-| Both OAuth and API key available | OAuth wins; override with `IRONCURTAIN_DOCKER_AUTH=apikey` |
-| macOS Keychain locked | Prompt user for password; fall back to API key on failure |
-| `~/.claude/.credentials.json` missing (macOS) | Try Keychain extraction |
-| `~/.claude/.credentials.json` missing (Linux) | Fall back to API key |
+| Scenario                                      | Behavior                                                         |
+| --------------------------------------------- | ---------------------------------------------------------------- |
+| Expired access token, valid refresh token     | Refresh at session start; proceed with new token                 |
+| Expired access + expired refresh token        | Fall back to API key; if none, error with "run `claude login`"   |
+| Both OAuth and API key available              | OAuth wins; override with `IRONCURTAIN_DOCKER_AUTH=apikey`       |
+| macOS Keychain locked                         | Prompt user for password; fall back to API key on failure        |
+| `~/.claude/.credentials.json` missing (macOS) | Try Keychain extraction                                          |
+| `~/.claude/.credentials.json` missing (Linux) | Fall back to API key                                             |
 | Token expires mid-session (401 from upstream) | Session errors; user restarts (future: host-side refresh on 401) |
-| Corrupt credentials file | JSON parse error caught; fall back to API key |
+| Corrupt credentials file                      | JSON parse error caught; fall back to API key                    |
 
 ## 7. Implementation Plan
 
 ### Phase 1: OAuth credential detection and provider config
 
 **New file:** `src/docker/oauth-credentials.ts`
+
 - `loadOAuthCredentials(): OAuthCredentials | null` — reads `~/.claude/.credentials.json`
 - `extractFromKeychain(): OAuthCredentials | null` — macOS Keychain extraction
 - `detectAuthMethod(config: IronCurtainConfig): AuthMethod` — preference logic
@@ -356,6 +367,7 @@ Refresh token rotation means concurrent refreshes (IronCurtain + host Claude Cod
 - Types: `OAuthCredentials`, `AuthMethod`
 
 **Modified:** `src/docker/provider-config.ts`
+
 - Add `anthropicOAuthProvider` and `claudePlatformOAuthProvider`
 
 **New tests:** `test/oauth-credentials.test.ts`
@@ -363,27 +375,33 @@ Refresh token rotation means concurrent refreshes (IronCurtain + host Claude Cod
 ### Phase 2: Integration (adapter, infrastructure, entrypoint)
 
 **Modified:** `src/docker/docker-infrastructure.ts`
+
 - `prepareDockerInfrastructure()` calls `detectAuthMethod()` early
 - Uses OAuth providers when `kind === 'oauth'`; real key = `credentials.accessToken`
 - Stores auth kind on `DockerInfrastructure` for adapter to use
 
 **Modified:** `src/docker/adapters/claude-code.ts`
+
 - `getProviders()` accepts auth kind parameter
 - `buildEnv()` sets `CLAUDE_CODE_OAUTH_TOKEN` in OAuth mode, `IRONCURTAIN_API_KEY` in API key mode
 
 **Modified:** `docker/entrypoint-claude-code.sh`
+
 - Conditional `apiKeyHelper` (omitted in OAuth mode)
 
 **Modified:** `src/docker/agent-adapter.ts`
+
 - `getProviders()` signature gains optional `authKind` parameter
 
 ### Phase 3: Token refresh at session start
 
 **Added to:** `src/docker/oauth-credentials.ts`
+
 - `refreshOAuthToken(credentials: OAuthCredentials): Promise<OAuthCredentials | null>`
 - Writes new credentials back to `~/.claude/.credentials.json`
 
 **Modified:** `src/docker/docker-infrastructure.ts`
+
 - Refresh before generating fake key if token is expired
 
 ### Phase 4: UX polish
@@ -395,16 +413,16 @@ Refresh token rotation means concurrent refreshes (IronCurtain + host Claude Cod
 
 ## 8. Files Changed Summary
 
-| File | Change |
-|------|--------|
-| `src/docker/oauth-credentials.ts` | **New** — credential detection, Keychain extraction, refresh |
-| `src/docker/provider-config.ts` | Add `anthropicOAuthProvider`, `claudePlatformOAuthProvider` |
-| `src/docker/docker-infrastructure.ts` | Auth method detection, conditional provider selection |
-| `src/docker/adapters/claude-code.ts` | Auth-aware `buildEnv()` and `getProviders()` |
-| `src/docker/agent-adapter.ts` | Optional `authKind` on `getProviders()` |
-| `docker/entrypoint-claude-code.sh` | Conditional `apiKeyHelper` |
-| `src/config/types.ts` | Optional `dockerAuth` on config |
-| `test/oauth-credentials.test.ts` | **New** — unit tests |
+| File                                  | Change                                                       |
+| ------------------------------------- | ------------------------------------------------------------ |
+| `src/docker/oauth-credentials.ts`     | **New** — credential detection, Keychain extraction, refresh |
+| `src/docker/provider-config.ts`       | Add `anthropicOAuthProvider`, `claudePlatformOAuthProvider`  |
+| `src/docker/docker-infrastructure.ts` | Auth method detection, conditional provider selection        |
+| `src/docker/adapters/claude-code.ts`  | Auth-aware `buildEnv()` and `getProviders()`                 |
+| `src/docker/agent-adapter.ts`         | Optional `authKind` on `getProviders()`                      |
+| `docker/entrypoint-claude-code.sh`    | Conditional `apiKeyHelper`                                   |
+| `src/config/types.ts`                 | Optional `dockerAuth` on config                              |
+| `test/oauth-credentials.test.ts`      | **New** — unit tests                                         |
 
 ## 9. Security Considerations
 

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -541,6 +541,13 @@ export async function prepareDockerInfrastructure(
   // Providers sharing the same fakeKeyPrefix (and thus the same real credential)
   // reuse the same fake key so a single container token authenticates against all hosts.
   const oauthAccessToken = authMethod.kind === 'oauth' ? authMethod.credentials.accessToken : undefined;
+  // Re-reads and refresh write-backs must target the file the credentials
+  // were detected in — writing a rotated refresh token to the wrong file
+  // would strand the host's Claude Code login with an invalidated token.
+  const tokenManagerFileDeps =
+    authMethod.kind === 'oauth' && authMethod.source === 'file' && authMethod.filePath
+      ? { credentialsFilePath: authMethod.filePath }
+      : undefined;
   const tokenManagerKeychainDeps =
     authMethod.kind === 'oauth' && authMethod.source === 'keychain'
       ? { writeToKeychain, keychainServiceName: authMethod.keychainServiceName }
@@ -560,6 +567,7 @@ export async function prepareDockerInfrastructure(
           authMethod.credentials,
           { canRefresh: canRefreshOAuth(authMethod.credentials.refreshToken) },
           {
+            ...tokenManagerFileDeps,
             ...tokenManagerKeychainDeps,
             ...tokenManagerCodexDeps,
           },

--- a/src/docker/oauth-credentials.ts
+++ b/src/docker/oauth-credentials.ts
@@ -88,11 +88,13 @@ export function getCredentialsFilePath(): string {
  * Resolution: ANTHROPIC_CONFIG_DIR > $XDG_CONFIG_HOME/anthropic > ~/.config/anthropic.
  */
 export function getAnthropicCredentialsFilePath(): string {
-  const configDir =
-    process.env.ANTHROPIC_CONFIG_DIR ??
-    (process.env.XDG_CONFIG_HOME
+  // Truthy checks (not ??): an empty env var must fall through to the next
+  // candidate rather than resolving to a cwd-relative path.
+  const configDir = process.env.ANTHROPIC_CONFIG_DIR
+    ? process.env.ANTHROPIC_CONFIG_DIR
+    : process.env.XDG_CONFIG_HOME
       ? resolve(process.env.XDG_CONFIG_HOME, 'anthropic')
-      : resolve(homedir(), '.config', 'anthropic'));
+      : resolve(homedir(), '.config', 'anthropic');
   return resolve(configDir, 'credentials', 'default.json');
 }
 
@@ -126,15 +128,29 @@ export function loadOAuthCredentials(): OAuthCredentials | null {
 }
 
 /**
- * Like loadOAuthCredentials(), but also reports which file the credentials
- * came from so token refresh can write back to the same file.
+ * Loads credentials from every known credential file, in detection-priority
+ * order (~/.claude/.credentials.json first, then the Anthropic CLI store).
+ * Expired entries are included — detectAuthMethod() decides per file whether
+ * to use, refresh, or skip them.
  */
-export function loadOAuthCredentialsWithSource(): FileCredentialsResult | null {
+export function loadAllOAuthCredentialFiles(): FileCredentialsResult[] {
+  const results: FileCredentialsResult[] = [];
   for (const filePath of [getCredentialsFilePath(), getAnthropicCredentialsFilePath()]) {
     const credentials = loadCredentialsFromFile(filePath);
-    if (credentials) return { credentials, filePath };
+    if (credentials) results.push({ credentials, filePath });
   }
-  return null;
+  return results;
+}
+
+/**
+ * Like loadOAuthCredentials(), but also reports which file the credentials
+ * came from so token refresh can write back to the same file. Prefers the
+ * first file with an unexpired token; an expired higher-priority file must
+ * not shadow a valid lower-priority one.
+ */
+export function loadOAuthCredentialsWithSource(): FileCredentialsResult | null {
+  const all = loadAllOAuthCredentialFiles();
+  return all.find((r) => !isTokenExpired(r.credentials)) ?? all.at(0) ?? null;
 }
 
 /**
@@ -207,7 +223,10 @@ export function parseAnthropicCredentialsJson(json: string): OAuthCredentials | 
     if (typeof parsed !== 'object' || parsed === null) return null;
 
     const creds = parsed as Record<string, unknown>;
-    if (creds.type !== 'oauth_token') return null;
+    // The documented store schema (version, access_token, expires_at,
+    // refresh_token, scope) does not include `type`; observed files carry
+    // type: 'oauth_token'. Accept both, but reject explicit non-OAuth types.
+    if (creds.type !== undefined && creds.type !== 'oauth_token') return null;
     if (!isNonEmptyString(creds.access_token)) return null;
     if (!isNonEmptyString(creds.refresh_token)) return null;
     if (!isPositiveFiniteNumber(creds.expires_at)) return null;
@@ -495,12 +514,28 @@ function parseCodexTokenResponse(data: Record<string, unknown>, fallbackRefreshT
 }
 
 /**
+ * Decides whether a credentials write should use the Anthropic CLI's flat
+ * snake_case shape. Content is authoritative: a top-level snake_case token
+ * (or explicit type: 'oauth_token') marks a CLI file, a claudeAiOauth object
+ * marks a Claude Code file. When the content is ambiguous — the origin file
+ * was deleted or emptied between detection and this write-back — fall back
+ * to the path: writing the claudeAiOauth wrapper into the CLI store's own
+ * location would leave the Anthropic CLI unable to read its credentials.
+ */
+function shouldWriteAnthropicCliFormat(credPath: string, existing: Record<string, unknown>): boolean {
+  if (existing.type === 'oauth_token' || isNonEmptyString(existing.access_token)) return true;
+  if (typeof existing.claudeAiOauth === 'object' && existing.claudeAiOauth !== null) return false;
+  return credPath === getAnthropicCredentialsFilePath();
+}
+
+/**
  * Writes updated OAuth credentials back to a credentials file (default
  * ~/.claude/.credentials.json), preserving other fields in the file
  * (e.g., scopes, subscriptionType). The write matches the file's existing
  * format: Anthropic CLI files keep their flat snake_case shape (with
  * `expires_at` in epoch seconds); everything else gets the claudeAiOauth
- * shape.
+ * shape. For an empty or unreadable file the format falls back to the
+ * target path (CLI store path -> CLI shape).
  */
 export function saveOAuthCredentials(credentials: OAuthCredentials, filePath?: string): void {
   const credPath = filePath ?? getCredentialsFilePath();
@@ -517,7 +552,7 @@ export function saveOAuthCredentials(credentials: OAuthCredentials, filePath?: s
     // Start fresh if file is unreadable
   }
 
-  if (existing.type === 'oauth_token' && isNonEmptyString(existing.access_token)) {
+  if (shouldWriteAnthropicCliFormat(credPath, existing)) {
     existing.access_token = credentials.accessToken;
     existing.refresh_token = credentials.refreshToken;
     existing.expires_at = Math.round(credentials.expiresAt / 1000);
@@ -580,8 +615,13 @@ export interface CredentialSources {
   loadFromKeychain: () => OAuthCredentials | null;
   refreshToken?: (refreshToken: string) => Promise<OAuthCredentials | null>;
   saveToFile?: (credentials: OAuthCredentials, filePath?: string) => void;
-  /** Path-aware file loader; preferred over loadFromFile when present. */
-  loadFromFileWithSource?: () => FileCredentialsResult | null;
+  /**
+   * Path-aware multi-file loader; preferred over loadFromFile when present.
+   * Returns every parseable credential file in detection-priority order so
+   * detection can fall through to the next file when one is expired and
+   * unrefreshable.
+   */
+  loadFromFilesWithSource?: () => FileCredentialsResult[];
   loadFromKeychainWithService?: () => KeychainResult | null;
   writeToKeychain?: (credentials: OAuthCredentials, serviceName: string) => void;
 }
@@ -591,7 +631,7 @@ const defaultSources: CredentialSources = {
   loadFromKeychain: extractFromKeychain,
   refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
   saveToFile: saveOAuthCredentials,
-  loadFromFileWithSource: loadOAuthCredentialsWithSource,
+  loadFromFilesWithSource: loadAllOAuthCredentialFiles,
   loadFromKeychainWithService: extractFromKeychainWithService,
   writeToKeychain,
 };
@@ -609,7 +649,7 @@ export const preflightCredentialSources: CredentialSources = {
   loadFromKeychain: extractFromKeychain,
   refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
   saveToFile: saveOAuthCredentials,
-  loadFromFileWithSource: loadOAuthCredentialsWithSource,
+  loadFromFilesWithSource: loadAllOAuthCredentialFiles,
   loadFromKeychainWithService: extractFromKeychainWithService,
   writeToKeychain,
 };
@@ -623,7 +663,7 @@ export const preflightCredentialSources: CredentialSources = {
 export const readOnlyCredentialSources: CredentialSources = {
   loadFromFile: loadOAuthCredentials,
   loadFromKeychain: extractFromKeychain,
-  loadFromFileWithSource: loadOAuthCredentialsWithSource,
+  loadFromFilesWithSource: loadAllOAuthCredentialFiles,
   loadFromKeychainWithService: extractFromKeychainWithService,
 };
 
@@ -649,10 +689,11 @@ export async function detectAuthMethod(config: IronCurtainConfig, sources?: Cred
     return resolveApiKeyAuth(config);
   }
 
-  // Try OAuth from credentials files
-  const fileResult = s.loadFromFileWithSource ? s.loadFromFileWithSource() : toFileResult(s.loadFromFile());
-  if (fileResult) {
-    const { credentials: fileCreds, filePath } = fileResult;
+  // Try OAuth from credentials files, in detection-priority order. Each file
+  // is considered independently: an expired, unrefreshable file must not
+  // shadow a valid (or refreshable) lower-priority file.
+  const fileResults = s.loadFromFilesWithSource ? s.loadFromFilesWithSource() : toFileResults(s.loadFromFile());
+  for (const { credentials: fileCreds, filePath } of fileResults) {
     if (!isTokenExpired(fileCreds)) {
       logger.info(`Detected OAuth credentials from ${filePath ?? 'credentials file'}`);
       return { kind: 'oauth', credentials: fileCreds, source: 'file', filePath };
@@ -663,11 +704,11 @@ export async function detectAuthMethod(config: IronCurtainConfig, sources?: Cred
       const refreshed = await tryRefreshFileCreds(fileCreds, s.refreshToken, s.saveToFile, filePath);
       if (refreshed) return refreshed;
     }
-    logger.warn('OAuth token from credentials file is expired');
+    logger.warn(`OAuth token from ${filePath ?? 'credentials file'} is expired`);
   }
 
   // Try macOS Keychain if no credentials file was found
-  if (!fileResult) {
+  if (fileResults.length === 0) {
     const keychainResult = s.loadFromKeychainWithService?.() ?? toKeychainResult(s.loadFromKeychain());
     if (keychainResult) {
       if (!isTokenExpired(keychainResult.credentials)) {
@@ -703,12 +744,12 @@ function toKeychainResult(creds: OAuthCredentials | null): KeychainResult | null
 
 /**
  * Wraps a plain OAuthCredentials from loadFromFile() into the path-aware
- * shape. The path is unknown for legacy loaders, so refresh write-back
+ * list shape. The path is unknown for legacy loaders, so refresh write-back
  * falls to saveToFile's default path.
  */
-function toFileResult(creds: OAuthCredentials | null): { credentials: OAuthCredentials; filePath?: string } | null {
-  if (!creds) return null;
-  return { credentials: creds };
+function toFileResults(creds: OAuthCredentials | null): Array<{ credentials: OAuthCredentials; filePath?: string }> {
+  if (!creds) return [];
+  return [{ credentials: creds }];
 }
 
 /**

--- a/src/docker/oauth-credentials.ts
+++ b/src/docker/oauth-credentials.ts
@@ -8,8 +8,9 @@
  *
  * Detection order (prefer OAuth):
  * 1. ~/.claude/.credentials.json (claudeAiOauth)
- * 2. macOS Keychain (if credentials file missing)
- * 3. Fall back to API key from config
+ * 2. ~/.config/anthropic/credentials/default.json (Anthropic CLI store)
+ * 3. macOS Keychain (if no credentials file found)
+ * 4. Fall back to API key from config
  */
 
 import { existsSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
@@ -43,7 +44,13 @@ export interface KeychainResult {
 
 /** Authentication method detected on the host. */
 export type AuthMethod =
-  | { readonly kind: 'oauth'; readonly credentials: OAuthCredentials; readonly source: 'file' }
+  | {
+      readonly kind: 'oauth';
+      readonly credentials: OAuthCredentials;
+      readonly source: 'file';
+      /** Which credentials file the tokens came from; refresh writes back here. */
+      readonly filePath?: string;
+    }
   | {
       readonly kind: 'oauth';
       readonly credentials: OAuthCredentials;
@@ -76,6 +83,25 @@ export function getCredentialsFilePath(): string {
   return resolve(homedir(), '.claude', '.credentials.json');
 }
 
+/**
+ * Returns the path to the Anthropic CLI credential store's default profile.
+ * Resolution: ANTHROPIC_CONFIG_DIR > $XDG_CONFIG_HOME/anthropic > ~/.config/anthropic.
+ */
+export function getAnthropicCredentialsFilePath(): string {
+  const configDir =
+    process.env.ANTHROPIC_CONFIG_DIR ??
+    (process.env.XDG_CONFIG_HOME
+      ? resolve(process.env.XDG_CONFIG_HOME, 'anthropic')
+      : resolve(homedir(), '.config', 'anthropic'));
+  return resolve(configDir, 'credentials', 'default.json');
+}
+
+/** OAuth credentials together with the file they were loaded from. */
+export interface FileCredentialsResult {
+  readonly credentials: OAuthCredentials;
+  readonly filePath: string;
+}
+
 /** Returns Codex's auth cache path, honoring CODEX_HOME when set. */
 export function getCodexAuthFilePath(): string {
   return resolve(process.env.CODEX_HOME ?? resolve(homedir(), '.codex'), 'auth.json');
@@ -90,23 +116,38 @@ export function isTokenExpired(credentials: OAuthCredentials): boolean {
 }
 
 /**
- * Loads OAuth credentials from ~/.claude/.credentials.json.
- * Returns null if the file is missing, unreadable, or lacks valid credentials.
+ * Loads OAuth credentials from the first credential file that yields valid
+ * credentials, checking ~/.claude/.credentials.json before the Anthropic CLI
+ * store at ~/.config/anthropic/credentials/default.json.
+ * Returns null if no file contains valid credentials.
  */
 export function loadOAuthCredentials(): OAuthCredentials | null {
-  const credPath = getCredentialsFilePath();
-  return loadCredentialsFromFile(credPath);
+  return loadOAuthCredentialsWithSource()?.credentials ?? null;
 }
 
 /**
- * Parses credentials from a file path. Extracted for testability.
+ * Like loadOAuthCredentials(), but also reports which file the credentials
+ * came from so token refresh can write back to the same file.
+ */
+export function loadOAuthCredentialsWithSource(): FileCredentialsResult | null {
+  for (const filePath of [getCredentialsFilePath(), getAnthropicCredentialsFilePath()]) {
+    const credentials = loadCredentialsFromFile(filePath);
+    if (credentials) return { credentials, filePath };
+  }
+  return null;
+}
+
+/**
+ * Parses credentials from a file path, accepting either Claude Code's
+ * claudeAiOauth shape or the Anthropic CLI's flat snake_case shape.
+ * Extracted for testability.
  */
 export function loadCredentialsFromFile(filePath: string): OAuthCredentials | null {
   if (!existsSync(filePath)) return null;
 
   try {
     const raw = readFileSync(filePath, 'utf-8');
-    return parseCredentialsJson(raw);
+    return parseCredentialsJson(raw) ?? parseAnthropicCredentialsJson(raw);
   } catch {
     logger.warn(`Failed to read OAuth credentials from ${filePath}`);
     return null;
@@ -148,6 +189,33 @@ export function parseCredentialsJson(json: string): OAuthCredentials | null {
       accessToken: creds.accessToken,
       refreshToken: creds.refreshToken,
       expiresAt: creds.expiresAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parses the Anthropic CLI credential store shape
+ * (~/.config/anthropic/credentials/default.json): flat snake_case fields
+ * with `expires_at` in epoch seconds (normalized to milliseconds here).
+ * Returns null if parsing fails or required fields are missing.
+ */
+export function parseAnthropicCredentialsJson(json: string): OAuthCredentials | null {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+
+    const creds = parsed as Record<string, unknown>;
+    if (creds.type !== 'oauth_token') return null;
+    if (!isNonEmptyString(creds.access_token)) return null;
+    if (!isNonEmptyString(creds.refresh_token)) return null;
+    if (!isPositiveFiniteNumber(creds.expires_at)) return null;
+
+    return {
+      accessToken: creds.access_token,
+      refreshToken: creds.refresh_token,
+      expiresAt: creds.expires_at * 1000,
     };
   } catch {
     return null;
@@ -427,8 +495,12 @@ function parseCodexTokenResponse(data: Record<string, unknown>, fallbackRefreshT
 }
 
 /**
- * Writes updated OAuth credentials back to ~/.claude/.credentials.json,
- * preserving other fields in the file (e.g., scopes, subscriptionType).
+ * Writes updated OAuth credentials back to a credentials file (default
+ * ~/.claude/.credentials.json), preserving other fields in the file
+ * (e.g., scopes, subscriptionType). The write matches the file's existing
+ * format: Anthropic CLI files keep their flat snake_case shape (with
+ * `expires_at` in epoch seconds); everything else gets the claudeAiOauth
+ * shape.
  */
 export function saveOAuthCredentials(credentials: OAuthCredentials, filePath?: string): void {
   const credPath = filePath ?? getCredentialsFilePath();
@@ -436,23 +508,32 @@ export function saveOAuthCredentials(credentials: OAuthCredentials, filePath?: s
   let existing: Record<string, unknown> = {};
   try {
     if (existsSync(credPath)) {
-      existing = JSON.parse(readFileSync(credPath, 'utf-8')) as Record<string, unknown>;
+      const parsed: unknown = JSON.parse(readFileSync(credPath, 'utf-8'));
+      if (typeof parsed === 'object' && parsed !== null) {
+        existing = parsed as Record<string, unknown>;
+      }
     }
   } catch {
     // Start fresh if file is unreadable
   }
 
-  const existingOauth =
-    typeof existing.claudeAiOauth === 'object' && existing.claudeAiOauth !== null
-      ? (existing.claudeAiOauth as Record<string, unknown>)
-      : {};
+  if (existing.type === 'oauth_token' && isNonEmptyString(existing.access_token)) {
+    existing.access_token = credentials.accessToken;
+    existing.refresh_token = credentials.refreshToken;
+    existing.expires_at = Math.round(credentials.expiresAt / 1000);
+  } else {
+    const existingOauth =
+      typeof existing.claudeAiOauth === 'object' && existing.claudeAiOauth !== null
+        ? (existing.claudeAiOauth as Record<string, unknown>)
+        : {};
 
-  existing.claudeAiOauth = {
-    ...existingOauth,
-    accessToken: credentials.accessToken,
-    refreshToken: credentials.refreshToken,
-    expiresAt: credentials.expiresAt,
-  };
+    existing.claudeAiOauth = {
+      ...existingOauth,
+      accessToken: credentials.accessToken,
+      refreshToken: credentials.refreshToken,
+      expiresAt: credentials.expiresAt,
+    };
+  }
 
   writeFileSync(credPath, JSON.stringify(existing, null, 2) + '\n', { mode: 0o600 });
   // chmod after write — writeFileSync's mode only applies when creating new files;
@@ -498,7 +579,9 @@ export interface CredentialSources {
   loadFromFile: () => OAuthCredentials | null;
   loadFromKeychain: () => OAuthCredentials | null;
   refreshToken?: (refreshToken: string) => Promise<OAuthCredentials | null>;
-  saveToFile?: (credentials: OAuthCredentials) => void;
+  saveToFile?: (credentials: OAuthCredentials, filePath?: string) => void;
+  /** Path-aware file loader; preferred over loadFromFile when present. */
+  loadFromFileWithSource?: () => FileCredentialsResult | null;
   loadFromKeychainWithService?: () => KeychainResult | null;
   writeToKeychain?: (credentials: OAuthCredentials, serviceName: string) => void;
 }
@@ -508,6 +591,7 @@ const defaultSources: CredentialSources = {
   loadFromKeychain: extractFromKeychain,
   refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
   saveToFile: saveOAuthCredentials,
+  loadFromFileWithSource: loadOAuthCredentialsWithSource,
   loadFromKeychainWithService: extractFromKeychainWithService,
   writeToKeychain,
 };
@@ -525,6 +609,7 @@ export const preflightCredentialSources: CredentialSources = {
   loadFromKeychain: extractFromKeychain,
   refreshToken: async (rt) => refreshResultToCreds(await refreshOAuthToken(rt)),
   saveToFile: saveOAuthCredentials,
+  loadFromFileWithSource: loadOAuthCredentialsWithSource,
   loadFromKeychainWithService: extractFromKeychainWithService,
   writeToKeychain,
 };
@@ -538,6 +623,7 @@ export const preflightCredentialSources: CredentialSources = {
 export const readOnlyCredentialSources: CredentialSources = {
   loadFromFile: loadOAuthCredentials,
   loadFromKeychain: extractFromKeychain,
+  loadFromFileWithSource: loadOAuthCredentialsWithSource,
   loadFromKeychainWithService: extractFromKeychainWithService,
 };
 
@@ -548,7 +634,8 @@ export const readOnlyCredentialSources: CredentialSources = {
  *
  * Priority:
  * 1. IRONCURTAIN_DOCKER_AUTH=apikey env var forces API key mode
- * 2. OAuth credentials from ~/.claude/.credentials.json (valid or refreshable)
+ * 2. OAuth credentials from ~/.claude/.credentials.json or
+ *    ~/.config/anthropic/credentials/default.json (valid or refreshable)
  * 3. OAuth credentials from macOS Keychain (valid or refreshable)
  * 4. API key from config
  * 5. None
@@ -562,24 +649,25 @@ export async function detectAuthMethod(config: IronCurtainConfig, sources?: Cred
     return resolveApiKeyAuth(config);
   }
 
-  // Try OAuth from credentials file
-  const fileCreds = s.loadFromFile();
-  if (fileCreds) {
+  // Try OAuth from credentials files
+  const fileResult = s.loadFromFileWithSource ? s.loadFromFileWithSource() : toFileResult(s.loadFromFile());
+  if (fileResult) {
+    const { credentials: fileCreds, filePath } = fileResult;
     if (!isTokenExpired(fileCreds)) {
-      logger.info('Detected OAuth credentials from ~/.claude/.credentials.json');
-      return { kind: 'oauth', credentials: fileCreds, source: 'file' };
+      logger.info(`Detected OAuth credentials from ${filePath ?? 'credentials file'}`);
+      return { kind: 'oauth', credentials: fileCreds, source: 'file', filePath };
     }
 
     // Attempt refresh if refresh function is available
     if (s.refreshToken) {
-      const refreshed = await tryRefreshFileCreds(fileCreds, s.refreshToken, s.saveToFile);
+      const refreshed = await tryRefreshFileCreds(fileCreds, s.refreshToken, s.saveToFile, filePath);
       if (refreshed) return refreshed;
     }
     logger.warn('OAuth token from credentials file is expired');
   }
 
-  // Try macOS Keychain if credentials file was not found
-  if (!fileCreds) {
+  // Try macOS Keychain if no credentials file was found
+  if (!fileResult) {
     const keychainResult = s.loadFromKeychainWithService?.() ?? toKeychainResult(s.loadFromKeychain());
     if (keychainResult) {
       if (!isTokenExpired(keychainResult.credentials)) {
@@ -614,24 +702,35 @@ function toKeychainResult(creds: OAuthCredentials | null): KeychainResult | null
 }
 
 /**
+ * Wraps a plain OAuthCredentials from loadFromFile() into the path-aware
+ * shape. The path is unknown for legacy loaders, so refresh write-back
+ * falls to saveToFile's default path.
+ */
+function toFileResult(creds: OAuthCredentials | null): { credentials: OAuthCredentials; filePath?: string } | null {
+  if (!creds) return null;
+  return { credentials: creds };
+}
+
+/**
  * Attempts to refresh expired file-sourced credentials.
- * On success, saves to file and returns the oauth AuthMethod.
+ * On success, saves to the originating file and returns the oauth AuthMethod.
  */
 async function tryRefreshFileCreds(
   fileCreds: OAuthCredentials,
   doRefresh: (refreshToken: string) => Promise<OAuthCredentials | null>,
-  saveToFile?: (credentials: OAuthCredentials) => void,
+  saveToFile?: (credentials: OAuthCredentials, filePath?: string) => void,
+  filePath?: string,
 ): Promise<AuthMethod | null> {
   const refreshed = await doRefresh(fileCreds.refreshToken);
   if (!refreshed) return null;
 
   try {
-    saveToFile?.(refreshed);
+    saveToFile?.(refreshed, filePath);
   } catch (err) {
     logger.warn(`Failed to save refreshed credentials to file: ${err instanceof Error ? err.message : String(err)}`);
   }
   logger.info('Refreshed expired OAuth token from credentials file');
-  return { kind: 'oauth', credentials: refreshed, source: 'file' };
+  return { kind: 'oauth', credentials: refreshed, source: 'file', filePath };
 }
 
 /**

--- a/src/doctor/oauth-checks.ts
+++ b/src/doctor/oauth-checks.ts
@@ -169,7 +169,7 @@ function formatRefreshFailure(result: Exclude<RefreshResult, { kind: 'ok' }>, el
  */
 function persistRefreshedOAuth(auth: Extract<AuthMethod, { kind: 'oauth' }>, credentials: OAuthCredentials): void {
   if (auth.source === 'file') {
-    saveOAuthCredentials(credentials);
+    saveOAuthCredentials(credentials, auth.filePath);
   } else {
     writeToKeychain(credentials, auth.keychainServiceName);
   }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -753,6 +753,7 @@ describe('checkOAuthRefresh', () => {
   const oauthAuth = {
     kind: 'oauth' as const,
     source: 'file' as const,
+    filePath: '/home/user/.claude/.credentials.json',
     credentials: { accessToken: 'old', refreshToken: 'rt-old', expiresAt: Date.now() + 60_000 },
   };
   const freshCreds = { accessToken: 'new', refreshToken: 'rt-new', expiresAt: Date.now() + 3_600_000 };
@@ -773,7 +774,7 @@ describe('checkOAuthRefresh', () => {
     const r = await checkOAuthRefresh(baseConfig);
     expect(r.status).toBe('ok');
     expect(r.message).toMatch(/valid \(.*, file\)/);
-    expect(saveOAuthCredentials).toHaveBeenCalledWith(freshCreds);
+    expect(saveOAuthCredentials).toHaveBeenCalledWith(freshCreds, oauthAuth.filePath);
   });
 
   it('reports HTTP rejection with the status code and a re-login hint', async () => {

--- a/test/oauth-credentials.test.ts
+++ b/test/oauth-credentials.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { resolve, join } from 'node:path';
-import { tmpdir, platform } from 'node:os';
+import { tmpdir, platform, homedir } from 'node:os';
 import type { IronCurtainConfig } from '../src/config/types.js';
 import {
   parseCredentialsJson,
+  parseAnthropicCredentialsJson,
+  getAnthropicCredentialsFilePath,
   parseCodexAuthJson,
   loadCodexOAuthCredentials,
   loadCredentialsFromFile,
@@ -30,6 +32,17 @@ const VALID_CREDENTIALS = {
     scopes: ['user:inference', 'user:profile'],
     subscriptionType: 'max',
   },
+};
+
+// Valid Anthropic CLI credential store fixture (~/.config/anthropic/credentials/default.json)
+const VALID_ANTHROPIC_CLI_CREDENTIALS = {
+  version: '1.0',
+  type: 'oauth_token',
+  access_token: 'sk-ant-oat01-cli-access-token',
+  expires_at: Math.floor((Date.now() + 3_600_000) / 1000),
+  refresh_token: 'sk-ant-ort01-cli-refresh-token',
+  scope: 'user:developer user:inference user:profile',
+  organization_uuid: 'org-uuid-1234',
 };
 
 function makeConfig(overrides?: Partial<IronCurtainConfig['userConfig']>): IronCurtainConfig {
@@ -199,6 +212,67 @@ describe('parseCredentialsJson', () => {
   });
 });
 
+// --- parseAnthropicCredentialsJson ---
+
+describe('parseAnthropicCredentialsJson', () => {
+  it('parses Anthropic CLI credentials and converts expires_at to milliseconds', () => {
+    const result = parseAnthropicCredentialsJson(JSON.stringify(VALID_ANTHROPIC_CLI_CREDENTIALS));
+    expect(result).not.toBeNull();
+    expect(result!.accessToken).toBe('sk-ant-oat01-cli-access-token');
+    expect(result!.refreshToken).toBe('sk-ant-ort01-cli-refresh-token');
+    expect(result!.expiresAt).toBe(VALID_ANTHROPIC_CLI_CREDENTIALS.expires_at * 1000);
+  });
+
+  it('returns null when type is not oauth_token', () => {
+    const creds = { ...VALID_ANTHROPIC_CLI_CREDENTIALS, type: 'api_key' };
+    expect(parseAnthropicCredentialsJson(JSON.stringify(creds))).toBeNull();
+  });
+
+  it('returns null when required fields are missing or invalid', () => {
+    // JSON.stringify drops keys whose value is undefined
+    const noAccess = { ...VALID_ANTHROPIC_CLI_CREDENTIALS, access_token: undefined };
+    const noRefresh = { ...VALID_ANTHROPIC_CLI_CREDENTIALS, refresh_token: undefined };
+    expect(parseAnthropicCredentialsJson(JSON.stringify(noAccess))).toBeNull();
+    expect(parseAnthropicCredentialsJson(JSON.stringify(noRefresh))).toBeNull();
+    expect(
+      parseAnthropicCredentialsJson(JSON.stringify({ ...VALID_ANTHROPIC_CLI_CREDENTIALS, expires_at: 'soon' })),
+    ).toBeNull();
+    expect(parseAnthropicCredentialsJson('not json')).toBeNull();
+    expect(parseAnthropicCredentialsJson('null')).toBeNull();
+  });
+});
+
+// --- getAnthropicCredentialsFilePath ---
+
+describe('getAnthropicCredentialsFilePath', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('defaults to ~/.config/anthropic/credentials/default.json', () => {
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', '');
+    delete process.env.ANTHROPIC_CONFIG_DIR;
+    vi.stubEnv('XDG_CONFIG_HOME', '');
+    delete process.env.XDG_CONFIG_HOME;
+    expect(getAnthropicCredentialsFilePath()).toBe(
+      resolve(homedir(), '.config', 'anthropic', 'credentials', 'default.json'),
+    );
+  });
+
+  it('honors XDG_CONFIG_HOME', () => {
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', '');
+    delete process.env.ANTHROPIC_CONFIG_DIR;
+    vi.stubEnv('XDG_CONFIG_HOME', '/custom/xdg');
+    expect(getAnthropicCredentialsFilePath()).toBe(resolve('/custom/xdg', 'anthropic', 'credentials', 'default.json'));
+  });
+
+  it('prefers ANTHROPIC_CONFIG_DIR over XDG_CONFIG_HOME', () => {
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', '/custom/anthropic');
+    vi.stubEnv('XDG_CONFIG_HOME', '/custom/xdg');
+    expect(getAnthropicCredentialsFilePath()).toBe(resolve('/custom/anthropic', 'credentials', 'default.json'));
+  });
+});
+
 describe('parseCodexAuthJson', () => {
   it('parses Codex ChatGPT auth.json credentials', () => {
     const accessToken = unsignedJwt({ exp: 4_102_444_800, sub: 'codex-test' });
@@ -296,6 +370,16 @@ describe('loadCredentialsFromFile', () => {
     const result = loadCredentialsFromFile(filePath);
     expect(result).toBeNull();
   });
+
+  it('loads Anthropic CLI-format credentials', () => {
+    const filePath = resolve(tmpDir, 'default.json');
+    writeFileSync(filePath, JSON.stringify(VALID_ANTHROPIC_CLI_CREDENTIALS));
+
+    const result = loadCredentialsFromFile(filePath);
+    expect(result).not.toBeNull();
+    expect(result!.accessToken).toBe('sk-ant-oat01-cli-access-token');
+    expect(result!.expiresAt).toBe(VALID_ANTHROPIC_CLI_CREDENTIALS.expires_at * 1000);
+  });
 });
 
 describe('loadCodexOAuthCredentials', () => {
@@ -382,6 +466,39 @@ describe('detectAuthMethod', () => {
       expect(result.credentials.accessToken).toBe('sk-ant-oat01-test-access-token');
       expect(result.source).toBe('file');
     }
+  });
+
+  it('reports the source file path when loadFromFileWithSource is available', async () => {
+    const creds = validCreds();
+    const filePath = '/home/user/.config/anthropic/credentials/default.json';
+    const sources = makeSources({
+      loadFromFileWithSource: () => ({ credentials: creds, filePath }),
+    });
+
+    const result = await detectAuthMethod(makeConfig(), sources);
+    expect(result.kind).toBe('oauth');
+    if (result.kind === 'oauth' && result.source === 'file') {
+      expect(result.filePath).toBe(filePath);
+    }
+  });
+
+  it('saves refreshed credentials back to the originating file', async () => {
+    const filePath = '/home/user/.config/anthropic/credentials/default.json';
+    const refreshed = validCreds({ accessToken: 'sk-ant-oat01-refreshed' });
+    const saveToFile = vi.fn();
+    const sources = makeSources({
+      loadFromFileWithSource: () => ({ credentials: expiredCreds(), filePath }),
+      refreshToken: async () => refreshed,
+      saveToFile,
+    });
+
+    const result = await detectAuthMethod(makeConfig(), sources);
+    expect(result.kind).toBe('oauth');
+    if (result.kind === 'oauth' && result.source === 'file') {
+      expect(result.credentials.accessToken).toBe('sk-ant-oat01-refreshed');
+      expect(result.filePath).toBe(filePath);
+    }
+    expect(saveToFile).toHaveBeenCalledWith(refreshed, filePath);
   });
 
   it('falls back to apikey when no OAuth credentials', async () => {
@@ -499,7 +616,7 @@ describe('detectAuthMethod', () => {
       expect(result.credentials.accessToken).toBe('sk-ant-oat01-refreshed');
       expect(result.source).toBe('file');
     }
-    expect(saveFn).toHaveBeenCalledWith(refreshed);
+    expect(saveFn).toHaveBeenCalledWith(refreshed, undefined);
   });
 
   it('refreshes expired Keychain credentials and returns keychainServiceName', async () => {
@@ -956,6 +1073,28 @@ describe('saveOAuthCredentials', () => {
 
     const saved = JSON.parse(readFileSync(filePath, 'utf-8'));
     expect(saved.claudeAiOauth.accessToken).toBe(creds.accessToken);
+  });
+
+  it('preserves the Anthropic CLI format when writing to an Anthropic CLI file', () => {
+    const filePath = resolve(tmpDir, 'default.json');
+    writeFileSync(filePath, JSON.stringify(VALID_ANTHROPIC_CLI_CREDENTIALS));
+
+    const expiresAt = Date.now() + 7_200_000;
+    const creds = validCreds({ accessToken: 'new-at', refreshToken: 'new-rt', expiresAt });
+    saveOAuthCredentials(creds, filePath);
+
+    const saved = JSON.parse(readFileSync(filePath, 'utf-8'));
+    // Updated fields, snake_case, expires_at back in epoch seconds
+    expect(saved.access_token).toBe('new-at');
+    expect(saved.refresh_token).toBe('new-rt');
+    expect(saved.expires_at).toBe(Math.round(expiresAt / 1000));
+    // Preserved fields
+    expect(saved.type).toBe('oauth_token');
+    expect(saved.version).toBe('1.0');
+    expect(saved.scope).toBe(VALID_ANTHROPIC_CLI_CREDENTIALS.scope);
+    expect(saved.organization_uuid).toBe(VALID_ANTHROPIC_CLI_CREDENTIALS.organization_uuid);
+    // No claudeAiOauth wrapper introduced
+    expect(saved.claudeAiOauth).toBeUndefined();
   });
 });
 

--- a/test/oauth-credentials.test.ts
+++ b/test/oauth-credentials.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { tmpdir, platform, homedir } from 'node:os';
 import type { IronCurtainConfig } from '../src/config/types.js';
@@ -223,9 +223,18 @@ describe('parseAnthropicCredentialsJson', () => {
     expect(result!.expiresAt).toBe(VALID_ANTHROPIC_CLI_CREDENTIALS.expires_at * 1000);
   });
 
-  it('returns null when type is not oauth_token', () => {
+  it('returns null when type is present but not oauth_token', () => {
     const creds = { ...VALID_ANTHROPIC_CLI_CREDENTIALS, type: 'api_key' };
     expect(parseAnthropicCredentialsJson(JSON.stringify(creds))).toBeNull();
+  });
+
+  it('accepts credentials without a type field (documented store schema)', () => {
+    // The WIF reference documents {version, access_token, expires_at,
+    // refresh_token, scope} without a type discriminator.
+    const noType = { ...VALID_ANTHROPIC_CLI_CREDENTIALS, type: undefined };
+    const result = parseAnthropicCredentialsJson(JSON.stringify(noType));
+    expect(result).not.toBeNull();
+    expect(result!.accessToken).toBe('sk-ant-oat01-cli-access-token');
   });
 
   it('returns null when required fields are missing or invalid', () => {
@@ -270,6 +279,12 @@ describe('getAnthropicCredentialsFilePath', () => {
     vi.stubEnv('ANTHROPIC_CONFIG_DIR', '/custom/anthropic');
     vi.stubEnv('XDG_CONFIG_HOME', '/custom/xdg');
     expect(getAnthropicCredentialsFilePath()).toBe(resolve('/custom/anthropic', 'credentials', 'default.json'));
+  });
+
+  it('treats an empty ANTHROPIC_CONFIG_DIR as unset', () => {
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', '');
+    vi.stubEnv('XDG_CONFIG_HOME', '/custom/xdg');
+    expect(getAnthropicCredentialsFilePath()).toBe(resolve('/custom/xdg', 'anthropic', 'credentials', 'default.json'));
   });
 });
 
@@ -468,11 +483,11 @@ describe('detectAuthMethod', () => {
     }
   });
 
-  it('reports the source file path when loadFromFileWithSource is available', async () => {
+  it('reports the source file path when loadFromFilesWithSource is available', async () => {
     const creds = validCreds();
     const filePath = '/home/user/.config/anthropic/credentials/default.json';
     const sources = makeSources({
-      loadFromFileWithSource: () => ({ credentials: creds, filePath }),
+      loadFromFilesWithSource: () => [{ credentials: creds, filePath }],
     });
 
     const result = await detectAuthMethod(makeConfig(), sources);
@@ -487,7 +502,7 @@ describe('detectAuthMethod', () => {
     const refreshed = validCreds({ accessToken: 'sk-ant-oat01-refreshed' });
     const saveToFile = vi.fn();
     const sources = makeSources({
-      loadFromFileWithSource: () => ({ credentials: expiredCreds(), filePath }),
+      loadFromFilesWithSource: () => [{ credentials: expiredCreds(), filePath }],
       refreshToken: async () => refreshed,
       saveToFile,
     });
@@ -499,6 +514,53 @@ describe('detectAuthMethod', () => {
       expect(result.filePath).toBe(filePath);
     }
     expect(saveToFile).toHaveBeenCalledWith(refreshed, filePath);
+  });
+
+  it('does not let an expired legacy file shadow a valid Anthropic CLI file', async () => {
+    const legacyPath = '/home/user/.claude/.credentials.json';
+    const cliPath = '/home/user/.config/anthropic/credentials/default.json';
+    const cliCreds = validCreds({ accessToken: 'sk-ant-oat01-cli-valid' });
+    const sources = makeSources({
+      loadFromFilesWithSource: () => [
+        { credentials: expiredCreds(), filePath: legacyPath },
+        { credentials: cliCreds, filePath: cliPath },
+      ],
+      // Legacy refresh token is stale/revoked
+      refreshToken: async () => null,
+    });
+
+    const result = await detectAuthMethod(makeConfig(), sources);
+    expect(result.kind).toBe('oauth');
+    if (result.kind === 'oauth' && result.source === 'file') {
+      expect(result.credentials.accessToken).toBe('sk-ant-oat01-cli-valid');
+      expect(result.filePath).toBe(cliPath);
+    }
+  });
+
+  it('falls through to the next file when the first is expired and unrefreshable', async () => {
+    const legacyPath = '/home/user/.claude/.credentials.json';
+    const cliPath = '/home/user/.config/anthropic/credentials/default.json';
+    const expiredLegacy = expiredCreds({ refreshToken: 'sk-ant-ort01-legacy-stale' });
+    const expiredCli = expiredCreds({ refreshToken: 'sk-ant-ort01-cli-good' });
+    const refreshed = validCreds({ accessToken: 'sk-ant-oat01-cli-refreshed' });
+    const saveToFile = vi.fn();
+    const sources = makeSources({
+      loadFromFilesWithSource: () => [
+        { credentials: expiredLegacy, filePath: legacyPath },
+        { credentials: expiredCli, filePath: cliPath },
+      ],
+      // Only the CLI store's refresh token still works
+      refreshToken: async (rt) => (rt === 'sk-ant-ort01-cli-good' ? refreshed : null),
+      saveToFile,
+    });
+
+    const result = await detectAuthMethod(makeConfig(), sources);
+    expect(result.kind).toBe('oauth');
+    if (result.kind === 'oauth' && result.source === 'file') {
+      expect(result.credentials.accessToken).toBe('sk-ant-oat01-cli-refreshed');
+      expect(result.filePath).toBe(cliPath);
+    }
+    expect(saveToFile).toHaveBeenCalledWith(refreshed, cliPath);
   });
 
   it('falls back to apikey when no OAuth credentials', async () => {
@@ -1095,6 +1157,41 @@ describe('saveOAuthCredentials', () => {
     expect(saved.organization_uuid).toBe(VALID_ANTHROPIC_CLI_CREDENTIALS.organization_uuid);
     // No claudeAiOauth wrapper introduced
     expect(saved.claudeAiOauth).toBeUndefined();
+  });
+
+  it('preserves the Anthropic CLI format for a file without a type field', () => {
+    const filePath = resolve(tmpDir, 'default.json');
+    const noType = { ...VALID_ANTHROPIC_CLI_CREDENTIALS, type: undefined };
+    writeFileSync(filePath, JSON.stringify(noType));
+
+    const creds = validCreds({ accessToken: 'new-at' });
+    saveOAuthCredentials(creds, filePath);
+
+    const saved = JSON.parse(readFileSync(filePath, 'utf-8'));
+    expect(saved.access_token).toBe('new-at');
+    expect(saved.claudeAiOauth).toBeUndefined();
+  });
+
+  it('writes the Anthropic CLI format when the CLI store file vanished before save', () => {
+    // The origin file can be deleted or rotated by the Anthropic CLI between
+    // detection and refresh write-back; the path must decide the format.
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', resolve(tmpDir, 'anthropic'));
+    try {
+      const cliPath = resolve(tmpDir, 'anthropic', 'credentials', 'default.json');
+      mkdirSync(resolve(tmpDir, 'anthropic', 'credentials'), { recursive: true });
+
+      const expiresAt = Date.now() + 3_600_000;
+      const creds = validCreds({ accessToken: 'new-at', refreshToken: 'new-rt', expiresAt });
+      saveOAuthCredentials(creds, cliPath);
+
+      const saved = JSON.parse(readFileSync(cliPath, 'utf-8'));
+      expect(saved.access_token).toBe('new-at');
+      expect(saved.refresh_token).toBe('new-rt');
+      expect(saved.expires_at).toBe(Math.round(expiresAt / 1000));
+      expect(saved.claudeAiOauth).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Claude Code supports OAuth credentials from the Anthropic CLI credential store at `~/.config/anthropic/credentials/default.json` in addition to `~/.claude/.credentials.json`, but IronCurtain only read the latter. This adds detection of the new location.

- New `getAnthropicCredentialsFilePath()` resolves `ANTHROPIC_CONFIG_DIR` → `$XDG_CONFIG_HOME/anthropic` → `~/.config/anthropic`, and `parseAnthropicCredentialsJson()` parses the store's flat snake_case schema (`access_token`, `refresh_token`, `expires_at` in **epoch seconds**), normalizing expiry to milliseconds internally.
- Detection order is now: `~/.claude/.credentials.json` → Anthropic CLI store → macOS Keychain → API key, so existing setups are unaffected.
- **Refresh write-back targets the originating file in its native format.** Anthropic rotates refresh tokens on every grant; previously a refresh for credentials sourced from anywhere but the legacy path would have written the rotated token to `~/.claude/.credentials.json` and stranded the host's login. The file-sourced `AuthMethod` now carries a `filePath`, threaded through `OAuthTokenManager` (via `prepareDockerInfrastructure`) and doctor's `checkOAuthRefresh` persistence. `saveOAuthCredentials()` preserves the target file's format, including converting expiry back to seconds and keeping extra fields (`scope`, `organization_uuid`, …).
- `loadCredentialsFromFile()` accepts either schema, so injected/custom paths keep working.
- Updated `docs/designs/oauth-docker-support.md` detection-order section.

## Testing

- New unit tests: Anthropic CLI schema parsing (including seconds→ms conversion and rejection cases), path resolution env overrides, format-sniffing load, format-preserving save, and `filePath` threading through `detectAuthMethod`.
- `npm test`: all credential/doctor/token-manager tests pass; the only failures on my machine (mitm-proxy/proxy-integration/apple-container/doctor-runtime) are pre-existing environment-dependent failures that reproduce identically on a clean master checkout.
- Verified end-to-end on a host whose only credential source is `~/.config/anthropic/credentials/default.json`: detection finds the file, parses it, and reports correct expiry.