### PR TITLE
feat(workflow): add live watch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **Streaming workflow watch command** — `ironcurtain workflow watch <workflowId|runDir>` replays and follows operational `messages.jsonl` records with JSON, timestamp, and event filters, remains open across human gates, and returns phase-derived terminal exit codes. ID-based watches reconcile through the daemon's existing RPC/event surface while run-directory watches work from disk alone (#439).
+- **Streaming workflow watch command** — `ironcurtain workflow watch <workflowId|runDir>` replays and follows operational `messages.jsonl` records with JSON, timestamp, and event filters, while `--lines N` provides a bounded last-N snapshot for scripts. Live watches remain open across human gates and return phase-derived terminal exit codes. ID-based watches reconcile through the daemon's existing RPC/event surface while run-directory watches work from disk alone (#439).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- **Streaming workflow watch command** — `ironcurtain workflow watch <workflowId|runDir>` replays and follows operational `messages.jsonl` records with JSON, timestamp, and event filters, remains open across human gates, and returns phase-derived terminal exit codes. ID-based watches reconcile through the daemon's existing RPC/event surface while run-directory watches work from disk alone (#439).
+
 ### Fixes
 
 - **LLM-metrics SQLite workers boot without `tsx` on Node 22** — the persistence workers were spawned with `execArgv: ['--import', 'tsx']` for source runs, but tsx's loader hooks do not take effect inside worker threads on Node 22, so the worker failed to load its TypeScript sources. Source runs now boot through a self-contained ESM entry shim that registers a `.js` → `.ts` specifier remap hook in-thread and relies on Node's native type stripping; compiled runs load the emitted `.js` worker directly and spawn no shim.

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -214,6 +214,31 @@ Shows: workflow ID, current state, artifacts, lint diagnostics on the checkpoint
 
 Lint output is informational only — it never changes the exit code.
 
+### `ironcurtain workflow watch`
+
+Replay and follow a single workflow's operational message log until it reaches
+a terminal outcome:
+
+```bash
+ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]
+```
+
+An ID resolves under `~/.ironcurtain/workflow-runs/`; a path must name an
+individual existing run directory, not the parent runs directory. By default,
+watch prints transitions, verdicts, retries, errors, transient/quota failures,
+gates, and fan-out joins. Agent prompts (`sent`) are excluded unless selected.
+
+- `--json` -- Emit each selected `messages.jsonl` record as one JSON line on stdout
+- `--since <ISO>` -- Include records whose timestamps are at or after the timestamp
+- `--events <list>` -- Comma-separated `transition,verdict,retry,error,transient,quota,gate,fanout,sent`, or `all`
+
+Human gates are reported but do not stop the watch. Exit codes are `0` for
+completed, `3` for failed/aborted/interrupted, `130` for Ctrl+C, `2` for usage
+errors, and `1` for operational errors. When invoked with an ID, watch uses the
+existing daemon's `workflows.get` and lifecycle events only to reconcile status;
+the streamed records always come from `messages.jsonl`. A run-directory path is
+fully disk-only.
+
 ### `ironcurtain workflow lint`
 
 Run semantic checks on a workflow definition without executing it. The linter catches cross-cutting issues that structural (Zod) validation doesn't: unreachable states, dangling artifact references, missing personas, and similar smells.

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -220,7 +220,7 @@ Replay and follow a single workflow's operational message log until it reaches
 a terminal outcome:
 
 ```bash
-ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]
+ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>] [--lines <N>]
 ```
 
 An ID resolves under `~/.ironcurtain/workflow-runs/`; a path must name an
@@ -231,8 +231,10 @@ gates, and fan-out joins. Agent prompts (`sent`) are excluded unless selected.
 - `--json` -- Emit each selected `messages.jsonl` record as one JSON line on stdout
 - `--since <ISO>` -- Include records whose timestamps are at or after the timestamp
 - `--events <list>` -- Comma-separated `transition,verdict,retry,error,transient,quota,gate,fanout,sent`, or `all`
+- `--lines <N>` -- Print the last N selected records from the log as it existed when invoked, then exit without following
 
-Human gates are reported but do not stop the watch. Exit codes are `0` for
+Snapshot mode (`--lines`) exits `0` after writing the selected records and does
+not contact or wait for the daemon. In live mode, human gates are reported but do not stop the watch. Exit codes are `0` for
 completed, `3` for failed/aborted/interrupted, `130` for Ctrl+C, `2` for usage
 errors, and `1` for operational errors. When invoked with an ID, watch uses the
 existing daemon's `workflows.get` and lifecycle events only to reconcile status;

--- a/src/web-ui/dispatch/workflow-dispatch.ts
+++ b/src/web-ui/dispatch/workflow-dispatch.ts
@@ -50,6 +50,7 @@ import type { StateGraphDto } from '../web-ui-types.js';
 import { isWithinDirectory } from '../../types/argument-roles.js';
 import { runPreflight } from '../../workflow/lint-integration.js';
 import * as logger from '../../logger.js';
+import { terminalPhaseFromStateName } from '../../workflow/terminal-phase.js';
 
 // ---------------------------------------------------------------------------
 // State graph cache (definition never changes during execution)
@@ -61,11 +62,6 @@ const PAST_RUN_PHASES = new Set<PastRunPhase>(['completed', 'aborted', 'failed',
 
 function isPastRunPhase(value: string | undefined): value is PastRunPhase {
   return value !== undefined && PAST_RUN_PHASES.has(value as PastRunPhase);
-}
-
-/** Map a terminal state's name to a phase using the orchestrator's name convention. */
-function phaseFromTerminalStateName(name: string): 'completed' | 'aborted' {
-  return name === 'aborted' || name.toLowerCase().includes('abort') ? 'aborted' : 'completed';
 }
 
 /** Returns the entry with the largest `ts` among `state_transition` entries, or undefined. */
@@ -603,7 +599,7 @@ export function computePastRunPhase(
   // Legacy pre-B3b path: derive from the state name.
   const stateName = extractLastState(checkpoint.machineState);
   const stateDef = getStateDef(definition, stateName);
-  if (stateDef?.type === 'terminal') return phaseFromTerminalStateName(stateName);
+  if (stateDef?.type === 'terminal') return terminalPhaseFromStateName(stateName);
   if (stateDef?.type === 'human_gate') return 'waiting_human';
   return 'interrupted';
 }
@@ -644,7 +640,7 @@ export function synthesizePhaseFromMessageLog(
   }
   if (lastTransition === undefined) return 'interrupted';
   const stateDef = getStateDef(definition, lastTransition.event);
-  if (stateDef?.type === 'terminal') return phaseFromTerminalStateName(lastTransition.event);
+  if (stateDef?.type === 'terminal') return terminalPhaseFromStateName(lastTransition.event);
   if (stateDef?.type === 'human_gate') return 'waiting_human';
   if (sawQuotaExhausted) return 'aborted';
   if (sawTransientFailure) return 'aborted';

--- a/src/workflow/daemon-gate-commands.ts
+++ b/src/workflow/daemon-gate-commands.ts
@@ -30,6 +30,7 @@ import {
 import { parseArgsResult, type ParseArgsResult, type ParseArgsOptions } from './cli-shared.js';
 import type { WorkflowDetailDto } from '../web-ui/web-ui-types.js';
 import type { HumanGateRequestDto } from './types.js';
+import { isTerminalWorkflowPhase } from './terminal-phase.js';
 
 // ---------------------------------------------------------------------------
 // Exit codes (stable contract for shell-only agents)
@@ -200,10 +201,6 @@ function exitCodeForPhase(phase: WorkflowPhase): number {
       // non-failure so the agent re-issues `await`.
       return EXIT_OK;
   }
-}
-
-function isTerminalPhase(phase: WorkflowPhase): boolean {
-  return phase === 'completed' || phase === 'failed' || phase === 'aborted';
 }
 
 // ---------------------------------------------------------------------------
@@ -583,7 +580,7 @@ async function awaitDecisionPoint(
  * block for the full timeout waiting on an event that will never come.
  */
 function isRestingPhase(phase: WorkflowPhase): boolean {
-  return phase === 'waiting_human' || phase === 'interrupted' || isTerminalPhase(phase);
+  return phase === 'waiting_human' || phase === 'interrupted' || isTerminalWorkflowPhase(phase);
 }
 
 function isResolvingEvent(eventName: string): boolean {

--- a/src/workflow/message-log.ts
+++ b/src/workflow/message-log.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { TransientFailureKind } from '../docker/agent-adapter.js';
+import type { TerminalWorkflowPhase } from './terminal-phase.js';
 
 // ---------------------------------------------------------------------------
 // Log entry types
@@ -10,6 +11,30 @@ interface BaseEntry {
   readonly ts: string;
   readonly workflowId: string;
   readonly state: string;
+}
+
+/** Declares that a newly-started attempt will emit a terminal phase barrier. */
+interface RunStartedControlEntry extends BaseEntry {
+  readonly type: 'run_started';
+}
+
+/**
+ * Internal attempt boundary. It deliberately is not part of MessageLogEntry:
+ * callers reading the public message history should not have to understand
+ * workflow-control records.
+ */
+interface RunResumedControlEntry extends BaseEntry {
+  readonly type: 'run_resumed';
+  /** mtime of the checkpoint being resumed, used to reject stale terminal data. */
+  readonly checkpointMtimeMs?: number;
+  /** Exact digest of the checkpoint being resumed (preferred over mtimes). */
+  readonly checkpointFingerprint?: string;
+}
+
+/** Durable ordering barrier written after the terminal checkpoint attempt. */
+interface RunTerminalControlEntry extends BaseEntry {
+  readonly type: 'run_terminal';
+  readonly phase: TerminalWorkflowPhase;
 }
 
 export interface AgentSentEntry extends BaseEntry {
@@ -116,6 +141,8 @@ export type MessageLogEntry =
   | QuotaExhaustedEntry
   | TransientFailureEntry;
 
+type MessageLogRecord = MessageLogEntry | RunStartedControlEntry | RunResumedControlEntry | RunTerminalControlEntry;
+
 // ---------------------------------------------------------------------------
 // MessageLog
 // ---------------------------------------------------------------------------
@@ -131,7 +158,22 @@ export class MessageLog {
 
   /** Append a single entry as a JSON line. */
   append(entry: MessageLogEntry): void {
-    appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
+    this.appendRecord(entry);
+  }
+
+  /** Declare the terminal-barrier protocol immediately before a new actor starts. */
+  appendRunStarted(entry: Omit<RunStartedControlEntry, 'type'>): void {
+    this.appendRecord({ ...entry, type: 'run_started' });
+  }
+
+  /** Append an internal boundary immediately before a resumed actor starts. */
+  appendRunResumed(entry: Omit<RunResumedControlEntry, 'type'>): void {
+    this.appendRecord({ ...entry, type: 'run_resumed' });
+  }
+
+  /** Append the authoritative terminal phase after terminal persistence. */
+  appendRunTerminal(entry: Omit<RunTerminalControlEntry, 'type'>): void {
+    this.appendRecord({ ...entry, type: 'run_terminal' });
   }
 
   /** Read and parse all entries. Skips blank and malformed lines. */
@@ -144,11 +186,18 @@ export class MessageLog {
     for (const line of content.split('\n')) {
       if (line.trim().length === 0) continue;
       try {
-        entries.push(JSON.parse(line) as MessageLogEntry);
+        const record = JSON.parse(line) as MessageLogRecord;
+        if (record.type !== 'run_started' && record.type !== 'run_resumed' && record.type !== 'run_terminal') {
+          entries.push(record);
+        }
       } catch {
         // Skip malformed lines (e.g., truncated writes from crashes)
       }
     }
     return entries;
+  }
+
+  private appendRecord(entry: MessageLogRecord): void {
+    appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
   }
 }

--- a/src/workflow/orchestrator.ts
+++ b/src/workflow/orchestrator.ts
@@ -13,7 +13,9 @@ import {
 import { resolve } from 'node:path';
 import { isWithinDirectory } from '../types/argument-roles.js';
 import { errorMessage } from '../utils/error-message.js';
+import { sha256Hex } from '../hash.js';
 import { MessageLog, type AgentRetryReason } from './message-log.js';
+import { isTerminalWorkflowPhase, terminalPhaseFromStateName } from './terminal-phase.js';
 import { createHash, type Hash } from 'node:crypto';
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -898,6 +900,17 @@ export class WorkflowOrchestrator implements WorkflowController {
     };
   }
 
+  /** Best-effort durable phase barrier for log consumers such as `workflow watch`. */
+  private appendTerminalControl(instance: WorkflowInstance): void {
+    const phase = instance.finalStatus?.phase;
+    if (!isTerminalWorkflowPhase(phase)) return;
+    try {
+      instance.messageLog.appendRunTerminal({ ...this.logBase(instance), phase });
+    } catch (err) {
+      writeStderr(`[workflow] Failed to append terminal log marker for ${instance.id}: ${toErrorMessage(err)}`);
+    }
+  }
+
   // -----------------------------------------------------------------------
   // Pre-flight validation
   // -----------------------------------------------------------------------
@@ -1612,6 +1625,7 @@ export class WorkflowOrchestrator implements WorkflowController {
     // Persist the initial executable state before it can transition directly
     // to a terminal. Terminal saves preserve this non-terminal resume point.
     this.saveCheckpoint(instance, actor.getSnapshot() as { value: unknown; context: unknown });
+    messageLog.appendRunStarted(this.logBase(instance));
     actor.start();
     return workflowId;
   }
@@ -1731,6 +1745,20 @@ export class WorkflowOrchestrator implements WorkflowController {
       taskDescription: checkpoint.context.taskDescription,
     });
     this.subscribeToActor(instance);
+    let checkpointMtimeMs: number | undefined;
+    let checkpointFingerprint: string | undefined;
+    try {
+      const checkpointPath = resolve(this.deps.baseDir, workflowId, 'checkpoint.json');
+      checkpointMtimeMs = statSync(checkpointPath).mtimeMs;
+      checkpointFingerprint = sha256Hex(readFileSync(checkpointPath));
+    } catch {
+      // Custom checkpoint stores need not use the default on-disk layout.
+    }
+    messageLog.appendRunResumed({
+      ...this.logBase(instance),
+      ...(checkpointMtimeMs !== undefined ? { checkpointMtimeMs } : {}),
+      ...(checkpointFingerprint !== undefined ? { checkpointFingerprint } : {}),
+    });
     actor.start();
 
     // XState v5's resolveState() restores *to* a state but does not *enter* it.
@@ -1967,6 +1995,7 @@ export class WorkflowOrchestrator implements WorkflowController {
     }
     const containerSnapshots = await this.snapshotResumableScopes(instance);
     this.saveTerminalCheckpoint(instance, instance.finalStatus, containerSnapshots, previousCheckpoint);
+    this.appendTerminalControl(instance);
 
     // Release the token-stream bus subscription before the async infra
     // teardown so no late events land against a finalized workflow.
@@ -4550,12 +4579,12 @@ export class WorkflowOrchestrator implements WorkflowController {
         error: context.lastError,
         lastState,
       };
-    } else if (stateValue === 'aborted' || stateValue.includes('abort')) {
+    } else if (terminalPhaseFromStateName(stateValue) === 'aborted') {
       instance.finalStatus = {
         phase: 'aborted',
         reason: context.lastError ?? 'Workflow reached aborted state',
       };
-    } else if (stateValue === 'failed' || stateValue.includes('fail') || context.lastError) {
+    } else if (terminalPhaseFromStateName(stateValue) === 'failed' || context.lastError) {
       instance.finalStatus = {
         phase: 'failed',
         error: context.lastError ?? `Workflow reached failed state "${stateValue}"`,
@@ -4586,6 +4615,7 @@ export class WorkflowOrchestrator implements WorkflowController {
     // instead of immediately re-completing on a terminal snapshot. The
     // fallback path covers legacy runs or an earlier checkpoint write failure.
     this.saveTerminalCheckpoint(instance, instance.finalStatus, containerSnapshots, existing);
+    this.appendTerminalControl(instance);
 
     instance.tab.write(`[done] ${instance.finalStatus.phase}`);
     instance.tab.close();

--- a/src/workflow/terminal-phase.ts
+++ b/src/workflow/terminal-phase.ts
@@ -1,0 +1,17 @@
+/** Terminal phases shared by the daemon projection and disk-only CLI tools. */
+export type TerminalWorkflowPhase = 'completed' | 'failed' | 'aborted';
+
+/**
+ * Map a terminal state name using the same convention as the orchestrator.
+ * Abort/fail matching is case-insensitive; every other terminal is success.
+ */
+export function terminalPhaseFromStateName(name: string): TerminalWorkflowPhase {
+  const normalized = name.toLowerCase();
+  if (normalized.includes('abort')) return 'aborted';
+  if (normalized.includes('fail')) return 'failed';
+  return 'completed';
+}
+
+export function isTerminalWorkflowPhase(value: string | undefined): value is TerminalWorkflowPhase {
+  return value === 'completed' || value === 'failed' || value === 'aborted';
+}

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -5,7 +5,7 @@
  *   start   <definition> "task" [--model <model>] [--workspace <path>]
  *   resume  <baseDir> [--state <stateName>] [--model <model>]
  *   inspect <baseDir> [--all]
- *   watch   <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]
+ *   watch   <workflowId|runDir> [--json] [--since <ISO>] [--events <list>] [--lines <N>]
  */
 
 import { existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
@@ -76,7 +76,7 @@ const workflowSpec: CommandSpec = {
     'ironcurtain workflow run <name-or-path> "task" [--workspace <path>] [--json] [--ensure-daemon]',
     'ironcurtain workflow status <workflowId> [--json]',
     'ironcurtain workflow await <workflowId> [--timeout <sec>] [--json]',
-    'ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]',
+    'ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>] [--lines <N>]',
     'ironcurtain workflow gate <workflowId> --event <EVENT> [--prompt <text>] [--json]',
     'ironcurtain workflow show <workflowId> --artifact <name> [--json]',
   ],
@@ -90,7 +90,7 @@ const workflowSpec: CommandSpec = {
     { name: 'run', description: 'Start a gated workflow on the daemon (non-interactive, machine-readable)' },
     { name: 'status', description: 'Print a workflow status snapshot (poll)' },
     { name: 'await', description: 'Block until a workflow reaches a gate or terminal' },
-    { name: 'watch', description: 'Stream workflow events until a terminal outcome' },
+    { name: 'watch', description: 'Stream workflow events or replay a last-N snapshot' },
     { name: 'gate', description: 'Resolve a human gate with an event (APPROVE/FORCE_REVISION/REPLAN/ABORT)' },
     { name: 'show', description: 'Print a presented artifact for a gated workflow' },
   ],
@@ -134,6 +134,7 @@ const workflowSpec: CommandSpec = {
       description: 'Watch event filters (comma-separated, or all)',
       placeholder: '<list>',
     },
+    { flag: 'lines', description: 'Replay only the last N selected watch records', placeholder: '<N>' },
     { flag: 'help', short: 'h', description: 'Show this help message' },
   ],
   examples: [
@@ -149,6 +150,7 @@ const workflowSpec: CommandSpec = {
     'ironcurtain workflow run design-and-code "Build a REST API" --json --ensure-daemon',
     'ironcurtain workflow await wf-7a3 --json',
     'ironcurtain workflow watch wf-7a3 --events transition,verdict,retry,error',
+    'ironcurtain workflow watch wf-7a3 --lines 20 --json',
     'ironcurtain workflow show wf-7a3 --artifact spec --json',
     'ironcurtain workflow gate wf-7a3 --event FORCE_REVISION --prompt "tighten the intro" --json',
     'ironcurtain workflow gate wf-7a3 --event APPROVE --json',

--- a/src/workflow/workflow-command.ts
+++ b/src/workflow/workflow-command.ts
@@ -5,6 +5,7 @@
  *   start   <definition> "task" [--model <model>] [--workspace <path>]
  *   resume  <baseDir> [--state <stateName>] [--model <model>]
  *   inspect <baseDir> [--all]
+ *   watch   <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]
  */
 
 import { existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
@@ -47,6 +48,7 @@ import {
 } from './cli-support.js';
 import { runRunState } from './run-state-command.js';
 import { runDaemonGateCommand } from './daemon-gate-commands.js';
+import { runWorkflowWatch } from './workflow-watch-command.js';
 import { sweepContainerSnapshots } from './container-snapshots.js';
 import { installWorkflowShutdownSignals } from './shutdown-signals.js';
 import {
@@ -74,6 +76,7 @@ const workflowSpec: CommandSpec = {
     'ironcurtain workflow run <name-or-path> "task" [--workspace <path>] [--json] [--ensure-daemon]',
     'ironcurtain workflow status <workflowId> [--json]',
     'ironcurtain workflow await <workflowId> [--timeout <sec>] [--json]',
+    'ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]',
     'ironcurtain workflow gate <workflowId> --event <EVENT> [--prompt <text>] [--json]',
     'ironcurtain workflow show <workflowId> --artifact <name> [--json]',
   ],
@@ -87,6 +90,7 @@ const workflowSpec: CommandSpec = {
     { name: 'run', description: 'Start a gated workflow on the daemon (non-interactive, machine-readable)' },
     { name: 'status', description: 'Print a workflow status snapshot (poll)' },
     { name: 'await', description: 'Block until a workflow reaches a gate or terminal' },
+    { name: 'watch', description: 'Stream workflow events until a terminal outcome' },
     { name: 'gate', description: 'Resolve a human gate with an event (APPROVE/FORCE_REVISION/REPLAN/ABORT)' },
     { name: 'show', description: 'Print a presented artifact for a gated workflow' },
   ],
@@ -107,7 +111,7 @@ const workflowSpec: CommandSpec = {
     { flag: 'strict-lint', description: 'Treat lint warnings as errors (start, resume)' },
     { flag: 'strict', description: 'Treat lint warnings as errors (lint only)' },
     { flag: 'capture-traces', description: 'Capture LLM API traces for this run (start only)' },
-    { flag: 'json', description: 'Emit machine-readable JSON to stdout (run, status, await, gate, show)' },
+    { flag: 'json', description: 'Emit machine-readable JSON to stdout (run, status, await, watch, gate, show)' },
     {
       flag: 'ensure-daemon',
       description: 'Auto-start a detached daemon if none is running (run, status, await, gate, show)',
@@ -124,6 +128,12 @@ const workflowSpec: CommandSpec = {
     },
     { flag: 'artifact', description: 'Artifact name to read (show only)', placeholder: '<name>' },
     { flag: 'timeout', description: 'Max seconds to block (await only)', placeholder: '<sec>' },
+    { flag: 'since', description: 'Replay watch records at or after an ISO timestamp', placeholder: '<ISO>' },
+    {
+      flag: 'events',
+      description: 'Watch event filters (comma-separated, or all)',
+      placeholder: '<list>',
+    },
     { flag: 'help', short: 'h', description: 'Show this help message' },
   ],
   examples: [
@@ -138,6 +148,7 @@ const workflowSpec: CommandSpec = {
     'ironcurtain workflow inspect /tmp/workflow-abc123 --all',
     'ironcurtain workflow run design-and-code "Build a REST API" --json --ensure-daemon',
     'ironcurtain workflow await wf-7a3 --json',
+    'ironcurtain workflow watch wf-7a3 --events transition,verdict,retry,error',
     'ironcurtain workflow show wf-7a3 --artifact spec --json',
     'ironcurtain workflow gate wf-7a3 --event FORCE_REVISION --prompt "tighten the intro" --json',
     'ironcurtain workflow gate wf-7a3 --event APPROVE --json',
@@ -755,6 +766,17 @@ export async function main(args: string[]): Promise<void> {
     case 'inspect':
       runInspect(subArgs);
       break;
+    case 'watch': {
+      if (subArgs.includes('--help') || subArgs.includes('-h')) {
+        process.stderr.write(formatHelp(workflowSpec) + '\n');
+        return;
+      }
+      const code = await runWorkflowWatch(subArgs);
+      // Let Node drain stdout/stderr naturally; synchronous process.exit()
+      // can truncate the final replayed JSONL records on piped output.
+      process.exitCode = code;
+      return;
+    }
     case 'lint':
       runLintCommand(subArgs);
       break;

--- a/src/workflow/workflow-watch-command.ts
+++ b/src/workflow/workflow-watch-command.ts
@@ -1,0 +1,983 @@
+/**
+ * Streaming `workflow watch` command.
+ *
+ * Message records always come from messages.jsonl. The daemon is consulted
+ * only for authoritative liveness/terminal status when the target was given
+ * as an ID, which keeps this command compatible with already-running daemons.
+ */
+
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readSync, statSync, type Stats } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { createHash, type Hash } from 'node:crypto';
+
+import { createDaemonClient, type DaemonClient, type DaemonEvent } from '../daemon-client/daemon-client.js';
+import { getWorkflowRunDir } from '../config/paths.js';
+import { sha256Hex } from '../hash.js';
+import { isPlainObject } from '../utils/is-plain-object.js';
+import type { WorkflowDetailDto } from '../web-ui/web-ui-types.js';
+import { parseArgsResult } from './cli-shared.js';
+import { isTerminalWorkflowPhase, terminalPhaseFromStateName, type TerminalWorkflowPhase } from './terminal-phase.js';
+
+const EXIT_OK = 0;
+const EXIT_ERROR = 1;
+const EXIT_USAGE = 2;
+const EXIT_TERMINAL_FAILURE = 3;
+const EXIT_SIGINT = 130;
+const EXIT_SIGTERM = 143;
+
+const DEFAULT_POLL_MS = 100;
+const DEFAULT_RECONCILE_MS = 2_000;
+const DEFAULT_RECONNECT_WINDOW_MS = 5_000;
+const DEFAULT_RECONNECT_POLL_MS = 250;
+const DEFAULT_QUIESCENCE_MS = 1_000;
+const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_RECORDS_PER_POLL = 256;
+const DEFAULT_CHECKPOINT_RECHECK_MS = 1_000;
+const READ_CHUNK_BYTES = 64 * 1024;
+const MAX_RECORD_BYTES = 1024 * 1024;
+
+const EVENT_FILTERS = [
+  'transition',
+  'verdict',
+  'retry',
+  'error',
+  'transient',
+  'quota',
+  'gate',
+  'fanout',
+  'sent',
+] as const;
+type EventFilter = (typeof EVENT_FILTERS)[number];
+
+const DEFAULT_FILTERS = new Set<EventFilter>(EVENT_FILTERS.filter((filter) => filter !== 'sent'));
+
+interface WatchRecord {
+  readonly type: string;
+  readonly ts?: string;
+  readonly workflowId?: string;
+  readonly state?: string;
+  readonly [key: string]: unknown;
+}
+
+interface ParsedLine {
+  readonly record: WatchRecord;
+  readonly raw: string;
+}
+
+interface TailerOptions {
+  readonly onLine: (line: ParsedLine) => void | Promise<void>;
+  readonly onWarning: (message: string) => void;
+}
+
+/**
+ * Byte-offset JSONL reader. Split records are kept as bounded chunks and only
+ * decoded after a newline. On replacement, a constant-memory digest verifies
+ * whether the bytes already consumed are an unchanged prefix of the new file.
+ */
+export class JsonlTailer {
+  private offset = 0;
+  private observedSize = 0;
+  private identity: string | undefined;
+  private present = false;
+  private prefixHasher: Hash = createHash('sha256');
+  private partialChunks: Buffer[] = [];
+  private partialBytes = 0;
+  private discardingOversizeRecord = false;
+
+  constructor(
+    private readonly path: string,
+    private readonly options: TailerOptions,
+  ) {}
+
+  async poll(maxRecords = DEFAULT_MAX_RECORDS_PER_POLL): Promise<number> {
+    const recordLimit = Math.max(1, maxRecords);
+    const byteLimit = Math.max(READ_CHUNK_BYTES, recordLimit * READ_CHUNK_BYTES);
+    let fd: number;
+    try {
+      fd = openSync(this.path, 'r');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.present = false;
+        this.observedSize = this.offset;
+        return 0;
+      }
+      throw err;
+    }
+    let delivered = 0;
+    let processed = 0;
+    let bytesRead = 0;
+    try {
+      const stats = fstatSync(fd);
+      if (!stats.isFile()) throw new Error(`Message log is not a file: ${this.path}`);
+      const identity = `${String(stats.dev)}:${String(stats.ino)}`;
+      const replaced =
+        this.identity !== undefined && (!this.present || identity !== this.identity || stats.size < this.offset);
+      if (replaced && !this.hasUnchangedPrefix(fd, stats.size)) this.reset();
+      this.identity = identity;
+      this.present = true;
+      this.observedSize = stats.size;
+
+      while (this.offset < stats.size && processed < recordLimit && bytesRead < byteLimit) {
+        const wanted = Math.min(READ_CHUNK_BYTES, stats.size - this.offset, byteLimit - bytesRead);
+        const chunk = Buffer.allocUnsafe(wanted);
+        const read = readSync(fd, chunk, 0, wanted, this.offset);
+        if (read === 0) break;
+        bytesRead += read;
+        let start = 0;
+        while (start < read && processed < recordLimit) {
+          const newline = chunk.indexOf(0x0a, start);
+          if (newline < 0 || newline >= read) {
+            const remainder = chunk.subarray(start, read);
+            this.consume(remainder);
+            this.appendPartial(remainder);
+            start = read;
+            continue;
+          }
+
+          const linePart = chunk.subarray(start, newline);
+          this.consume(chunk.subarray(start, newline + 1));
+          this.appendPartial(linePart);
+          start = newline + 1;
+          processed += 1;
+          if (await this.deliverCompleteRecord()) delivered += 1;
+        }
+      }
+    } finally {
+      closeSync(fd);
+    }
+    return delivered;
+  }
+
+  hasUnreadData(): boolean {
+    return this.offset < this.observedSize;
+  }
+
+  /** Stable progress token used to detect a quiet producer without decoding partial data. */
+  cursor(): string {
+    return `${this.present ? (this.identity ?? 'unknown') : 'missing'}:${this.offset}:${this.partialBytes}`;
+  }
+
+  private consume(bytes: Buffer): void {
+    this.prefixHasher.update(bytes);
+    this.offset += bytes.length;
+  }
+
+  private appendPartial(bytes: Buffer): void {
+    if (this.discardingOversizeRecord || bytes.length === 0) return;
+    if (this.partialBytes + bytes.length > MAX_RECORD_BYTES) {
+      this.partialChunks = [];
+      this.partialBytes = 0;
+      this.discardingOversizeRecord = true;
+      this.options.onWarning(`Ignoring JSONL record larger than ${String(MAX_RECORD_BYTES)} bytes in ${this.path}`);
+      return;
+    }
+    this.partialChunks.push(Buffer.from(bytes));
+    this.partialBytes += bytes.length;
+  }
+
+  private async deliverCompleteRecord(): Promise<boolean> {
+    if (this.discardingOversizeRecord) {
+      this.discardingOversizeRecord = false;
+      return false;
+    }
+    let lineBytes =
+      this.partialChunks.length === 1 ? this.partialChunks[0] : Buffer.concat(this.partialChunks, this.partialBytes);
+    this.partialChunks = [];
+    this.partialBytes = 0;
+    if (lineBytes.at(-1) === 0x0d) lineBytes = lineBytes.subarray(0, -1);
+    const raw = lineBytes.toString('utf8');
+    if (raw.trim().length === 0) return false;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      this.options.onWarning(`Ignoring malformed complete JSONL record in ${this.path}`);
+      return false;
+    }
+    if (!isWatchRecord(parsed)) {
+      this.options.onWarning(`Ignoring JSONL value that is not a workflow record in ${this.path}`);
+      return false;
+    }
+    await this.options.onLine({ record: parsed, raw });
+    return true;
+  }
+
+  private hasUnchangedPrefix(fd: number, size: number): boolean {
+    if (size < this.offset) return false;
+    const hasher = createHash('sha256');
+    const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+    let position = 0;
+    while (position < this.offset) {
+      const read = readSync(fd, buffer, 0, Math.min(buffer.length, this.offset - position), position);
+      if (read === 0) return false;
+      hasher.update(buffer.subarray(0, read));
+      position += read;
+    }
+    return hasher.digest('hex') === this.prefixHasher.copy().digest('hex');
+  }
+
+  private reset(): void {
+    this.offset = 0;
+    this.prefixHasher = createHash('sha256');
+    this.partialChunks = [];
+    this.partialBytes = 0;
+    this.discardingOversizeRecord = false;
+  }
+}
+
+function isWatchRecord(value: unknown): value is WatchRecord {
+  return isPlainObject(value) && typeof value.type === 'string';
+}
+
+interface WatchTarget {
+  readonly workflowId: string;
+  readonly runDir: string;
+  readonly useDaemon: boolean;
+}
+
+interface DiskEvidence {
+  readonly phase: TerminalWorkflowPhase;
+  readonly key: string;
+  readonly source: 'terminal_marker' | 'checkpoint' | 'legacy_checkpoint' | 'legacy_transition';
+}
+
+class DiskRunInspector {
+  private markerCapable = false;
+  private markerTimestamp: string | undefined;
+  private markerCheckpointMtimeMs: number | undefined;
+  private markerCheckpointFingerprint: string | undefined;
+  private terminalMarker: { phase: TerminalWorkflowPhase; ts: string } | undefined;
+  private latestTerminalTransition: { state: string; ts: string } | undefined;
+  private definition: Record<string, { type?: unknown }> | undefined;
+  private definitionStamp: string | undefined;
+  private checkpointWarningStamp: string | undefined;
+  private checkpointStamp: string | undefined;
+  private checkpointMtimeMs: number | undefined;
+  private checkpointFingerprint: string | undefined;
+  private checkpoint: { timestamp?: unknown; finalStatus?: unknown; machineState?: unknown } | undefined;
+  private nextSameStampCheckpointRead = 0;
+
+  constructor(
+    private readonly runDir: string,
+    private readonly warn: (message: string) => void,
+    private readonly checkpointRecheckMs = DEFAULT_CHECKPOINT_RECHECK_MS,
+  ) {}
+
+  observe(record: WatchRecord): void {
+    if (record.type === 'run_started') {
+      this.beginMarkerCapableAttempt();
+      return;
+    }
+    if (record.type === 'run_resumed') {
+      this.beginMarkerCapableAttempt();
+      this.markerTimestamp = typeof record.ts === 'string' ? record.ts : new Date().toISOString();
+      this.markerCheckpointMtimeMs =
+        typeof record.checkpointMtimeMs === 'number' ? record.checkpointMtimeMs : undefined;
+      this.markerCheckpointFingerprint =
+        typeof record.checkpointFingerprint === 'string' ? record.checkpointFingerprint : undefined;
+      return;
+    }
+    if (record.type === 'run_terminal') {
+      if (typeof record.phase === 'string' && isTerminalWorkflowPhase(record.phase)) {
+        this.terminalMarker = {
+          phase: record.phase,
+          ts: typeof record.ts === 'string' ? record.ts : '',
+        };
+      }
+      return;
+    }
+    if (record.type !== 'state_transition' || typeof record.event !== 'string') return;
+    const states = this.readStates();
+    if (states?.[record.event]?.type === 'terminal') {
+      this.latestTerminalTransition = {
+        state: record.event,
+        ts: typeof record.ts === 'string' ? record.ts : '',
+      };
+    } else {
+      // An old daemon cannot emit run_resumed, so a later non-terminal
+      // transition is also an attempt boundary for legacy logs.
+      this.markerTimestamp = typeof record.ts === 'string' ? record.ts : new Date().toISOString();
+      this.markerCheckpointMtimeMs = undefined;
+      this.markerCheckpointFingerprint = undefined;
+      this.terminalMarker = undefined;
+      this.latestTerminalTransition = undefined;
+    }
+  }
+
+  evidence(): DiskEvidence | undefined {
+    const terminalMarker = this.terminalMarker;
+    if (terminalMarker) {
+      return {
+        phase: terminalMarker.phase,
+        key: `terminal-marker:${terminalMarker.ts}:${terminalMarker.phase}`,
+        source: 'terminal_marker',
+      };
+    }
+
+    const checkpoint = this.readCheckpoint();
+    if (checkpoint && this.isFresh(checkpoint.timestamp)) {
+      const finalPhase = readFinalPhase(checkpoint.finalStatus);
+      const checkpointTimestamp = typeof checkpoint.timestamp === 'string' ? checkpoint.timestamp : '';
+      if (finalPhase) {
+        return {
+          phase: finalPhase,
+          key: `checkpoint:${checkpointTimestamp}:${finalPhase}`,
+          source: 'checkpoint',
+        };
+      }
+
+      // A marker-capable producer promises an exact terminal phase after its
+      // terminal checkpoint and operational log records. A fresh finalStatus
+      // is itself authoritative, but do not race the marker with a generic
+      // transition or an intermediate checkpoint.
+      if (this.markerCapable && this.latestTerminalTransition) return undefined;
+
+      const state = extractStateName(checkpoint.machineState);
+      if (state && this.readStates()?.[state]?.type === 'terminal') {
+        const phase = terminalPhaseFromStateName(state);
+        return { phase, key: `legacy-checkpoint:${checkpointTimestamp}:${state}`, source: 'legacy_checkpoint' };
+      }
+    }
+
+    if (this.markerCapable && this.latestTerminalTransition) return undefined;
+
+    const transition = this.latestTerminalTransition;
+    if (transition) {
+      const phase = terminalPhaseFromStateName(transition.state);
+      return { phase, key: `transition:${transition.ts}:${transition.state}`, source: 'legacy_transition' };
+    }
+    return undefined;
+  }
+
+  private beginMarkerCapableAttempt(): void {
+    this.markerCapable = true;
+    this.markerTimestamp = undefined;
+    this.markerCheckpointMtimeMs = undefined;
+    this.markerCheckpointFingerprint = undefined;
+    this.terminalMarker = undefined;
+    this.latestTerminalTransition = undefined;
+  }
+
+  private isFresh(timestamp: unknown): boolean {
+    if (this.markerTimestamp === undefined) return true;
+    if (this.markerCheckpointFingerprint !== undefined && this.checkpointFingerprint !== undefined) {
+      return this.checkpointFingerprint !== this.markerCheckpointFingerprint;
+    }
+    if (this.markerCheckpointMtimeMs !== undefined && this.checkpointMtimeMs !== undefined) {
+      return this.checkpointMtimeMs > this.markerCheckpointMtimeMs;
+    }
+    if (typeof timestamp !== 'string') return false;
+    const checkpointTime = Date.parse(timestamp);
+    const markerTime = Date.parse(this.markerTimestamp);
+    return Number.isFinite(checkpointTime) && Number.isFinite(markerTime) && checkpointTime > markerTime;
+  }
+
+  private readStates(): Record<string, { type?: unknown }> | undefined {
+    const path = resolve(this.runDir, 'definition.json');
+    let stats: Stats;
+    try {
+      stats = statSync(path);
+    } catch {
+      return undefined;
+    }
+    const stamp = `${String(stats.dev)}:${String(stats.ino)}:${stats.mtimeMs}:${stats.size}`;
+    if (this.definitionStamp === stamp) return this.definition;
+    this.definitionStamp = stamp;
+    try {
+      const parsed = JSON.parse(readFileSync(path, 'utf8')) as { states?: unknown };
+      this.definition = isPlainObject(parsed.states)
+        ? (parsed.states as Record<string, { type?: unknown }>)
+        : undefined;
+    } catch {
+      this.definition = undefined;
+      this.warn(`Unable to read workflow definition: ${path}`);
+    }
+    return this.definition;
+  }
+
+  private readCheckpoint(): { timestamp?: unknown; finalStatus?: unknown; machineState?: unknown } | undefined {
+    const path = resolve(this.runDir, 'checkpoint.json');
+    let stats: Stats;
+    try {
+      stats = statSync(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw err;
+    }
+    this.checkpointMtimeMs = stats.mtimeMs;
+    const stamp = `${String(stats.dev)}:${String(stats.ino)}:${stats.mtimeMs}:${stats.size}`;
+    const sameStamp = this.checkpointStamp === stamp;
+    const markerStillMatches =
+      this.markerCheckpointFingerprint !== undefined && this.checkpointFingerprint === this.markerCheckpointFingerprint;
+    if (sameStamp && (!markerStillMatches || Date.now() < this.nextSameStampCheckpointRead)) return this.checkpoint;
+    this.checkpointStamp = stamp;
+    try {
+      const raw = readFileSync(path, 'utf8');
+      this.checkpointFingerprint = sha256Hex(raw);
+      this.nextSameStampCheckpointRead = Date.now() + this.checkpointRecheckMs;
+      this.checkpoint = JSON.parse(raw) as {
+        timestamp?: unknown;
+        finalStatus?: unknown;
+        machineState?: unknown;
+      };
+      return this.checkpoint;
+    } catch {
+      this.checkpoint = undefined;
+      this.checkpointFingerprint = undefined;
+      if (this.checkpointWarningStamp !== stamp) {
+        this.checkpointWarningStamp = stamp;
+        this.warn(`Unable to parse workflow checkpoint: ${path}`);
+      }
+      return undefined;
+    }
+  }
+}
+
+function readFinalPhase(value: unknown): TerminalWorkflowPhase | undefined {
+  if (!isPlainObject(value) || typeof value.phase !== 'string') return undefined;
+  return isTerminalWorkflowPhase(value.phase) ? value.phase : undefined;
+}
+
+function extractStateName(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!isPlainObject(value)) return undefined;
+  return Object.keys(value)[0];
+}
+
+export interface WorkflowWatchDependencies {
+  readonly createClient?: () => DaemonClient;
+  readonly pollIntervalMs?: number;
+  readonly reconcileIntervalMs?: number;
+  readonly reconnectWindowMs?: number;
+  readonly reconnectPollMs?: number;
+  /** Required quiet interval for a legacy producer with no terminal barrier. */
+  readonly quiescenceMs?: number;
+  /** Upper bound while draining a terminal producer. */
+  readonly drainTimeoutMs?: number;
+  /** Internal test/embedding override for bounded replay batches. */
+  readonly maxRecordsPerPoll?: number;
+  /** Internal fallback cadence for same-metadata checkpoint rewrites. */
+  readonly checkpointRecheckMs?: number;
+  readonly signal?: AbortSignal;
+  readonly installProcessSignals?: boolean;
+  readonly writeStdout?: (text: string) => void | Promise<void>;
+  readonly writeStderr?: (text: string) => void;
+}
+
+/** Execute `workflow watch`; returns a process exit code without exiting. */
+export async function runWorkflowWatch(args: string[], deps: WorkflowWatchDependencies = {}): Promise<number> {
+  const parsed = parseArgsResult({
+    args,
+    options: {
+      json: { type: 'boolean' },
+      since: { type: 'string' },
+      events: { type: 'string' },
+    },
+    allowPositionals: true,
+  });
+  const stderr = deps.writeStderr ?? ((text: string) => process.stderr.write(text));
+  const diagnostic = (message: string): void => stderr(`[workflow watch] ${sanitizeHumanText(message, '', 1_000)}\n`);
+
+  if (!parsed.ok) {
+    diagnostic(
+      `${parsed.message}\nUsage: ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]`,
+    );
+    return EXIT_USAGE;
+  }
+  if (parsed.positionals.length !== 1) {
+    diagnostic('Usage: ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]');
+    return EXIT_USAGE;
+  }
+
+  const since = parseSince(parsed.values.since);
+  if (since === null) {
+    diagnostic('--since must be a valid ISO timestamp');
+    return EXIT_USAGE;
+  }
+  const filters = parseFilters(parsed.values.events);
+  if (!filters) {
+    diagnostic(`--events must be a comma-separated list of: ${EVENT_FILTERS.join(',')},all`);
+    return EXIT_USAGE;
+  }
+
+  const targetResult = resolveWatchTarget(parsed.positionals[0]);
+  if ('error' in targetResult) {
+    diagnostic(targetResult.error);
+    return EXIT_USAGE;
+  }
+  const target = targetResult.target;
+  const ownController = new AbortController();
+  const stdout = deps.writeStdout
+    ? async (text: string): Promise<void> => deps.writeStdout?.(text)
+    : async (text: string): Promise<void> => writeProcessStdout(text, ownController.signal);
+  const inspector = new DiskRunInspector(target.runDir, diagnostic, deps.checkpointRecheckMs);
+  const json = parsed.values.json === true;
+  const warnedForeignWorkflowIds = new Set<string>();
+  const tailer = new JsonlTailer(resolve(target.runDir, 'messages.jsonl'), {
+    onWarning: diagnostic,
+    onLine: async ({ record, raw }) => {
+      if (record.workflowId !== target.workflowId) {
+        const foreignId = typeof record.workflowId === 'string' ? record.workflowId : '(missing)';
+        if (!warnedForeignWorkflowIds.has(foreignId)) {
+          warnedForeignWorkflowIds.add(foreignId);
+          diagnostic(`Ignoring message record for workflow ${foreignId}; expected ${target.workflowId}`);
+        }
+        return;
+      }
+      inspector.observe(record);
+      if (
+        record.type === 'run_started' ||
+        record.type === 'run_resumed' ||
+        record.type === 'run_terminal' ||
+        !recordPassesSince(record, since)
+      )
+        return;
+      const filter = filterForRecord(record.type);
+      if (!filter || !filters.has(filter)) return;
+      await stdout(json ? `${raw}\n` : `${formatHumanRecord(record)}\n`);
+    },
+  });
+
+  let signalExitCode = EXIT_SIGINT;
+  const onSigint = (): void => {
+    signalExitCode = EXIT_SIGINT;
+    ownController.abort();
+  };
+  const onSigterm = (): void => {
+    signalExitCode = EXIT_SIGTERM;
+    ownController.abort();
+  };
+  const installSignals = deps.installProcessSignals !== false;
+  if (installSignals) {
+    process.once('SIGINT', onSigint);
+    process.once('SIGTERM', onSigterm);
+  }
+  const externalAbort = (): void => ownController.abort();
+  deps.signal?.addEventListener('abort', externalAbort, { once: true });
+
+  try {
+    await tailer.poll(deps.maxRecordsPerPoll);
+    const initialEvidence = inspector.evidence();
+    if (!target.useDaemon && !tailer.hasUnreadData() && initialEvidence) {
+      const settled = await settleDiskEvidence(tailer, inspector, initialEvidence, ownController.signal, deps);
+      if (ownController.signal.aborted) return signalExitCode;
+      if (settled) return exitCodeForPhase(settled.phase);
+    }
+    return await watchLoop(target, tailer, inspector, diagnostic, ownController.signal, () => signalExitCode, deps);
+  } catch (err) {
+    diagnostic(err instanceof Error ? err.message : String(err));
+    return EXIT_ERROR;
+  } finally {
+    deps.signal?.removeEventListener('abort', externalAbort);
+    if (installSignals) {
+      process.removeListener('SIGINT', onSigint);
+      process.removeListener('SIGTERM', onSigterm);
+    }
+  }
+}
+
+async function watchLoop(
+  target: WatchTarget,
+  tailer: JsonlTailer,
+  inspector: DiskRunInspector,
+  diagnostic: (message: string) => void,
+  signal: AbortSignal,
+  getSignalExitCode: () => number,
+  deps: WorkflowWatchDependencies,
+): Promise<number> {
+  const pollMs = deps.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const reconcileMs = deps.reconcileIntervalMs ?? DEFAULT_RECONCILE_MS;
+  const reconnectWindowMs = deps.reconnectWindowMs ?? DEFAULT_RECONNECT_WINDOW_MS;
+  const reconnectPollMs = deps.reconnectPollMs ?? DEFAULT_RECONNECT_POLL_MS;
+  const createClient =
+    deps.createClient ?? (() => createDaemonClient({ requestTimeoutMs: 2_500, connectTimeoutMs: 1_000 }));
+
+  let client: DaemonClient | undefined;
+  let unsubscribeEvent: (() => void) | undefined;
+  let unsubscribeClose: (() => void) | undefined;
+  let nextReconcile = 0;
+  let immediateQuery = true;
+  let lastEvidenceKey: string | undefined;
+  let daemonNonterminal = false;
+  let reconnectDeadline: number | undefined;
+  let nextReconnect = 0;
+  let authoritativePhase: TerminalWorkflowPhase | 'interrupted' | undefined;
+
+  const detachClient = async (): Promise<void> => {
+    unsubscribeEvent?.();
+    unsubscribeClose?.();
+    unsubscribeEvent = undefined;
+    unsubscribeClose = undefined;
+    const old = client;
+    client = undefined;
+    await old?.close().catch(() => {});
+  };
+
+  const connect = async (): Promise<boolean> => {
+    let candidate: DaemonClient | undefined;
+    try {
+      candidate = createClient();
+      await candidate.connect();
+    } catch {
+      await candidate?.close().catch(() => {});
+      return false;
+    }
+    client = candidate;
+    reconnectDeadline = undefined;
+    // Subscribe before the initial get/requery to close the event/query race.
+    unsubscribeEvent = candidate.onEvent((event) => {
+      if (eventTargetsWorkflow(event, target.workflowId)) immediateQuery = true;
+    });
+    unsubscribeClose = candidate.onClose(() => {
+      if (client !== candidate) return;
+      client = undefined;
+      unsubscribeEvent = undefined;
+      unsubscribeClose = undefined;
+      reconnectDeadline ??= Date.now() + reconnectWindowMs;
+      nextReconnect = 0;
+    });
+    immediateQuery = true;
+    return true;
+  };
+
+  if (target.useDaemon && !(await connect())) {
+    diagnostic('daemon unavailable; watching disk for positive terminal evidence');
+  }
+
+  try {
+    for (;;) {
+      if (signal.aborted) return getSignalExitCode();
+      await tailer.poll(deps.maxRecordsPerPoll);
+      const evidence = inspector.evidence();
+      if (evidence?.key !== lastEvidenceKey) {
+        lastEvidenceKey = evidence?.key;
+        if (evidence) immediateQuery = true;
+      }
+
+      const now = Date.now();
+      if (!client && reconnectDeadline !== undefined && now >= nextReconnect && now < reconnectDeadline) {
+        nextReconnect = now + reconnectPollMs;
+        await connect();
+      }
+
+      if (client && (immediateQuery || now >= nextReconcile)) {
+        immediateQuery = false;
+        nextReconcile = now + reconcileMs;
+        const queriedClient = client;
+        try {
+          const result = await queriedClient.call<WorkflowDetailDto>('workflows.get', {
+            workflowId: target.workflowId,
+          });
+          if (result.ok) {
+            const phase = result.payload.phase;
+            if (phase === 'running' || phase === 'waiting_human') {
+              daemonNonterminal = true;
+            } else if (phase === 'interrupted' || isTerminalWorkflowPhase(phase)) {
+              authoritativePhase = phase;
+            }
+          } else if (result.code === 'WORKFLOW_NOT_FOUND') {
+            diagnostic('daemon does not know this workflow; continuing with disk evidence');
+            await detachClient();
+          } else {
+            diagnostic(`daemon status query failed: ${result.code}: ${result.message}`);
+          }
+        } catch (err) {
+          diagnostic(`daemon disconnected: ${err instanceof Error ? err.message : String(err)}; reconnecting`);
+          reconnectDeadline ??= Date.now() + reconnectWindowMs;
+          nextReconnect = 0;
+          await detachClient();
+        }
+      }
+
+      if (authoritativePhase) {
+        await drainToQuiescence(tailer, inspector, signal, deps);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the awaited drain can receive a signal
+        if (signal.aborted) return getSignalExitCode();
+        return exitCodeForPhase(authoritativePhase);
+      }
+
+      if (!client && reconnectDeadline !== undefined && Date.now() >= reconnectDeadline) {
+        const finalEvidence = inspector.evidence();
+        const settled = finalEvidence
+          ? await settleDiskEvidence(tailer, inspector, finalEvidence, signal, deps)
+          : await drainToQuiescence(tailer, inspector, signal, deps);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the awaited drain can receive a signal
+        if (signal.aborted) return getSignalExitCode();
+        if (settled) return exitCodeForPhase(settled.phase);
+        diagnostic('daemon connection was lost and no definitive terminal evidence was found');
+        return EXIT_ERROR;
+      }
+
+      // A connected daemon saying running/waiting wins over stale disk. With
+      // no daemon (including an initial best-effort miss), positive disk
+      // evidence is sufficient and silence/non-terminal state never is.
+      if (!client && reconnectDeadline === undefined && !tailer.hasUnreadData() && evidence) {
+        const settled = await settleDiskEvidence(tailer, inspector, evidence, signal, deps);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the awaited drain can receive a signal
+        if (signal.aborted) return getSignalExitCode();
+        if (settled) return exitCodeForPhase(settled.phase);
+      }
+      if (client && evidence && !daemonNonterminal) immediateQuery = true;
+
+      await delay(tailer.hasUnreadData() ? 0 : pollMs, signal);
+    }
+  } finally {
+    await detachClient();
+  }
+}
+
+function resolveWatchTarget(value: string): { target: WatchTarget } | { error: string } {
+  const candidate = resolve(value);
+  if (existsSync(candidate)) {
+    let isDirectory = false;
+    try {
+      isDirectory = statSync(candidate).isDirectory();
+    } catch {
+      // Report the stable usage diagnostic below.
+    }
+    if (!isDirectory) return { error: `Run path is not a directory: ${candidate}` };
+    if (!looksLikeRunDirectory(candidate)) {
+      return { error: `Path is not a workflow run directory (parent directories are not accepted): ${candidate}` };
+    }
+    return { target: { workflowId: basename(candidate), runDir: candidate, useDaemon: false } };
+  }
+
+  if (value.includes('/') || value.includes('\\') || value === '.' || value === '..') {
+    return { error: `Run directory does not exist: ${candidate}` };
+  }
+  let runDir: string;
+  try {
+    runDir = getWorkflowRunDir(value);
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+  if (!existsSync(runDir) || !looksLikeRunDirectory(runDir)) {
+    return { error: `Workflow run not found: ${value}` };
+  }
+  return { target: { workflowId: value, runDir, useDaemon: true } };
+}
+
+function looksLikeRunDirectory(path: string): boolean {
+  return ['definition.json', 'checkpoint.json', 'messages.jsonl'].some((name) => existsSync(resolve(path, name)));
+}
+
+function parseSince(value: unknown): number | undefined | null {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseFilters(value: unknown): ReadonlySet<EventFilter> | undefined {
+  if (value === undefined) return DEFAULT_FILTERS;
+  if (typeof value !== 'string') return undefined;
+  const tokens = value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) return undefined;
+  if (tokens.includes('all'))
+    return tokens.every((token) => token === 'all' || EVENT_FILTERS.includes(token as EventFilter))
+      ? new Set(EVENT_FILTERS)
+      : undefined;
+  const selected = new Set<EventFilter>();
+  for (const token of tokens) {
+    if (!EVENT_FILTERS.includes(token as EventFilter)) return undefined;
+    selected.add(token as EventFilter);
+  }
+  return selected;
+}
+
+function recordPassesSince(record: WatchRecord, since: number | undefined): boolean {
+  if (since === undefined) return true;
+  if (typeof record.ts !== 'string') return false;
+  const timestamp = Date.parse(record.ts);
+  return Number.isFinite(timestamp) && timestamp >= since;
+}
+
+function filterForRecord(type: string): EventFilter | undefined {
+  switch (type) {
+    case 'state_transition':
+      return 'transition';
+    case 'agent_received':
+      return 'verdict';
+    case 'agent_retry':
+      return 'retry';
+    case 'error':
+      return 'error';
+    case 'transient_failure':
+      return 'transient';
+    case 'quota_exhausted':
+      return 'quota';
+    case 'gate_raised':
+    case 'gate_resolved':
+      return 'gate';
+    case 'fanout_join':
+      return 'fanout';
+    case 'agent_sent':
+      return 'sent';
+    default:
+      return undefined;
+  }
+}
+
+function formatHumanRecord(record: WatchRecord): string {
+  const ts = sanitizeHumanText(record.ts);
+  const role = sanitizeHumanText(record.role);
+  switch (record.type) {
+    case 'state_transition':
+      return `${ts} transition ${scalar(record.from)} -> ${scalar(record.event)}`;
+    case 'agent_received':
+      return `${ts} verdict/${role} ${scalar(record.verdict)} ${oneLine(record.message)}`.trimEnd();
+    case 'agent_retry':
+      return `${ts} retry/${role} ${scalar(record.reason)} ${oneLine(record.details)}`.trimEnd();
+    case 'error':
+      return `${ts} error ${oneLine(record.error)}`;
+    case 'transient_failure':
+      return `${ts} transient/${role} ${scalar(record.kind)} ${oneLine(record.rawMessage)}`.trimEnd();
+    case 'quota_exhausted':
+      return `${ts} quota/${role} reset=${scalar(record.resetAt, 'unknown')} ${oneLine(record.rawMessage)}`.trimEnd();
+    case 'gate_raised':
+      return `${ts} gate raised ${stringList(record.acceptedEvents)}`.trimEnd();
+    case 'gate_resolved':
+      return `${ts} gate resolved ${scalar(record.event)}`;
+    case 'fanout_join':
+      return `${ts} fanout ${scalar(record.fanOutState ?? record.state)} workers=${scalar(record.workers)}`;
+    case 'agent_sent':
+      return `${ts} sent/${role} ${oneLine(record.message)}`.trimEnd();
+    default:
+      return `${ts} ${record.type}`;
+  }
+}
+
+function scalar(value: unknown, fallback = '-'): string {
+  return sanitizeHumanText(value, fallback);
+}
+
+function oneLine(value: unknown): string {
+  return sanitizeHumanText(value, '');
+}
+
+function stringList(value: unknown): string {
+  return Array.isArray(value)
+    ? value
+        .map((item) => sanitizeHumanText(item, ''))
+        .filter(Boolean)
+        .join(',')
+    : '';
+}
+
+// Strip complete CSI/OSC sequences first, then every remaining control or
+// formatting code. Even an unrecognized escape form becomes inert when its
+// ESC/C1 byte is removed. JSON mode intentionally bypasses this function.
+// eslint-disable-next-line no-control-regex
+const TERMINAL_ESCAPE_SEQUENCE = /\u001b\][^\u0007]*(?:\u0007|\u001b\\)|\u001b\[[0-?]*[ -/]*[@-~]/gu;
+const TERMINAL_CONTROL_CHARACTER = /[\p{Cc}\p{Cf}]/gu;
+
+function sanitizeHumanText(value: unknown, fallback = '-', maxLength = 160): string {
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return fallback;
+  const text = String(value)
+    .replace(TERMINAL_ESCAPE_SEQUENCE, '')
+    .replace(TERMINAL_CONTROL_CHARACTER, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (text.length === 0) return fallback;
+  return text.length <= maxLength ? text : `${text.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function eventTargetsWorkflow(event: DaemonEvent, workflowId: string): boolean {
+  return isPlainObject(event.payload) && event.payload.workflowId === workflowId;
+}
+
+function exitCodeForPhase(phase: TerminalWorkflowPhase | 'interrupted'): number {
+  return phase === 'completed' ? EXIT_OK : EXIT_TERMINAL_FAILURE;
+}
+
+async function settleDiskEvidence(
+  tailer: JsonlTailer,
+  inspector: DiskRunInspector,
+  evidence: DiskEvidence,
+  signal: AbortSignal,
+  deps: WorkflowWatchDependencies,
+): Promise<DiskEvidence | undefined> {
+  // Current producers write these only after all operational records and the
+  // terminal checkpoint. Only transition-only legacy evidence needs settling.
+  if (evidence.source !== 'legacy_transition' && !tailer.hasUnreadData()) return evidence;
+  return drainToQuiescence(tailer, inspector, signal, deps, true);
+}
+
+async function drainToQuiescence(
+  tailer: JsonlTailer,
+  inspector: DiskRunInspector,
+  signal: AbortSignal,
+  deps: WorkflowWatchDependencies,
+  requireEvidence = false,
+): Promise<DiskEvidence | undefined> {
+  const pollMs = deps.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const quiescenceMs = deps.quiescenceMs ?? DEFAULT_QUIESCENCE_MS;
+  const deadline = Date.now() + (deps.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS);
+  let quietSince = Date.now();
+  let cursor = tailer.cursor();
+  let evidence = inspector.evidence();
+  let evidenceKey = evidence?.key;
+
+  for (;;) {
+    if (signal.aborted) return evidence;
+    const hasUnreadData = tailer.hasUnreadData();
+    if (!hasUnreadData) {
+      if (evidence?.source === 'terminal_marker') return evidence;
+      if (requireEvidence && evidence === undefined) return undefined;
+      if (requireEvidence && evidence?.source !== 'legacy_transition') return evidence;
+    }
+
+    const now = Date.now();
+    if (!hasUnreadData && (now - quietSince >= quiescenceMs || now >= deadline)) return evidence;
+    await delay(hasUnreadData ? 0 : Math.min(pollMs, deadline - now), signal);
+    await tailer.poll(deps.maxRecordsPerPoll);
+
+    const nextCursor = tailer.cursor();
+    const nextEvidence = inspector.evidence();
+    const nextEvidenceKey = nextEvidence?.key;
+    if (nextCursor !== cursor || nextEvidenceKey !== evidenceKey) {
+      cursor = nextCursor;
+      evidenceKey = nextEvidenceKey;
+      quietSince = Date.now();
+    }
+    evidence = nextEvidence;
+  }
+}
+
+function writeProcessStdout(text: string, signal: AbortSignal): Promise<void> {
+  if (process.stdout.write(text)) return Promise.resolve();
+  return new Promise((resolveWrite) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      process.stdout.removeListener('drain', finish);
+      signal.removeEventListener('abort', finish);
+      resolveWrite();
+    };
+    process.stdout.once('drain', finish);
+    signal.addEventListener('abort', finish, { once: true });
+    if (signal.aborted) finish();
+  });
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolveDelay) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolveDelay();
+    };
+    const onAbort = (): void => finish();
+    const timer = setTimeout(finish, Math.max(0, ms));
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) finish();
+  });
+}

--- a/src/workflow/workflow-watch-command.ts
+++ b/src/workflow/workflow-watch-command.ts
@@ -87,6 +87,7 @@ export class JsonlTailer {
   constructor(
     private readonly path: string,
     private readonly options: TailerOptions,
+    private readonly fixedEndOffset?: number,
   ) {}
 
   async poll(maxRecords = DEFAULT_MAX_RECORDS_PER_POLL): Promise<number> {
@@ -109,16 +110,17 @@ export class JsonlTailer {
     try {
       const stats = fstatSync(fd);
       if (!stats.isFile()) throw new Error(`Message log is not a file: ${this.path}`);
+      const visibleSize = Math.min(stats.size, this.fixedEndOffset ?? stats.size);
       const identity = `${String(stats.dev)}:${String(stats.ino)}`;
       const replaced =
-        this.identity !== undefined && (!this.present || identity !== this.identity || stats.size < this.offset);
-      if (replaced && !this.hasUnchangedPrefix(fd, stats.size)) this.reset();
+        this.identity !== undefined && (!this.present || identity !== this.identity || visibleSize < this.offset);
+      if (replaced && !this.hasUnchangedPrefix(fd, visibleSize)) this.reset();
       this.identity = identity;
       this.present = true;
-      this.observedSize = stats.size;
+      this.observedSize = visibleSize;
 
-      while (this.offset < stats.size && processed < recordLimit && bytesRead < byteLimit) {
-        const wanted = Math.min(READ_CHUNK_BYTES, stats.size - this.offset, byteLimit - bytesRead);
+      while (this.offset < visibleSize && processed < recordLimit && bytesRead < byteLimit) {
+        const wanted = Math.min(READ_CHUNK_BYTES, visibleSize - this.offset, byteLimit - bytesRead);
         const chunk = Buffer.allocUnsafe(wanted);
         const read = readSync(fd, chunk, 0, wanted, this.offset);
         if (read === 0) break;
@@ -472,6 +474,7 @@ export async function runWorkflowWatch(args: string[], deps: WorkflowWatchDepend
       json: { type: 'boolean' },
       since: { type: 'string' },
       events: { type: 'string' },
+      lines: { type: 'string' },
     },
     allowPositionals: true,
   });
@@ -480,12 +483,14 @@ export async function runWorkflowWatch(args: string[], deps: WorkflowWatchDepend
 
   if (!parsed.ok) {
     diagnostic(
-      `${parsed.message}\nUsage: ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]`,
+      `${parsed.message}\nUsage: ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>] [--lines <N>]`,
     );
     return EXIT_USAGE;
   }
   if (parsed.positionals.length !== 1) {
-    diagnostic('Usage: ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>]');
+    diagnostic(
+      'Usage: ironcurtain workflow watch <workflowId|runDir> [--json] [--since <ISO>] [--events <list>] [--lines <N>]',
+    );
     return EXIT_USAGE;
   }
 
@@ -497,6 +502,11 @@ export async function runWorkflowWatch(args: string[], deps: WorkflowWatchDepend
   const filters = parseFilters(parsed.values.events);
   if (!filters) {
     diagnostic(`--events must be a comma-separated list of: ${EVENT_FILTERS.join(',')},all`);
+    return EXIT_USAGE;
+  }
+  const lineLimit = parseLineLimit(parsed.values.lines);
+  if (lineLimit === null) {
+    diagnostic('--lines must be a positive integer');
     return EXIT_USAGE;
   }
 
@@ -512,31 +522,53 @@ export async function runWorkflowWatch(args: string[], deps: WorkflowWatchDepend
     : async (text: string): Promise<void> => writeProcessStdout(text, ownController.signal);
   const inspector = new DiskRunInspector(target.runDir, diagnostic, deps.checkpointRecheckMs);
   const json = parsed.values.json === true;
+  const snapshotLines: string[] = [];
+  let selectedSnapshotLines = 0;
+  const rememberSnapshotLine = (line: string): void => {
+    if (lineLimit === undefined) return;
+    if (snapshotLines.length < lineLimit) snapshotLines.push(line);
+    else snapshotLines[selectedSnapshotLines % lineLimit] = line;
+    selectedSnapshotLines += 1;
+  };
   const warnedForeignWorkflowIds = new Set<string>();
-  const tailer = new JsonlTailer(resolve(target.runDir, 'messages.jsonl'), {
-    onWarning: diagnostic,
-    onLine: async ({ record, raw }) => {
-      if (record.workflowId !== target.workflowId) {
-        const foreignId = typeof record.workflowId === 'string' ? record.workflowId : '(missing)';
-        if (!warnedForeignWorkflowIds.has(foreignId)) {
-          warnedForeignWorkflowIds.add(foreignId);
-          diagnostic(`Ignoring message record for workflow ${foreignId}; expected ${target.workflowId}`);
+  const logPath = resolve(target.runDir, 'messages.jsonl');
+  let snapshotEnd: number | undefined;
+  try {
+    snapshotEnd = lineLimit === undefined ? undefined : snapshotFileEnd(logPath);
+  } catch (err) {
+    diagnostic(err instanceof Error ? err.message : String(err));
+    return EXIT_ERROR;
+  }
+  const tailer = new JsonlTailer(
+    logPath,
+    {
+      onWarning: diagnostic,
+      onLine: async ({ record, raw }) => {
+        if (record.workflowId !== target.workflowId) {
+          const foreignId = typeof record.workflowId === 'string' ? record.workflowId : '(missing)';
+          if (!warnedForeignWorkflowIds.has(foreignId)) {
+            warnedForeignWorkflowIds.add(foreignId);
+            diagnostic(`Ignoring message record for workflow ${foreignId}; expected ${target.workflowId}`);
+          }
+          return;
         }
-        return;
-      }
-      inspector.observe(record);
-      if (
-        record.type === 'run_started' ||
-        record.type === 'run_resumed' ||
-        record.type === 'run_terminal' ||
-        !recordPassesSince(record, since)
-      )
-        return;
-      const filter = filterForRecord(record.type);
-      if (!filter || !filters.has(filter)) return;
-      await stdout(json ? `${raw}\n` : `${formatHumanRecord(record)}\n`);
+        if (lineLimit === undefined) inspector.observe(record);
+        if (
+          record.type === 'run_started' ||
+          record.type === 'run_resumed' ||
+          record.type === 'run_terminal' ||
+          !recordPassesSince(record, since)
+        )
+          return;
+        const filter = filterForRecord(record.type);
+        if (!filter || !filters.has(filter)) return;
+        const output = json ? `${raw}\n` : `${formatHumanRecord(record)}\n`;
+        if (lineLimit !== undefined) rememberSnapshotLine(output);
+        else await stdout(output);
+      },
     },
-  });
+    snapshotEnd,
+  );
 
   let signalExitCode = EXIT_SIGINT;
   const onSigint = (): void => {
@@ -556,6 +588,26 @@ export async function runWorkflowWatch(args: string[], deps: WorkflowWatchDepend
   deps.signal?.addEventListener('abort', externalAbort, { once: true });
 
   try {
+    if (lineLimit !== undefined) {
+      do {
+        await tailer.poll(deps.maxRecordsPerPoll);
+        if (ownController.signal.aborted) return signalExitCode;
+        if (tailer.hasUnreadData()) await delay(0, ownController.signal);
+      } while (tailer.hasUnreadData());
+
+      const start = selectedSnapshotLines > lineLimit ? selectedSnapshotLines % lineLimit : 0;
+      const orderedLines =
+        selectedSnapshotLines > lineLimit
+          ? [...snapshotLines.slice(start), ...snapshotLines.slice(0, start)]
+          : snapshotLines;
+      for (const line of orderedLines) {
+        await stdout(line);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the awaited writer can receive a signal
+        if (ownController.signal.aborted) return signalExitCode;
+      }
+      return EXIT_OK;
+    }
+
     await tailer.poll(deps.maxRecordsPerPoll);
     const initialEvidence = inspector.evidence();
     if (!target.useDaemon && !tailer.hasUnreadData() && initialEvidence) {
@@ -759,6 +811,30 @@ function resolveWatchTarget(value: string): { target: WatchTarget } | { error: s
 
 function looksLikeRunDirectory(path: string): boolean {
   return ['definition.json', 'checkpoint.json', 'messages.jsonl'].some((name) => existsSync(resolve(path, name)));
+}
+
+function snapshotFileEnd(path: string): number {
+  let fd: number;
+  try {
+    fd = openSync(path, 'r');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+    throw err;
+  }
+  try {
+    const stats = fstatSync(fd);
+    if (!stats.isFile()) throw new Error(`Message log is not a file: ${path}`);
+    return stats.size;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function parseLineLimit(value: unknown): number | undefined | null {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !/^\d+$/u.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function parseSince(value: unknown): number | undefined | null {

--- a/test/workflow/message-log.test.ts
+++ b/test/workflow/message-log.test.ts
@@ -98,4 +98,30 @@ describe('MessageLog', () => {
 
     expect(read).toEqual(entry);
   });
+
+  it('keeps workflow control records private from readAll callers', () => {
+    const log = new MessageLog(logPath);
+    log.append(makeEntry({ type: 'error', error: 'before resume' }));
+    log.appendRunStarted({
+      ts: '2026-08-21T11:59:00.000Z',
+      workflowId: 'test-wf-1',
+      state: 'plan',
+    });
+    log.appendRunResumed({
+      ts: '2026-08-21T12:00:00.000Z',
+      workflowId: 'test-wf-1',
+      state: 'plan',
+    });
+    log.appendRunTerminal({
+      ts: '2026-08-21T12:00:01.000Z',
+      workflowId: 'test-wf-1',
+      state: 'done',
+      phase: 'completed',
+    });
+
+    expect(log.readAll()).toHaveLength(1);
+    expect(readFileSync(logPath, 'utf8')).toContain('"type":"run_started"');
+    expect(readFileSync(logPath, 'utf8')).toContain('"type":"run_resumed"');
+    expect(readFileSync(logPath, 'utf8')).toContain('"type":"run_terminal"');
+  });
 });

--- a/test/workflow/orchestrator-resume.test.ts
+++ b/test/workflow/orchestrator-resume.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync, mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionOptions } from '../../src/session/types.js';
@@ -94,6 +94,16 @@ const simpleAgentDef: WorkflowDefinition = {
     done: { type: 'terminal', description: 'Done' },
   },
 };
+
+function terminalControlPhases(baseDir: string, workflowId: WorkflowId): string[] {
+  const lines = readFileSync(resolve(baseDir, workflowId, 'messages.jsonl'), 'utf8')
+    .trim()
+    .split('\n');
+  return lines
+    .map((line) => JSON.parse(line) as { type?: unknown; phase?: unknown })
+    .filter((entry) => entry.type === 'run_terminal' && typeof entry.phase === 'string')
+    .map((entry) => entry.phase as string);
+}
 
 /**
  * Agent definition where errors go to a human gate instead of terminal.
@@ -260,6 +270,7 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
 
     const orchestrator = trackOrchestrator(new WorkflowOrchestrator(deps));
     const workflowId = await orchestrator.start(defPath, 'build API');
+    expect(readFileSync(resolve(tmpDir, workflowId, 'messages.jsonl'), 'utf8')).toContain('"type":"run_started"');
 
     // After plan completes, machine enters plan_gate => checkpoint saved
     await waitForGate(raiseGate, 1);
@@ -302,6 +313,7 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
     await waitForCompletion(orchestrator, workflowId);
 
     expect(orchestrator.getStatus(workflowId)?.phase).toBe('completed');
+    expect(terminalControlPhases(tmpDir, workflowId).at(-1)).toBe('completed');
 
     // B3b: The checkpoint is retained on disk with `finalStatus` populated
     // so the past-runs UI can surface the canonical phase and `listResumable`
@@ -411,6 +423,7 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
     await orchestrator.abort(workflowId);
 
     expect(orchestrator.getStatus(workflowId)?.phase).toBe('aborted');
+    expect(terminalControlPhases(tmpDir, workflowId).at(-1)).toBe('aborted');
     const surviving = checkpointStore.load(workflowId);
     expect(surviving).toBeDefined();
     expect(surviving!.machineState).toBe('plan_gate');
@@ -787,6 +800,7 @@ describe('WorkflowOrchestrator checkpoint + resume', () => {
     const workflowId = await first.start(defPath, 'recover initial state');
     await waitForCompletion(first, workflowId);
     expect(first.getStatus(workflowId)?.phase).toBe('failed');
+    expect(terminalControlPhases(tmpDir, workflowId).at(-1)).toBe('failed');
     expect(checkpointStore.load(workflowId)?.machineState).toBe('implement');
 
     const resumedFactory = vi.fn(async () => {

--- a/test/workflow/workflow-watch-command.test.ts
+++ b/test/workflow/workflow-watch-command.test.ts
@@ -1,0 +1,741 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  appendFileSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import type { DaemonClient } from '../../src/daemon-client/daemon-client.js';
+import { JsonlTailer, runWorkflowWatch } from '../../src/workflow/workflow-watch-command.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function temporaryRun(): string {
+  const root = mkdtempSync(join(tmpdir(), 'workflow-watch-'));
+  temporaryDirectories.push(root);
+  const runDir = resolve(root, 'wf-test');
+  mkdirSync(runDir);
+  writeFileSync(
+    resolve(runDir, 'definition.json'),
+    JSON.stringify({
+      initial: 'work',
+      states: {
+        work: { type: 'agent' },
+        done: { type: 'terminal' },
+        FAILED_REVIEW: { type: 'terminal' },
+      },
+    }),
+  );
+  return runDir;
+}
+
+function record(type: string, ts: string, fields: Record<string, unknown> = {}): string {
+  return JSON.stringify({ type, ts, workflowId: 'wf-test', state: 'work', ...fields });
+}
+
+describe('JsonlTailer', () => {
+  it('waits for complete lines and decodes a UTF-8 code point split across appends', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const raw = Buffer.from(record('error', '2026-08-21T12:00:00.000Z', { error: 'bad 💥' }));
+    const emojiStart = raw.indexOf(Buffer.from('💥'));
+    writeFileSync(path, raw.subarray(0, emojiStart + 2));
+
+    const seen: string[] = [];
+    const warnings: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ raw: line }) => seen.push(line),
+      onWarning: (warning) => warnings.push(warning),
+    });
+    expect(await tailer.poll()).toBe(0);
+    expect(warnings).toEqual([]);
+
+    appendFileSync(path, Buffer.concat([raw.subarray(emojiStart + 2), Buffer.from('\n')]));
+    expect(await tailer.poll()).toBe(1);
+    expect(seen).toEqual([raw.toString('utf8')]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('assembles a large record split across many read chunks', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const raw = record('error', '2026-08-21T12:00:00.000Z', { error: 'x'.repeat(512 * 1024) });
+    writeFileSync(path, raw.slice(0, 200_000));
+    const seen: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ raw: line }) => seen.push(line),
+      onWarning: vi.fn(),
+    });
+
+    expect(await tailer.poll()).toBe(0);
+    appendFileSync(path, raw.slice(200_000, 400_000));
+    expect(await tailer.poll()).toBe(0);
+    appendFileSync(path, `${raw.slice(400_000)}\n`);
+    expect(await tailer.poll()).toBe(1);
+    expect(seen).toEqual([raw]);
+  });
+
+  it('drops an oversized record and continues at the next newline', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const valid = record('error', '2026-08-21T12:00:01.000Z', { error: 'after' });
+    writeFileSync(
+      path,
+      `${record('error', '2026-08-21T12:00:00.000Z', { error: 'x'.repeat(1024 * 1024 + 1) })}\n${valid}\n`,
+    );
+    const seen: string[] = [];
+    const warnings: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ raw }) => seen.push(raw),
+      onWarning: (warning) => warnings.push(warning),
+    });
+
+    expect(await tailer.poll()).toBe(1);
+    expect(seen).toEqual([valid]);
+    expect(warnings).toEqual([expect.stringContaining('larger than')]);
+  });
+
+  it('warns for malformed complete lines and resumes with the next record', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    writeFileSync(path, `{broken}\n${record('error', '2026-08-21T12:00:00.000Z', { error: 'boom' })}\n`);
+    const seen: string[] = [];
+    const warnings: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ record: parsed }) => seen.push(parsed.type),
+      onWarning: (warning) => warnings.push(warning),
+    });
+
+    expect(await tailer.poll()).toBe(1);
+    expect(seen).toEqual(['error']);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('handles file replacement without repeating records retained in the replacement', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const first = record('error', '2026-08-21T12:00:00.000Z', { error: 'first' });
+    writeFileSync(path, `${first}\n`);
+    const seen: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ raw }) => seen.push(raw),
+      onWarning: vi.fn(),
+    });
+    expect(await tailer.poll()).toBe(1);
+
+    const replacement = resolve(runDir, 'replacement.jsonl');
+    const second = record('error', '2026-08-21T12:00:01.000Z', { error: 'second' });
+    writeFileSync(replacement, `${first}\n${second}\n`);
+    renameSync(replacement, path);
+
+    expect(await tailer.poll()).toBe(1);
+    expect(seen).toEqual([first, second]);
+  });
+
+  it('preserves intentional identical records appended in the same file generation', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const duplicate = record('error', '2026-08-21T12:00:00.000Z', { error: 'same' });
+    writeFileSync(path, `${duplicate}\n${duplicate}\n`);
+    const seen: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ raw }) => seen.push(raw),
+      onWarning: vi.fn(),
+    });
+
+    expect(await tailer.poll()).toBe(2);
+    expect(seen).toEqual([duplicate, duplicate]);
+  });
+
+  it('processes only the requested number of complete records per poll', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const records = [0, 1, 2].map((index) =>
+      record('error', `2026-08-21T12:00:0${String(index)}.000Z`, { error: String(index) }),
+    );
+    writeFileSync(path, `${records.join('\n')}\n`);
+    const seen: string[] = [];
+    const tailer = new JsonlTailer(path, {
+      onLine: ({ raw }) => seen.push(raw),
+      onWarning: vi.fn(),
+    });
+
+    expect(await tailer.poll(1)).toBe(1);
+    expect(tailer.hasUnreadData()).toBe(true);
+    expect(await tailer.poll(1)).toBe(1);
+    expect(tailer.hasUnreadData()).toBe(true);
+    expect(await tailer.poll(1)).toBe(1);
+    expect(tailer.hasUnreadData()).toBe(false);
+    expect(seen).toEqual(records);
+  });
+
+  it('bounds work for an unterminated oversized record', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    writeFileSync(path, 'x'.repeat(2 * 1024 * 1024));
+    const tailer = new JsonlTailer(path, {
+      onLine: vi.fn(),
+      onWarning: vi.fn(),
+    });
+
+    expect(await tailer.poll(1)).toBe(0);
+    expect(tailer.hasUnreadData()).toBe(true);
+  });
+});
+
+describe('workflow watch', () => {
+  it('waits for an asynchronous output writer before continuing replay', async () => {
+    const runDir = temporaryRun();
+    const error = record('error', '2026-08-21T12:00:00.000Z', { error: 'boom' });
+    const terminal = record('run_terminal', '2026-08-21T12:00:01.000Z', { phase: 'completed' });
+    writeFileSync(resolve(runDir, 'messages.jsonl'), `${error}\n${terminal}\n`);
+    let releaseWrite: (() => void) | undefined;
+    const writeStdout = vi.fn(
+      () =>
+        new Promise<void>((resolveWrite) => {
+          releaseWrite = resolveWrite;
+        }),
+    );
+    let settled = false;
+    const watching = runWorkflowWatch([runDir], {
+      installProcessSignals: false,
+      pollIntervalMs: 1,
+      writeStdout,
+      writeStderr: vi.fn(),
+    }).finally(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(writeStdout).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    releaseWrite?.();
+    expect(await watching).toBe(0);
+  });
+
+  it('replays selected JSON records with inclusive --since and exits on checkpoint-less completion', async () => {
+    const runDir = temporaryRun();
+    const at = '2026-08-21T12:00:00.000Z';
+    const sent = record('agent_sent', '2026-08-21T11:59:59.999Z', { role: 'coder', message: 'secret prompt' });
+    const received = record('agent_received', at, {
+      role: 'coder',
+      verdict: 'approved',
+      confidence: 'deprecated',
+      message: 'looks good',
+    });
+    const terminal = record('state_transition', '2026-08-21T12:00:01.000Z', { from: 'work', event: 'done' });
+    writeFileSync(resolve(runDir, 'messages.jsonl'), `${sent}\n${received}\n${terminal}\n`);
+    const output: string[] = [];
+
+    const code = await runWorkflowWatch([runDir, '--json', '--since', at, '--events', 'verdict'], {
+      installProcessSignals: false,
+      pollIntervalMs: 1,
+      quiescenceMs: 1,
+      writeStdout: (text) => output.push(text),
+      writeStderr: vi.fn(),
+    });
+
+    expect(code).toBe(0);
+    expect(output.join('')).toBe(`${received}\n`);
+  });
+
+  it('does not display confidence in human verdict output', async () => {
+    const runDir = temporaryRun();
+    const received = record('agent_received', '2026-08-21T12:00:00.000Z', {
+      role: 'reviewer',
+      verdict: 'revise',
+      confidence: 'high',
+      message: 'tighten it',
+    });
+    const terminal = record('state_transition', '2026-08-21T12:00:01.000Z', { from: 'work', event: 'done' });
+    writeFileSync(resolve(runDir, 'messages.jsonl'), `${received}\n${terminal}\n`);
+    const output: string[] = [];
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        quiescenceMs: 1,
+        writeStdout: (text) => output.push(text),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(0);
+    expect(output.join('')).toContain('verdict/reviewer revise tighten it');
+    expect(output.join('')).not.toContain('confidence');
+    expect(output.join('')).not.toContain('high');
+  });
+
+  it('ignores terminal checkpoint and transition evidence before the latest resume marker', async () => {
+    const runDir = temporaryRun();
+    const oldTimestamp = '2026-08-21T12:00:00.000Z';
+    const markerTimestamp = '2026-08-21T12:01:00.000Z';
+    writeFileSync(
+      resolve(runDir, 'checkpoint.json'),
+      JSON.stringify({
+        timestamp: oldTimestamp,
+        machineState: 'work',
+        finalStatus: { phase: 'completed' },
+      }),
+    );
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('state_transition', oldTimestamp, { from: 'work', event: 'done' })}\n` +
+        `${record('run_resumed', markerTimestamp)}\n`,
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+
+    const code = await runWorkflowWatch([runDir], {
+      signal: controller.signal,
+      installProcessSignals: false,
+      pollIntervalMs: 1,
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+    });
+    expect(code).toBe(130);
+  });
+
+  it('uses checkpoint fingerprints when timestamp and mtime freshness signals tie', async () => {
+    const runDir = temporaryRun();
+    const tiedTimestamp = '2026-08-21T12:00:00.000Z';
+    const checkpointPath = resolve(runDir, 'checkpoint.json');
+    const oldCheckpoint = JSON.stringify({
+      timestamp: tiedTimestamp,
+      machineState: 'work',
+      finalStatus: { phase: 'aborted', pad: 'xx' },
+    });
+    writeFileSync(checkpointPath, oldCheckpoint);
+    const tiedMtime = new Date('2026-08-21T12:00:00.000Z');
+    utimesSync(checkpointPath, tiedMtime, tiedMtime);
+    const oldMtimeMs = statSync(checkpointPath).mtimeMs;
+    const oldFingerprint = createHash('sha256').update(oldCheckpoint).digest('hex');
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('run_resumed', tiedTimestamp, {
+        checkpointMtimeMs: oldMtimeMs,
+        checkpointFingerprint: oldFingerprint,
+      })}\n`,
+    );
+    const newCheckpoint = JSON.stringify({
+      timestamp: tiedTimestamp,
+      machineState: 'work',
+      finalStatus: { phase: 'completed', pad: '' },
+    });
+    expect(Buffer.byteLength(newCheckpoint)).toBe(Buffer.byteLength(oldCheckpoint));
+    const watching = runWorkflowWatch([runDir], {
+      installProcessSignals: false,
+      pollIntervalMs: 1,
+      checkpointRecheckMs: 1,
+      quiescenceMs: 1,
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+    });
+    setTimeout(() => {
+      writeFileSync(checkpointPath, newCheckpoint);
+      utimesSync(checkpointPath, tiedMtime, tiedMtime);
+    }, 5);
+
+    expect(await watching).toBe(0);
+  });
+
+  it.each(['failed', 'aborted'] as const)(
+    'lets delayed %s checkpoint authority override a generic done transition',
+    async (phase) => {
+      const runDir = temporaryRun();
+      writeFileSync(
+        resolve(runDir, 'messages.jsonl'),
+        `${record('state_transition', '2026-08-21T12:00:00.000Z', { from: 'work', event: 'done' })}\n`,
+      );
+      setTimeout(() => {
+        writeFileSync(
+          resolve(runDir, 'checkpoint.json'),
+          JSON.stringify({
+            timestamp: '2026-08-21T12:00:01.000Z',
+            machineState: 'work',
+            finalStatus: { phase },
+          }),
+        );
+      }, 5);
+
+      expect(
+        await runWorkflowWatch([runDir], {
+          installProcessSignals: false,
+          pollIntervalMs: 1,
+          quiescenceMs: 15,
+          drainTimeoutMs: 100,
+          writeStdout: vi.fn(),
+          writeStderr: vi.fn(),
+        }),
+      ).toBe(3);
+    },
+  );
+
+  it.each([
+    ['completed', 0],
+    ['failed', 3],
+    ['aborted', 3],
+  ] as const)('waits for a delayed %s barrier from a marker-capable producer', async (phase, expectedCode) => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('run_started', '2026-08-21T12:00:00.000Z')}\n` +
+        `${record('state_transition', '2026-08-21T12:00:01.000Z', { from: 'work', event: 'done' })}\n`,
+    );
+    const watching = runWorkflowWatch([runDir], {
+      installProcessSignals: false,
+      pollIntervalMs: 1,
+      quiescenceMs: 2,
+      drainTimeoutMs: 5,
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+    });
+    let barrierAppended = false;
+
+    // This is deliberately well beyond both legacy settling bounds. A
+    // marker-capable attempt must not infer "completed" from `done`.
+    setTimeout(() => {
+      barrierAppended = true;
+      appendFileSync(
+        resolve(runDir, 'messages.jsonl'),
+        `${record('run_terminal', '2026-08-21T12:00:02.000Z', { phase })}\n`,
+      );
+    }, 25);
+
+    expect(await watching).toBe(expectedCode);
+    expect(barrierAppended).toBe(true);
+  });
+
+  it('keeps waiting when a marker-capable producer crashes before its terminal barrier', async () => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('run_started', '2026-08-21T12:00:00.000Z')}\n` +
+        `${record('state_transition', '2026-08-21T12:00:01.000Z', { from: 'work', event: 'done' })}\n`,
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 25);
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        signal: controller.signal,
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        quiescenceMs: 2,
+        drainTimeoutMs: 5,
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(130);
+  });
+
+  it('accepts a fresh final checkpoint if a marker-capable producer cannot append its terminal barrier', async () => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('run_started', '2026-08-21T12:00:00.000Z')}\n` +
+        `${record('state_transition', '2026-08-21T12:00:01.000Z', { from: 'work', event: 'done' })}\n`,
+    );
+    writeFileSync(
+      resolve(runDir, 'checkpoint.json'),
+      JSON.stringify({
+        timestamp: '2026-08-21T12:00:02.000Z',
+        machineState: 'work',
+        finalStatus: { phase: 'failed' },
+      }),
+    );
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(3);
+  });
+
+  it('treats the private terminal phase marker as authoritative over a generic terminal name', async () => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('state_transition', '2026-08-21T12:00:00.000Z', { from: 'work', event: 'done' })}\n` +
+        `${record('run_terminal', '2026-08-21T12:00:00.001Z', { phase: 'failed' })}\n`,
+    );
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(3);
+  });
+
+  it('clears legacy terminal evidence on a later non-terminal transition', async () => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'checkpoint.json'),
+      JSON.stringify({
+        timestamp: '2026-08-21T12:00:00.000Z',
+        machineState: 'work',
+        finalStatus: { phase: 'completed' },
+      }),
+    );
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('state_transition', '2026-08-21T12:00:00.000Z', { from: 'work', event: 'done' })}\n` +
+        `${record('run_terminal', '2026-08-21T12:00:00.001Z', { phase: 'completed' })}\n` +
+        `${record('state_transition', '2026-08-21T12:00:01.000Z', { from: 'done', event: 'work' })}\n`,
+    );
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        signal: controller.signal,
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        quiescenceMs: 1,
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(130);
+  });
+
+  it('ignores mixed-workflow records for output and terminal evidence', async () => {
+    const runDir = temporaryRun();
+    const foreign = record('state_transition', '2026-08-21T12:00:00.000Z', {
+      workflowId: 'wf-foreign',
+      from: 'work',
+      event: 'done',
+    });
+    writeFileSync(resolve(runDir, 'messages.jsonl'), `${foreign}\n`);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+    const output: string[] = [];
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        signal: controller.signal,
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        quiescenceMs: 1,
+        writeStdout: (text) => output.push(text),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(130);
+    expect(output).toEqual([]);
+  });
+
+  it('sanitizes every human-rendered field into one inert line', async () => {
+    const runDir = temporaryRun();
+    const hostile = record('agent_received', '2026-08-21T12:00:00.000Z\nFORGED', {
+      role: '\u001b[31mreviewer\u001b[0m\nrole',
+      verdict: 'approved\r\nFORGED',
+      message: '\u001b]0;owned\u0007safe\nFORGED',
+    });
+    const terminal = record('run_terminal', '2026-08-21T12:00:01.000Z', { phase: 'completed' });
+    writeFileSync(resolve(runDir, 'messages.jsonl'), `${hostile}\n${terminal}\n`);
+    const output: string[] = [];
+
+    expect(
+      await runWorkflowWatch([runDir], {
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        quiescenceMs: 1,
+        writeStdout: (text) => output.push(text),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(0);
+    const rendered = output.join('');
+    expect(rendered.split('\n')).toHaveLength(2);
+    expect(rendered).not.toContain('\u001b');
+    expect(rendered).toContain('reviewer role approved FORGED safe FORGED');
+  });
+
+  it('maps case-insensitive fail terminal names to exit 3', async () => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('state_transition', '2026-08-21T12:00:00.000Z', { from: 'work', event: 'FAILED_REVIEW' })}\n`,
+    );
+    expect(
+      await runWorkflowWatch([runDir, '--events', 'transition'], {
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        quiescenceMs: 1,
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(3);
+  });
+
+  it('uses only existing workflows.get support when watching by ID against an old daemon', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'workflow-watch-home-'));
+    temporaryDirectories.push(home);
+    const originalHome = process.env.IRONCURTAIN_HOME;
+    process.env.IRONCURTAIN_HOME = home;
+    try {
+      const runDir = resolve(home, 'workflow-runs', 'wf-old-daemon');
+      // temporaryRun created a sibling fixture; this target lives under the
+      // default ID root to exercise ID resolution.
+      const sourceRun = temporaryRun();
+      mkdirSync(resolve(home, 'workflow-runs'), { recursive: true });
+      cpSync(sourceRun, runDir, { recursive: true });
+      writeFileSync(
+        resolve(runDir, 'messages.jsonl'),
+        `${record('state_transition', '2026-08-21T12:00:00.000Z', {
+          workflowId: 'wf-old-daemon',
+          from: 'work',
+          event: 'done',
+        })}\n`,
+      );
+
+      const calls: string[] = [];
+      let query = 0;
+      const fake = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        call: vi.fn(async (method: string) => {
+          calls.push(method);
+          query += 1;
+          return {
+            ok: true,
+            payload: { workflowId: 'wf-old-daemon', phase: query === 1 ? 'running' : 'completed' },
+          };
+        }),
+        onEvent: vi.fn(() => () => {}),
+        onClose: vi.fn(() => () => {}),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DaemonClient;
+
+      const code = await runWorkflowWatch(['wf-old-daemon'], {
+        createClient: () => fake,
+        installProcessSignals: false,
+        pollIntervalMs: 1,
+        reconcileIntervalMs: 1,
+        quiescenceMs: 1,
+        writeStdout: vi.fn(),
+        writeStderr: vi.fn(),
+      });
+      expect(code).toBe(0);
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(calls)).toEqual(new Set(['workflows.get']));
+    } finally {
+      if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+      else process.env.IRONCURTAIN_HOME = originalHome;
+    }
+  });
+
+  it('continues through a human gate until the daemon reports a terminal phase', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'workflow-watch-home-'));
+    temporaryDirectories.push(home);
+    const originalHome = process.env.IRONCURTAIN_HOME;
+    process.env.IRONCURTAIN_HOME = home;
+    try {
+      const sourceRun = temporaryRun();
+      const runDir = resolve(home, 'workflow-runs', 'wf-gate');
+      mkdirSync(resolve(home, 'workflow-runs'), { recursive: true });
+      cpSync(sourceRun, runDir, { recursive: true });
+      const phases = ['waiting_human', 'completed'] as const;
+      let query = 0;
+      const fake = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        call: vi.fn(async () => ({
+          ok: true,
+          payload: { workflowId: 'wf-gate', phase: phases[Math.min(query++, phases.length - 1)] },
+        })),
+        onEvent: vi.fn(() => () => {}),
+        onClose: vi.fn(() => () => {}),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DaemonClient;
+
+      expect(
+        await runWorkflowWatch(['wf-gate'], {
+          createClient: () => fake,
+          installProcessSignals: false,
+          pollIntervalMs: 1,
+          reconcileIntervalMs: 1,
+          quiescenceMs: 1,
+          writeStdout: vi.fn(),
+          writeStderr: vi.fn(),
+        }),
+      ).toBe(0);
+      expect(fake.call).toHaveBeenCalledTimes(2);
+    } finally {
+      if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+      else process.env.IRONCURTAIN_HOME = originalHome;
+    }
+  });
+
+  it('reconnects and re-queries after an involuntary daemon disconnect', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'workflow-watch-home-'));
+    temporaryDirectories.push(home);
+    const originalHome = process.env.IRONCURTAIN_HOME;
+    process.env.IRONCURTAIN_HOME = home;
+    try {
+      const sourceRun = temporaryRun();
+      const runDir = resolve(home, 'workflow-runs', 'wf-reconnect');
+      mkdirSync(resolve(home, 'workflow-runs'), { recursive: true });
+      cpSync(sourceRun, runDir, { recursive: true });
+
+      const first = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        call: vi.fn(async () => ({
+          ok: true,
+          payload: { workflowId: 'wf-reconnect', phase: 'running' },
+        })),
+        onEvent: vi.fn(() => () => {}),
+        onClose: vi.fn((listener: (info: { reason: string }) => void) => {
+          setTimeout(() => listener({ reason: 'old daemon stopped' }), 5);
+          return () => {};
+        }),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DaemonClient;
+      const second = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        call: vi.fn(async () => ({
+          ok: true,
+          payload: { workflowId: 'wf-reconnect', phase: 'completed' },
+        })),
+        onEvent: vi.fn(() => () => {}),
+        onClose: vi.fn(() => () => {}),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DaemonClient;
+      let connection = 0;
+
+      expect(
+        await runWorkflowWatch(['wf-reconnect'], {
+          createClient: () => (connection++ === 0 ? first : second),
+          installProcessSignals: false,
+          pollIntervalMs: 1,
+          reconcileIntervalMs: 50,
+          reconnectPollMs: 1,
+          reconnectWindowMs: 100,
+          quiescenceMs: 1,
+          writeStdout: vi.fn(),
+          writeStderr: vi.fn(),
+        }),
+      ).toBe(0);
+      expect(first.call).toHaveBeenCalledTimes(1);
+      expect(second.call).toHaveBeenCalledTimes(1);
+    } finally {
+      if (originalHome === undefined) delete process.env.IRONCURTAIN_HOME;
+      else process.env.IRONCURTAIN_HOME = originalHome;
+    }
+  });
+});

--- a/test/workflow/workflow-watch-command.test.ts
+++ b/test/workflow/workflow-watch-command.test.ts
@@ -199,6 +199,113 @@ describe('JsonlTailer', () => {
 });
 
 describe('workflow watch', () => {
+  it('prints the last N selected snapshot records without following new appends', async () => {
+    const runDir = temporaryRun();
+    const path = resolve(runDir, 'messages.jsonl');
+    const errors = [0, 1, 2].map((index) =>
+      record('error', `2026-08-21T12:00:0${String(index)}.000Z`, { error: String(index) }),
+    );
+    writeFileSync(path, `${errors.join('\n')}\n`);
+    const output: string[] = [];
+    const appended = record('error', '2026-08-21T12:00:03.000Z', { error: 'new append' });
+
+    const watching = runWorkflowWatch([runDir, '--lines', '2', '--json', '--events', 'error'], {
+      installProcessSignals: false,
+      maxRecordsPerPoll: 1,
+      writeStdout: (text) => output.push(text),
+      writeStderr: vi.fn(),
+    });
+    setTimeout(() => appendFileSync(path, `${appended}\n`), 0);
+
+    expect(await watching).toBe(0);
+    expect(output.join('')).toBe(`${errors[1]}\n${errors[2]}\n`);
+  });
+
+  it('composes --lines with filters and ignores malformed, foreign, control, and partial records', async () => {
+    const runDir = temporaryRun();
+    const at = '2026-08-21T12:00:00.000Z';
+    const before = record('error', '2026-08-21T11:59:59.999Z', { error: 'before' });
+    const selected = record('error', at, { error: 'selected' });
+    const foreign = record('error', '2026-08-21T12:00:01.000Z', {
+      workflowId: 'wf-foreign',
+      error: 'foreign',
+    });
+    const partial = record('error', '2026-08-21T12:00:02.000Z', { error: 'partial' });
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${before}\n${record('run_started', at)}\n{malformed}\n${foreign}\n${selected}\n${partial}`,
+    );
+    const output: string[] = [];
+    const diagnostics: string[] = [];
+
+    expect(
+      await runWorkflowWatch([runDir, '--lines', '5', '--json', '--since', at, '--events', 'error'], {
+        installProcessSignals: false,
+        writeStdout: (text) => output.push(text),
+        writeStderr: (text) => diagnostics.push(text),
+      }),
+    ).toBe(0);
+    expect(output).toEqual([`${selected}\n`]);
+    expect(diagnostics.join('')).toContain('malformed complete JSONL record');
+    expect(diagnostics.join('')).toContain('wf-foreign');
+  });
+
+  it('returns an empty successful snapshot when the message log is missing', async () => {
+    const runDir = temporaryRun();
+    const output = vi.fn();
+
+    expect(
+      await runWorkflowWatch([runDir, '--lines', '10'], {
+        installProcessSignals: false,
+        writeStdout: output,
+        writeStderr: vi.fn(),
+      }),
+    ).toBe(0);
+    expect(output).not.toHaveBeenCalled();
+  });
+
+  it('honors asynchronous output backpressure in snapshot mode', async () => {
+    const runDir = temporaryRun();
+    writeFileSync(
+      resolve(runDir, 'messages.jsonl'),
+      `${record('error', '2026-08-21T12:00:00.000Z', { error: 'snapshot' })}\n`,
+    );
+    let releaseWrite: (() => void) | undefined;
+    const writeStdout = vi.fn(
+      () =>
+        new Promise<void>((resolveWrite) => {
+          releaseWrite = resolveWrite;
+        }),
+    );
+    let settled = false;
+    const watching = runWorkflowWatch([runDir, '--lines', '1'], {
+      installProcessSignals: false,
+      writeStdout,
+      writeStderr: vi.fn(),
+    }).finally(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(writeStdout).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    releaseWrite?.();
+    expect(await watching).toBe(0);
+  });
+
+  it.each(['0', '-1', '1.5', 'many', '9007199254740992'])('rejects invalid --lines value %s', async (value) => {
+    const runDir = temporaryRun();
+    const diagnostics: string[] = [];
+
+    expect(
+      await runWorkflowWatch([runDir, '--lines', value], {
+        installProcessSignals: false,
+        writeStdout: vi.fn(),
+        writeStderr: (text) => diagnostics.push(text),
+      }),
+    ).toBe(2);
+    expect(diagnostics.join('')).toContain('--lines');
+  });
+
   it('waits for an asynchronous output writer before continuing replay', async () => {
     const runDir = temporaryRun();
     const error = record('error', '2026-08-21T12:00:00.000Z', { error: 'boom' });


### PR DESCRIPTION
## Summary
- add workflow watch for replaying and following workflow events
- support JSONL, timestamp and event filters, daemon reconciliation, and disk-only runs
- add durable resume and terminal boundaries while keeping control records private
- document existing-daemon compatibility and terminal exit behavior

## Validation
- 126 focused workflow tests
- 8 daemon command integration tests
- TypeScript, ESLint, Prettier, cycle detection, CLI help, and diff checks

Closes #439