### PR TITLE
fix(deps): await the isolate script run before disposing it

### DIFF
--- a/.github/workflows/flake-probe.yml
+++ b/.github/workflows/flake-probe.yml
@@ -1,0 +1,80 @@
+# Manual instrument for issue #363: the macOS vitest teardown flake.
+#
+# Runs one slice of the suite in a loop and counts how many attempts hit the
+# worker-death signature. Deliberately calls `npx vitest run` directly rather
+# than `npm test`, because scripts/test.sh retries on exactly this signature
+# and would mask what we are trying to measure.
+#
+# Measured baseline (issue #363): ~10.2% of macOS root-suite attempts, 0% on
+# Linux. At that rate ~40 attempts distinguishes "fixed" from "unchanged".
+name: Flake probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which slice to loop
+        type: choice
+        default: isolated-vm
+        options: [isolated-vm, exclude-isolated-vm, full]
+      iterations:
+        description: Number of attempts
+        type: string
+        default: '40'
+      node-version:
+        description: Node major version
+        type: string
+        default: '26'
+      os:
+        description: Runner
+        type: choice
+        default: macos-latest
+        options: [macos-latest, ubuntu-latest]
+
+jobs:
+  probe:
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+      - run: npm ci --foreground-scripts
+      - name: Report patch state
+        run: |
+          echo "isolate dispose-race patch applied: $(grep -c 'await Promise.allSettled(\[runPromise\])' node_modules/@utcp/code-mode/dist/index.js || echo 0)"
+      - name: Loop and count worker deaths
+        run: |
+          set -uo pipefail
+          ISOLATED_VM_FILES="test/workflow-policy-cycling.integration.test.ts test/help-integration.test.ts test/docker-code-mode.integration.test.ts test/sandbox-tool-errors.integration.test.ts"
+          case "${{ inputs.target }}" in
+            isolated-vm)         ARGS="$ISOLATED_VM_FILES" ;;
+            exclude-isolated-vm) ARGS=""; for f in $ISOLATED_VM_FILES; do ARGS="$ARGS --exclude $f"; done ;;
+            full)                ARGS="" ;;
+          esac
+          SIG='Worker exited unexpectedly|prevents Vite server from exiting|close timed out after [0-9]+ms'
+          hits=0; testfails=0; n=${{ inputs.iterations }}
+          for i in $(seq 1 "$n"); do
+            out="$(npx vitest run $ARGS 2>&1 | perl -pe 's/\x1b\[[0-9;]*m//g')"
+            if printf '%s\n' "$out" | grep -qE "$SIG"; then
+              hits=$((hits+1)); echo "::warning::attempt $i/$n: WORKER DEATH"
+              printf '%s\n' "$out" | grep -E "$SIG" | head -3
+            fi
+            if printf '%s\n' "$out" | grep -qE '(Test Files|Tests)[[:space:]]+[0-9]+ failed'; then
+              testfails=$((testfails+1)); echo "::warning::attempt $i/$n: REAL TEST FAILURE"
+              printf '%s\n' "$out" | grep -E "FAIL |(Test Files|Tests)[[:space:]]+[0-9]+ failed" | head -5
+            fi
+            echo "attempt $i/$n done (worker-deaths=$hits real-failures=$testfails)"
+          done
+          echo "### Flake probe result" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| field | value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| target | ${{ inputs.target }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| runner / node | ${{ inputs.os }} / ${{ inputs.node-version }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| attempts | $n |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| worker deaths | $hits |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| real test failures | $testfails |" >> "$GITHUB_STEP_SUMMARY"
+          echo "worker-deaths=$hits real-failures=$testfails out of $n attempts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "eslint-config-prettier": "^10.1.8",
         "lint-staged": "^17.0.8",
         "madge": "^8.0.0",
+        "patch-package": "^8.0.1",
         "prettier": "^3.8.4",
         "smol-toml": "^1.4.2",
         "tsx": "^4.22.4",
@@ -70,7 +71,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=22.13.0 <27"
+        "node": ">=22.15.0 <27"
       },
       "optionalDependencies": {
         "node-pty": "^1.1.0",
@@ -3263,6 +3264,13 @@
         "addons/*"
       ]
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3625,6 +3633,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"
@@ -3813,6 +3822,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3926,6 +3954,22 @@
       "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==",
       "license": "(BSD-3-Clause AND Apache-2.0)",
       "optional": true
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -5625,6 +5669,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5756,6 +5810,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -6249,6 +6318,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6375,6 +6460,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6589,6 +6694,26 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6615,6 +6740,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6623,6 +6771,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/known-css-properties": {
@@ -7985,6 +8143,23 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "6.45.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
@@ -8182,6 +8357,69 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -9434,6 +9672,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -9644,6 +9900,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/slice-ansi": {
@@ -10576,6 +10842,16 @@
       "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10857,6 +11133,16 @@
       "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "check:cycles": "madge --circular --extensions ts --ts-config tsconfig.json src",
     "format": "prettier --log-level=warn --write 'src/**/*.ts' 'src/**/*.mjs' 'test/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts' 'src/**/*.mjs' 'test/**/*.ts'",
+    "prepare": "patch-package",
     "pre-commit": "lint-staged",
     "setup-hooks": "cp .hooks/pre-commit .git/hooks/pre-commit && cp .hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-commit .git/hooks/pre-push && echo 'Pre-commit and pre-push hooks installed.'"
   },
