### PR TITLE
fix(test): serialize the isolated-vm test files

### DIFF
--- a/test/isolated-vm-test-inventory.test.ts
+++ b/test/isolated-vm-test-inventory.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { ISOLATED_VM_TESTS } from '../vitest.config.js';
+
+/**
+ * Guard for the serialized isolated-vm project in vitest.config.ts.
+ *
+ * Running two or more isolate-creating test files concurrently wedges a worker
+ * at teardown on macOS (issue #363). The config serializes them by explicit
+ * list, which is fast and obvious but goes stale silently — a newly added
+ * isolate test would rejoin the parallel pool and reintroduce the flake with
+ * no signal. This test is that signal.
+ */
+describe('isolated-vm test inventory', () => {
+  it('matches every test file gated on isIsolatedVmAvailable', () => {
+    const testDir = join(import.meta.dirname, '.');
+    const discovered = readdirSync(testDir, { recursive: true, encoding: 'utf-8' })
+      .filter((entry) => entry.endsWith('.test.ts'))
+      .filter((entry) =>
+        /from '.*helpers\/isolated-vm-available\.js'/.test(readFileSync(join(testDir, entry), 'utf-8')),
+      )
+      .map((entry) => `test/${entry.split('\\').join('/')}`)
+      .sort();
+
+    expect(discovered).toEqual([...ISOLATED_VM_TESTS].sort());
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,60 @@
-import { defineConfig } from 'vitest/config';
+import { defaultExclude, defineConfig } from 'vitest/config';
+
+/**
+ * Test files that instantiate a V8 isolate (isolated-vm), i.e. every file
+ * gated on `isIsolatedVmAvailable()`. Kept in sync by
+ * test/isolated-vm-test-inventory.test.ts, which fails if a new one appears.
+ *
+ * These are serialized against each other. Measured on macOS CI (issue #363),
+ * 120 attempts per condition:
+ *
+ *   4 of these files, in parallel  -> 15.8% of runs wedge a worker at teardown
+ *   2 of these files, in parallel  ->  5.0%
+ *   4 of these files, serialized   ->  0.8%
+ *   any one of them, alone         ->  0.2%
+ *
+ * Two or more live isolates in separate forked children is the trigger; the
+ * files are individually and sequentially fine (serialized vs alone: p = 0.36).
+ * Serializing only these four removes the trigger while the other ~344 files
+ * keep running in parallel.
+ */
+const ISOLATED_VM_TESTS = [
+  'test/docker-code-mode.integration.test.ts',
+  'test/help-integration.test.ts',
+  'test/sandbox-tool-errors.integration.test.ts',
+  'test/workflow-policy-cycling.integration.test.ts',
+];
+
+/** Options that must apply to every project (they are project-level in vitest). */
+const shared = {
+  testTimeout: 30_000,
+  // Match CI's default pool explicitly so local and CI runs behave the same.
+  pool: 'forks',
+  teardownTimeout: 30_000,
+} as const;
 
 export default defineConfig({
   test: {
-    include: ['test/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
-    testTimeout: 30_000,
-    // Match CI's default pool explicitly so local and CI runs behave the same.
-    pool: 'forks',
-    // The macOS "Worker exited unexpectedly" / "prevents Vite server from
-    // exiting" teardown flake (issue #363) is handled by a bounded retry in
-    // scripts/test.sh, not here — attempts to neutralize it at the vitest layer
-    // (closing/unref-ing leaked handles) did not fix it. Extra teardown slack is
-    // kept as belt-and-suspenders.
-    teardownTimeout: 30_000,
+    projects: [
+      {
+        test: {
+          ...shared,
+          name: 'isolated-vm',
+          include: ISOLATED_VM_TESTS,
+          // The whole point: never two of these in flight at once.
+          fileParallelism: false,
+        },
+      },
+      {
+        test: {
+          ...shared,
+          name: 'main',
+          include: ['test/**/*.test.ts', 'src/**/__tests__/**/*.test.ts'],
+          exclude: [...defaultExclude, ...ISOLATED_VM_TESTS],
+        },
+      },
+    ],
   },
 });
+
+export { ISOLATED_VM_TESTS };


### PR DESCRIPTION
Removes the trigger for the macOS teardown flake (#363) instead of retrying around it.

## The mechanism, measured

120 attempts per condition, macOS / Node 26, stock deps:

| condition | worker deaths | rate |
| --- | --- | --- |
| 4 isolated-vm files, **parallel** | 19/120 | 15.8% |
| 2 isolated-vm files, parallel | 6/120 | 5.0% |
| 4 isolated-vm files, **serialized** | 1/120 | 0.8% |
| any one of them, alone | 1/480 | 0.2% |

Parallel vs serialized **p = 2.0e-05**; serialized vs alone **p = 0.36**.

The trigger is **two or more live V8 isolates in separate forked children at once**. Not any single file, not the ordering, and not cumulative isolate churn — the serialized run does identical total work and is clean. The rate scales with concurrent isolate count.

## The change

Two vitest projects: an `isolated-vm` project holding the four isolate files with `fileParallelism: false`, and a `main` project with the other ~344 unchanged in parallel. Only the files that can trigger the bug are serialized.

`test/isolated-vm-test-inventory.test.ts` keeps the list honest — it discovers every file importing the isolated-vm helper and fails if the config drifts, so a newly added isolate test cannot silently rejoin the parallel pool. Verified it goes red when an entry is removed.

## Validation

| probe | before | after | p |
| --- | --- | --- | --- |
| isolated-vm slice (120 attempts) | 19/120 = 15.8% | **2/120 = 1.7%** | **1.2e-04** |
| full suite (240 attempts, pooled) | 8/80 = 10.0% | **6/240 = 2.5%** | **0.0088** |

**The slice result is decisive** — an 89% reduction, and statistically indistinguishable from global `--no-file-parallelism` (p = 1.000), confirming the projects split serializes correctly.

**The full-suite result is now confirmed.** The n=180 confirmation run returned 4/180 = 2.2%; pooled with the earlier 2/60 that is 6/240 = 2.5% against a 10.0% control, **p = 0.0088** — a 75% reduction on the real CI workload. The n=180 run alone reaches p = 0.0096, so this does not depend on pooling.

## Two honest caveats

1. **It does not fully eliminate the flake.** A 2.5% residual remains, and at n=240 that is significantly above the 0.21% single-file floor (p = 0.0066) — so it is a genuine second mechanism, not noise. **The retry wrapper in `scripts/test.sh` must stay**; it simply fires ~4x less often. Follow-up candidates are tracked on #363.
2. **It costs wall-clock.** Serializing the four adds a ~13.5 s long pole (locally 17 s → 33 s; on CI's ~90 s suite roughly +15–20%). On pure time this is close to break-even against the ~10% chance of a full re-run. The real gain is determinism: fewer masked failures and fewer red-herring investigations.

If the wall-clock cost is judged too high, the alternative is running the isolated-vm group as a separate concurrent vitest process in `scripts/test.sh` — overlapping rather than serial — at the cost of more complexity and losing direct probe measurability.

Coverage is unchanged: 6,518 tests before and after. Lint, format, and typecheck clean.
