### PR TITLE
fix(docker): restore a fully visible /proc for nested Docker on container 1.2.x

### DIFF
--- a/docs/designs/apple-container-runtime.md
+++ b/docs/designs/apple-container-runtime.md
@@ -129,3 +129,43 @@ Implementation deltas vs the Linux `uds` path:
 - **UID remap stays Linux-only.** `buildAgentUidRemap` is skipped when `runtimeKind === 'apple-container'` (it was previously keyed on `useTcp`, which is now `false` here).
 
 The container-side wiring is unchanged: the entrypoints' `[ -S /run/ironcurtain/mitm-proxy.sock ]` gate sees the vsock-relayed socket as type `s`, and the `socat TCP-LISTEN:18080 → UNIX-CONNECT` bridge / `HTTPS_PROXY=http://127.0.0.1:18080` env work identically to Linux.
+
+## 1.2.1 — OCI `readonlyPaths` and the nested-daemon floor bump
+
+`container` 1.2.0 (July 2026) bumped apple/containerization to 0.40.x, where the OCI `maskedPaths`/`readonlyPaths` sets moved from "available to the caller" to **applied by default** (`LinuxContainer.Configuration.readonlyPaths = defaultReadonlyPaths()`). `defaultReadonlyPaths()` is `/proc/bus`, `/proc/fs`, `/proc/irq`, **`/proc/sys`**, `/proc/sysrq-trigger`.
+
+That read-only bind on `/proc/sys` breaks the secure nested Docker runtime. rootlesskit does not remount `/proc`, so the bind is inherited by the daemon's mount namespace, and `APPLE_VM_DAEMON_NETWORK_PREREQUISITES` (`docker-workload/apple-vm-daemon.ts`) dies on its one namespace-local prerequisite:
+
+```
+sh: 4: cannot create /proc/sys/net/ipv4/ip_forward: Read-only file system
+[rootlesskit:child ] error: command [sh -c set -e …] exited: exit status 2
+```
+
+**EROFS, not EACCES** — the distinction matters when triaging, because the privilege-shaped failures in this path (the `newuidmap` setuid/fcaps trap) report `Operation not permitted` instead. Reproduced deterministically by re-binding `/proc/sys` read-only inside a rootlesskit child on 1.1.0, which yields the identical message; the same bootstrap on an untouched 1.1.0 guest writes the sysctl successfully.
+
+1.2.1 added `--read-only-path` / `--masked-path` to `container run`/`create`, which is the only way to express the override. The CLI **appends** values to the defaults; the literal `NONE` sentinel (case-insensitive) resets the accumulated list, so a leading `NONE` makes the remaining values the complete set.
+
+Worse, the read-only binds are only half the problem. The masked-path set is also implemented as covering mounts under `/proc` (devtmpfs over `/proc/keys`, `/proc/timer_list`, …), and `mnt_already_visible()` refuses a fresh procfs mount in a user namespace unless some existing proc mount has **no locked children covering it**. Every one of these binds is locked from the perspective of rootlesskit's user namespace, so the nested daemon boots but its runc cannot create a single container:
+
+```
+OCI runtime create failed: runc create failed: error during container init:
+error mounting "proc" to rootfs at "/proc": operation not permitted
+```
+
+Measured on 1.2.2 / guest kernel 6.18.15, mounting procfs in a fresh pidns inside rootlesskit:
+
+| container path config                      | covering mounts under `/proc` | nested procfs mount            |
+| ------------------------------------------ | ----------------------------- | ------------------------------ |
+| 1.2.x defaults                             | 6                             | denied                         |
+| `--read-only-path NONE` only               | 2 (masks remain)              | denied                         |
+| narrowed read-only set, `net` rw           | 12                            | denied — "Mount too revealing" |
+| `--read-only-path NONE --masked-path NONE` | 0                             | **OK**                         |
+
+The narrowed variant is the trap: it fixes the EROFS bootstrap failure and leaves every inner `docker run` broken, so a daemon-readiness check passes and the feature is still dead. The opt-out has to be all-or-nothing.
+
+Consequences for this backend:
+
+- **The floor is 1.2.1, not 1.2.0.** 1.2.0 applies the default and cannot override it, so it is a release the nested daemon cannot boot on at all. The availability probe therefore compares major/minor/**patch** (`isAtLeastMinimumVersion`), where it previously compared major/minor only. 1.1.0 — the release the UDS topology above was qualified on — is dropped.
+- **The opt-out is scoped to nested-Docker agent containers.** `DockerContainerConfig.fullyVisibleProc` is set only when `resolveNestedDaemonBundle` returns a bundle, and `buildAppleCreateArgs` then emits `APPLE_FULLY_VISIBLE_PROC_ARGS` (`--read-only-path NONE --masked-path NONE`). Ordinary sessions pass neither flag and keep the full 1.2.x hardening.
+- **This restores the 1.1.0 `/proc` exposure, it does not invent a new concession.** 1.1.0 applied no masked or read-only paths at all, and that is the configuration the nested runtime was qualified against. The residual exposure is small regardless: the agent holds neither CAP_SYS_ADMIN nor CAP_NET_ADMIN, so it cannot write the sysctls a writable `/proc/sys` nominally offers, and the VM is single-tenant per session.
+- **`NONE` is the reset sentinel.** The flags append to the defaults; a bare `NONE` (case-insensitive) empties the accumulated list. Emitting any path alongside it would re-cover `/proc` and silently reintroduce the runc failure, which is what the unit test pins.

--- a/src/docker/apple-container-manager.ts
+++ b/src/docker/apple-container-manager.ts
@@ -75,13 +75,13 @@ const CONTAINER_INVENTORY_RETRY_DELAY_MS = 250;
  *
  * The floor is now 1.2.1 because of a hard conflict introduced by 1.2.0: it
  * bumped apple/containerization to 0.40.x, where the OCI `readonlyPaths`
- * default set is APPLIED rather than merely available, and that set contains
- * `/proc/sys`. rootlesskit does not remount `/proc`, so the read-only bind is
- * inherited by the nested daemon's mount namespace and the rootless dockerd
- * bootstrap dies with EROFS on `/proc/sys/net/ipv4/ip_forward`
- * (see {@link APPLE_NESTED_DAEMON_READONLY_PATHS}). 1.2.1 is the first release
- * that can express the override — it added `--read-only-path`/`--masked-path`
- * to `container run`/`create` — so 1.2.0 is a version the secure nested Docker
+ * default sets are APPLIED rather than merely available. Both cover paths
+ * under `/proc`, which breaks the nested daemon at boot (EROFS writing
+ * `/proc/sys/net/ipv4/ip_forward`) and, independently, breaks every inner
+ * container create (`VFS: Mount too revealing`) — see
+ * {@link APPLE_FULLY_VISIBLE_PROC_ARGS}. 1.2.1 is the first release that can
+ * express the opt-out — it added `--read-only-path`/`--masked-path` to
+ * `container run`/`create` — so 1.2.0 is a version the secure nested Docker
  * runtime cannot be made to work on at all, and 1.1.0 predates the flags.
  */
 const MIN_MAJOR_VERSION = 1;
