### PR TITLE
fix(docker): survive slow self-hosted gateways instead of aborting the workflow

### DIFF
--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -395,10 +395,27 @@ exit $STATUS
         // watchdog off restores the pre-2.1.196 behavior; the workflow
         // orchestrator already enforces its own wall-clock/step budgets.
         CLAUDE_ENABLE_STREAM_WATCHDOG: '0',
-        // DGX-backed gateway requests can have a long quiet prefill or
-        // reasoning interval before the first response byte. Extend Claude
-        // Code's byte-idle watchdog to its documented 30-minute maximum for
-        // batch/workflow containers only.
+        // Disable the BYTE-stream idle watchdog for batch/workflow
+        // containers. This is separate from CLAUDE_ENABLE_STREAM_WATCHDOG
+        // above: turning that one off leaves the byte watchdog in charge of
+        // the idle deadline, and the byte deadline is HARD-CLAMPED to 30
+        // minutes inside the CLI (floor 10s, ceiling 1_800_000ms; the
+        // default is 180_000ms — 3 min — whenever the base URL resolves to
+        // api.anthropic.com, which is exactly what the MITM presents).
+        //
+        // A self-hosted gateway (e.g. a DGX-backed vLLM lane) can legitimately
+        // take longer than 30 minutes to produce a single response, and some
+        // requests arrive NON-streaming, where no bytes at all reach the client
+        // until generation completes. For those, no idle value below the full
+        // generation time can ever pass — the ceiling is unreachable by
+        // construction. Turning the watchdog off is the only setting that
+        // tolerates them; the orchestrator's per-turn wall-clock budget
+        // (`resourceBudget.maxSessionSeconds`, applied as the docker-exec
+        // timeout) remains the backstop against a genuinely wedged upstream.
+        CLAUDE_ENABLE_BYTE_WATCHDOG: '0',
+        // Kept at the ceiling so that if the watchdog is ever re-enabled
+        // (host env / future default flip), the deadline is as generous as
+        // the CLI permits rather than the 3-minute first-party default.
         CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '1800000',
       };
     },
@@ -434,6 +451,10 @@ exit $STATUS
         const transient = parsed ? detectTransientFailure(parsed, stdout) : undefined;
         if (transient) {
           return asTransientFailure('degenerate_response', transient.rawMessage);
+        }
+        const apiError = parsed ? detectTerminalApiError(parsed, stdout) : undefined;
+        if (apiError) {
+          return asTransientFailure('upstream_api_error', apiError.rawMessage);
         }
         // Zero output on non-zero exit indicates the claude process was
         // killed (SIGTERM) or crashed before producing any assistant text —
@@ -580,6 +601,42 @@ function detectUpstreamFiveXx(parsed: Record<string, unknown>, stdout: string): 
   const status = parsed.api_error_status;
   if (typeof status !== 'number') return undefined;
   if (status < 500 || status >= 600) return undefined;
