### PR TITLE
fix(web-ui): retain PTY sessions until exit

### DIFF
--- a/docs/designs/webui-pty-terminal.md
+++ b/docs/designs/webui-pty-terminal.md
@@ -61,7 +61,7 @@ Confirmed reuse points (plumbing review, 9/9 core claims verified):
 | Escalation dir watch + resolve-by-response-file | `createEscalationWatcher` / `.resolve` | `escalation-watcher.ts:60,131` | as-is (same leaf mux uses at `mux-escalation-manager.ts:134`) |
 | PTY registration (sessionId + escalationDir) | registry file | `pty-session.ts:1207-1219` → `~/.ironcurtain/pty-registry/session-<id>.json` | as-is |
 | Container resize all the way down | `bridge.resize` → SIGWINCH → `attachPty` `stdout.on('resize')` → `resize-pty.sh` | `pty-bridge.ts:238`, `pty-session.ts:973,927` | as-is |
-| Container teardown + resume snapshot on kill | `runPtySession` finally | `pty-session.ts:734` | as-is (SIGTERM via `bridge.kill()`) |
+| Container teardown + resume snapshot on normal termination | `runPtySession` finally | `pty-session.ts:734` | SIGTERM gets cleanup grace; force-kill may interrupt; reconcile/GC backstop |
 | Per-session targeted WS streaming + subscribe + `removeAllForClient` | `sendToSubscribers`, token-stream pattern | `web-ui-server.ts:241`, `token-stream-dispatch.ts` | pattern reused |
 | Shared label space (distinct kind) | `reserveLabel()` | `session-manager.ts:119` | as-is (same as workflow-agent labels) |
 | Escalation event + DTO consumed by UI | `escalation.created`, `EscalationDto` | `web-event-bus.ts:42`, `web-ui-types.ts` | as-is → zero escalation-UI change |
@@ -267,10 +267,19 @@ feature.**
 **Ruling — mux-faithful with a guarded backstop:**
 1. PTY sessions are **not** subject to the existing 60s turn-based orphan sweep. A transient
    disconnect detaches the client only; the child + container keep running and reconnect replays.
-2. Guaranteed reaping happens on **explicit `sessions.end`** (`bridge.kill()` → child `finally`
-   tears down container + writes resume snapshot) and on **daemon shutdown**
-   (`PtySessionManager.close()` kills all bridges with a bounded await, mirroring mux `doShutdown`,
-   `mux-app.ts:533`).
+2. **`sessions.end` is a termination request, not proof of reaping.** It asks the bridge to begin
+   shutdown and marks the session as stopping; the session is removed and `session.ended` is emitted
+   only after the lifecycle observes the child's `onExit`. The normal **SIGTERM** path receives a
+   60-second grace period for capture finalization and Docker/snapshot cleanup. If it still has not
+   exited, the bridge/lifecycle may escalate to **SIGKILL** as crash recovery. SIGKILL is not a
+   cleanup path:
+   it may interrupt the child's `finally`, so owned resources are reclaimed by later startup
+   reconciliation or explicit garbage collection. The observed-`onExit` boundary remains
+   authoritative for a tracked session: neither the SIGTERM nor force-kill request itself removes
+   the session or emits `session.ended`. **Daemon shutdown is a distinct best-effort path:**
+   `PtySessionManager.close()` clears its tracking map first, disposes the sessions, attempts all
+   kills, and waits only for a bounded shutdown window. Force-kill may interrupt cleanup, so owned
+   resources may require later startup reconciliation or explicit garbage collection.
 3. Add a **generous idle-TTL** as the leak backstop — no-clients-for-N, distinct from the 60s
    turn-based sweep. **v1: hard-code a named constant (`PTY_IDLE_TTL_MS`, 30 min)** — do NOT wire a
    config schema / Settings surface for it. A backstop that is rarely tuned does not justify the

--- a/packages/web-ui/src/__test_stubs__/Stub.svelte
+++ b/packages/web-ui/src/__test_stubs__/Stub.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
-  // Vitest mock target for routes and features in App.test.ts. Empty
-  // destructure avoids the Svelte 5 `state_referenced_locally` warning.
-  const {}: Record<string, unknown> = $props();
+  // Vitest mock target for routes and features in App.test.ts. The optional
+  // input hook lets Sessions.test exercise the TerminalConsole callback while
+  // keeping this stub inert for every other consumer.
+  let { oninput }: { oninput?: (dataB64: string) => void } = $props();
 </script>
 
 <span data-testid="test-stub"></span>