@@ -329,7 +329,7 @@ export async function checkAppleContainerAvailable(
       detailedMessage:
         `Found "${versionLine}" but IronCurtain requires >= ${minimumVersion} ` +
         '(Unix-domain-socket relays and `--network none` for the UDS topology; ' +
-        '`--read-only-path` so the secure nested Docker runtime can keep `/proc/sys/net` writable). ' +
+        '`--read-only-path`/`--masked-path` so the secure nested Docker runtime can leave `/proc` fully visible). ' +
         'Upgrade from https://github.com/apple/container/releases.',
     };
   }

--- a/src/docker/apple-container-manager.ts
+++ b/src/docker/apple-container-manager.ts
@@ -10,7 +10,9 @@
  * always with argument arrays (no shell strings). Ordinary operations use
  * execFile; runtime-native PTY exec inherits the host terminal via spawn.
  *
- * CLI semantics verified against `container` 1.0.0:
+ * CLI semantics verified against `container` 1.0.0 (with the 1.1.0 UDS and
+ * 1.2.1 read-only-path deltas recorded in
+ * docs/designs/apple-container-runtime.md):
  *   - `create`/`start`/`exec`/`stop`/`delete` mirror the Docker verbs;
  *     `--init`, `--cap-drop ALL`, `--label`, `--cpus`/`--memory`, `--user`,
  *     `--entrypoint`, `-t` all exist with Docker-compatible meanings.
