### PR TITLE
test(mitm): stop deep-comparing multi-MiB Buffers

### DIFF
--- a/test/docker/llm-observation-content-decoder.test.ts
+++ b/test/docker/llm-observation-content-decoder.test.ts
@@ -61,7 +61,7 @@ describe('BoundedContentDecoder', () => {
 
     expect(result.failure).toBeUndefined();
     expect(result.state).toBe('ended');
-    expect(result.body).toEqual(largeBody);
+    expect(result.body.equals(largeBody)).toBe(true);
   });
 
   it('detaches when synchronous writes outrun the compressed-input backlog bound', async () => {

--- a/test/docker/mitm-llm-metrics.test.ts
+++ b/test/docker/mitm-llm-metrics.test.ts
@@ -189,6 +189,19 @@ function proxyAuthorization(lease: MetricsInvocationLease): string {
   return `Basic ${Buffer.from(credentials).toString('base64')}`;
 }
 
+/**
+ * Byte-identity for response payloads.
+ *
+ * `toEqual` deep-compares Buffers element-by-element, which costs ~5s per
+ * assertion on the multi-MiB bodies below; `Buffer.equals` is a single memcmp.
+ * Take the cheap path when the bytes match and fall back to `toEqual` only on
+ * mismatch, so a real failure still gets vitest's readable diff.
+ */
+function expectBytesEqual(actual: Buffer, expected: Buffer): void {
+  if (actual.equals(expected)) return;
+  expect(actual).toEqual(expected);
+}
+
 interface BufferResponse {
   readonly statusCode: number;
   readonly headers: Readonly<Record<string, string>>;
@@ -442,7 +455,7 @@ describe('MITM LLM metrics integration', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-encoding']).toBe('gzip');
-    expect(response.body).toEqual(compressed);
+    expectBytesEqual(response.body, compressed);
     await expect.poll(() => exchanges.length).toBe(1);
     expect(exchanges[0]?.attribution).toMatchObject({ quality: 'bundle_only', bundleId: 'bundle-fallback' });
     expect(exchanges[0]?.usage).toMatchObject({ inputTokensTotal: 130, outputTokensTotal: 50, thinkingTokens: 30 });
@@ -477,7 +490,7 @@ describe('MITM LLM metrics integration', () => {
       apiKey: GOOGLE_FAKE_KEY,
     });
 
-    expect(response.body).toEqual(responseBody);
+    expectBytesEqual(response.body, responseBody);
     await expect.poll(() => exchanges.length).toBe(1);
     expect(exchanges[0]?.route).toMatchObject({ logicalProvider: 'google', protocol: 'google-generate-content' });
     expect(exchanges[0]?.identity.requestedModel).toEqual({ value: 'gemini-2.5-flash', source: 'request' });
@@ -559,7 +572,7 @@ describe('MITM LLM metrics integration', () => {
     const requestBody = Buffer.from(JSON.stringify({ model: 'claude-requested', stream: true, messages: [] }));
     const capturedConnect = await sendConnect(socketPath, CLIENT_HOST, 443);
     const capturedResponse = await makeHttpsBufferRequest(capturedConnect.socket as Socket, ca, requestBody);
-    expect(capturedResponse.body).toEqual(compressed);
+    expectBytesEqual(capturedResponse.body, compressed);
     await expect.poll(() => exchanges.length, { timeout: 10_000 }).toBe(1);
     expect(exchanges[0]?.usage).toMatchObject({ inputTokensTotal: 8, outputTokensTotal: 4242 });
     expect(exchanges[0]?.qualityFlags).not.toContain('consumer-decoded-byte-limit');
@@ -569,7 +582,7 @@ describe('MITM LLM metrics integration', () => {
     proxy.setCaptureSessionId(undefined);
     const uncapturedConnect = await sendConnect(socketPath, CLIENT_HOST, 443);
     const uncapturedResponse = await makeHttpsBufferRequest(uncapturedConnect.socket as Socket, ca, requestBody);
-    expect(uncapturedResponse.body).toEqual(compressed);
+    expectBytesEqual(uncapturedResponse.body, compressed);
     await expect.poll(() => exchanges.length, { timeout: 10_000 }).toBe(2);
     expect(exchanges[1]?.usage).toMatchObject({ inputTokensTotal: 8, outputTokensTotal: 4242 });
   }, 60_000);


### PR DESCRIPTION
Addresses the cost half of #427.

## The payload was never the problem

`test/docker/mitm-llm-metrics.test.ts` was the slowest file in the suite by 7×. From the Node 22 CI job:

| File | Duration | Tests |
| --- | --- | --- |
| **`test/docker/mitm-llm-metrics.test.ts`** | **68,863 ms** | 12 |
| `test/mitm-proxy.test.ts` | 9,533 ms | 98 |
| `test/fetch-server.test.ts` | 5,422 ms | 25 |

I profiled the fixture before touching it. Generating the >8 MiB SSE, gzipping it, and gunzipping it cost ~220 ms combined:

```
randomBytes(6.25MiB).toString(base64)          2 ms
build SSE events (JSON.stringify x N)          7 ms
zlib.gzipSync(8.3MiB incompressible)         192 ms
gunzipSync (proxy-side decode)                18 ms
```

The cost was the assertion. `expect(buf).toEqual(other)` deep-compares Buffers element by element; `Buffer.equals` is a single memcmp:

```
toEqual on 6.3MiB Buffers   5338 ms
.equals on 6.3MiB Buffers      0 ms
```

The test did that twice, so ~10.7 s of its runtime was assertion overhead on a fast machine — considerably more on a 2-core runner.

## Change

Compare with `Buffer.equals`, falling back to `toEqual` only on mismatch so a genuine failure still produces vitest's readable diff. I verified the helper actually fails on differing bytes and on differing length rather than silently passing.

The assertion is unchanged — byte-identity either way — and the fixture still exceeds the 8 MiB `maxPendingInputBytes` boundary in `TRAJECTORY_DECODER_LIMITS` that it exists to cross. **No production code changes, no test seams added, no coverage lost.**

| | before | after |
| --- | --- | --- |
| large-SSE test (local, Node 26) | 11,847 ms | **516 ms** |
| whole file (local, Node 26) | 13.17 s | **1.93 s** |
| large-SSE test (local, Node 22) | — | **519 ms** |

Node 22 is the version where this test times out at 60 s on CI; it now runs in half a second locally on that version.

Also fixes the same antipattern in `llm-observation-content-decoder.test.ts` (3,201 ms on CI), where one 256 KiB comparison used `toEqual` across three parameterized encodings — while the assertion directly above it already used `.equals`.

## What this does not fix

#427 stays open. The post-merge master run surfaced a **second, different** failure in the same test on `macos-latest, 26`: `outputTokensTotal: null` instead of `4242` on the second exchange — the observer missing the `message_delta` at the tail of the 8.5 MiB stream. I could not reproduce it locally, and deliberately injecting a 5.3 s synchronous block (simulating the old `toEqual`) did **not** reproduce it. So I am not claiming this PR fixes that; it may be a real robustness issue in the observation path. Details in #427.

Full suite green: 6386 passed / 121 skipped, plus 540 web-ui tests. Lint and format clean.