### PR TITLE
fix(llm-metrics): make SQLite workers self-contained on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
       - '**/*.md'
       - 'docs/**'
       - 'LICENSE'
+  # Manual trigger: the Node 22 job is otherwise master-push-only, so a PR can
+  # never validate a Node-22-specific fix before merge. Run this workflow from
+  # the Actions tab on the PR branch to get the full matrix, Node 22 included.
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -30,10 +34,11 @@ jobs:
         node-version: [24, 26]
         # Node 22 has NO isolated-vm 7.0.0 prebuild → it source-compiles via
         # node-gyp during `npm ci` (~tens of seconds on CI). Run it on master
-        # pushes only, and ubuntu-only, to keep that cost off every PR and off
-        # the ~10x-pricier macOS runners. `push` here fires only on master (see
-        # trigger above), so github.event_name == 'push' means "a master push".
-        include: ${{ github.event_name == 'push' && fromJSON('[{"os":"ubuntu-latest","node-version":22}]') || fromJSON('[]') }}
+        # pushes and on manual dispatch only, and ubuntu-only, to keep that cost
+        # off every PR and off the ~10x-pricier macOS runners. `push` here fires
+        # only on master (see trigger above), so github.event_name == 'push'
+        # means "a master push"; workflow_dispatch lets a PR opt in on demand.
+        include: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && fromJSON('[{"os":"ubuntu-latest","node-version":22}]') || fromJSON('[]') }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+### Fixes
+
+- **LLM-metrics SQLite workers boot without `tsx` on Node 22** — the persistence workers were spawned with `execArgv: ['--import', 'tsx']` for source runs, but tsx's loader hooks do not take effect inside worker threads on Node 22, so the worker failed to load its TypeScript sources. Source runs now boot through a self-contained ESM entry shim that registers a `.js` → `.ts` specifier remap hook in-thread and relies on Node's native type stripping; compiled runs load the emitted `.js` worker directly and spawn no shim.
+
+### Behavior changes
+
+- **Node.js engine floor raised to 22.15.0** (from 22.13.0). The SQLite worker entry shim registers its resolve hook via `module.registerHooks`, the synchronous module-customization API added in Node 22.15; the older async `module.register()` API cannot express the hook correctly and is now deprecated (`DEP0205`). Node 22.13/22.14 are the only versions dropped — 22.15+, 24, and 26 are unaffected, and `ironcurtain doctor` now reports sub-22.15 as a failure rather than an `ok`. CI additionally gained a `workflow_dispatch` trigger so the Node 22 job (otherwise master-push-only) can be run on demand against a PR branch.
 
 ## [0.13.0] - 2026-07-11
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,17 @@ export default tseslint.config(
       ],
     },
   },
+  // Plain-ESM runtime shims under src/ (worker entry points, loader hooks).
+  // They ship as .mjs because they must run without tsc, so they are outside
+  // the tsconfig.eslint project — lint them with the untyped ruleset rather
+  // than skipping them entirely.
+  {
+    files: ['src/**/*.mjs'],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      parserOptions: { project: null, projectService: false },
+    },
+  },
   // Relaxed rules for test files — mocking patterns, deprecated API testing,
   // and vitest callbacks make strict unsafe-* rules too noisy.
   {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=22.13.0 <27"
+    "node": ">=22.15.0 <27"
   },
   "bin": {
     "ironcurtain": "dist/cli.js"
@@ -76,8 +76,8 @@
     "lint": "eslint src/ test/",
     "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "check:cycles": "madge --circular --extensions ts --ts-config tsconfig.json src",
-    "format": "prettier --log-level=warn --write 'src/**/*.ts' 'test/**/*.ts'",
-    "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",
+    "format": "prettier --log-level=warn --write 'src/**/*.ts' 'src/**/*.mjs' 'test/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts' 'src/**/*.mjs' 'test/**/*.ts'",
     "pre-commit": "lint-staged",
     "setup-hooks": "cp .hooks/pre-commit .git/hooks/pre-commit && cp .hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-commit .git/hooks/pre-push && echo 'Pre-commit and pre-push hooks installed.'"
   },