@@ -63,14 +65,73 @@ const CONTAINER_INVENTORY_TIMEOUT_MS = 30_000;
 const CONTAINER_INVENTORY_RETRY_DELAY_MS = 250;
 
 /**
- * Minimum supported `container` CLI version. 1.1.0 is the floor for the
- * `uds` topology this backend now uses: it adds working per-file UDS
- * relays via `-v <host.sock>:<guest.sock>` (host-listens / guest-connects
- * over vsock) and a functional `--network none`. 1.0.x lacks both and
- * would need the retired `tcp-hostonly` topology.
+ * Minimum supported `container` CLI version.
+ *
+ * 1.1.0 was the original floor for the `uds` topology this backend uses: it
+ * adds working per-file UDS relays via `-v <host.sock>:<guest.sock>`
+ * (host-listens / guest-connects over vsock) and a functional
+ * `--network none`. 1.0.x lacks both and would need the retired
+ * `tcp-hostonly` topology.
+ *
+ * The floor is now 1.2.1 because of a hard conflict introduced by 1.2.0: it
+ * bumped apple/containerization to 0.40.x, where the OCI `readonlyPaths`
+ * default set is APPLIED rather than merely available, and that set contains
+ * `/proc/sys`. rootlesskit does not remount `/proc`, so the read-only bind is
+ * inherited by the nested daemon's mount namespace and the rootless dockerd
+ * bootstrap dies with EROFS on `/proc/sys/net/ipv4/ip_forward`
+ * (see {@link APPLE_NESTED_DAEMON_READONLY_PATHS}). 1.2.1 is the first release
+ * that can express the override — it added `--read-only-path`/`--masked-path`
+ * to `container run`/`create` — so 1.2.0 is a version the secure nested Docker
+ * runtime cannot be made to work on at all, and 1.1.0 predates the flags.
  */
 const MIN_MAJOR_VERSION = 1;
