### PR TITLE
test(mitm): report quality flags when a usage assertion fails

### DIFF
--- a/test/docker/mitm-llm-metrics.test.ts
+++ b/test/docker/mitm-llm-metrics.test.ts
@@ -190,6 +190,21 @@ function proxyAuthorization(lease: MetricsInvocationLease): string {
 }
 
 /**
+ * Usage assertion that names the exchange's quality flags in its failure
+ * message.
+ *
+ * A detached or truncated observation surfaces as `outputTokensTotal: null`
+ * with no indication of why, which is exactly how the intermittent macOS
+ * failure in #427 presents. The detach reason is recorded in `qualityFlags`
+ * (see ExchangeObserver's onDetach), so carry it into the message: the next
+ * occurrence then reports the cause instead of only the symptom. This does not
+ * change what passes -- it only makes a failure legible.
+ */
+function expectUsage(exchange: LlmExchangeCompleted | undefined, expected: Record<string, unknown>): void {
+  expect(exchange?.usage, `qualityFlags: ${JSON.stringify(exchange?.qualityFlags ?? null)}`).toMatchObject(expected);
+}
+
+/**
  * Byte-identity for response payloads.
  *
  * `toEqual` deep-compares Buffers element-by-element, which costs ~5s per
@@ -574,7 +589,7 @@ describe('MITM LLM metrics integration', () => {
     const capturedResponse = await makeHttpsBufferRequest(capturedConnect.socket as Socket, ca, requestBody);
     expectBytesEqual(capturedResponse.body, compressed);
     await expect.poll(() => exchanges.length, { timeout: 10_000 }).toBe(1);
-    expect(exchanges[0]?.usage).toMatchObject({ inputTokensTotal: 8, outputTokensTotal: 4242 });
+    expectUsage(exchanges[0], { inputTokensTotal: 8, outputTokensTotal: 4242 });
     expect(exchanges[0]?.qualityFlags).not.toContain('consumer-decoded-byte-limit');
     await captureWriter.endSession(captureSessionId);
     expect(captureWriter.stats()).toMatchObject({ written: 1, dropped: 0, openSessions: 0 });
@@ -584,7 +599,7 @@ describe('MITM LLM metrics integration', () => {
     const uncapturedResponse = await makeHttpsBufferRequest(uncapturedConnect.socket as Socket, ca, requestBody);
     expectBytesEqual(uncapturedResponse.body, compressed);
     await expect.poll(() => exchanges.length, { timeout: 10_000 }).toBe(2);
-    expect(exchanges[1]?.usage).toMatchObject({ inputTokensTotal: 8, outputTokensTotal: 4242 });
+    expectUsage(exchanges[1], { inputTokensTotal: 8, outputTokensTotal: 4242 });
   }, 60_000);
 
   it('finalizes once when the client aborts a live upstream stream', async () => {


### PR DESCRIPTION
Diagnostic-only follow-up to #427. No pass/fail behavior changes — only what a failure prints.

## Why

The intermittent macOS failure in #427 presents as:

```
  {
    "inputTokensTotal": 8,
-   "outputTokensTotal": 4242,
+   "outputTokensTotal": null,
  }
```

with no indication of *why* the observation came up short. Mining the last 40 CI runs, it has now happened **three times** — macOS 24 (2026-08-17), macOS 26 (2026-08-17), macOS 26 (2026-08-18) — and every occurrence is at **exactly `mitm-llm-metrics.test.ts:574`**: the second exchange, the one with trajectory capture **off**. Never the first. That is a code-path fingerprint, not random timing.

Each occurrence has cost a CI run and told us nothing new, because the reason was thrown away.

## The gap

`ExchangeObserver`'s `onDetach` already records the detach reason into the exchange's `qualityFlags` (`src/llm-metrics/exchange-observer.ts:156`). The test asserts flags on `exchanges[0]` but not `exchanges[1]`, so on the capture-off path we see only the symptom.

## Change

Route both usage assertions through a helper that carries the flags into the assertion message:

```
qualityFlags: ["consumer-decoded-byte-limit"]: expected { inputTokensTotal: 8, …(1) } to match object { … }
```

Verified the message actually surfaces on failure rather than being swallowed.

I chose the message over a symmetric `expect(exchanges[1]?.qualityFlags).not.toContain(...)` deliberately: an added assertion can only catch the one reason we guess, and would risk turning a newly-green master red on a guess. The message reports whatever the real reason turns out to be, at zero risk.

## What I ruled out while investigating

Not the consumer caps — the metrics consumer allows 32 MiB decoded / 100,000 SSE events (`src/llm-metrics/exchange-observer.ts:149-150`) against a stream of 8.57 MiB / ~2,100 events. Not a naive finalize-before-drain race either: `tryFinalize()` (`src/llm-metrics/exchange-observer.ts:277`) correctly requires observation-end plus both response-end timestamps. Injecting a 5.3s synchronous block to simulate the pre-#429 `toEqual` did **not** reproduce it.

So the mechanism is still unknown, and #427 stays open. This is the cheapest way to make the next occurrence tell us something.

Full suite green: 6386 passed / 121 skipped, plus 540 web-ui tests. Lint and format clean.