+  return { rawMessage: stdout.trim() };
+}
+
+/**
+ * Detects the terminal API-error envelope: Claude Code's API layer gave up on
+ * the turn after exhausting its internal retries, and the CLI finalized
+ * whatever partial content it had.
+ *
+ * Recognizable ONLY by `terminal_reason === 'api_error'`. This covers more
+ * than one underlying cause — the byte-stream idle watchdog firing ("the
+ * response stopped arriving") and a failed connection ("Connection refused")
+ * both produce it, with an identical envelope shape — so the kind is named
+ * for the signal, not for a mechanism it cannot actually distinguish.
+ *
+ * The sibling detectors cannot see this envelope:
+ *   - `detectUpstreamFiveXx` requires a numeric `api_error_status`; this
+ *     envelope carries `null` (there is no HTTP status — no response ever
+ *     completed).
+ *   - `detectTransientFailure` requires `output_tokens === 0` and a null
+ *     `stop_reason`; an abort that interrupts a partially-yielded response
+ *     reports the tokens already emitted, and the CLI *synthesizes* a
+ *     `stop_reason` (observed: `"stop_sequence"`) for the partial message.
+ *
+ * Without this branch the envelope falls through to the generic
+ * `Agent exited with code N` text, and the orchestrator mistakes a dead turn
+ * for one that merely forgot its `agent_status` block — burning its single
+ * reprompt on a conversation the CLI can no longer continue.
+ *
+ * `terminal_reason` is a closed enum in practice (`completed` | `api_error`
+ * across every captured run), so gating on it has no false-positive surface
+ * beyond the `is_error === true` guard that already precedes it.
+ */
+function detectTerminalApiError(parsed: Record<string, unknown>, stdout: string): { rawMessage: string } | undefined {
+  if (parsed.type !== 'result') return undefined;
+  if (parsed.is_error !== true) return undefined;
+  if (parsed.terminal_reason !== 'api_error') return undefined;
   return { rawMessage: stdout.trim() };
 }
 

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -104,7 +104,7 @@ export interface AgentResponse {
  * Discriminant for the `transientFailure.kind` field. Exported as a single
  * source of truth so adding a new kind only requires editing one file.
  */
-export type TransientFailureKind = 'degenerate_response' | 'upstream_5xx';
+export type TransientFailureKind = 'degenerate_response' | 'upstream_5xx' | 'upstream_api_error';
 
 /**
  * Human-readable description of a transient-failure kind, used in
@@ -118,6 +118,8 @@ export function describeTransientFailureKind(kind: TransientFailureKind): string
       return 'agent returned no content (output_tokens=0, stop_reason=null)';
     case 'upstream_5xx':
       return 'upstream returned a 5xx error after SDK retries exhausted';
+    case 'upstream_api_error':
+      return "agent's API layer aborted the turn after internal retries (stalled stream or failed connection)";
   }
 }
 

--- a/src/workflow/workflows/vuln-discovery/workflow.yaml
+++ b/src/workflow/workflows/vuln-discovery/workflow.yaml
@@ -8,7 +8,11 @@ settings:
   sharedContainer: true
   model: anthropic:claude-opus-4-8[1m]
   maxRounds: 12
-  maxSessionSeconds: 10800
+  # Per-turn wall clock (becomes the docker-exec timeout). Sized for
+  # self-hosted gateways: with the agent's byte-idle watchdog disabled,
+  # this budget is the only backstop against a wedged upstream, so it
+  # must exceed the slowest legitimate turn rather than truncate it.
+  maxSessionSeconds: 21600
   unversionedArtifacts:
     - journal
   systemPrompt: |

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -505,6 +505,94 @@ describe('Claude Code Adapter', () => {
     expect(claudeCodeAdapter.extractResponse(1, noFlag).transientFailure).toBeUndefined();
   });
 
+  /**
+   * Verbatim shape of the envelope Claude Code emits when its byte-stream
+   * idle watchdog aborts a request ("the response stopped arriving").
+   * Captured from workflow run a822c784 — all six aborts in that run had
+   * this shape, and every one of them fell through every detector.
+   */
+  function makeTerminalApiErrorEnvelope(extras: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      terminal_reason: 'api_error',
+      api_error_status: null,
+      stop_reason: 'stop_sequence',
+      usage: { input_tokens: 467920, output_tokens: 83614 },
+      result: 'API Error: The response stopped arriving. The response above may be incomplete.',
+      ...extras,
+    });
+  }
+
+  it('surfaces transientFailure as upstream_api_error on the captured idle-watchdog envelope (exit=1)', () => {
+    const response = claudeCodeAdapter.extractResponse(1, makeTerminalApiErrorEnvelope());
+    expect(response.transientFailure).toBeDefined();
+    expect(response.transientFailure!.kind).toBe('upstream_api_error');
+    expect(response.text).toContain('The response stopped arriving');
+    // Must NOT be a hardFailure: rotating the conversation id would discard
+    // the state's partial transcript for an upstream that simply went quiet.
+    expect(response.hardFailure).toBeUndefined();
+    expect(response.quotaExhausted).toBeUndefined();
+  });
+
+  it('classifies the stall envelope regardless of how much output was already yielded', () => {
+    // The two sibling detectors both key off output volume / stop_reason;
+    // the stall is orthogonal to both. Real captures ranged 0..83614 tokens.
+    for (const outputTokens of [0, 405, 12283, 83614]) {
+      const envelope = makeTerminalApiErrorEnvelope({
+        usage: { input_tokens: 1000, output_tokens: outputTokens },
+      });
+      expect(claudeCodeAdapter.extractResponse(1, envelope).transientFailure?.kind).toBe('upstream_api_error');
+    }
+  });
+
+  it('classifies a failed-connection envelope the same way (not just idle stalls)', () => {
+    // Captured verbatim from a Claude Code run against an unreachable base URL.
+    // Byte-idle stall and connection failure are indistinguishable at this
+    // layer: same type/is_error/terminal_reason/api_error_status/stop_reason.
+    const envelope = makeTerminalApiErrorEnvelope({
+      usage: { input_tokens: 0, output_tokens: 0 },
+      result: 'API Error: Connection refused — a firewall or proxy may be blocking it (ConnectionRefused)',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.transientFailure?.kind).toBe('upstream_api_error');
+    expect(response.hardFailure).toBeUndefined();
+  });
+
+  it('does not flag upstream_api_error when terminal_reason is absent or "completed"', () => {
+    // `terminal_reason` is a closed enum in practice (completed | api_error).
+    // A `completed` run that merely exited non-zero must stay on the generic
+    // path so real errors are not swallowed into a resumable abort.
+    for (const terminal_reason of [undefined, 'completed', 'cancelled']) {
+      const envelope = makeTerminalApiErrorEnvelope({ terminal_reason });
+      expect(claudeCodeAdapter.extractResponse(1, envelope).transientFailure).toBeUndefined();
+    }
+  });
+
+  it('does not flag upstream_api_error when is_error is false (predicate strictness)', () => {
+    const envelope = makeTerminalApiErrorEnvelope({ is_error: false });
+    expect(claudeCodeAdapter.extractResponse(1, envelope).transientFailure).toBeUndefined();
+  });
+
+  it('prefers upstream_5xx over upstream_api_error when both signals are present', () => {
+    // A real 5xx envelope also carries terminal_reason: api_error. The more
+    // specific classification (numeric HTTP status) must win, so the 5xx
+    // detector has to run first.
+    const envelope = makeTerminalApiErrorEnvelope({ api_error_status: 503 });
+    expect(claudeCodeAdapter.extractResponse(1, envelope).transientFailure?.kind).toBe('upstream_5xx');
+  });
+
+  it('prefers quotaExhausted over upstream_api_error when both signals are present', () => {
+    const envelope = makeTerminalApiErrorEnvelope({
+      api_error_status: 429,
+      result: 'Usage limit reached for 5 hour. Your limit will reset at 2026-05-16 22:00:00',
+    });
+    const response = claudeCodeAdapter.extractResponse(1, envelope);
+    expect(response.quotaExhausted).toBeDefined();
+    expect(response.transientFailure).toBeUndefined();
+  });
+
   it('does not break the existing 429 (quota) path — 429 must still route to quotaExhausted', () => {
     // Mutual-exclusion regression guard: the new 5xx detector must run
     // AFTER the quota check so a 429 envelope (which would also pass

--- a/test/docker/openrouter-agent-session.test.ts
+++ b/test/docker/openrouter-agent-session.test.ts
@@ -384,6 +384,7 @@ describe('OpenRouter OFF — native profile is byte-identical to today', () => {
     expect(adapter.buildBatchEnv?.(nativeConfig, fakeKeys)).toEqual({
       CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1',
       CLAUDE_ENABLE_STREAM_WATCHDOG: '0',
+      CLAUDE_ENABLE_BYTE_WATCHDOG: '0',
       CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '1800000',
     });
     // No OpenRouter vars leaked in.

--- a/test/pty-session.test.ts
+++ b/test/pty-session.test.ts
@@ -177,6 +177,32 @@ describe('Claude Code adapter PTY orientation files', () => {
     expect(batchEnv?.CLAUDE_ENABLE_STREAM_WATCHDOG).toBe('0');
   });
 
+  it('disables the byte-stream idle watchdog for batch/workflow containers', () => {
+    // Both watchdogs must be off for one-shot runs. Disabling only the
+    // stream watchdog leaves the byte watchdog owning the idle deadline,
+    // and that deadline is hard-clamped to 30 minutes inside the CLI —
+    // unreachable for a self-hosted gateway whose single responses can run
+    // longer than that, or that answers non-streaming (no bytes at all
+    // until generation completes).
+    const config = { userConfig: { anthropicApiKey: 'sk-test' } } as import('../src/config/types.js').IronCurtainConfig;
+    const batchEnv = claudeCodeAdapter.buildBatchEnv?.(config, new Map([['api.anthropic.com', 'sk-ant-fake']]));
+
+    expect(batchEnv?.CLAUDE_ENABLE_BYTE_WATCHDOG).toBe('0');
+    expect(batchEnv?.CLAUDE_ENABLE_STREAM_WATCHDOG).toBe('0');
+    // Ceiling retained so a re-enabled watchdog gets the most generous
+    // deadline the CLI allows rather than the 3-minute first-party default.
+    expect(batchEnv?.CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS).toBe('1800000');
+  });
+
+  it('leaves the byte watchdog untouched for interactive PTY sessions', () => {
+    vi.stubEnv('CLAUDE_ENABLE_BYTE_WATCHDOG', undefined);
+    const env = claudeCodeAdapter.buildEnv(
+      { userConfig: { anthropicApiKey: 'sk-test' } } as import('../src/config/types.js').IronCurtainConfig,
+      new Map([['api.anthropic.com', 'sk-ant-fake']]),
+    );
+    expect(env.CLAUDE_ENABLE_BYTE_WATCHDOG).toBeUndefined();
+  });
+
   it('start-claude.sh includes stty initialization from env vars', () => {
     const files = claudeCodeAdapter.generateOrientationFiles();
     const startScript = files.find((f) => f.path === 'start-claude.sh');


### PR DESCRIPTION
## What broke

A `vuln-discovery` run against a local DGX-backed vLLM lane (via LiteLLM) aborted **six times over 9h39m**, every time reporting:

```
Agent failed to provide agent_status block after retry
```

That message was a misdiagnosis. In all six cases the agent's turn had already been killed by Claude Code's byte-stream idle watchdog, and the orchestrator was reprompting a conversation the CLI could no longer continue.

Slowness was never the failure — the run was unattended and multi-hour generation was acceptable. **Truncating it was the failure.**

## Two defects, one per layer

### 1. The stall envelope was unclassifiable

Claude Code reports an idle-watchdog abort as:

```json
{"type":"result","is_error":true,"terminal_reason":"api_error",
 "api_error_status":null,"stop_reason":"stop_sequence",
 "usage":{"output_tokens":83614},
 "result":"API Error: The response stopped arriving. The response above may be incomplete."}
```

Every existing detector misses it:

| detector | requires | actual | result |
|---|---|---|---|
| `detectUpstreamFiveXx` | numeric `api_error_status` in 5xx | `null` — nothing HTTP failed | miss |
| `detectTransientFailure` | `output_tokens === 0` **and** null `stop_reason` | `83614`, and the CLI **synthesizes** a `stop_reason` for the partial message | miss |
| `hardFailure` | empty stdout | full JSON envelope present | miss |

So it fell through to the generic `Agent exited with code N` text, the orchestrator mistook a dead turn for one that merely forgot its `agent_status` block, burned its single reprompt, and aborted.

Adds `detectTerminalApiError`, keyed on `terminal_reason === 'api_error'` — a closed enum (`completed` | `api_error`) across every captured run, so no false-positive surface beyond the `is_error === true` guard already preceding it.

**Routed to `transientFailure`, not `hardFailure`.** The hard-retry path rotates the conversation id and resends the original command, which cannot recover a stalled upstream and would discard the state's partial transcript. `transientFailure` preserves the checkpoint for `workflow resume` — and matches the rationale already stated in the sibling branch.

**Named `upstream_api_error`, not for a mechanism.** `terminal_reason` does not distinguish causes: a byte-idle stall and a failed connection produce byte-identical envelopes. I found this out when a connectivity test failed and emitted the same shape with `"API Error: Connection refused"`. Both captured shapes are in the tests.

### 2. The 30-minute ceiling is unreachable by construction

`CLAUDE_ENABLE_STREAM_WATCHDOG=0` (already set) does **not** remove the idle deadline — it leaves the *byte* watchdog owning it:

```js
Uu = Math.min(Iga(Yn()), Wp ? ll : 1/0)   // Wp=false → byte-idle clamp still governs
```

And that value is hard-clamped inside the CLI:

```js
U4b = 180_000     // 3 min — default when base URL resolves to api.anthropic.com
B4b =  10_000     // floor
F4b = 1_800_000   // 30 min — hard ceiling
return Math.min(Math.max(n, B4b), F4b);
```

The MITM presents `api.anthropic.com`, so the lane gets the 3-minute first-party default. Measured silence before each abort tracks this exactly:

| turn | silence | ceiling raised to 30m? |
|---|---|---|
| orchestrator | 3.3m | no |
| analyze | 5.3m | no |
| harness_design | 6.2m | no |
| harness_design | 23.6m | no |
| harness_design_review | 3.1m | no |
| harness_build | **34.9m** | **yes** |

Raising `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS` further does nothing — 1800000 is already the ceiling. And ~13% of requests on this lane arrive **non-streaming** (TTFT == total duration), where no bytes reach the client until generation completes, so no idle value below the full generation time can ever pass.

Sets `CLAUDE_ENABLE_BYTE_WATCHDOG=0` for **batch/workflow containers only** (`buildBatchEnv`); interactive PTY sessions keep their escape hatch. `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS` is retained at the ceiling so a re-enabled watchdog gets the most generous deadline rather than the 3-minute default.

The orchestrator's per-turn wall clock is now the only backstop against a genuinely wedged upstream, so `vuln-discovery`'s `maxSessionSeconds` goes 10800 → 21600.

## Testing

- 9 new tests in `docker-agent-adapter.test.ts` built from **verbatim captured envelopes** (both the stall and the connection-refused shape), covering output-token independence (0 / 405 / 12283 / 83614), predicate strictness, and precedence — `upstream_5xx` and `quotaExhausted` must still win when their signals co-occur.
- 2 new tests in `pty-session.test.ts` asserting the batch/PTY split.
- `openrouter-agent-session.test.ts` batch-env expectation updated (it asserts the env with `toEqual`).
- `tsc --noEmit`, `npm run lint`, and `workflow lint` clean.

## Not verified

`CLAUDE_ENABLE_BYTE_WATCHDOG=0` surviving a >30-minute stall end-to-end. The disable rests on the decompiled `yup()` gate and the wrapper's install condition, plus the measured before/after on the ceiling. My attempt to confirm it against a local stalling SSE server failed on container→host loopback (Docker runs in a separate netns here), so both arms died with ConnectionRefused and proved nothing about the watchdog. `src/docker/stream-delay.ts` is the purpose-built harness for this once the networking is sorted.

## Out of scope

The underlying model pathology (this lane degenerates into token soup past ~2k output tokens, saturating `max_tokens: 64000` and taking ~53 min per response) is a serving-stack issue, not an IronCurtain one. This PR only stops IronCurtain from converting it into a silent 9-hour abort. LiteLLM deployment timeouts were separately raised 1800 → 14400 in the operator's own config repo.