-const MIN_MINOR_VERSION = 1;
+const MIN_MINOR_VERSION = 2;
+const MIN_PATCH_VERSION = 1;
+
+/**
+ * Path-masking opt-out applied ONLY to the agent container of a secure nested
+ * Docker bundle: it restores a **fully visible** `/proc`, which the kernel
+ * requires before a nested container can mount its own procfs.
+ *
+ * `container` 1.2.0+ (apple/containerization 0.40.x) applies the OCI
+ * `maskedPaths`/`readonlyPaths` default sets instead of leaving them to the
+ * caller. Both are implemented as mounts that COVER paths under `/proc`
+ * (read-only proc binds, and devtmpfs binds over the masked entries), and
+ * every one of them is locked from the perspective of the user namespace
+ * rootlesskit creates. That breaks the nested daemon twice over:
+ *
+ *  1. `/proc/sys` read-only means the rootless dockerd bootstrap cannot write
+ *     `/proc/sys/net/ipv4/ip_forward` in its own network namespace — EROFS.
+ *  2. `mnt_already_visible()` refuses a fresh procfs mount in a user namespace
+ *     unless some existing proc mount is fully visible, i.e. has no locked
+ *     children covering it. Any covering mount disqualifies it, so runc inside
+ *     the nested daemon fails every container create with
+ *     `VFS: Mount too revealing`.
+ *
+ * (2) is why this is an all-or-nothing opt-out rather than a narrowed list.
+ * Measured on 1.2.2 / kernel 6.18.15: 6 covering mounts (defaults) and 2
+ * (masks only) both deny, as does a hand-narrowed 12-entry read-only set that
+ * leaves `/proc/sys/net` writable — it fixes (1) and leaves (2) broken. Only
+ * an empty set on BOTH options lets the nested daemon run containers.
+ *
+ * The `NONE` sentinel (case-insensitive) is how the CLI expresses "empty": the
+ * flags otherwise APPEND to the defaults.
+ *
+ * Security note: this restores exactly the `/proc` exposure the backend had on
+ * 1.1.0, which is the configuration the nested runtime was qualified against —
+ * it is not a new concession, and it is scoped to the one opt-in container
+ * that needs it. Ordinary sessions pass none of this and keep the full 1.2.x
+ * hardening. The residual exposure is small in any case: the agent holds
+ * neither CAP_SYS_ADMIN nor CAP_NET_ADMIN, so it cannot write the sysctls a
+ * writable `/proc/sys` nominally offers, and the VM is single-tenant per
+ * session.
+ */
+export const APPLE_FULLY_VISIBLE_PROC_ARGS: readonly string[] = Object.freeze([
+  '--read-only-path',
+  'NONE',
+  '--masked-path',
+  'NONE',
+]);
 
 /**
  * Minimum Darwin kernel major for macOS 26. The `container network`
@@ -259,13 +320,16 @@ export async function checkAppleContainerAvailable(
   const match = /version\s+(\d+)\.(\d+)\.(\d+)/.exec(versionLine);
   const major = match ? Number.parseInt(match[1], 10) : 0;
   const minor = match ? Number.parseInt(match[2], 10) : 0;
-  if (!match || major < MIN_MAJOR_VERSION || (major === MIN_MAJOR_VERSION && minor < MIN_MINOR_VERSION)) {
+  const patch = match ? Number.parseInt(match[3], 10) : 0;
+  const minimumVersion = `${MIN_MAJOR_VERSION}.${MIN_MINOR_VERSION}.${MIN_PATCH_VERSION}`;
+  if (!match || !isAtLeastMinimumVersion(major, minor, patch)) {
     return {
       available: false,
-      reason: `container CLI too old (need >= ${MIN_MAJOR_VERSION}.${MIN_MINOR_VERSION}.0)`,
+      reason: `container CLI too old (need >= ${minimumVersion})`,
       detailedMessage:
-        `Found "${versionLine}" but IronCurtain requires >= ${MIN_MAJOR_VERSION}.${MIN_MINOR_VERSION}.0 ` +
-        '(Unix-domain-socket relays and `--network none` for the UDS topology). ' +
+        `Found "${versionLine}" but IronCurtain requires >= ${minimumVersion} ` +
+        '(Unix-domain-socket relays and `--network none` for the UDS topology; ' +
+        '`--read-only-path` so the secure nested Docker runtime can keep `/proc/sys/net` writable). ' +
         'Upgrade from https://github.com/apple/container/releases.',
     };
   }
@@ -281,6 +345,13 @@ export async function checkAppleContainerAvailable(
   }
 
   return { available: true };
+}
+
+/** Ordered major/minor/patch comparison against the supported floor. */
+function isAtLeastMinimumVersion(major: number, minor: number, patch: number): boolean {
+  if (major !== MIN_MAJOR_VERSION) return major > MIN_MAJOR_VERSION;
+  if (minor !== MIN_MINOR_VERSION) return minor > MIN_MINOR_VERSION;
+  return patch >= MIN_PATCH_VERSION;
 }
 
 /**
@@ -318,6 +389,13 @@ export function buildAppleCreateArgs(config: DockerContainerConfig): string[] {
   args.push('--cap-drop', 'ALL');
   for (const cap of config.capAdd ?? []) {
     args.push('--cap-add', cap);
+  }
+
+  // Nested-Docker agent containers only: leave `/proc` fully visible so the
+  // rootless daemon can boot and its runc can mount procfs for inner
+  // containers. See APPLE_FULLY_VISIBLE_PROC_ARGS.
+  if (config.fullyVisibleProc === true) {
+    args.push(...APPLE_FULLY_VISIBLE_PROC_ARGS);
   }
 
   for (const port of config.ports ?? []) {

--- a/src/docker/container-runtime.ts
+++ b/src/docker/container-runtime.ts
@@ -59,7 +59,7 @@ export function resetRuntimeKindResolutionForTests(): void {
  * Precedence: `IRONCURTAIN_CONTAINER_RUNTIME` env override > the
  * `containerRuntime` config field > 'auto'. 'auto' picks apple-container
  * when its availability probe passes (Apple silicon, macOS 26+,
- * container CLI >= 1.0 with services running) and Docker otherwise.
+ * container CLI >= 1.2.1 with services running) and Docker otherwise.
  * See docs/designs/apple-container-runtime.md, design decision 6.
  */
 export async function resolveRuntimeKind(

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -2084,6 +2084,11 @@ async function createSessionContainersAttempt(
           'DAC_OVERRIDE', // apt-get read/write files regardless of permissions during install
           'AUDIT_WRITE', // sudo audit logging
         ],
+        // Only an admitted nested-Docker bundle opts out of the OCI
+        // masked/read-only path sets; a fully visible /proc is what lets the
+        // nested daemon boot AND lets its runc mount procfs for inner
+        // containers.
+        fullyVisibleProc: nestedDaemon !== undefined,
       });
 
     // §8.2 step 1: ledger the agent container before create when a