+{#if oninput}
+  <button data-testid="test-stub-input" type="button" onclick={() => oninput?.('AQ==')}>Simulate input</button>
+{/if}

--- a/packages/web-ui/src/lib/__tests__/event-handler.test.ts
+++ b/packages/web-ui/src/lib/__tests__/event-handler.test.ts
@@ -7,7 +7,6 @@ import {
   type EventSideEffects,
 } from '../event-handler.js';
 import type {
-  SessionDto,
   EscalationDto,
   BudgetSummaryDto,
   OutputLine,
@@ -16,40 +15,11 @@ import type {
   LiveWorkflowPhase,
   PtySink,
 } from '../types.js';
+import { mockBudget, mockSession } from './fixtures.js';
 
 // ---------------------------------------------------------------------------
 // Factories
 // ---------------------------------------------------------------------------
-
-function mockBudget(): BudgetSummaryDto {
-  return {
-    totalTokens: 0,
-    stepCount: 0,
-    elapsedSeconds: 0,
-    estimatedCostUsd: 0,
-    tokenTrackingAvailable: true,
-    limits: {
-      maxTotalTokens: null,
-      maxSteps: null,
-      maxSessionSeconds: null,
-      maxEstimatedCostUsd: null,
-    },
-  };
-}
-
-function mockSession(label: number, overrides: Partial<SessionDto> = {}): SessionDto {
-  return {
-    label,
-    source: { kind: 'web' },
-    status: 'ready',
-    turnCount: 0,
-    createdAt: '2026-01-01T00:00:00Z',
-    hasPendingEscalation: false,
-    messageInFlight: false,
-    budget: mockBudget(),
-    ...overrides,
-  };
-}
 
 function createMockState(): AppStateLike & { outputs: Map<number, OutputLine[]> } {
   const outputs = new Map<number, OutputLine[]>();

--- a/packages/web-ui/src/lib/__tests__/fixtures.ts
+++ b/packages/web-ui/src/lib/__tests__/fixtures.ts
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------
+// Shared test factories
+// ---------------------------------------------------------------------------
+
+import type { BudgetSummaryDto, SessionDto } from '../types.js';
+
+/** A zeroed BudgetSummaryDto with all limits disabled. */
+export function mockBudget(): BudgetSummaryDto {
+  return {
+    totalTokens: 0,
+    stepCount: 0,
+    elapsedSeconds: 0,
+    estimatedCostUsd: 0,
+    tokenTrackingAvailable: true,
+    limits: {
+      maxTotalTokens: null,
+      maxSteps: null,
+      maxSessionSeconds: null,
+      maxEstimatedCostUsd: null,
+    },
+  };
+}
+
+/** A ready web-source SessionDto; `overrides` replace fields after the defaults. */
+export function mockSession(label: number, overrides: Partial<SessionDto> = {}): SessionDto {
+  return {
+    label,
+    source: { kind: 'web' },
+    status: 'ready',
+    turnCount: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    hasPendingEscalation: false,
+    messageInFlight: false,
+    budget: mockBudget(),
+    ...overrides,
+  };
+}
+
+/** A promise whose resolve/reject are reachable from the test body. */
+export function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/packages/web-ui/src/lib/__tests__/stores-pty.test.ts
+++ b/packages/web-ui/src/lib/__tests__/stores-pty.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { PtySink } from '../types.js';
+import type { JobListDto, PtySink, SessionDto } from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Mock the WS client dependency so getWsClient() returns a spyable client.
@@ -10,6 +10,7 @@ import type { PtySink } from '../types.js';
 
 const mockRequest = vi.fn<(method: string, params?: Record<string, unknown>) => Promise<unknown>>();
 let capturedOnEvent: ((event: string, payload: unknown) => void) | undefined;
+let capturedOnConnectionChange: ((connected: boolean) => void) | undefined;
 
 const mockClient = {
   request: mockRequest,
@@ -17,7 +18,10 @@ const mockClient = {
     capturedOnEvent = handler;
     return () => {};
   }),
-  onConnectionChange: vi.fn(() => () => {}),
+  onConnectionChange: vi.fn((handler: (connected: boolean) => void) => {
+    capturedOnConnectionChange = handler;
+    return () => {};
+  }),
   onAuthError: vi.fn(() => () => {}),
   get isConnected() {
     return false;
@@ -43,6 +47,7 @@ import {
   connectPtyTerminal,
   disconnectPtyTerminal,
   getWsClient,
+  appState,
 } from '../stores.svelte.js';
 
 describe('PTY store actions', () => {
@@ -74,6 +79,151 @@ describe('PTY store actions', () => {
   it('sendPtyPrompt sends sessions.ptyPrompt with PLAIN text (not base64)', async () => {
     await sendPtyPrompt(5, 'approve the write');
     expect(mockRequest).toHaveBeenCalledWith('sessions.ptyPrompt', { label: 5, text: 'approve the write' });
+  });
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function mockSession(label: number, overrides: Partial<SessionDto> = {}): SessionDto {
+  return {
+    label,
+    source: { kind: 'web' },
+    status: 'ready',
+    turnCount: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    hasPendingEscalation: false,
+    messageInFlight: false,
+    budget: {
+      totalTokens: 0,
+      stepCount: 0,
+      elapsedSeconds: 0,
+      estimatedCostUsd: 0,
+      tokenTrackingAvailable: true,
+      limits: {
+        maxTotalTokens: null,
+        maxSteps: null,
+        maxSessionSeconds: null,
+        maxEstimatedCostUsd: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('connection refresh ordering', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+    appState.sessions = new Map();
+    appState.jobs = [];
+    appState.sessionOutputs = new Map();
+    appState.selectedSessionLabel = null;
+  });
+
+  function configureRefresh(
+    sessionLists: Array<{ promise: Promise<SessionDto[]> }>,
+    jobsList: Promise<JobListDto[]> = Promise.resolve([{} as JobListDto]),
+  ): { sessionRequestCount: () => number } {
+    let sessionRequestCount = 0;
+    mockRequest.mockImplementation((method) => {
+      if (method === 'sessions.list') {
+        sessionRequestCount++;
+        return sessionLists.shift()?.promise ?? Promise.resolve([]);
+      }
+      if (method === 'jobs.list') return jobsList;
+      if (method === 'status') return Promise.resolve({});
+      if (method === 'escalations.list') return Promise.resolve([]);
+      if (method === 'workflows.list') return Promise.resolve([]);
+      if (method === 'personas.listCompiles') {
+        return Promise.resolve({ active: [], recent: [], queueDepth: 0 });
+      }
+      return Promise.resolve(undefined);
+    });
+    return { sessionRequestCount: () => sessionRequestCount };
+  }
+
+  it('replays a session event received before a stale sessions.list response', async () => {
+    const sessionsList = deferred<SessionDto[]>();
+    const existingSession = mockSession(1);
+    appState.sessions = new Map([[existingSession.label, existingSession]]);
+    configureRefresh([sessionsList]);
+
+    getWsClient();
+    capturedOnConnectionChange?.(true);
+
+    capturedOnEvent?.('session.ended', { label: existingSession.label, reason: 'budget_exhausted' });
+    expect(appState.sessions.has(existingSession.label)).toBe(false);
+
+    // The response was generated before the ended event and is stale.
+    sessionsList.resolve([existingSession]);
+    await vi.waitFor(() => expect(appState.jobs).toHaveLength(1));
+    expect(appState.sessions.has(existingSession.label)).toBe(false);
+  });
+
+  it('keeps a session event received after the snapshot while another refresh RPC is pending', async () => {
+    const sessionsList = deferred<SessionDto[]>();
+    const jobsList = deferred<JobListDto[]>();
+    const snapshotSession = mockSession(1);
+    const eventSession = mockSession(2);
+    configureRefresh([sessionsList], jobsList.promise);
+
+    getWsClient();
+    capturedOnConnectionChange?.(true);
+
+    sessionsList.resolve([snapshotSession]);
+    await vi.waitFor(() => expect(appState.sessions.has(snapshotSession.label)).toBe(true));
+
+    // The snapshot has arrived, but jobs.list is still pending. This event is
+    // later on the same socket and must remain authoritative after refreshAll.
+    capturedOnEvent?.('session.created', eventSession);
+    expect(appState.sessions.has(eventSession.label)).toBe(true);
+
+    jobsList.resolve([{} as JobListDto]);
+    await vi.waitFor(() => expect(appState.jobs).toHaveLength(1));
+    expect(appState.sessions.has(eventSession.label)).toBe(true);
+  });
+
+  it('applies the session snapshot when an unrelated refresh RPC rejects first', async () => {
+    const sessionsList = deferred<SessionDto[]>();
+    const jobsList = deferred<JobListDto[]>();
+    const snapshotSession = mockSession(1);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    configureRefresh([sessionsList], jobsList.promise);
+
+    getWsClient();
+    capturedOnConnectionChange?.(true);
+    jobsList.reject(new Error('jobs unavailable'));
+    sessionsList.resolve([snapshotSession]);
+
+    await vi.waitFor(() => expect(appState.sessions.get(snapshotSession.label)).toEqual(snapshotSession));
+    errorSpy.mockRestore();
+  });
+
+  it('queues a second session refresh behind a failing first request', async () => {
+    const firstSessionsList = deferred<SessionDto[]>();
+    const secondSessionsList = deferred<SessionDto[]>();
+    const newerSession = mockSession(1, { status: 'completed', turnCount: 2 });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const refreshes = configureRefresh([firstSessionsList, secondSessionsList]);
+
+    getWsClient();
+    capturedOnConnectionChange?.(true);
+    capturedOnConnectionChange?.(true);
+    await vi.waitFor(() => expect(refreshes.sessionRequestCount()).toBe(1));
+
+    firstSessionsList.reject(new Error('stale connection'));
+    await vi.waitFor(() => expect(refreshes.sessionRequestCount()).toBe(2));
+    secondSessionsList.resolve([newerSession]);
+
+    await vi.waitFor(() => expect(appState.sessions.get(newerSession.label)).toEqual(newerSession));
+    errorSpy.mockRestore();
   });
 });
 

--- a/packages/web-ui/src/lib/__tests__/stores-pty.test.ts
+++ b/packages/web-ui/src/lib/__tests__/stores-pty.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { JobListDto, PtySink, SessionDto } from '../types.js';
+import { deferred, mockSession } from './fixtures.js';
 
 // ---------------------------------------------------------------------------
 // Mock the WS client dependency so getWsClient() returns a spyable client.
@@ -81,42 +82,6 @@ describe('PTY store actions', () => {
     expect(mockRequest).toHaveBeenCalledWith('sessions.ptyPrompt', { label: 5, text: 'approve the write' });
   });
 });
-
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
-
-function mockSession(label: number, overrides: Partial<SessionDto> = {}): SessionDto {
-  return {
-    label,
-    source: { kind: 'web' },
-    status: 'ready',
-    turnCount: 0,
-    createdAt: '2026-01-01T00:00:00Z',
-    hasPendingEscalation: false,
-    messageInFlight: false,
-    budget: {
-      totalTokens: 0,
-      stepCount: 0,
-      elapsedSeconds: 0,
-      estimatedCostUsd: 0,
-      tokenTrackingAvailable: true,
-      limits: {
-        maxTotalTokens: null,
-        maxSteps: null,
-        maxSessionSeconds: null,
-        maxEstimatedCostUsd: null,
-      },
-    },
-    ...overrides,
-  };
-}
 
 describe('connection refresh ordering', () => {
   beforeEach(() => {

--- a/packages/web-ui/src/lib/components/features/session-sidebar.svelte
+++ b/packages/web-ui/src/lib/components/features/session-sidebar.svelte
@@ -184,6 +184,19 @@
             {session.source.kind}{#if session.persona}&nbsp;&middot; {session.persona}{/if}
           </span>
         </div>
+        {#if session.status === 'stopping'}
+          <div
+            data-testid="session-stopping-status"
+            class="mt-1 inline-flex items-center gap-1.5 text-xs text-warning"
+            aria-hidden={selectedLabel === session.label ? 'true' : undefined}
+          >
+            <span
+              class="h-3 w-3 rounded-full border-2 border-warning/30 border-t-warning animate-spin"
+              aria-hidden="true"
+            ></span>
+            Stopping…
+          </div>
+        {/if}
         <div class="text-xs text-muted-foreground mt-1">
           {session.turnCount} turns &middot; {session.budget.estimatedCostUsd.toFixed(2)}
         </div>

--- a/packages/web-ui/src/lib/components/features/session-sidebar.test.ts
+++ b/packages/web-ui/src/lib/components/features/session-sidebar.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import SessionSidebar from './session-sidebar.svelte';
+import { mockSession } from '../../__tests__/fixtures.js';
 import type { CreateSessionOptions, PersonaListItem, SessionDto } from '$lib/types.js';
 
 function makePersona(overrides: Partial<PersonaListItem> = {}): PersonaListItem {
@@ -8,32 +9,6 @@ function makePersona(overrides: Partial<PersonaListItem> = {}): PersonaListItem 
     name: 'coder',
     description: 'Code-focused persona',
     compiled: true,
-    ...overrides,
-  };
-}
-
-function makeSession(overrides: Partial<SessionDto> = {}): SessionDto {
-  return {
-    label: 1,
-    source: { kind: 'web-pty' },
-    status: 'ready',
-    turnCount: 0,
-    createdAt: '2026-01-01T00:00:00Z',
-    hasPendingEscalation: false,
-    messageInFlight: false,
-    budget: {
-      totalTokens: 0,
-      stepCount: 0,
-      elapsedSeconds: 0,
-      estimatedCostUsd: 0,
-      tokenTrackingAvailable: true,
-      limits: {
-        maxTotalTokens: null,
-        maxSteps: null,
-        maxSessionSeconds: null,
-        maxEstimatedCostUsd: null,
-      },
-    },
     ...overrides,
   };
 }
@@ -153,7 +128,7 @@ describe('SessionSidebar', () => {
     const onselect = vi.fn();
     render(SessionSidebar, {
       props: makeProps({
-        sessions: new Map([[3, makeSession({ label: 3 })]]),
+        sessions: new Map([[3, mockSession(3, { source: { kind: 'web-pty' } })]]),
         onselect,
       }),
     });
@@ -161,5 +136,19 @@ describe('SessionSidebar', () => {
     await fireEvent.click(screen.getByTestId('session-item-3'));
 
     expect(onselect).toHaveBeenCalledWith(3);
+  });
+
+  it('shows a live stopping state for sessions awaiting process exit', () => {
+    render(SessionSidebar, {
+      props: makeProps({
+        selectedLabel: 4,
+        sessions: new Map([[4, mockSession(4, { source: { kind: 'web-pty' }, status: 'stopping' })]]),
+      }),
+    });
+
+    const stoppingStatus = screen.getByTestId('session-stopping-status');
+    expect(stoppingStatus.textContent).toContain('Stopping…');
+    expect(stoppingStatus.getAttribute('aria-hidden')).toBe('true');
+    expect(screen.queryByRole('status')).toBeNull();
   });
 });

--- a/packages/web-ui/src/lib/event-handler.ts
+++ b/packages/web-ui/src/lib/event-handler.ts
@@ -203,6 +203,20 @@ export type WebEvent =
   | { event: 'session.pty_replay'; payload: PtyReplayEvent };
 
 /**
+ * Session-lifecycle events that carry the authoritative session state and are
+ * idempotent against the `sessions` map. The refresh barrier in
+ * stores.svelte.ts buffers these while a `sessions.list` snapshot is in flight
+ * and replays them after the snapshot lands, so a stale snapshot can never
+ * clobber a fresher event. Append-only stream events (session.output,
+ * session.pty_*) must NOT be listed — replaying those is not idempotent.
+ */
+export const SESSION_MUTATION_EVENTS: ReadonlySet<string> = new Set([
+  'session.created',
+  'session.updated',
+  'session.ended',
+]);
+
+/**
  * Parse a raw event name + payload into a typed WebEvent.
  * Returns undefined for unrecognized events.
  */

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -323,6 +323,44 @@ export async function verifyAuthToken(token: string, fetchImpl: typeof fetch = f
   }
 }
 
+type SessionMutationEventName = 'session.created' | 'session.updated' | 'session.ended';
+
+type BufferedSessionEvent = {
+  event: SessionMutationEventName;
+  payload: unknown;
+};
+
+type SessionRefreshBarrier = {
+  buffered: BufferedSessionEvent[];
+};
+
+let activeSessionRefresh: SessionRefreshBarrier | null = null;
+const queuedSessionRefreshes: Array<{ client: WsClient; barrier: SessionRefreshBarrier }> = [];
+let sessionRefreshQueueRunning = false;
+
+function isSessionMutationEvent(event: string): event is SessionMutationEventName {
+  return event === 'session.created' || event === 'session.updated' || event === 'session.ended';
+}
+
+function applyWebEvent(client: WsClient, event: string, payload: unknown): void {
+  handleEventPure(
+    appState,
+    {
+      refreshJobs: () => refreshJobs(client),
+      refreshPersonas: () => {
+        personasChangedGeneration.value++;
+      },
+      refreshConfig: () => {
+        configChangedGeneration.value++;
+      },
+      assignDisplayNumber: (_escalationId: string) => ++appState.escalationDisplayNumber,
+      getPtySink: (label: number) => ptySinks.get(label),
+    },
+    event,
+    payload,
+  );
+}
+
 function wireEventHandlers(client: WsClient): void {
   client.onConnectionChange((connected) => {
     appState.connected = connected;
@@ -339,22 +377,10 @@ function wireEventHandlers(client: WsClient): void {
   });
 
   client.onEvent((event, payload) => {
-    handleEventPure(
-      appState,
-      {
-        refreshJobs: () => refreshJobs(client),
-        refreshPersonas: () => {
-          personasChangedGeneration.value++;
-        },
-        refreshConfig: () => {
-          configChangedGeneration.value++;
-        },
-        assignDisplayNumber: (_escalationId: string) => ++appState.escalationDisplayNumber,
-        getPtySink: (label: number) => ptySinks.get(label),
-      },
-      event,
-      payload,
-    );
+    applyWebEvent(client, event, payload);
+    if (isSessionMutationEvent(event)) {
+      activeSessionRefresh?.buffered.push({ event, payload });
+    }
   });
 }
 
@@ -367,11 +393,60 @@ function handleAuthError(): void {
 
 let isInitialConnect = true;
 
-async function refreshAll(client: WsClient): Promise<void> {
+function applySessionsSnapshot(sessions: SessionDto[]): void {
+  const newSessions = new Map<number, SessionDto>();
+  for (const session of sessions) {
+    newSessions.set(session.label, session);
+  }
+  appState.sessions = newSessions;
+}
+
+function completeSessionRefresh(client: WsClient, barrier: SessionRefreshBarrier, sessions: SessionDto[]): void {
+  applySessionsSnapshot(sessions);
+  activeSessionRefresh = null;
+  for (const event of barrier.buffered) {
+    applyWebEvent(client, event.event, event.payload);
+  }
+}
+
+async function runSessionRefresh(client: WsClient, barrier: SessionRefreshBarrier): Promise<void> {
   try {
-    const [status, sessions, jobs, escalations, workflowsList, personaCompiles] = await Promise.all([
+    const sessions = await client.request<SessionDto[]>('sessions.list');
+    completeSessionRefresh(client, barrier, sessions);
+  } catch (err) {
+    // Session events were already applied live. Dropping only the replay
+    // buffer preserves those mutations while allowing the next queued refresh.
+    activeSessionRefresh = null;
+    console.error('Failed to refresh sessions:', err);
+  }
+}
+
+async function drainSessionRefreshQueue(): Promise<void> {
+  while (queuedSessionRefreshes.length > 0) {
+    const next = queuedSessionRefreshes.shift();
+    if (!next) continue;
+    activeSessionRefresh = next.barrier;
+    await runSessionRefresh(next.client, next.barrier);
+  }
+  activeSessionRefresh = null;
+  sessionRefreshQueueRunning = false;
+}
+
+function enqueueSessionRefresh(client: WsClient): void {
+  const barrier: SessionRefreshBarrier = { buffered: [] };
+  queuedSessionRefreshes.push({ client, barrier });
+  if (!sessionRefreshQueueRunning) {
+    sessionRefreshQueueRunning = true;
+    activeSessionRefresh = barrier;
+    void drainSessionRefreshQueue();
+  }
+}
+
+async function refreshAll(client: WsClient): Promise<void> {
+  enqueueSessionRefresh(client);
+  try {
+    const [status, jobs, escalations, workflowsList, personaCompiles] = await Promise.all([
       client.request<DaemonStatusDto>('status'),
-      client.request<SessionDto[]>('sessions.list'),
       client.request<JobListDto[]>('jobs.list'),
       client.request<EscalationDto[]>('escalations.list'),
       client.request<WorkflowSummaryDto[]>('workflows.list').catch(() => [] as WorkflowSummaryDto[]),
@@ -381,13 +456,6 @@ async function refreshAll(client: WsClient): Promise<void> {
     ]);
 
     appState.daemonStatus = status;
-
-    const newSessions = new Map<number, SessionDto>();
-    for (const session of sessions) {
-      newSessions.set(session.label, session);
-    }
-    appState.sessions = newSessions;
-
     appState.jobs = jobs;
 
     const newWorkflows = new Map<string, WorkflowSummaryDto>();

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -49,7 +49,7 @@ import type {
 } from './types.js';
 import { PHASE } from './types.js';
 import { createWsClient, type PreflightResult, type WsClient } from './ws-client.js';
-import { handleEvent as handleEventPure } from './event-handler.js';
+import { handleEvent as handleEventPure, SESSION_MUTATION_EVENTS } from './event-handler.js';
 
 export type ViewId =
   | 'dashboard'
@@ -323,24 +323,15 @@ export async function verifyAuthToken(token: string, fetchImpl: typeof fetch = f
   }
 }
 
-type SessionMutationEventName = 'session.created' | 'session.updated' | 'session.ended';
-
 type BufferedSessionEvent = {
-  event: SessionMutationEventName;
+  event: string;
   payload: unknown;
 };
 
-type SessionRefreshBarrier = {
-  buffered: BufferedSessionEvent[];
-};
-
-let activeSessionRefresh: SessionRefreshBarrier | null = null;
-const queuedSessionRefreshes: Array<{ client: WsClient; barrier: SessionRefreshBarrier }> = [];
+/** Replay buffer of the sessions.list refresh currently in flight (if any). */
+let activeSessionBuffer: BufferedSessionEvent[] | null = null;
+const queuedSessionRefreshes: Array<{ client: WsClient; buffered: BufferedSessionEvent[] }> = [];
 let sessionRefreshQueueRunning = false;
-
-function isSessionMutationEvent(event: string): event is SessionMutationEventName {
-  return event === 'session.created' || event === 'session.updated' || event === 'session.ended';
-}
 
 function applyWebEvent(client: WsClient, event: string, payload: unknown): void {
   handleEventPure(
@@ -378,8 +369,8 @@ function wireEventHandlers(client: WsClient): void {
 
   client.onEvent((event, payload) => {
     applyWebEvent(client, event, payload);
-    if (isSessionMutationEvent(event)) {
-      activeSessionRefresh?.buffered.push({ event, payload });
+    if (SESSION_MUTATION_EVENTS.has(event)) {
+      activeSessionBuffer?.push({ event, payload });
     }
   });
 }
@@ -401,22 +392,22 @@ function applySessionsSnapshot(sessions: SessionDto[]): void {
   appState.sessions = newSessions;
 }
 
-function completeSessionRefresh(client: WsClient, barrier: SessionRefreshBarrier, sessions: SessionDto[]): void {
+function completeSessionRefresh(client: WsClient, buffered: BufferedSessionEvent[], sessions: SessionDto[]): void {
   applySessionsSnapshot(sessions);
-  activeSessionRefresh = null;
-  for (const event of barrier.buffered) {
+  activeSessionBuffer = null;
+  for (const event of buffered) {
     applyWebEvent(client, event.event, event.payload);
   }
 }
 
-async function runSessionRefresh(client: WsClient, barrier: SessionRefreshBarrier): Promise<void> {
+async function runSessionRefresh(client: WsClient, buffered: BufferedSessionEvent[]): Promise<void> {
   try {
     const sessions = await client.request<SessionDto[]>('sessions.list');
-    completeSessionRefresh(client, barrier, sessions);
+    completeSessionRefresh(client, buffered, sessions);
   } catch (err) {
     // Session events were already applied live. Dropping only the replay
     // buffer preserves those mutations while allowing the next queued refresh.
-    activeSessionRefresh = null;
+    activeSessionBuffer = null;
     console.error('Failed to refresh sessions:', err);
   }
 }
@@ -425,19 +416,20 @@ async function drainSessionRefreshQueue(): Promise<void> {
   while (queuedSessionRefreshes.length > 0) {
     const next = queuedSessionRefreshes.shift();
     if (!next) continue;
-    activeSessionRefresh = next.barrier;
-    await runSessionRefresh(next.client, next.barrier);
+    activeSessionBuffer = next.buffered;
+    await runSessionRefresh(next.client, next.buffered);
   }
-  activeSessionRefresh = null;
   sessionRefreshQueueRunning = false;
 }
 
 function enqueueSessionRefresh(client: WsClient): void {
-  const barrier: SessionRefreshBarrier = { buffered: [] };
-  queuedSessionRefreshes.push({ client, barrier });
+  const buffered: BufferedSessionEvent[] = [];
+  queuedSessionRefreshes.push({ client, buffered });
   if (!sessionRefreshQueueRunning) {
     sessionRefreshQueueRunning = true;
-    activeSessionRefresh = barrier;
+    // The drain loop runs synchronously up to its first await, so the first
+    // buffer becomes active before this returns — events delivered in the
+    // same tick as the connect that queued the refresh are captured too.
     void drainSessionRefreshQueue();
   }
 }

--- a/packages/web-ui/src/routes/Sessions.svelte
+++ b/packages/web-ui/src/routes/Sessions.svelte
@@ -143,7 +143,7 @@
   $effect(() => {
     void appState.escalationDismissedAt;
     if (selectedPtyLabel === null) return;
-    tick().then(() => terminalRef?.focus());
+    tick().then(() => terminalRef?.focus?.());
   });
 </script>
 
@@ -172,9 +172,31 @@
             <Badge variant="secondary">terminal</Badge>
           </div>
           <div class="flex items-center gap-4">
+            {#if ptySession.status === 'stopping'}
+              <span
+                id="pty-stopping-message"
+                class="inline-flex max-w-xs items-center gap-1.5 text-right text-xs text-warning"
+                role="status"
+                aria-live="polite"
+                aria-label="Stopping. Input is unavailable while shutdown completes."
+              >
+                <span
+                  class="h-3 w-3 shrink-0 rounded-full border-2 border-warning/30 border-t-warning animate-spin"
+                  aria-hidden="true"
+                ></span>
+                Stopping… Input is unavailable while shutdown completes.
+              </span>
+            {/if}
             <span class="text-xs text-muted-foreground hidden sm:inline">Resizing affects all viewers</span>
-            <Button variant="destructive" size="sm" loading={endingSession === ptySession.label} onclick={handleEnd}>
-              {endingSession === ptySession.label ? 'Ending' : 'End'}
+            <Button
+              variant="destructive"
+              size="sm"
+              loading={ptySession.status === 'stopping' || endingSession === ptySession.label}
+              disabled={ptySession.status === 'stopping'}
+              aria-describedby={ptySession.status === 'stopping' ? 'pty-stopping-message' : undefined}
+              onclick={handleEnd}
+            >
+              {ptySession.status === 'stopping' ? 'Stopping…' : endingSession === ptySession.label ? 'Ending' : 'End'}
             </Button>
           </div>
         </div>
@@ -186,9 +208,11 @@
             bind:this={terminalRef}
             onready={(handle) => {
               connectPtyTerminal(ptySession.label, handle);
-              terminalRef?.focus();
+              terminalRef?.focus?.();
             }}
-            oninput={(dataB64) => sendPtyInput(ptySession.label, dataB64)}
+            oninput={(dataB64) => {
+              if (ptySession.status !== 'stopping') sendPtyInput(ptySession.label, dataB64);
+            }}
             onresize={(cols, rows) => sendPtyResize(ptySession.label, cols, rows)}
           />
         {/key}

--- a/packages/web-ui/src/routes/Sessions.test.ts
+++ b/packages/web-ui/src/routes/Sessions.test.ts
@@ -1,18 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 
-const { mockAppState, mockCreateSession, mockListPersonas, mockGetModelProviders } = vi.hoisted(() => ({
-  mockAppState: {
-    daemonStatus: null as Record<string, unknown> | null,
-    sessions: new Map(),
-    selectedSessionLabel: null as number | null,
-    selectedSession: null,
-    escalationDismissedAt: 0,
-  },
-  mockCreateSession: vi.fn<(opts?: unknown) => Promise<{ label: number }>>(),
-  mockListPersonas: vi.fn<() => Promise<unknown[]>>(),
-  mockGetModelProviders: vi.fn<() => Promise<{ profiles: Record<string, unknown> }>>(),
-}));
+const { mockAppState, mockCreateSession, mockListPersonas, mockGetModelProviders, mockSendPtyInput } = vi.hoisted(
+  () => ({
+    mockAppState: {
+      daemonStatus: null as Record<string, unknown> | null,
+      sessions: new Map(),
+      selectedSessionLabel: null as number | null,
+      selectedSession: null as {
+        label: number;
+        source: { kind: string };
+        status: string;
+        persona?: string;
+        turnCount: number;
+        budget: { estimatedCostUsd: number };
+      } | null,
+      escalationDismissedAt: 0,
+    },
+    mockCreateSession: vi.fn<(opts?: unknown) => Promise<{ label: number }>>(),
+    mockListPersonas: vi.fn<() => Promise<unknown[]>>(),
+    mockGetModelProviders: vi.fn<() => Promise<{ profiles: Record<string, unknown> }>>(),
+    mockSendPtyInput: vi.fn<(label: number, dataB64: string) => Promise<void>>(),
+  }),
+);
 
 vi.mock('../lib/stores.svelte.js', () => ({
   appState: mockAppState,
@@ -21,7 +31,7 @@ vi.mock('../lib/stores.svelte.js', () => ({
   listPersonas: mockListPersonas,
   attachPty: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   detachPty: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-  sendPtyInput: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  sendPtyInput: mockSendPtyInput,
   sendPtyResize: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   sendPtyPrompt: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   registerPtySink: vi.fn(),
@@ -60,6 +70,57 @@ describe('Sessions create flow guards', () => {
     mockListPersonas.mockResolvedValue([]);
     mockGetModelProviders.mockReset();
     mockGetModelProviders.mockResolvedValue({ profiles: { native: { type: 'native' } } });
+    mockSendPtyInput.mockReset();
+    mockSendPtyInput.mockResolvedValue(undefined);
+  });
+
+  it('explains PTY shutdown and disables ending it again while stopping', () => {
+    const stoppingSession = {
+      label: 4,
+      source: { kind: 'web-pty' },
+      status: 'stopping',
+      persona: undefined,
+      turnCount: 0,
+      budget: { estimatedCostUsd: 0 },
+    };
+    mockAppState.sessions = new Map([[4, stoppingSession]]);
+    mockAppState.selectedSessionLabel = 4;
+    mockAppState.selectedSession = stoppingSession;
+
+    render(Sessions);
+
+    expect(
+      screen.getByRole('status', { name: 'Stopping. Input is unavailable while shutdown completes.' }),
+    ).toBeTruthy();
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Stopping…' })).toHaveProperty('disabled', true);
+    expect(screen.getByTestId('pty-prompt-input')).toHaveProperty('disabled', true);
+    expect(screen.getByTestId('pty-prompt-send')).toHaveProperty('disabled', true);
+  });
+
+  it('suppresses terminal input while stopping but forwards it when ready', async () => {
+    const stoppingSession = {
+      label: 4,
+      source: { kind: 'web-pty' },
+      status: 'stopping',
+      persona: undefined,
+      turnCount: 0,
+      budget: { estimatedCostUsd: 0 },
+    };
+    mockAppState.sessions = new Map([[4, stoppingSession]]);
+    mockAppState.selectedSessionLabel = 4;
+    mockAppState.selectedSession = stoppingSession;
+
+    const { unmount } = render(Sessions);
+    await fireEvent.click(screen.getByTestId('test-stub-input'));
+    expect(mockSendPtyInput).not.toHaveBeenCalled();
+    unmount();
+
+    mockAppState.sessions = new Map([[4, { ...stoppingSession, status: 'ready' }]]);
+    mockAppState.selectedSession = { ...stoppingSession, status: 'ready' };
+    render(Sessions);
+    await fireEvent.click(screen.getByTestId('test-stub-input'));
+    expect(mockSendPtyInput).toHaveBeenCalledWith(4, 'AQ==');
   });
 
   it('does not create duplicate sessions from repeated native form submits while create is in flight', async () => {

--- a/src/pty/pty-bridge.ts
+++ b/src/pty/pty-bridge.ts
@@ -23,6 +23,7 @@ const { SerializeAddon } = serializeAddonPkg;
 import { getPtyRegistryDir } from '../config/paths.js';
 import { readActiveRegistrations } from '../escalation/session-registry.js';
 import type { PtySessionRegistration } from '../docker/pty-types.js';
+import * as logger from '../logger.js';
 
 export interface PtyBridge {
   /** The headless terminal instance for reading buffer state. */
@@ -34,7 +35,11 @@ export interface PtyBridge {
   /** The escalation directory path for this session. */
   readonly escalationDir: string | undefined;
 
-  /** Whether the child process is still running. */
+  /**
+   * Whether the child process is still running. Flips to false only inside
+   * the exit-notification path, before `onExit` callbacks run — see `onExit`
+   * for the full contract.
+   */
   readonly alive: boolean;
 
   /** The child process exit code, if exited. */
@@ -55,7 +60,9 @@ export interface PtyBridge {
   resize(cols: number, rows: number): void;
 
   /**
-   * Kills the child process and cleans up resources.
+   * Requests child termination and schedules SIGKILL crash recovery if needed.
+   * Does not itself complete the lifecycle: termination is always reported
+   * through `onExit`, never by synchronously flipping `alive` to false.
    */
   kill(): void;
 
@@ -85,7 +92,11 @@ export interface PtyBridge {
   serialize(options?: { scrollback?: number }): string;
 
   /**
-   * Registers a callback invoked when the child process exits.
+   * Registers a callback invoked when the child process exits. Exit is ALWAYS
+   * reported through this callback, whether the child died on its own or was
+   * killed; `alive` flips to false only as part of that same notification.
+   * Consumers should treat `onExit` as the sole lifecycle boundary — mux tab
+   * teardown and the web-ui session reaper both rely on this.
    */
   onExit(callback: (exitCode: number) => void): void;
 
@@ -168,6 +179,18 @@ export function buildSpawnArgs(options: PtyBridgeOptions): string[] {
 const DISCOVERY_POLL_MS = 200;
 /** Headless scrollback cap (lines). Bounds daemon memory on long-running sessions. */
 const SCROLLBACK_LINES = 5000;
+/**
+ * Grace period between requesting termination and SIGKILL crash recovery.
+ *
+ * Capture finalization can consume 30 seconds before Docker/snapshot cleanup
+ * starts. Allow another bounded cleanup window before SIGKILL crash recovery,
+ * so normal shutdown is not mistaken for a wedged child.
+ */
+export const PTY_KILL_GRACE_MS = 60_000;
+/** Retry interval for direct SIGKILL crash recovery while onExit is pending. */
+export const PTY_KILL_RETRY_MS = 1_000;
+/** Avoid flooding logs when a force-kill remains unavailable. */
+const PTY_KILL_ERROR_LOG_INTERVAL_MS = 10_000;
 
 /**
  * Spawns a new `ironcurtain start --pty` child process via node-pty
@@ -210,6 +233,63 @@ export async function createPtyBridge(options: PtyBridgeOptions): Promise<PtyBri
   let _alive = true;
   let _exitCode: number | undefined;
   let _registration: PtySessionRegistration | null | undefined;
+  let terminationRequested = false;
+  let killEscalationTimer: ReturnType<typeof setTimeout> | undefined;
+  let killRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  let forceKillAttempt = 0;
+  let lastForceKillErrorLogAt: number | undefined;
+
+  const clearKillTimers = (): void => {
+    if (killEscalationTimer !== undefined) {
+      clearTimeout(killEscalationTimer);
+      killEscalationTimer = undefined;
+    }
+    if (killRetryTimer !== undefined) {
+      clearTimeout(killRetryTimer);
+      killRetryTimer = undefined;
+    }
+  };
+
+  const scheduleKillRetry = (): void => {
+    if (!_alive || killRetryTimer !== undefined) return;
+    killRetryTimer = setTimeout(() => {
+      killRetryTimer = undefined;
+      attemptForceKill(true);
+    }, PTY_KILL_RETRY_MS);
+    killRetryTimer.unref();
+  };
+
+  const attemptForceKill = (retry: boolean): void => {
+    if (!_alive) return;
+    if (!retry) {
+      logger.warn(
+        `[PTY] Child pid=${child.pid} did not exit after SIGTERM; attempting SIGKILL crash recovery after ${PTY_KILL_GRACE_MS}ms`,
+      );
+    }
+    forceKillAttempt += 1;
+
+    // node-pty's Unix kill() wrapper can swallow signal errors. Use the OS
+    // process API for the force-kill request, then retry until the bridge's
+    // onExit notification confirms the lifecycle transition.
+    try {
+      if (process.platform === 'win32') {
+        // Windows has no Unix SIGKILL semantics. node-pty maps this native
+        // termination request to the platform's process termination API.
+        child.kill('SIGKILL');
+      } else {
+        process.kill(child.pid, 'SIGKILL');
+      }
+    } catch (error) {
+      const now = Date.now();
+      if (lastForceKillErrorLogAt === undefined || now - lastForceKillErrorLogAt >= PTY_KILL_ERROR_LOG_INTERVAL_MS) {
+        lastForceKillErrorLogAt = now;
+        logger.error(
+          `[PTY] SIGKILL crash recovery${retry ? ' retry' : ''} failed for child pid=${child.pid} (attempt ${forceKillAttempt}): ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    scheduleKillRetry();
+  };
 
   // Wire child output to the headless terminal. Both sinks fire from INSIDE the
   // write callback so the buffer already reflects `data`: the grid sink
@@ -225,6 +305,7 @@ export async function createPtyBridge(options: PtyBridgeOptions): Promise<PtyBri
   const discoveryAbort = new AbortController();
 
   child.onExit(({ exitCode }: { exitCode: number }) => {
+    clearKillTimers();
     _alive = false;
     _exitCode = exitCode;
     discoveryAbort.abort();
@@ -275,7 +356,26 @@ export async function createPtyBridge(options: PtyBridgeOptions): Promise<PtyBri
     },
 
     kill(): void {
-      if (_alive) child.kill('SIGTERM');
+      if (!_alive || terminationRequested) return;
+
+      terminationRequested = true;
+
+      killEscalationTimer = setTimeout(() => {
+        killEscalationTimer = undefined;
+        if (!_alive) return;
+        attemptForceKill(false);
+      }, PTY_KILL_GRACE_MS);
+      killEscalationTimer.unref();
+
+      try {
+        // Keep the synchronous throw observable: PtySessionManager uses it to
+        // roll back its stopping state when the initial signal cannot be sent.
+        child.kill('SIGTERM');
+      } catch (error) {
+        clearKillTimers();
+        terminationRequested = false;
+        throw error;
+      }
     },
 
     onOutput(callback: () => void): void {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -159,8 +159,9 @@ export interface SessionMetadata {
 }
 
 /**
- * The possible states a session can be in. Linear progression:
- * initializing -> ready -> (processing <-> ready) -> stopping -> closed.
+ * The possible states a session can be in. Conversational sessions progress
+ * from initializing -> ready -> (processing <-> ready) -> closed; process-backed
+ * sessions may enter stopping while awaiting confirmed process exit.
  *
  * - initializing: sandbox and resources being set up
  * - ready: accepting messages

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -160,14 +160,15 @@ export interface SessionMetadata {
 
 /**
  * The possible states a session can be in. Linear progression:
- * initializing -> ready -> (processing <-> ready) -> closed.
+ * initializing -> ready -> (processing <-> ready) -> stopping -> closed.
  *
  * - initializing: sandbox and resources being set up
  * - ready: accepting messages
  * - processing: a message is being processed (generateText in flight)
+ * - stopping: termination requested, awaiting confirmed process exit
  * - closed: resources released, no more messages accepted
  */
-export type SessionStatus = 'initializing' | 'ready' | 'processing' | 'closed';
+export type SessionStatus = 'initializing' | 'ready' | 'processing' | 'stopping' | 'closed';
 
 /**
  * Selects the session implementation.

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -30,6 +30,7 @@ import { loadConfig } from '../../config/index.js';
 import { createStandaloneSession } from '../../session/index.js';
 import { shouldAutoSaveMemory } from '../../memory/auto-save.js';
 import { BudgetExhaustedError } from '../../types/errors.js';
+import type { SessionId } from '../../session/types.js';
 import { getTokenStreamBus } from '../../docker/token-stream-bus.js';
 import * as logger from '../../logger.js';
 
@@ -107,11 +108,7 @@ export async function sessionDispatch(
         return;
       }
       const endManaged = ctx.sessionManager.get(label);
-      const endSessionId = endManaged?.session.getInfo().id;
-      await ctx.sessionManager.end(label);
-      if (endSessionId) getTokenStreamBus().endSession(endSessionId);
-      cleanupSessionQueue(ctx, label);
-      ctx.eventBus.emit('session.ended', { label, reason: 'user_ended' });
+      await endManagedSession(ctx, label, endManaged?.session.getInfo().id, 'user_ended');
       return;
     }
     case 'sessions.send': {
@@ -155,6 +152,23 @@ export async function sessionDispatch(
 /** Clean up session queue entry when session ends. */
 function cleanupSessionQueue(ctx: DispatchContext, label: number): void {
   ctx.sessionQueues.delete(label);
+}
+
+/**
+ * Ends a managed session through the full teardown sequence. `session.ended`
+ * is emitted last, after the session is gone from the manager, per the
+ * ordering contract on `WebEventMap['session.ended']`.
+ */
+async function endManagedSession(
+  ctx: DispatchContext,
+  label: number,
+  sessionId: SessionId | undefined,
+  reason: string,
+): Promise<void> {
+  await ctx.sessionManager.end(label);
+  if (sessionId) getTokenStreamBus().endSession(sessionId);
+  cleanupSessionQueue(ctx, label);
+  ctx.eventBus.emit('session.ended', { label, reason });
 }
 
 function listSessions(ctx: DispatchContext): SessionDto[] {
@@ -306,11 +320,7 @@ function sendToSession(ctx: DispatchContext, label: number, text: string): { acc
       }
     } catch (err) {
       if (err instanceof BudgetExhaustedError) {
-        const budgetSessionId = managed.session.getInfo().id;
-        await ctx.sessionManager.end(label);
-        getTokenStreamBus().endSession(budgetSessionId);
-        cleanupSessionQueue(ctx, label);
-        ctx.eventBus.emit('session.ended', { label, reason: `Budget exhausted: ${err.message}` });
+        await endManagedSession(ctx, label, managed.session.getInfo().id, `Budget exhausted: ${err.message}`);
       } else {
         const message = err instanceof Error ? err.message : String(err);
         ctx.eventBus.emit('session.output', { label, text: `Error: ${message}`, turnNumber });

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -307,10 +307,10 @@ function sendToSession(ctx: DispatchContext, label: number, text: string): { acc
     } catch (err) {
       if (err instanceof BudgetExhaustedError) {
         const budgetSessionId = managed.session.getInfo().id;
-        ctx.eventBus.emit('session.ended', { label, reason: `Budget exhausted: ${err.message}` });
         await ctx.sessionManager.end(label);
         getTokenStreamBus().endSession(budgetSessionId);
         cleanupSessionQueue(ctx, label);
+        ctx.eventBus.emit('session.ended', { label, reason: `Budget exhausted: ${err.message}` });
       } else {
         const message = err instanceof Error ? err.message : String(err);
         ctx.eventBus.emit('session.output', { label, text: `Error: ${message}`, turnNumber });

--- a/src/web-ui/dispatch/types.ts
+++ b/src/web-ui/dispatch/types.ts
@@ -109,7 +109,7 @@ export function toPtySessionDto(session: PtyWebSession): SessionDto {
   return {
     label: session.label,
     source: { kind: 'web-pty', ...(persona ? { persona } : {}) },
-    status: session.alive ? 'ready' : 'closed',
+    status: session.ending ? 'stopping' : session.alive ? 'ready' : 'closed',
     turnCount: 0,
     createdAt: session.createdAt,
     hasPendingEscalation: session.listEscalationDtos().length > 0,

--- a/src/web-ui/pty-session-manager.ts
+++ b/src/web-ui/pty-session-manager.ts
@@ -12,8 +12,9 @@
  * PTY sessions are a distinct session kind. They are NOT `ManagedSession`s (they
  * have no Session/Transport); they only borrow a label via
  * `sessionManager.reserveLabel()`. Lifecycle: created via `sessions.create` in
- * docker mode, reaped on explicit `sessions.end`, on child exit, on an idle-TTL
- * backstop ({@link PTY_IDLE_TTL_MS}), or on daemon shutdown (`close()`).
+ * docker mode, removed after child exit for natural or requested termination,
+ * requested for termination by explicit `sessions.end` or the idle-TTL
+ * backstop ({@link PTY_IDLE_TTL_MS}), or shut down by `close()`.
  *
  * Escalation bridging (Phase 4): once `bridge.onSessionDiscovered` yields an
  * `escalationDir`, an {@link EscalationWatcher} (the same file-watch primitive
@@ -126,6 +127,8 @@ export interface PtyStreamSender {
 /** Factory seam so tests can inject a stub bridge instead of spawning a child. */
 export type CreateBridge = (options: PtyBridgeOptions) => Promise<PtyBridge>;
 
+type PtyEndReason = 'user_ended' | 'idle_reaped';
+
 /**
  * Thrown by `create()` when the PTY runtime is unavailable (node-pty fails to
  * load, or the serialize addon is missing). Surfaced as a clean RPC error so a
@@ -175,6 +178,8 @@ export class PtyWebSession {
   private readonly subscribers = new Set<WsWebSocket>();
   /** Clients skipped due to backpressure; resynced with a fresh snapshot on drain. */
   private readonly desynced = new Set<WsWebSocket>();
+  /** End reason to use once a requested termination is confirmed by onExit. */
+  private pendingEndReason: PtyEndReason | undefined;
   private buffer = '';
   private bufferBytes = 0;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -194,6 +199,30 @@ export class PtyWebSession {
 
   get subscriberCount(): number {
     return this.subscribers.size;
+  }
+
+  /**
+   * Records a termination request without claiming that the child has exited.
+   * A bridge may accept a kill request but remain alive, and that live session
+   * must stay observable through sessions.list until onExit confirms the
+   * transition.
+   */
+  requestEnd(reason: PtyEndReason): boolean {
+    if (this.pendingEndReason !== undefined) return false;
+    this.pendingEndReason = reason;
+    return true;
+  }
+
+  get endReason(): PtyEndReason | undefined {
+    return this.pendingEndReason;
+  }
+
+  get ending(): boolean {
+    return this.pendingEndReason !== undefined;
+  }
+
+  cancelEnd(): void {
+    this.pendingEndReason = undefined;
   }
 
   hasSubscribers(): boolean {
@@ -490,6 +519,7 @@ export class PtySessionManager {
   /** Forwards decoded keystroke bytes to the child PTY stdin. */
   input(label: number, dataB64: string): void {
     const session = this.requireSession(label);
+    if (session.ending) return;
     session.bridge.write(decodeBytes(dataB64));
   }
 
@@ -505,7 +535,7 @@ export class PtySessionManager {
    */
   sendPrompt(label: number, text: string): void {
     const session = this.requireSession(label);
-    if (!session.bridge.alive) return;
+    if (session.ending || !session.bridge.alive) return;
     if (session.escalationDir) {
       try {
         writeTrustedUserContext(session.escalationDir, text);
@@ -643,26 +673,42 @@ export class PtySessionManager {
   }
 
   private handleExit(label: number): void {
-    // On explicit end()/idle reap the session is already removed; this fires
-    // for a child that exited on its own (agent quit / crash).
+    // This fires for a child that exited on its own (agent quit / crash) or
+    // after a requested termination. In both cases, onExit is the truthful
+    // lifecycle boundary.
     const session = this.sessions.get(label);
     if (!session) return;
     this.sessions.delete(label);
     this.clearIdleTimer(label);
     session.dispose();
-    this.eventBus.emit('session.ended', { label, reason: 'pty_exited' });
+    const reason = session.endReason ?? 'pty_exited';
+    logger.info(
+      `[WebUI] PTY session #${label}: exit observed (pid=${session.bridge.pid}, code=${session.bridge.exitCode ?? 'unknown'}, reason=${reason})`,
+    );
+    this.eventBus.emit('session.ended', { label, reason });
   }
 
-  private endInternal(label: number, reason: string): void {
+  private endInternal(label: number, reason: PtyEndReason): void {
     const session = this.sessions.get(label);
-    if (!session) return;
-    // Remove before killing so the bridge's onExit -> handleExit is a no-op
-    // (no duplicate session.ended, whether kill fires onExit sync or async).
-    this.sessions.delete(label);
+    if (!session || !session.requestEnd(reason)) return;
     this.clearIdleTimer(label);
-    session.dispose();
-    session.bridge.kill();
-    this.eventBus.emit('session.ended', { label, reason });
+    logger.info(`[WebUI] PTY session #${label}: ${reason} termination requested; waiting for PTY exit`);
+    this.eventBus.emit('session.updated', toPtySessionDto(session));
+    try {
+      session.bridge.kill();
+    } catch (error) {
+      session.cancelEnd();
+      logger.error(
+        `[WebUI] PTY session #${label}: termination request failed (${error instanceof Error ? error.message : String(error)})`,
+      );
+      this.eventBus.emit('session.updated', toPtySessionDto(session));
+      return;
+    }
+
+    // A bridge normally reports termination through onExit. Keep this fallback
+    // for a bridge that marks itself dead without invoking its callback; it is
+    // still truthful because the liveness probe has already changed to false.
+    if (!session.bridge.alive) this.handleExit(label);
   }
 
   private startIdleTimer(label: number): void {

--- a/src/web-ui/pty-session-manager.ts
+++ b/src/web-ui/pty-session-manager.ts
@@ -30,7 +30,7 @@ import type { WebSocket as WsWebSocket } from 'ws';
 import type { SessionManager } from '../session/session-manager.js';
 import type { SessionMode, EscalationRequest } from '../session/types.js';
 import type { WebEventBus } from './web-event-bus.js';
-import { createPtyBridge, type PtyBridge, type PtyBridgeOptions } from '../pty/pty-bridge.js';
+import { createPtyBridge, PTY_KILL_GRACE_MS, type PtyBridge, type PtyBridgeOptions } from '../pty/pty-bridge.js';
 import { resolveIroncurtainBin } from '../pty/resolve-ironcurtain-bin.js';
 import { createEscalationWatcher, type EscalationWatcher } from '../escalation/escalation-watcher.js';
 import { writeTrustedUserContext } from '../escalation/trusted-input.js';
@@ -75,8 +75,12 @@ const PTY_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
 /** Replayed scrollback tail cap (§11 Q2): keeps a pty_replay frame under maxPayload. */
 const PTY_REPLAY_SCROLLBACK = 1000;
 
-/** Bounded await for child exits on daemon shutdown (mirrors mux doShutdown). */
-const PTY_CLOSE_TIMEOUT_MS = 5000;
+/**
+ * Bounded await for child exits on daemon shutdown. It outlasts SIGTERM's
+ * grace period so the bridge's SIGKILL crash recovery can fire before close()
+ * falls back to its timeout.
+ */
+const PTY_CLOSE_TIMEOUT_MS = PTY_KILL_GRACE_MS + 5_000;
 
 /**
  * Delay before the injected Enter (`\r`) on a trusted message, so Claude Code's
@@ -566,7 +570,7 @@ export class PtySessionManager {
     session.bridge.resize(cols, rows);
   }
 
-  /** Explicitly ends a session (kills the child -> container teardown). */
+  /** Explicitly requests termination; removal waits for the observed PTY exit. */
   end(label: number): void {
     this.endInternal(label, 'user_ended');
   }
@@ -586,8 +590,19 @@ export class PtySessionManager {
           session.bridge.kill();
         }),
     );
-    const timeout = new Promise<void>((resolve) => setTimeout(resolve, PTY_CLOSE_TIMEOUT_MS));
-    await Promise.race([Promise.allSettled(exits), timeout]);
+    let closeTimeout: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, PTY_CLOSE_TIMEOUT_MS);
+      closeTimeout = timer;
+      timer.unref();
+    });
+    try {
+      await Promise.race([Promise.allSettled(exits), timeout]);
+    } finally {
+      if (closeTimeout !== undefined) {
+        clearTimeout(closeTimeout);
+      }
+    }
   }
 
   /** SessionDto snapshots for `sessions.list`. */

--- a/src/web-ui/pty-session-manager.ts
+++ b/src/web-ui/pty-session-manager.ts
@@ -702,6 +702,7 @@ export class PtySessionManager {
         `[WebUI] PTY session #${label}: termination request failed (${error instanceof Error ? error.message : String(error)})`,
       );
       this.eventBus.emit('session.updated', toPtySessionDto(session));
+      if (!session.hasSubscribers()) this.startIdleTimer(label);
       return;
     }
 

--- a/src/web-ui/web-event-bus.ts
+++ b/src/web-ui/web-event-bus.ts
@@ -30,6 +30,13 @@ import { TypedEventBus, type EventHandler } from '../event-bus/typed-event-bus.j
  */
 export interface WebEventMap {
   'session.created': SessionDto;
+  /**
+   * Ordering contract: emitted only AFTER the session has been removed from
+   * its manager (SessionManager / PtySessionManager), so a client that lists
+   * sessions on receipt never sees the ended session. All emitters must
+   * preserve this (see `endManagedSession` in dispatch/session-dispatch.ts
+   * and `handleExit` in pty-session-manager.ts).
+   */
   'session.ended': { label: number; reason: string };
   'session.updated': SessionDto;
   'session.thinking': { label: number; turnNumber: number };

--- a/test/json-rpc-dispatch.test.ts
+++ b/test/json-rpc-dispatch.test.ts
@@ -19,6 +19,7 @@ import { SessionManager, type PendingEscalationData } from '../src/session/sessi
 import type { ControlRequestHandler } from '../src/daemon/control-socket.js';
 import type { Session, SessionInfo, BudgetStatus } from '../src/session/types.js';
 import type { Transport } from '../src/session/transport.js';
+import { BudgetExhaustedError } from '../src/types/errors.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -225,6 +226,31 @@ describe('json-rpc-dispatch', () => {
       await dispatch(ctx, 'sessions.end', { label: 1 });
 
       expect(handler).toHaveBeenCalledWith('session.ended', { label: 1, reason: 'user_ended' });
+    });
+
+    it('removes a budget-exhausted session before emitting session.ended', async () => {
+      const ctx = makeCtx();
+      const transport = {
+        ...stubTransport(),
+        forwardMessage: vi.fn(),
+      } as Transport & { forwardMessage: ReturnType<typeof vi.fn> };
+      const label = ctx.sessionManager.register(stubSession(), transport, { kind: 'web' });
+      transport.forwardMessage.mockRejectedValue(new BudgetExhaustedError('tokens', 'token limit reached'));
+
+      let sessionAtEndedEvent: unknown = 'event-not-emitted';
+      ctx.eventBus.subscribe((event, payload) => {
+        if (event === 'session.ended' && payload.label === label) {
+          sessionAtEndedEvent = ctx.sessionManager.get(label);
+        }
+      });
+
+      await dispatch(ctx, 'sessions.send', { label, text: 'hello' });
+      const queuedSend = ctx.sessionQueues.get(label);
+      expect(queuedSend).toBeDefined();
+      await queuedSend;
+
+      expect(sessionAtEndedEvent).toBeUndefined();
+      expect(ctx.sessionManager.get(label)).toBeUndefined();
     });
 
     it('sessions.budget returns budget DTO', async () => {

--- a/test/pty-bridge.test.ts
+++ b/test/pty-bridge.test.ts
@@ -7,14 +7,25 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { buildSpawnArgs, createPtyBridge, type PtyBridgeOptions } from '../src/pty/pty-bridge.js';
+import * as logger from '../src/logger.js';
+import {
+  buildSpawnArgs,
+  createPtyBridge,
+  PTY_KILL_GRACE_MS,
+  PTY_KILL_RETRY_MS,
+  type PtyBridgeOptions,
+} from '../src/pty/pty-bridge.js';
 
 /** Shared, mutable fake-child state reachable from the hoisted node-pty mock. */
 const ptyMock = vi.hoisted(() => {
   const state: {
     dataCb?: (d: string) => void;
     exitCb?: (e: { exitCode: number }) => void;
+    killCalls: string[];
+    killExits: boolean;
   } = {};
+  state.killCalls = [];
+  state.killExits = true;
   return { state };
 });
 
@@ -29,7 +40,12 @@ vi.mock('node-pty', () => {
     },
     write: vi.fn(),
     resize: vi.fn(),
-    kill: vi.fn(() => ptyMock.state.exitCb?.({ exitCode: 0 })),
+    kill: (signal: string) => {
+      ptyMock.state.killCalls.push(signal);
+      if (ptyMock.state.killExits) {
+        ptyMock.state.exitCb?.({ exitCode: signal === 'SIGTERM' ? 143 : 137 });
+      }
+    },
   });
   return { default: { spawn }, spawn };
 });
@@ -154,6 +170,8 @@ describe('createPtyBridge — output wiring (onData / serialize)', () => {
   beforeEach(() => {
     ptyMock.state.dataCb = undefined;
     ptyMock.state.exitCb = undefined;
+    ptyMock.state.killCalls = [];
+    ptyMock.state.killExits = true;
   });
 
   it('onData fires with the chunk AFTER the headless buffer reflects it', async () => {
@@ -217,6 +235,139 @@ describe('createPtyBridge — output wiring (onData / serialize)', () => {
     const snap = bridge.serialize({ scrollback: 0 });
     expect(typeof snap).toBe('string');
     bridge.kill();
+  });
+});
+
+describe('createPtyBridge — termination escalation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ptyMock.state.dataCb = undefined;
+    ptyMock.state.exitCb = undefined;
+    ptyMock.state.killCalls = [];
+    ptyMock.state.killExits = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('escalates from SIGTERM to SIGKILL after the grace period', async () => {
+    const bridge = await createPtyBridge(baseOptions());
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const forceKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      ptyMock.state.exitCb?.({ exitCode: 137 });
+      return true;
+    });
+
+    try {
+      bridge.kill();
+      expect(ptyMock.state.killCalls).toEqual(['SIGTERM']);
+
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS - 1);
+      expect(ptyMock.state.killCalls).toEqual(['SIGTERM']);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(ptyMock.state.killCalls).toEqual(['SIGTERM']);
+      expect(forceKillSpy).toHaveBeenCalledWith(424242, 'SIGKILL');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`pid=424242`));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`${PTY_KILL_GRACE_MS}ms`));
+    } finally {
+      warnSpy.mockRestore();
+      forceKillSpy.mockRestore();
+    }
+  });
+
+  it('cancels SIGKILL when the child exits during the grace period', async () => {
+    const bridge = await createPtyBridge(baseOptions());
+    const forceKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    try {
+      bridge.kill();
+      ptyMock.state.exitCb?.({ exitCode: 143 });
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS);
+
+      expect(bridge.alive).toBe(false);
+      expect(ptyMock.state.killCalls).toEqual(['SIGTERM']);
+      expect(forceKillSpy).not.toHaveBeenCalled();
+    } finally {
+      forceKillSpy.mockRestore();
+    }
+  });
+
+  it('makes repeated kill calls idempotent while termination is pending', async () => {
+    const bridge = await createPtyBridge(baseOptions());
+    const forceKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      ptyMock.state.exitCb?.({ exitCode: 137 });
+      return true;
+    });
+
+    try {
+      bridge.kill();
+      bridge.kill();
+      expect(ptyMock.state.killCalls).toEqual(['SIGTERM']);
+      expect(vi.getTimerCount()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS);
+      expect(forceKillSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      forceKillSpy.mockRestore();
+    }
+  });
+
+  it('retries a failed direct SIGKILL until onExit confirms termination', async () => {
+    const bridge = await createPtyBridge(baseOptions());
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const forceKillSpy = vi
+      .spyOn(process, 'kill')
+      .mockImplementationOnce(() => {
+        throw new Error('force kill failed');
+      })
+      .mockImplementation(() => {
+        ptyMock.state.exitCb?.({ exitCode: 137 });
+        return true;
+      });
+
+    try {
+      bridge.kill();
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS);
+      expect(forceKillSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('pid=424242'));
+
+      await vi.advanceTimersByTimeAsync(PTY_KILL_RETRY_MS);
+      expect(forceKillSpy).toHaveBeenCalledTimes(2);
+      expect(bridge.alive).toBe(false);
+    } finally {
+      errorSpy.mockRestore();
+      forceKillSpy.mockRestore();
+    }
+  });
+
+  it('throttles persistent force-kill failure logs while continuing retries', async () => {
+    const bridge = await createPtyBridge(baseOptions());
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const forceKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('EPERM');
+    });
+
+    try {
+      bridge.kill();
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS);
+      expect(forceKillSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(9 * PTY_KILL_RETRY_MS);
+      expect(forceKillSpy).toHaveBeenCalledTimes(10);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(PTY_KILL_RETRY_MS);
+      expect(forceKillSpy).toHaveBeenCalledTimes(11);
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+
+      ptyMock.state.exitCb?.({ exitCode: 137 });
+    } finally {
+      errorSpy.mockRestore();
+      forceKillSpy.mockRestore();
+    }
   });
 });
 

--- a/test/pty/pty-session-manager.test.ts
+++ b/test/pty/pty-session-manager.test.ts
@@ -89,6 +89,11 @@ class StubBridge {
   }
 }
 
+/** Bridge whose kill request is accepted but does not terminate the child. */
+class NonExitingBridge extends StubBridge {
+  override readonly kill = vi.fn(() => {});
+}
+
 interface SenderCall {
   clients: Set<WsWebSocket>;
   event: string;
@@ -415,6 +420,30 @@ describe('PtySessionManager', () => {
       expect((ended[0].payload as { reason: string }).reason).toBe('idle_reaped');
     });
 
+    it('keeps a live session listed when the idle kill request does not exit the bridge', async () => {
+      const bridge = new NonExitingBridge();
+      const h = makeHarness({
+        idleTtlMs: 1000,
+        createBridge: async () => bridge as unknown as PtyBridge,
+      });
+      const { label } = await h.manager.create();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(bridge.kill).toHaveBeenCalledTimes(1);
+      expect(bridge.alive).toBe(true);
+      expect(h.manager.has(label)).toBe(true);
+      expect(h.manager.listDtos()[0].status).toBe('stopping');
+      expect(h.events.filter((e) => e.event === 'session.ended')).toHaveLength(0);
+
+      bridge.emitExit(0);
+
+      expect(h.manager.has(label)).toBe(false);
+      const ended = h.events.filter((e) => e.event === 'session.ended');
+      expect(ended).toHaveLength(1);
+      expect((ended[0].payload as { reason: string }).reason).toBe('idle_reaped');
+    });
+
     it('attach cancels the idle timer; detach re-arms it', async () => {
       const h = makeHarness({ idleTtlMs: 1000 });
       const { label } = await h.manager.create();
@@ -523,6 +552,53 @@ describe('PtySessionManager', () => {
       const ended = h.events.filter((e) => e.event === 'session.ended');
       expect(ended).toHaveLength(1);
       expect((ended[0].payload as { reason: string }).reason).toBe('user_ended');
+    });
+
+    it('keeps a live session listed when an explicit end request does not exit the bridge', async () => {
+      const bridge = new NonExitingBridge();
+      const h = makeHarness({ createBridge: async () => bridge as unknown as PtyBridge });
+      const { label } = await h.manager.create();
+
+      h.manager.end(label);
+      h.manager.end(label);
+
+      expect(bridge.kill).toHaveBeenCalledTimes(1);
+      expect(h.manager.has(label)).toBe(true);
+      expect(h.manager.listDtos()[0].status).toBe('stopping');
+      expect(h.events.filter((e) => e.event === 'session.ended')).toHaveLength(0);
+      const updated = h.events.filter((e) => e.event === 'session.updated');
+      expect((updated[updated.length - 1].payload as { status: string }).status).toBe('stopping');
+
+      h.manager.input(label, b64('ignored'));
+      h.manager.sendPrompt(label, 'also ignored');
+      expect(bridge.write).not.toHaveBeenCalled();
+
+      bridge.emitExit(0);
+
+      expect(h.manager.has(label)).toBe(false);
+      const ended = h.events.filter((e) => e.event === 'session.ended');
+      expect(ended).toHaveLength(1);
+      expect((ended[0].payload as { reason: string }).reason).toBe('user_ended');
+    });
+
+    it('rolls back a failed kill request so explicit end can be retried', async () => {
+      const bridge = new NonExitingBridge();
+      bridge.kill.mockImplementationOnce(() => {
+        throw new Error('signal failed');
+      });
+      const h = makeHarness({ createBridge: async () => bridge as unknown as PtyBridge });
+      const { label } = await h.manager.create();
+
+      h.manager.end(label);
+
+      expect(h.manager.has(label)).toBe(true);
+      expect(h.manager.listDtos()[0].status).toBe('ready');
+      expect(h.events.filter((e) => e.event === 'session.ended')).toHaveLength(0);
+
+      h.manager.end(label);
+
+      expect(bridge.kill).toHaveBeenCalledTimes(2);
+      expect(h.manager.listDtos()[0].status).toBe('stopping');
     });
 
     it('a child exit reaps the session and emits session.ended', async () => {

--- a/test/pty/pty-session-manager.test.ts
+++ b/test/pty/pty-session-manager.test.ts
@@ -22,6 +22,7 @@ import {
   type PtyStreamSender,
   type PtySessionManagerOptions,
 } from '../../src/web-ui/pty-session-manager.js';
+import { PTY_KILL_GRACE_MS } from '../../src/pty/pty-bridge.js';
 import type { PtyBridge, PtyBridgeOptions } from '../../src/pty/pty-bridge.js';
 import type { PtySessionRegistration } from '../../src/docker/pty-types.js';
 import type { EscalationRequest } from '../../src/session/types.js';
@@ -158,6 +159,24 @@ function makeHarness(overrides: Partial<PtySessionManagerOptions> = {}): Harness
 
 const ptyOutputs = (calls: SenderCall[]) => calls.filter((c) => c.event === 'session.pty_output');
 const ptyReplays = (calls: SenderCall[]) => calls.filter((c) => c.event === 'session.pty_replay');
+
+/** Harness whose bridge accepts kill requests but only exits when driven. */
+function makeNonExitingHarness(opts: { idleTtlMs?: number; failFirstKill?: boolean } = {}): {
+  h: Harness;
+  bridge: NonExitingBridge;
+} {
+  const bridge = new NonExitingBridge();
+  if (opts.failFirstKill) {
+    bridge.kill.mockImplementationOnce(() => {
+      throw new Error('signal failed');
+    });
+  }
+  const h = makeHarness({
+    ...(opts.idleTtlMs !== undefined ? { idleTtlMs: opts.idleTtlMs } : {}),
+    createBridge: async () => bridge as unknown as PtyBridge,
+  });
+  return { h, bridge };
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -421,11 +440,7 @@ describe('PtySessionManager', () => {
     });
 
     it('keeps a live session listed when the idle kill request does not exit the bridge', async () => {
-      const bridge = new NonExitingBridge();
-      const h = makeHarness({
-        idleTtlMs: 1000,
-        createBridge: async () => bridge as unknown as PtyBridge,
-      });
+      const { h, bridge } = makeNonExitingHarness({ idleTtlMs: 1000 });
       const { label } = await h.manager.create();
 
       vi.advanceTimersByTime(1000);
@@ -445,14 +460,7 @@ describe('PtySessionManager', () => {
     });
 
     it('re-arms idle cleanup when an idle kill request throws', async () => {
-      const bridge = new NonExitingBridge();
-      bridge.kill.mockImplementationOnce(() => {
-        throw new Error('signal failed');
-      });
-      const h = makeHarness({
-        idleTtlMs: 1000,
-        createBridge: async () => bridge as unknown as PtyBridge,
-      });
+      const { h, bridge } = makeNonExitingHarness({ idleTtlMs: 1000, failFirstKill: true });
       const { label } = await h.manager.create();
 
       vi.advanceTimersByTime(1000);
@@ -578,8 +586,7 @@ describe('PtySessionManager', () => {
     });
 
     it('keeps a live session listed when an explicit end request does not exit the bridge', async () => {
-      const bridge = new NonExitingBridge();
-      const h = makeHarness({ createBridge: async () => bridge as unknown as PtyBridge });
+      const { h, bridge } = makeNonExitingHarness();
       const { label } = await h.manager.create();
 
       h.manager.end(label);
@@ -605,11 +612,7 @@ describe('PtySessionManager', () => {
     });
 
     it('rolls back a failed kill request so explicit end can be retried', async () => {
-      const bridge = new NonExitingBridge();
-      bridge.kill.mockImplementationOnce(() => {
-        throw new Error('signal failed');
-      });
-      const h = makeHarness({ createBridge: async () => bridge as unknown as PtyBridge });
+      const { h, bridge } = makeNonExitingHarness({ failFirstKill: true });
       const { label } = await h.manager.create();
 
       h.manager.end(label);
@@ -676,6 +679,62 @@ describe('PtySessionManager', () => {
       expect(b1.kill).toHaveBeenCalledTimes(1);
       expect(b2.kill).toHaveBeenCalledTimes(1);
       expect(h.manager.size).toBe(0);
+    });
+
+    it('attempts later bridge kills when an earlier kill throws', async () => {
+      const first = new StubBridge();
+      first.kill.mockImplementationOnce(() => {
+        throw new Error('signal unavailable');
+      });
+      const second = new StubBridge();
+      const bridges = [first, second];
+      const h = makeHarness({
+        createBridge: async () => bridges.shift()! as unknown as PtyBridge,
+      });
+
+      await h.manager.create();
+      await h.manager.create();
+      await h.manager.close();
+
+      expect(first.kill).toHaveBeenCalledTimes(1);
+      expect(second.kill).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('clears the close timeout after immediate exits', async () => {
+      const h = makeHarness();
+      await h.manager.create();
+
+      await h.manager.close();
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('does not leave a close timeout when there are no sessions', async () => {
+      const h = makeHarness();
+
+      await h.manager.close();
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('waits through the SIGKILL grace boundary before close timeout wins', async () => {
+      const { h, bridge } = makeNonExitingHarness();
+      await h.manager.create();
+
+      let resolved = false;
+      const closePromise = h.manager.close().then(() => {
+        resolved = true;
+      });
+      setTimeout(() => bridge.emitExit(0), PTY_KILL_GRACE_MS);
+
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS - 1);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await closePromise;
+      expect(resolved).toBe(true);
+      expect(bridge.kill).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/pty/pty-session-manager.test.ts
+++ b/test/pty/pty-session-manager.test.ts
@@ -444,6 +444,29 @@ describe('PtySessionManager', () => {
       expect((ended[0].payload as { reason: string }).reason).toBe('idle_reaped');
     });
 
+    it('re-arms idle cleanup when an idle kill request throws', async () => {
+      const bridge = new NonExitingBridge();
+      bridge.kill.mockImplementationOnce(() => {
+        throw new Error('signal failed');
+      });
+      const h = makeHarness({
+        idleTtlMs: 1000,
+        createBridge: async () => bridge as unknown as PtyBridge,
+      });
+      const { label } = await h.manager.create();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(bridge.kill).toHaveBeenCalledTimes(1);
+      expect(h.manager.listDtos()[0].status).toBe('ready');
+
+      vi.advanceTimersByTime(1000);
+
+      expect(bridge.kill).toHaveBeenCalledTimes(2);
+      expect(h.manager.has(label)).toBe(true);
+      expect(h.manager.listDtos()[0].status).toBe('stopping');
+    });
+
     it('attach cancels the idle timer; detach re-arms it', async () => {
       const h = makeHarness({ idleTtlMs: 1000 });
       const { label } = await h.manager.create();


### PR DESCRIPTION
Summary
- keep PTY sessions authoritative and visible until child exit is observed
- expose a stopping state and suppress new input after termination is requested
- preserve termination reasons, log request/exit boundaries, and allow retry after signal failure

Regression coverage
- idle reap with a child that ignores kill
- explicit end with delayed exit and idempotent requests
- kill failure rollback and retry

Validation
- npm test: 6,374 backend tests and 533 WebUI tests passed
- ESLint, TypeScript, Prettier, diff checks, and cycle checks passed