@@ -125,6 +125,10 @@
   },
   "lint-staged": {
     "!(packages/**)/*.ts": [
+      "prettier --check",
+      "eslint"
+    ],
+    "src/**/*.mjs": [
       "prettier --check",
       "eslint"
     ],

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -58,10 +58,17 @@ const SUPPORTED_MAJORS = [22, 24, 26];
 /** Outer bounds — derived from SUPPORTED_MAJORS so they can't drift from it. */
 const NODE_MIN_MAJOR = Math.min(...SUPPORTED_MAJORS);
 const NODE_MAX_MAJOR = Math.max(...SUPPORTED_MAJORS);
+/**
+ * Minor floor on the oldest supported major. The LLM-metrics SQLite worker
+ * boots through an ESM entry shim that requires `module.registerHooks`, added
+ * in Node 22.15. Keep in sync with the `engines` field in package.json.
+ */
+const NODE_MIN_MINOR_ON_MIN_MAJOR = 15;
 
 export function checkNodeVersion(versionString: string = process.versions.node): CheckResult {
-  const match = /^(\d+)\./.exec(versionString);
+  const match = /^(\d+)\.(\d+)/.exec(versionString);
   const major = match ? Number(match[1]) : NaN;
+  const minor = match ? Number(match[2]) : NaN;
   if (!Number.isFinite(major)) {
     return {
       name: 'Node.js',
@@ -78,6 +85,17 @@ export function checkNodeVersion(versionString: string = process.versions.node):
       hint:
         'IronCurtain supports Node.js 22, 24, or 26. ' +
         'Node 22 source-compiles the V8 sandbox (isolated-vm); 24 and 26 use prebuilt binaries.',
+    };
+  }
+  if (major === NODE_MIN_MAJOR && minor < NODE_MIN_MINOR_ON_MIN_MAJOR) {
+    return {
+      name: 'Node.js',
+      status: 'fail',
+      message: `${versionString} (unsupported)`,
+      hint:
+        `IronCurtain requires Node ${NODE_MIN_MAJOR}.${NODE_MIN_MINOR_ON_MIN_MAJOR} or newer on the ` +
+        `${NODE_MIN_MAJOR}.x line — the LLM-metrics SQLite worker needs module.registerHooks. ` +
+        'Upgrade to the latest Node 22, or use Node 24 or 26.',
     };
   }
   if (!SUPPORTED_MAJORS.includes(major)) {

--- a/src/llm-metrics/persistence/sqlite-repository.ts
+++ b/src/llm-metrics/persistence/sqlite-repository.ts
@@ -121,13 +121,27 @@ function sanitizeError(error: unknown): string {
 }
 
 function workerUrl(): URL {
-  const extension = import.meta.url.endsWith('.ts') ? 'ts' : 'js';
-  return new URL(`./sqlite-worker.${extension}`, import.meta.url);
+  // Source runs boot through the .mjs entry shim, which registers the
+  // .js -> .ts specifier remap hook itself; compiled runs load the .js worker.
+  return import.meta.url.endsWith('.ts')
+    ? new URL('./sqlite-worker-entry.mjs', import.meta.url)
+    : new URL('./sqlite-worker.js', import.meta.url);
 }
 
-function defaultWorkerFactory(url: URL, options: WorkerOptions): Worker {
-  const tsOptions = url.pathname.endsWith('.ts') ? { execArgv: ['--import', 'tsx'] } : {};
-  return new Worker(url, { ...options, ...tsOptions });
+/**
+ * Default worker spawn. Exported so tests that wrap the factory (to count or
+ * fault-inject spawns) delegate here instead of re-implementing the spawn and
+ * silently drifting from the flags production actually uses.
+ */
+export function defaultWorkerFactory(url: URL, options: WorkerOptions): Worker {
+  // The entry shim loads .ts sources via native type stripping, which is
+  // flag-gated before Node 22.18 and a silent no-op afterwards. The worker
+  // must be self-contained: tsx's loader hooks do not take effect inside
+  // worker threads on Node 22, so inheriting the parent's loaders is unsafe.
+  if (url.pathname.endsWith('.mjs')) {
+    return new Worker(url, { ...options, execArgv: ['--experimental-strip-types'] });
+  }
+  return new Worker(url, options);
 }
 
 function estimateBytes(exchange: LlmExchangeCompleted): number {

--- a/src/llm-metrics/persistence/sqlite-worker-entry.mjs
+++ b/src/llm-metrics/persistence/sqlite-worker-entry.mjs
@@ -1,0 +1,21 @@
+/**
+ * Worker entry point for source runs.
+ *
+ * Registers the TypeScript specifier remap hook in-thread so the worker never
+ * depends on loaders inherited from the parent process (tsx's hooks do not
+ * apply inside worker threads on Node 22), then loads the real worker. The
+ * compiled dist build spawns sqlite-worker.js directly and bypasses this shim.
+ *
+ * `module.registerHooks` (Node >= 22.15) is required: it is the synchronous
+ * hooks API, and the remap hook below depends on `nextResolve` throwing
+ * synchronously. The async `module.register()` API returns a promise instead,
+ * so the hook's fallback would never fire there. The package `engines` floor
+ * is >=22.15.0 for exactly this reason.
+ */
+
+import * as nodeModule from 'node:module';
+import { resolve } from './ts-specifier-remap.mjs';
+
+nodeModule.registerHooks({ resolve });
+
+await import('./sqlite-worker.ts');

--- a/src/llm-metrics/persistence/ts-specifier-remap.mjs
+++ b/src/llm-metrics/persistence/ts-specifier-remap.mjs
@@ -1,0 +1,28 @@
+/**
+ * ESM resolve hook for worker threads that load TypeScript sources directly.
+ *
+ * Node's native type stripping loads `.ts` modules but does not apply the
+ * TypeScript convention of resolving a `./x.js` specifier to `x.ts`, and tsx
+ * loader hooks do not take effect inside worker threads on Node 22. This hook
+ * performs exactly that remap; every other specifier passes through unchanged.
+ *
+ * Requires the SYNCHRONOUS hooks API (`module.registerHooks`, Node >= 22.15):
+ * the retry below relies on `nextResolve` throwing synchronously. Under the
+ * async `module.register()` API `nextResolve` returns a promise, the catch
+ * never runs, and the remap silently does nothing.
+ */
+
+export function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('.') && specifier.endsWith('.js')) {
+    try {
+      return nextResolve(specifier, context);
+    } catch (error) {
+      try {
+        return nextResolve(`${specifier.slice(0, -3)}.ts`, context);
+      } catch {
+        throw error;
+      }
+    }
+  }
+  return nextResolve(specifier, context);
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -163,9 +163,19 @@ function buildConfig(overrides: Partial<IronCurtainConfig> = {}): IronCurtainCon
 
 describe('checkNodeVersion', () => {
   it('passes for supported (even-numbered) major versions', () => {
-    expect(checkNodeVersion('22.13.0').status).toBe('ok');
+    expect(checkNodeVersion('22.15.0').status).toBe('ok');
     expect(checkNodeVersion('24.0.0').status).toBe('ok');
     expect(checkNodeVersion('26.0.0').status).toBe('ok');
+  });
+
+  it('fails below the 22.15 minor floor (module.registerHooks)', () => {
+    const result = checkNodeVersion('22.13.0');
+    expect(result.status).toBe('fail');
+    expect(result.hint).toMatch(/registerHooks/);
+    expect(checkNodeVersion('22.14.9').status).toBe('fail');
+    expect(checkNodeVersion('22.15.0').status).toBe('ok');
+    // The floor applies only to the oldest major, not to later lines.
+    expect(checkNodeVersion('24.0.0').status).toBe('ok');
   });
 
   it('warns for in-range non-LTS (odd) major versions', () => {
@@ -908,7 +918,7 @@ describe('checkAgentApiRoundtrip', () => {
 describe('CheckResult shape', () => {
   it('all unit checks return a name, status, and message', () => {
     const samples: CheckResult[] = [
-      checkNodeVersion('22.13.0'),
+      checkNodeVersion('22.15.0'),
       checkAnnotationDrift({ generatedAt: '', servers: {} }, {}),
     ];
     for (const r of samples) {

--- a/test/llm-metrics-persistence.test.ts
+++ b/test/llm-metrics-persistence.test.ts
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { LlmStatisticsQueryService } from '../src/llm-metrics/query-service.js';
 import { LlmMetricsRepositoryUnavailableError } from '../src/llm-metrics/persistence/repository.js';
-import { SqliteLlmMetricsRepository } from '../src/llm-metrics/persistence/sqlite-repository.js';
+import { defaultWorkerFactory, SqliteLlmMetricsRepository } from '../src/llm-metrics/persistence/sqlite-repository.js';
 import type { LlmExchangeCompleted } from '../src/llm-metrics/types.js';
 
 const BASE_TIME = Date.parse('2026-08-15T12:00:00.000Z');
@@ -332,10 +332,7 @@ describe('SQLite LLM metrics repository', () => {
     const opened = await repository({
       readWorkerFactory: (url, options) => {
         readerWorkers++;
-        return new Worker(url, {
-          ...options,
-          ...(url.pathname.endsWith('.ts') ? { execArgv: ['--import', 'tsx'] } : {}),
-        });
+        return defaultWorkerFactory(url, options);
       },
     });
     opened.repository.enqueue(exchange('exchange-safe-query'));
@@ -692,10 +689,7 @@ describe('SQLite LLM metrics repository', () => {
             { eval: true },
           );
         }
-        return new Worker(url, {
-          ...options,
-          ...(url.pathname.endsWith('.ts') ? { execArgv: ['--import', 'tsx'] } : {}),
-        });
+        return defaultWorkerFactory(url, options);
       },
     });
 
@@ -730,10 +724,7 @@ describe('SQLite LLM metrics repository', () => {
             { eval: true },
           );
         }
-        return new Worker(url, {
-          ...options,
-          ...(url.pathname.endsWith('.ts') ? { execArgv: ['--import', 'tsx'] } : {}),
-        });
+        return defaultWorkerFactory(url, options);
       },
     });
     const query = { fromMs: BASE_TIME, toMs: BASE_TIME + 1_000, limit: 10 };


### PR DESCRIPTION
## Problem

The LLM-metrics persistence workers were spawned with `execArgv: ['--import', 'tsx']` for source runs. tsx's loader hooks **do not take effect inside worker threads on Node 22**, so the worker failed to load its TypeScript sources and the Node 22 CI job went red.

## Fix

Source runs now boot through a self-contained ESM entry shim (`sqlite-worker-entry.mjs`) that registers a `.js` → `.ts` specifier remap hook *in-thread* and relies on Node's native type stripping. The worker inherits nothing from the parent's loaders. Compiled runs load the emitted `.js` worker directly and spawn no shim.

## Engine floor: `>=22.13.0` → `>=22.15.0`

The shim registers its hook via `module.registerHooks` — the **synchronous** module-customization API added in Node 22.15. The older async `module.register()` API cannot express this hook correctly: its `nextResolve` returns a promise, so the remap's `catch` never fires and the `.js` → `.ts` retry silently does nothing (verified with a standalone repro — it fails with `ERR_MODULE_NOT_FOUND`). That API is also deprecated as of `DEP0205`.

Only 22.13/22.14 are dropped; 22.15+, 24, and 26 are unaffected. `ironcurtain doctor` was major-only and would have reported 22.13.0 as `ok` while `engines` rejected it — it now enforces a minor floor on the oldest supported major.

## Also in this PR

- **Export `defaultWorkerFactory`.** The three tests that wrap the factory were re-implementing the spawn and had drifted from the flags production uses; they now delegate. The `{ eval: true }` fault-injection workers still construct directly, which is correct.
- **Lint/format the plain-ESM shims.** They were excluded from ESLint, the Prettier globs, and `lint-staged`. All three now cover `src/**/*.mjs`.
- **`workflow_dispatch` trigger on CI.** The Node 22 job is `push`-to-master-only, so a PR can never validate a Node-22-specific fix before merge. Manual dispatch now includes Node 22 in the matrix — verified on this PR's own branch, which runs `ci (ubuntu-latest, 22)` pre-merge.

## Verification

Full suite green: **6386 passed / 121 skipped** across 348 files, plus **540** web-ui tests. `lint`, `format:check`, and `build` clean.

Runtime paths re-verified against the final code on two runtimes:

| | Node 22.23.2 | Node 26.4.0 |
|---|---|---|
| persistence + doctor tests | 88/88 | 88/88 |
| dist path (write + read worker boot, `scan()`) | pass | pass |
| tsx source run — the original break | pass | pass |