--- a/src/docker/network-topology.ts
+++ b/src/docker/network-topology.ts
@@ -4,7 +4,7 @@
  * Docker Agent Mode reaches host-side proxies through one of three
  * topologies (see docs/designs/apple-container-runtime.md §2):
  *
- *  - `uds`          — Linux Docker AND Apple `container` (>= 1.1.0):
+ *  - `uds`          — Linux Docker AND Apple `container` (>= 1.2.1):
  *                     `--network none` + Unix-domain-socket proxies. On
  *                     Linux the sockets directory is bind-mounted; on
  *                     Apple `container` each socket file is mounted via
@@ -37,7 +37,7 @@ export type NetworkTopology = 'uds' | 'tcp-sidecar' | 'tcp-hostonly';
 
 /**
  * Resolves the proxy-transport topology for a runtime kind on the current
- * platform. Apple `container` (floor 1.1.0) uses the `uds` topology;
+ * platform. Apple `container` (floor 1.2.1) uses the `uds` topology;
  * Docker keeps its platform split (`dockerUsesTcp` is injectable for
  * tests, defaulting to the live platform check). `tcp-hostonly` is never
  * returned here — it exists only as a retained code path.

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -851,6 +851,11 @@ async function runPtySessionAttempt(
           'DAC_OVERRIDE', // apt-get read/write files regardless of permissions during install
           'AUDIT_WRITE', // sudo audit logging
         ],
+        // Only an admitted nested-Docker bundle opts out of the OCI
+        // masked/read-only path sets; a fully visible /proc is what lets the
+        // nested daemon boot AND lets its runc mount procfs for inner
+        // containers.
+        fullyVisibleProc: nestedDaemon !== undefined,
         // Apple Container allocates the agent TTY on `container exec -it`;
         // the outer `sleep infinity` process does not need a second TTY.
         tty: nativePtyCommand === undefined,

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -100,6 +100,26 @@ export interface DockerContainerConfig {
   readonly capAdd?: readonly string[];
 
   /**
+   * Leave `/proc` fully visible inside the container by opting out of the OCI
+   * masked-path and read-only-path sets (`container create --masked-path NONE
+   * --read-only-path NONE`).
+   *
+   * Apple `container` only, and set ONLY for the agent container of an
+   * admitted secure nested Docker bundle. Two things need it: the rootless
+   * dockerd bootstrap writes `/proc/sys/net/ipv4/ip_forward` in its own
+   * network namespace, and — the binding constraint — the kernel refuses a
+   * fresh procfs mount in a user namespace unless an existing proc mount has
+   * no locked children covering it, so runc inside the nested daemon cannot
+   * create any container while ANY path under `/proc` is masked or read-only
+   * bound. See `APPLE_FULLY_VISIBLE_PROC_ARGS` in `apple-container-manager.ts`
+   * for the measurements and the security rationale.
+   *
+   * Ignored by the Docker backend, where the nested daemon topology is not
+   * implemented at all.
+   */
+  readonly fullyVisibleProc?: boolean;
+
+  /**
    * Allocate a pseudo-TTY for the container (-t flag).
    * Required for PTY mode where the container runs an interactive process.
    * Optional. Defaults to false (no TTY allocated).

--- a/test/apple-container-manager.test.ts
+++ b/test/apple-container-manager.test.ts
@@ -185,6 +185,31 @@ describe('buildAppleCreateArgs', () => {
     expect(args.slice(-3)).toEqual(['ironcurtain-claude-code:latest', 'sleep', 'infinity']);
   });
 
+  it('omits the proc-visibility opt-out for an ordinary session', () => {
+    const args = buildAppleCreateArgs(sampleConfig);
+    expect(args).not.toContain('--read-only-path');
+    expect(args).not.toContain('--masked-path');
+  });
+
+  // All-or-nothing on purpose: any covering mount under /proc (read-only bind
+  // OR masked path) leaves no fully-visible proc mount, and the kernel then
+  // refuses the nested container's procfs mount with "Mount too revealing".
+  // A narrowed read-only set that keeps /proc/sys/net writable fixes the
+  // daemon bootstrap and still breaks every inner container create.
+  it('opts out of BOTH path sets for a nested-Docker agent container', () => {
+    const args = buildAppleCreateArgs({ ...sampleConfig, fullyVisibleProc: true });
+
+    expect(args.join(' ')).toContain('--read-only-path NONE');
+    expect(args.join(' ')).toContain('--masked-path NONE');
+
+    // Exactly the reset sentinel and nothing else: a single stray path would
+    // re-cover /proc and silently reintroduce the runc failure.
+    const readOnly = args.filter((_, i) => args[i - 1] === '--read-only-path');
+    const masked = args.filter((_, i) => args[i - 1] === '--masked-path');
+    expect(readOnly).toEqual(['NONE']);
+    expect(masked).toEqual(['NONE']);
+  });
+
   it('never emits --add-host or --restart flags', () => {
     const args = buildAppleCreateArgs(sampleConfig);
     expect(args.join(' ')).not.toContain('--add-host');
@@ -332,14 +357,35 @@ describe('checkAppleContainerAvailable', () => {
     const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
     expect(result.available).toBe(false);
     if (!result.available) {
-      expect(result.reason).toMatch(/>= 1\.1\.0/);
+      expect(result.reason).toMatch(/>= 1\.2\.1/);
       expect(result.detailedMessage).toMatch(/Unix-domain-socket/);
     }
   });
 
+  it('reports unavailable on 1.1.x (no --read-only-path override)', async () => {
+    mock.setResponse('container CLI version 1.1.0 (build: release, commit: 5973b9c)');
+    const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
+    expect(result.available).toBe(false);
+    if (!result.available) {
+      expect(result.reason).toMatch(/>= 1\.2\.1/);
+      expect(result.detailedMessage).toMatch(/read-only-path/);
+    }
+  });
+
+  // 1.2.0 applies the OCI readonlyPaths default (which covers /proc/sys) but
+  // predates the flags that can override it, so the nested daemon cannot be
+  // made to boot on it at all. The floor is a patch-level comparison for
+  // exactly this reason.
+  it('reports unavailable on 1.2.0 (readonlyPaths applied, not yet overridable)', async () => {
+    mock.setResponse('container CLI version 1.2.0 (build: release, commit: abc)');
+    const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
+    expect(result.available).toBe(false);
+    if (!result.available) expect(result.reason).toMatch(/>= 1\.2\.1/);
+  });
+
   it('reports unavailable when system services are not running', async () => {
     mock.setSequence([
-      { stdout: 'container CLI version 1.1.0 (build: release, commit: 5973b9c)' },
+      { stdout: 'container CLI version 1.2.2 (build: release, commit: 5973b9c)' },
       { error: true, code: 1, stderr: 'apiserver not running' },
     ]);
     const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
@@ -349,13 +395,25 @@ describe('checkAppleContainerAvailable', () => {
 
   it('reports available when all checks pass', async () => {
     mock.setSequence([
-      { stdout: 'container CLI version 1.1.0 (build: release, commit: 5973b9c)' },
+      { stdout: 'container CLI version 1.2.2 (build: release, commit: 5973b9c)' },
       { stdout: 'status running' },
     ]);
     const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
     expect(result).toEqual({ available: true });
     expect(mock.calls[0]?.args).toEqual(['--version']);
     expect(mock.calls[1]?.args).toEqual(['system', 'status']);
+  });
+
+  it('accepts the exact floor release', async () => {
+    mock.setSequence([{ stdout: 'container CLI version 1.2.1' }, { stdout: 'status running' }]);
+    const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
+    expect(result).toEqual({ available: true });
+  });
+
+  it('accepts a future minor version', async () => {
+    mock.setSequence([{ stdout: 'container CLI version 1.3.0' }, { stdout: 'status running' }]);
+    const result = await checkAppleContainerAvailable(mock.mockExec, darwinHost);
+    expect(result).toEqual({ available: true });
   });
 
   it('accepts a future major version', async () => {

--- a/test/docker/nested-daemon-wiring.test.ts
+++ b/test/docker/nested-daemon-wiring.test.ts
@@ -398,7 +398,12 @@ describe('nested daemon — feature-off equivalence', () => {
         JSON.stringify(enabled.config()[key as keyof DockerContainerConfig]) !==
         JSON.stringify(off.config()[key as keyof DockerContainerConfig]),
     );
-    expect(differing.sort()).toEqual(['env', 'labels', 'mounts', 'name']);
+    expect(differing.sort()).toEqual(['env', 'fullyVisibleProc', 'labels', 'mounts', 'name']);
+    // The proc-visibility opt-out is one of the differences the feature is
+    // allowed to introduce, and ONLY when admitted: an ordinary session must
+    // keep the runtime's masked/read-only path hardening.
+    expect(enabled.config().fullyVisibleProc).toBe(true);
+    expect(off.config().fullyVisibleProc).not.toBe(true);
     expect(Object.keys(off.config().env)).not.toContain('DOCKER_HOST');
     expect(Object.keys(off.config().env)).not.toContain(APPLE_VM_DOCKER_WORKLOAD_NETWORK_ENV);
     expect(off.config().mounts).not.toContainEqual(

--- a/test/network-topology.test.ts
+++ b/test/network-topology.test.ts
@@ -49,7 +49,7 @@ function makeNetworkRuntime(behavior: {
 }
 
 describe('resolveNetworkTopology', () => {
-  it('always picks uds for apple-container (>= 1.1.0 floor)', () => {
+  it('always picks uds for apple-container (>= 1.2.1 floor)', () => {
     expect(resolveNetworkTopology('apple-container', true)).toBe('uds');
     expect(resolveNetworkTopology('apple-container', false)).toBe('uds');
   });


### PR DESCRIPTION
## Summary

Fixes #424. The nested Docker smoke fails on `container` 1.2.x with `cannot create /proc/sys/net/ipv4/ip_forward: Read-only file system`. This is a runtime-version regression, not an IronCurtain one — but it has a second half that the reported symptom hides.

`container` 1.2.0 bumped apple/containerization to 0.40.x, which **applies** the OCI `maskedPaths`/`readonlyPaths` defaults instead of leaving them to the caller. Both are implemented as mounts covering paths under `/proc`, which breaks the nested runtime two independent ways:

1. `/proc/sys` is read-only → the rootless dockerd bootstrap cannot write `ip_forward` in its own netns → **EROFS** (the reported symptom).
2. Any covering mount under `/proc` leaves no fully visible proc mount, so `mnt_already_visible()` refuses a fresh procfs mount in a user namespace → runc inside the nested daemon fails **every** container create with `VFS: Mount too revealing`.

(2) is why this is an all-or-nothing opt-out rather than a narrowed path list. Measured on 1.2.2 / guest kernel 6.18.15, mounting procfs in a fresh pidns inside rootlesskit:

| container path config | covering mounts under `/proc` | nested procfs mount |
| --- | --- | --- |
| 1.2.x defaults | 6 | denied |
| `--read-only-path NONE` only | 2 (masks remain) | denied |
| narrowed read-only set, `net` writable | 12 | denied — "Mount too revealing" |
| `--read-only-path NONE --masked-path NONE` | 0 | **OK** |

**The narrowed variant is the trap.** It fixes (1), so the daemon reaches full readiness and `docker info` reports `rootless`+`vfs` — while every inner `docker run` still fails. Daemon readiness is not evidence the feature works; only the inner-workload smoke is.

### Changes

- `buildAppleCreateArgs` emits `--read-only-path NONE --masked-path NONE` for the agent container of an admitted nested Docker bundle **only**, via `DockerContainerConfig.fullyVisibleProc` (set where `resolveNestedDaemonBundle` returns a bundle). Ordinary sessions pass neither flag and keep the full 1.2.x hardening.
- Supported floor raised **1.1.0 → 1.2.1**, compared at patch level. 1.2.0 applies the defaults but predates the `--read-only-path`/`--masked-path` flags that override them, so it is a release the nested daemon cannot boot on at all.

This restores exactly the `/proc` exposure the backend had on 1.1.0 — the configuration the nested runtime was originally qualified against — rather than introducing a new concession. Residual exposure is small regardless: the agent holds neither CAP_SYS_ADMIN nor CAP_NET_ADMIN, so it cannot write the sysctls a writable `/proc/sys` nominally offers, and the VM is single-tenant per session.

⚠️ **User-visible consequence:** every apple-container user must upgrade to ≥ 1.2.1. There is no version-conditional fallback, because 1.1.0 lacks the override flags entirely.

## Security Impact

- [x] None of the above

Container path-masking config only, scoped to the opt-in nested Docker agent container. No change to policy evaluation, the V8 sandbox boundary, MCP spawning/IPC/credentials, or argument roles. See the `APPLE_FULLY_VISIBLE_PROC_ARGS` doc comment and the new `docs/designs/apple-container-runtime.md` §1.2.1 for the rationale.

## Test plan

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for the change
- [x] Manual testing (described below)

Validated on macOS 26.5 / `container` 1.2.2 / guest kernel 6.18.15:

- `npm run qualify:apple` — 162 tests, zero reporter-visible skips
- `npm run smoke:nested:apple` — passed, clean teardown
- `npm run smoke:nested:apple:public-registry` — passed, clean teardown
- Confirmed #424 reproduces verbatim on 1.2.2 before the fix, and that the live agent container has 0 covering mounts under `/proc` after it
- `npm test` — 6397 passed. Two failures remain, both reproduced on clean `master` and unrelated to this change: `pty-web-escalation.integration` (`posix_spawnp failed`) and `apple-container.integration`'s subnet-guarded `0.0.0.0` listener case, which passes in isolation and only fails under full-suite contention. Both are macOS/container-local and skip on CI.

New unit coverage pins that an ordinary session emits neither flag, that an admitted bundle emits **exactly** the `NONE` sentinel for both (a stray path would re-cover `/proc` and silently reintroduce the runc failure), and that 1.2.0 is rejected by the floor. The feature-off equivalence guard in `nested-daemon-wiring` now also asserts `fullyVisibleProc` is set only when admitted.
