### PR TITLE
Show today's LLM statistics in the sidebar

### DIFF
--- a/packages/web-ui/e2e/helpers.ts
+++ b/packages/web-ui/e2e/helpers.ts
@@ -4,6 +4,7 @@ import { parsePort } from '../scripts/parse-port.js';
 
 export const PTY_BANNER_TEXT = 'Type to send keystrokes';
 export const PTY_LIVE_FRAME_TEXT = '[mock] agent working';
+const MOCK_PORT = parsePort(process.env.IRONCURTAIN_MOCK_PORT, 7400);
 const MOCK_RESET_PORT = parsePort(process.env.IRONCURTAIN_MOCK_RESET_PORT, 7401);
 
 /**
@@ -36,13 +37,15 @@ export async function connectWithToken(page: Page): Promise<void> {
 }
 
 /**
- * Click a navigation item in the sidebar by its label text.
+ * Click a navigation item in the sidebar. Nav buttons carry stable
+ * `nav-{id}` test ids — their accessible names absorb badge counts
+ * (e.g. "Workflows 1"), so name-based matching is fragile here.
  */
 export async function navigateTo(
   page: Page,
   view: 'Dashboard' | 'Sessions' | 'Escalations' | 'Jobs' | 'Workflows' | 'Personas' | 'Statistics' | 'Settings',
 ): Promise<void> {
-  await page.getByTestId('sidebar-nav').getByRole('button', { name: view }).click();
+  await page.getByTestId('sidebar-nav').getByTestId(`nav-${view.toLowerCase()}`).click();
 }
 
 /**
@@ -59,10 +62,7 @@ export async function navigateToWorkflowsList(page: Page): Promise<void> {
   // effect has fired by the time we land on the Workflows view. The gate badge
   // on the sidebar's Workflows nav item is the visible signal that
   // pendingGates is populated.
-  const workflowsNavBadge = page
-    .getByTestId('sidebar-nav')
-    .locator('button', { hasText: 'Workflows' })
-    .locator('.font-mono');
+  const workflowsNavBadge = page.getByTestId('sidebar-nav').getByTestId('nav-workflows').locator('.font-mono');
   await expect(workflowsNavBadge).toBeVisible({ timeout: 10_000 });
 
   await navigateTo(page, 'Workflows');
@@ -168,7 +168,7 @@ let rpcSeq = 0;
  * test raise a terminal-backed escalation while the UI remains on another view.
  */
 export async function sendPtyPromptRpc(label: number, text: string): Promise<void> {
-  const ws = new WebSocket('ws://127.0.0.1:7400/ws?token=mock-dev-token');
+  const ws = new WebSocket(`ws://127.0.0.1:${MOCK_PORT}/ws?token=mock-dev-token`);
 
   try {
     await new Promise<void>((resolve, reject) => {

--- a/packages/web-ui/e2e/statistics.spec.ts
+++ b/packages/web-ui/e2e/statistics.spec.ts
@@ -53,7 +53,15 @@ test.describe('LLM statistics', () => {
 
   test('renders the mixed provider and model dataset on desktop', async ({ page, request }, testInfo) => {
     await resetMockServer(request, { statisticsScenario: 'mixed' });
-    await openStatistics(page);
+    await connectWithToken(page);
+
+    const navSummary = page.getByTestId('sidebar-nav').getByTestId('statistics-nav-summary');
+    await expect(navSummary).toBeVisible();
+    await expect(navSummary).toContainText('tok/s');
+    await expect(navSummary).toContainText('Middle 50%');
+    await expect(navSummary).toContainText('Output');
+    await expect(navSummary).toContainText('Measured');
+    await navSummary.click();
 
     await expect(page.getByRole('heading', { name: 'LLM statistics' })).toBeVisible();
     await expect(page.getByLabel('Effective output speed', { exact: true })).toContainText('output tokens/s');
@@ -138,6 +146,10 @@ test.describe('LLM statistics', () => {
     expect(new Set(activeStyles).size).toBe(activeStyles.length);
 
     await attachScreenshot(page, testInfo, 'statistics-longitudinal-routed-desktop');
+    await testInfo.attach('statistics-sidebar-receipt-desktop', {
+      body: await page.getByTestId('sidebar-nav').screenshot({ animations: 'disabled' }),
+      contentType: 'image/png',
+    });
 
     await page.getByRole('button', { name: 'Served model' }).click();
     await expect(page.getByRole('button', { name: 'Served model' })).toHaveAttribute('aria-pressed', 'true');

--- a/packages/web-ui/src/App.svelte
+++ b/packages/web-ui/src/App.svelte
@@ -11,13 +11,18 @@
   import { onMount } from 'svelte';
   import {
     appState,
-    initConnection,
+    configChangedGeneration,
     connectWithToken,
+    connectionGeneration,
+    getStatisticsSummary,
+    initConnection,
     resolveEscalation,
     getTheme,
     setTheme,
     type ThemeId,
   } from './lib/stores.svelte.js';
+  import type { StatisticsMetricSummaryDto } from './lib/types.js';
+  import { calendarRange, localTimeZone } from '$lib/components/features/statistics/statistics-helpers.js';
   import Dashboard from './routes/Dashboard.svelte';
   import Statistics from './routes/Statistics.svelte';
   import Sessions from './routes/Sessions.svelte';
@@ -33,6 +38,7 @@
   import { Badge } from '$lib/components/ui/badge/index.js';
   import EscalationModal from '$lib/components/features/escalation-modal.svelte';
   import MatrixRain from '$lib/components/features/matrix-rain.svelte';
+  import StatisticsNavSummary from '$lib/components/features/statistics/StatisticsNavSummary.svelte';
   import { startFlashTitle } from '$lib/flash-title.js';
 
   import ShieldCheck from 'phosphor-svelte/lib/ShieldCheck';
@@ -85,6 +91,73 @@
     mql.addEventListener('change', onChange);
     return () => mql.removeEventListener('change', onChange);
   });
+
+  // The statistics summary card is desktop-only chrome (hidden below md), so its
+  // data load is gated on the same breakpoint. Mirrors the reduced-motion setup.
+  function readDesktopViewport(): boolean {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia('(min-width: 768px)').matches;
+  }
+  let desktopViewport = $state(readDesktopViewport());
+
+  $effect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(min-width: 768px)');
+    const onChange = (e: MediaQueryListEvent) => {
+      desktopViewport = e.matches;
+    };
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  });
+
+  // Sidebar "today" statistics summary. Polled on a slow cadence (the daemon
+  // has no statistics push event); re-arms on reconnect and config changes.
+  // The generation counter discards responses from a superseded effect run —
+  // the same pattern as the Statistics route.
+  const STATISTICS_SUMMARY_REFRESH_MS = 2 * 60 * 1_000;
+  let statisticsSummaries = $state<readonly StatisticsMetricSummaryDto[]>([]);
+  let statisticsAvailable = $state(false);
+  let statisticsLoadGeneration = 0;
+  let statisticsTimer: ReturnType<typeof setTimeout> | undefined;
+
+  $effect(() => {
+    void connectionGeneration.value;
+    void configChangedGeneration.value;
+    if (!appState.connected || !desktopViewport) {
+      statisticsLoadGeneration++;
+      statisticsAvailable = false;
+      statisticsSummaries = [];
+      return;
+    }
+    const generation = ++statisticsLoadGeneration;
+    // Debounce the initial load: `connected` and `connectionGeneration` flip in
+    // separate turns on connect, and the cleanup cancels the first schedule
+    // before any request is sent.
+    statisticsTimer = setTimeout(() => void refreshStatisticsSummary(generation), 100);
+    return () => {
+      clearTimeout(statisticsTimer);
+      statisticsLoadGeneration++;
+    };
+  });
+
+  async function refreshStatisticsSummary(generation: number): Promise<void> {
+    try {
+      const next = await getStatisticsSummary({
+        ...calendarRange(Date.now(), 1, localTimeZone),
+        measures: ['effectiveOutputTokensPerSecond', 'outputTokens', 'requestCount'],
+      });
+      if (generation !== statisticsLoadGeneration) return;
+      statisticsSummaries = next;
+      statisticsAvailable = true;
+    } catch {
+      if (generation !== statisticsLoadGeneration) return;
+      statisticsSummaries = [];
+      statisticsAvailable = false;
+    }
+    if (generation === statisticsLoadGeneration) {
+      statisticsTimer = setTimeout(() => void refreshStatisticsSummary(generation), STATISTICS_SUMMARY_REFRESH_MS);
+    }
+  }
 
   // Auto-open the escalation modal when new escalations arrive (unless on the Escalations page),
   // and auto-close when no escalations remain.
@@ -175,6 +248,13 @@
     { id: 'personas', label: 'Personas', icon: UserCircle },
     { id: 'settings', label: 'Settings', icon: GearSix },
   ] as const;
+
+  type NavView = (typeof navItems)[number]['id'];
+
+  function selectView(view: NavView): void {
+    appState.currentView = view;
+    closeDrawer();
+  }
 </script>
 
 <svelte:window onkeydown={onWindowKeydown} />
@@ -226,7 +306,7 @@
     </div>
   </div>
 {:else}
-  {#snippet navContents()}
+  {#snippet navContents(showStatisticsSummary: boolean)}
     <div class="px-4 py-4 border-b border-border">
       <div class="flex items-center gap-2.5">
         <div class="w-7 h-7 rounded-lg bg-primary/15 flex items-center justify-center shrink-0">
@@ -248,10 +328,8 @@
     <div class="flex-1 py-2 px-2 space-y-0.5">
       {#each navItems as item (item.id)}
         <button
-          onclick={() => {
-            appState.currentView = item.id;
-            closeDrawer();
-          }}
+          onclick={() => selectView(item.id)}
+          data-testid={`nav-${item.id}`}
           aria-current={appState.currentView === item.id ? 'page' : undefined}
           class="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all
             {appState.currentView === item.id
@@ -284,6 +362,15 @@
         </button>
       {/each}
     </div>
+
+    {#if showStatisticsSummary}
+      <StatisticsNavSummary
+        available={statisticsAvailable}
+        summaries={statisticsSummaries}
+        active={appState.currentView === 'statistics'}
+        onselect={() => selectView('statistics')}
+      />
+    {/if}
 
     {#if appState.daemonStatus}
       <div class="px-4 py-3 border-t border-border text-[11px] text-muted-foreground space-y-1.5 font-mono">
@@ -354,7 +441,7 @@
 
     <!-- Desktop sidebar: hidden below md. -->
     <nav data-testid="sidebar-nav" class="hidden md:flex w-56 bg-sidebar border-r border-border flex-col shrink-0">
-      {@render navContents()}
+      {@render navContents(true)}
     </nav>
 
     <!-- Mobile drawer backdrop. Click to dismiss. -->
@@ -387,7 +474,7 @@
             <X size={18} />
           </button>
         </div>
-        {@render navContents()}
+        {@render navContents(false)}
       </nav>
     </div>
 

--- a/packages/web-ui/src/App.test.ts
+++ b/packages/web-ui/src/App.test.ts
@@ -47,6 +47,11 @@ vi.mock('./lib/stores.svelte.js', () => ({
   resolveEscalation: vi.fn(),
   getTheme: () => 'iron',
   setTheme: vi.fn(),
+  // App.svelte loads the sidebar statistics summary through the store; the
+  // matchMedia stub reports a mobile viewport, so the load path stays dormant.
+  connectionGeneration: { value: 0 },
+  configChangedGeneration: { value: 0 },
+  getStatisticsSummary: vi.fn().mockResolvedValue([]),
 }));
 
 // Stub routed views and feature components -- their internals pull in WS/store

--- a/packages/web-ui/src/lib/components/features/statistics/StatisticsNavSummary.svelte
+++ b/packages/web-ui/src/lib/components/features/statistics/StatisticsNavSummary.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import ChartLineUp from 'phosphor-svelte/lib/ChartLineUp';
+
+  import type { StatisticsMetricSummaryDto } from '$lib/types.js';
+  import { findMeasure, formatCompactNumber, formatSpeed } from './statistics-helpers.js';
+
+  let {
+    available = false,
+    summaries = [],
+    active = false,
+    onselect,
+  }: {
+    /** Whether a summary query succeeded; false keeps the card out of the sidebar. */
+    available?: boolean;
+    summaries?: readonly StatisticsMetricSummaryDto[];
+    active?: boolean;
+    onselect: () => void;
+  } = $props();
+
+  const speed = $derived(findMeasure(summaries, 'effectiveOutputTokensPerSecond'));
+  const output = $derived(findMeasure(summaries, 'outputTokens'));
+  const requests = $derived(findMeasure(summaries, 'requestCount'));
+  const speedMedian = $derived(speed?.median ?? null);
+  const speedLabel = $derived(formatSpeed(speedMedian));
+  const speedAvailable = $derived(speedMedian !== null);
+  const hasRequests = $derived((requests?.value ?? 0) > 0);
+  const countLabel = $derived(speedAvailable ? 'Measured' : 'Requests');
+  const countValue = $derived(speedAvailable ? (speed?.sampleCount ?? 0) : (requests?.value ?? null));
+  const iqr = $derived(iqrPositions(speed));
+  const description = $derived(
+    speedAvailable
+      ? `Today median effective output speed ${speedLabel} tokens per second based on ${formatCompactNumber(speed?.sampleCount ?? null, 0)} measured requests. ${formatCompactNumber(output?.value ?? null, 0)} output tokens observed.`
+      : hasRequests
+        ? `Today has ${formatCompactNumber(requests?.value ?? null, 0)} observed requests. Effective output speed is unavailable.`
+        : 'No LLM observations today.',
+  );
+
+  function iqrPositions(summary: StatisticsMetricSummaryDto | undefined): {
+    start: number;
+    width: number;
+    median: number;
+  } | null {
+    if (!summary || summary.median == null || summary.lowerQuartile == null || summary.upperQuartile == null) {
+      return null;
+    }
+    const maximum = Math.max(summary.upperQuartile * 1.18, summary.median * 1.18, 1);
+    const start = Math.max(0, Math.min(100, (summary.lowerQuartile / maximum) * 100));
+    const end = Math.max(start, Math.min(100, (summary.upperQuartile / maximum) * 100));
+    const median = Math.max(0, Math.min(100, (summary.median / maximum) * 100));
+    return { start, width: Math.max(1.5, end - start), median };
+  }
+</script>
+
+{#if available}
+  <div class="px-2 pb-2">
+    <button
+      type="button"
+      data-testid="statistics-nav-summary"
+      onclick={onselect}
+      aria-label={`Open Statistics. ${description}`}
+      class="group relative w-full overflow-hidden rounded-xl border px-3 pb-3 pt-2.5 text-left shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar
+        {active
+        ? 'border-primary/45 bg-primary/10'
+        : 'border-border/80 bg-card/70 hover:border-primary/40 hover:bg-accent/35'}"
+    >
+      <span
+        class="pointer-events-none absolute inset-x-0 top-0 h-14 bg-gradient-to-b from-primary/10 to-transparent opacity-80"
+        aria-hidden="true"
+      ></span>
+
+      <span class="relative flex items-center justify-between gap-2">
+        <span class="text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground"
+          >Today · effective speed</span
+        >
+        <ChartLineUp size={14} class="shrink-0 text-primary transition-transform group-hover:-translate-y-0.5" />
+      </span>
+
+      {#if speedAvailable}
+        <span class="relative mt-1 flex items-baseline gap-1">
+          <strong class="font-mono text-[2rem] leading-none tracking-[-0.06em] text-primary">{speedLabel}</strong>
+          <span class="text-[10px] font-medium text-foreground/75">tok/s</span>
+        </span>
+
+        {#if iqr}
+          <span class="relative mt-2 block h-2" aria-hidden="true">
+            <span class="absolute inset-x-0 top-[3px] h-px bg-border"></span>
+            <span
+              class="absolute top-px h-[5px] rounded-full bg-primary/30"
+              style={`left: ${iqr.start}%; width: ${iqr.width}%`}
+            ></span>
+            <span
+              class="absolute top-0 h-[7px] w-[2px] -translate-x-1/2 rounded-full bg-primary"
+              style={`left: ${iqr.median}%`}
+            ></span>
+          </span>
+          <span class="relative mt-0.5 flex justify-between text-[9px] text-muted-foreground">
+            <span>Middle 50%</span>
+            <span class="font-mono"
+              >{formatSpeed(speed?.lowerQuartile ?? null)}–{formatSpeed(speed?.upperQuartile ?? null)}</span
+            >
+          </span>
+        {/if}
+      {:else if hasRequests}
+        <span class="relative mt-2 block text-sm font-semibold text-foreground">Speed unavailable</span>
+      {:else}
+        <span class="relative mt-2 block text-sm font-semibold text-foreground">No observations today</span>
+      {/if}
+
+      <span
+        class="relative mt-2.5 grid grid-cols-2 gap-2 border-t border-border/70 pt-2 text-[9px] text-muted-foreground"
+      >
+        <span class="min-w-0">
+          <span class="block truncate uppercase tracking-wide">Output</span>
+          <strong class="mt-0.5 block truncate font-mono text-[11px] font-semibold text-foreground/85"
+            >{formatCompactNumber(output?.value ?? null, 0)} tok</strong
+          >
+        </span>
+        <span class="min-w-0 text-right">
+          <span class="block truncate uppercase tracking-wide">{countLabel}</span>
+          <strong class="mt-0.5 block truncate font-mono text-[11px] font-semibold text-foreground/85"
+            >{formatCompactNumber(countValue, 0)}</strong
+          >
+        </span>
+      </span>
+    </button>
+  </div>
+{/if}

--- a/packages/web-ui/src/lib/components/features/statistics/StatisticsNavSummary.test.ts
+++ b/packages/web-ui/src/lib/components/features/statistics/StatisticsNavSummary.test.ts
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LlmStatisticsMeasure, StatisticsMetricSummaryDto } from '$lib/types.js';
+
+import StatisticsNavSummary from './StatisticsNavSummary.svelte';
+
+function summary(
+  measure: LlmStatisticsMeasure,
+  value: number | null,
+  distribution?: { median: number; lowerQuartile: number; upperQuartile: number },
+): StatisticsMetricSummaryDto {
+  return {
+    dimensions: {},
+    measure,
+    value,
+    sampleCount: 14,
+    sampleSessionCount: 2,
+    eligibleCount: 14,
+    coverage: 1,
+    median: distribution?.median ?? null,
+    lowerQuartile: distribution?.lowerQuartile ?? null,
+    upperQuartile: distribution?.upperQuartile ?? null,
+    formulaVersion: 1,
+  };
+}
+
+describe('StatisticsNavSummary', () => {
+  it('renders a compact, honest speed receipt and opens Statistics', () => {
+    const onselect = vi.fn();
+    render(StatisticsNavSummary, {
+      available: true,
+      summaries: [
+        summary('effectiveOutputTokensPerSecond', 65.4, {
+          median: 65.4,
+          lowerQuartile: 52.1,
+          upperQuartile: 78.2,
+        }),
+        summary('outputTokens', 871_400),
+        summary('requestCount', 1_405),
+      ],
+      onselect,
+    });
+
+    const receipt = screen.getByTestId('statistics-nav-summary');
+    expect(receipt.textContent).toMatch(/65\.4\s*tok\/s/);
+    expect(receipt.textContent).toMatch(/Middle 50%\s*52\.1–78\.2/);
+    expect(receipt.textContent).toMatch(/Output\s*871K tok/);
+    expect(receipt.textContent).toMatch(/Measured\s*14/);
+    expect(receipt.getAttribute('aria-label')).toMatch(
+      /Today median effective output speed 65\.4 tokens per second based on 14 measured requests/,
+    );
+
+    fireEvent.click(receipt);
+    expect(onselect).toHaveBeenCalledOnce();
+  });
+
+  it('distinguishes an observed day with missing speed from an empty day', () => {
+    const onselect = vi.fn();
+    const { rerender } = render(StatisticsNavSummary, {
+      available: true,
+      summaries: [
+        summary('effectiveOutputTokensPerSecond', null),
+        summary('outputTokens', 12_500),
+        summary('requestCount', 7),
+      ],
+      onselect,
+    });
+    expect(screen.getByText('Speed unavailable')).toBeTruthy();
+
+    rerender({ available: true, summaries: [], onselect });
+    expect(screen.getByText('No observations today')).toBeTruthy();
+  });
+
+  it('stays out of the sidebar when statistics cannot be queried', () => {
+    render(StatisticsNavSummary, { available: false, summaries: [], onselect: vi.fn() });
+    expect(screen.queryByTestId('statistics-nav-summary')).toBeNull();
+  });
+});

--- a/packages/web-ui/src/lib/components/features/statistics/statistics-helpers.ts
+++ b/packages/web-ui/src/lib/components/features/statistics/statistics-helpers.ts
@@ -7,6 +7,9 @@ import type {
 
 export type StatisticsIdentityMode = 'routed' | 'served';
 
+/** Resolved once per module load; calendar math is local-time by contract. */
+export const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+
 const IDENTITY_DIMENSIONS: Readonly<
   Record<StatisticsIdentityMode, readonly [LlmStatisticsDimension, LlmStatisticsDimension]>
 > = {
@@ -163,6 +166,12 @@ export function allocateSeriesStyles(keys: readonly string[]): ReadonlyMap<strin
     });
   }
   return styles;
+}
+
+/** Compact throughput display for the speed figures (median, quartiles). */
+export function formatSpeed(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return '—';
+  return value.toFixed(value >= 100 ? 0 : 1);
 }
 
 export function formatCompactNumber(value: number | null, maximumFractionDigits = 1): string {

--- a/packages/web-ui/src/routes/Statistics.svelte
+++ b/packages/web-ui/src/routes/Statistics.svelte
@@ -33,13 +33,14 @@
     collapseHiddenTrendSignals,
     createStatisticsRequestLimiter,
     findMeasure,
+    localTimeZone,
     statisticsIdentityDimensions,
     type StatisticsIdentityMode,
   } from '$lib/components/features/statistics/statistics-helpers.js';
 
   const HOUR_MS = 60 * 60 * 1_000;
   const STALE = Symbol('stale statistics request');
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const timeZone = localTimeZone;
   const limiter = createStatisticsRequestLimiter(2);
   const MAX_VISIBLE_TREND_SERIES = 4;
   const MAX_RETURNED_TREND_SERIES = 8;


### PR DESCRIPTION
## Summary

- add a desktop sidebar “Today” receipt with median effective output speed, middle-50% range, output-token volume, and measured-request count
- refresh the summary on a bounded two-minute cadence, reconnect, and statistics configuration changes; hide it when statistics are unavailable
- make the receipt a direct, accessible entry point to the full Statistics view
- stabilize Web UI navigation selectors and make the auxiliary E2E WebSocket honor isolated mock-server ports

## Validation

- Web UI unit tests: 528 passed
- Statistics Playwright scenarios: 7 passed
- Full Playwright sweep: 105/106 passed; the existing escalation-modal Escape focus race passed on immediate isolated rerun
- Svelte check: 0 errors (2 pre-existing shared primitive warnings)
- Web UI ESLint and Prettier
- root TypeScript
- production Web UI build
- pre-commit lint/type checks and pre-push dependency-cycle check