@@ -152,6 +153,7 @@
     "eslint-config-prettier": "^10.1.8",
     "lint-staged": "^17.0.8",
     "madge": "^8.0.0",
+    "patch-package": "^8.0.1",
     "prettier": "^3.8.4",
     "smol-toml": "^1.4.2",
     "tsx": "^4.22.4",

--- a/patches/@utcp+code-mode+1.2.12.patch
+++ b/patches/@utcp+code-mode+1.2.12.patch
@@ -1,0 +1,60 @@
+diff --git a/node_modules/@utcp/code-mode/dist/index.cjs b/node_modules/@utcp/code-mode/dist/index.cjs
+index a2108fc..07810c4 100644
+--- a/node_modules/@utcp/code-mode/dist/index.cjs
++++ b/node_modules/@utcp/code-mode/dist/index.cjs
+@@ -190,6 +190,7 @@ ${interfaces.join("\n\n")}`;
+     const logs = [];
+     const isolate = new import_isolated_vm.default.Isolate({ memoryLimit });
+     let timeoutHandle;
++    let runPromise;
+     try {
+       const context = await isolate.createContext();
+       const jail = context.global;
+@@ -235,7 +236,8 @@ ${interfaces.join("\n\n")}`;
+       timeoutPromise.catch(() => {
+       });
+       const script = await isolate.compileScript(wrappedCode);
+-      script.run(context, { timeout }).catch(() => {
++      runPromise = script.run(context, { timeout });
++      runPromise.catch(() => {
+       });
+       const resultJson = await settledPromise;
+       const result = JSON.parse(resultJson).__result;
+@@ -248,6 +250,7 @@ ${interfaces.join("\n\n")}`;
+       };
+     } finally {
+       if (timeoutHandle) clearTimeout(timeoutHandle);
++      if (runPromise) await Promise.allSettled([runPromise]);
+       isolate.dispose();
+     }
+   }
+diff --git a/node_modules/@utcp/code-mode/dist/index.js b/node_modules/@utcp/code-mode/dist/index.js
+index c5788fd..19f1d3c 100644
+--- a/node_modules/@utcp/code-mode/dist/index.js
++++ b/node_modules/@utcp/code-mode/dist/index.js
+@@ -154,6 +154,7 @@ ${interfaces.join("\n\n")}`;
+     const logs = [];
+     const isolate = new ivm.Isolate({ memoryLimit });
+     let timeoutHandle;
++    let runPromise;
+     try {
+       const context = await isolate.createContext();
+       const jail = context.global;
+@@ -199,7 +200,8 @@ ${interfaces.join("\n\n")}`;
+       timeoutPromise.catch(() => {
+       });
+       const script = await isolate.compileScript(wrappedCode);
+-      script.run(context, { timeout }).catch(() => {
++      runPromise = script.run(context, { timeout });
++      runPromise.catch(() => {
+       });
+       const resultJson = await settledPromise;
+       const result = JSON.parse(resultJson).__result;
+@@ -212,6 +214,7 @@ ${interfaces.join("\n\n")}`;
+       };
+     } finally {
+       if (timeoutHandle) clearTimeout(timeoutHandle);
++      if (runPromise) await Promise.allSettled([runPromise]);
+       isolate.dispose();
+     }
+   }


### PR DESCRIPTION
Candidate fix for #363, plus the instrument to test it. **The mechanism is inferred from reading library source, not reproduced** — the probe is how we find out.

## Evidence (from the #363 sweep of 120 runs / 481 jobs)

| cell | attempts | worker deaths | rate |
| --- | --- | --- | --- |
| macOS (Node 24 + 26) | 176 | 18 | **10.2%** |
| Linux (Node 22 + 24 + 26) | 186 | 0 | 0% |

Fisher exact p = 5.1e-05 for the platform split. There is **no Node-version effect** (macOS 24 vs 26: p = 1.0) — worth stating plainly because an earlier 12-job sample suggested one, and a wider sweep killed it. Both macOS jobs run the identical `macos-26-arm64` image; the 24/26 in the job name is the Node version.

Two independent attribution methods agree that all 18 deaths landed in files that instantiate a V8 isolate:

| file | deaths |
| --- | --- |
| `test/workflow-policy-cycling.integration.test.ts` | 9 |
| `test/help-integration.test.ts` | 7 |
| `test/docker-code-mode.integration.test.ts` | 2 |
| *other 345 files* | **0** |

Those are three of the four files gated on `isIsolatedVmAvailable()`. Confounder excluded: five other files spawn the real MCP filesystem child *without* isolated-vm and have zero deaths, so the discriminator is isolated-vm, not child processes.

It is a **hang, not a crash**: the file passes its tests, goes silent for 3–66s, gets reaped, and close then blocks for exactly `teardownTimeout` (`vitest.config.ts:14`).

## The race

`@utcp/code-mode@1.2.12`, `callToolChain()`:

```js
script.run(context, { timeout }).catch(() => {});   // fire-and-forget, never awaited
const resultJson = await settledPromise;            // resolves from INSIDE the isolate
} finally { isolate.dispose(); }                    // races the still-unwinding run
```

`settledPromise` resolves via an in-isolate `__resolveResult.applySync` callback, so the host reaches `finally` and disposes while `script.run()` is still unwinding on the isolate's own native thread. isolated-vm documents nothing about disposing with a run in flight — undefined interaction, and a native thread race resolves differently on Darwin/arm64 than Linux/x64.

## The change

Hold the run promise; await its settlement before dispose:

```js
let runPromise;
...
runPromise = script.run(context, { timeout });
runPromise.catch(() => {});
...
} finally {
  if (timeoutHandle) clearTimeout(timeoutHandle);
  if (runPromise) await Promise.allSettled([runPromise]);
  isolate.dispose();
}
```

The wait is bounded by isolated-vm's own `{ timeout }` on `script.run`, so it cannot hang beyond a timeout the caller already accepted.

Vendored with patch-package against 1.2.12 (current latest on npm — no upstream release to pick up). Both `dist/index.js` and `dist/index.cjs` are patched.

### On `prepare` vs `postinstall`

Wired through **`prepare`** deliberately. npm runs `prepare` for the root project and for git dependencies, but **not** when the package is installed from the registry — so `npm i -g @provos/ironcurtain` never tries to invoke patch-package, which is a devDependency and absent there. `postinstall` *would* run for consumers and break global install. Verified `npm ci` reapplies the patch to both artifacts.

## The probe

`.github/workflows/flake-probe.yml` is dispatch-only (zero cost unless invoked). It loops one slice of the suite and counts the worker-death signature, with inputs for slice / iterations / runner / Node version. It calls `npx vitest run` directly rather than `npm test`, because `scripts/test.sh` retries on this exact signature and would mask the thing being measured.

At a 10.2% baseline, ~40 macOS attempts on the isolated-vm slice separates "fixed" from "unchanged". A single ordinary CI run cannot: it would come up clean ~90% of the time even with no fix at all.

## Verification

Four isolated-vm suites pass with the patch (21 tests). Full suite: 6391 passed, **0 failed tests**. Lint and format clean.

One local suite-level failure appeared in `test/pty-web-escalation.integration.test.ts` (`posix_spawnp failed` in node-pty). I verified it reproduces with the patch **reverted**, so it is a local artifact of the fresh `npm ci` rebuilding node-pty's native binding, not this change. CI has been green on that test.