### PR TITLE
fix(docker): report container workspace in prompts

### DIFF
--- a/scripts/show-system-prompt.ts
+++ b/scripts/show-system-prompt.ts
@@ -38,7 +38,6 @@ async function main(): Promise<void> {
   // --- Docker agent session prompt (Claude Code adapter) ---
   const orientationContext: OrientationContext = {
     workspaceDir: CONTAINER_WORKSPACE_DIR,
-    hostSandboxDir: config.allowedDirectory,
     serverListings,
     allowedDomains: extractAllowedDomains(config),
     networkMode: 'none',

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -155,7 +155,7 @@ export interface RunRecord {
   };
 
   /**
-   * Brief summary extracted from workspace/last-run.md, if it exists.
+   * Brief summary extracted from last-run.md at the workspace root, if it exists.
    * Truncated to 2000 chars. Null if the file was not written.
    */
   readonly summary: string | null;

--- a/src/daemon/ironcurtain-daemon.ts
+++ b/src/daemon/ironcurtain-daemon.ts
@@ -35,6 +35,7 @@ import { BudgetExhaustedError } from '../types/errors.js';
 import { validateWorkspacePath } from '../session/workspace-validation.js';
 import * as logger from '../logger.js';
 import { getDaemonLogPath } from '../config/paths.js';
+import { CONTAINER_WORKSPACE_DIR } from '../docker/agent-adapter.js';
 import { getTokenStreamBus } from '../docker/token-stream-bus.js';
 import { ControlSocketServer, type ControlRequestHandler, type DaemonStatus } from './control-socket.js';
 import type { LlmMetricsRuntimeLease } from '../llm-metrics/runtime.js';
@@ -537,8 +538,7 @@ export class IronCurtainDaemon {
 
     // Build system prompt augmentation
     const augmentation = buildCronSystemPromptAugmentation({
-      taskDescription: job.taskDescription,
-      workspacePath: workspace,
+      workspacePath: this.mode.kind === 'docker' ? CONTAINER_WORKSPACE_DIR : workspace,
     });
 
     // Create the headless transport. The job is already loaded; pass

--- a/src/docker/adapters/claude-code.ts
+++ b/src/docker/adapters/claude-code.ts
@@ -39,7 +39,7 @@ import { buildSystemPrompt } from '../../session/prompts.js';
 import {
   buildResizePtyScript,
   buildCheckPtySizeScript,
-  buildNetworkSection,
+  buildWorkspaceAccessSection,
   buildNestedDockerSection,
   buildPolicySection,
   buildAttributionSection,
@@ -79,38 +79,12 @@ const CLAUDE_SKILLS_MOUNT_TARGET = `${CLAUDE_SKILLS_PARENT}/.claude/skills`;
 function buildDockerEnvironmentPrompt(context: OrientationContext): string {
   return `## Docker Environment
 
-### Workspace (\`${context.workspaceDir}\`)
-This is YOUR local workspace inside the container. Use your normal built-in
-tools (Bash, Read, Write, Edit, etc.) freely here -- no restrictions.
-
-### When to use \`execute_code\` (MCP tools)
-Use \`execute_code\` ONLY for operations that your built-in tools cannot do:
-- **Network requests**: HTTP fetches, web searches, API calls
-- **Git remote operations**: clone, push, pull, fetch
-- **Reading files outside ${context.workspaceDir}**
-
-For everything else -- listing, reading, searching, writing, and editing files
-inside ${context.workspaceDir} -- use your built-in tools (Bash, Read, Write,
-Edit, Glob, Grep, etc.). Do NOT use MCP filesystem or git tools for local file
-operations inside ${context.workspaceDir}.
-
-After cloning a repo or writing files via \`execute_code\`, switch to built-in
-tools for all subsequent file operations on the cloned/written files.
-When cloning repos, use ${context.workspaceDir} as the target directory
-(e.g. \`${context.workspaceDir}/repo-name\`).
-
-${buildNetworkSection('the sandbox tools via `execute_code`')}
+${buildWorkspaceAccessSection(context, 'built-in tools (Bash, Read, Write, Edit, Glob, Grep)', '`execute_code`')}
 
 ${buildNestedDockerSection(context)}
 
-IMPORTANT: Your built-in server-side web search tool (WebSearch) is DISABLED
-and will NOT work — it is stripped by the security proxy. You MUST use the
-sandbox tools via \`execute_code\` instead. Do NOT attempt to use your
-built-in WebSearch or WebFetch tools.
-
-To search the web:
+Built-in WebSearch and WebFetch are disabled. Use these through \`execute_code\`:
   \`const results = fetch.web_search({ query: "search terms" });\`
-To fetch a URL:
   \`const page = fetch.http_fetch({ url: "https://example.com" });\`
 
 ${buildPolicySection('tool call through `execute_code`')}
@@ -266,7 +240,7 @@ exit $STATUS
 
     buildSystemPrompt(context: OrientationContext): string {
       // Layer 1: Code Mode instructions (tool discovery, sync calls, return semantics)
-      const codeModePrompt = buildSystemPrompt(context.serverListings, context.hostSandboxDir);
+      const codeModePrompt = buildSystemPrompt(context.serverListings);
 
       // Layer 2: Docker environment specifics (workspace, host access, policy)
       const dockerPrompt = buildDockerEnvironmentPrompt(context);

--- a/src/docker/adapters/codex.ts
+++ b/src/docker/adapters/codex.ts
@@ -28,7 +28,7 @@ import { parseModelId } from '../../config/model-provider.js';
 import {
   buildAttributionSection,
   buildCheckPtySizeScript,
-  buildNetworkSection,
+  buildWorkspaceAccessSection,
   buildNestedDockerSection,
   buildPolicySection,
   buildResizePtyScript,
@@ -47,20 +47,7 @@ function tomlString(value: string): string {
 function buildCodexDockerEnvironmentPrompt(context: OrientationContext): string {
   return `## Docker Environment
 
-### Workspace (\`${context.workspaceDir}\`)
-This is your workspace inside the container. You have full access here.
-For local file operations inside ${context.workspaceDir}, use your built-in shell tools.
-
-### External Operations (MCP tools)
-Use the IronCurtain MCP server for operations that require external access:
-- Network requests (HTTP fetches, web searches, API calls)
-- Git remote operations (clone, push, pull, fetch)
-- Reading files outside ${context.workspaceDir}
-
-After cloning a repo or writing files via MCP tools, use your built-in
-tools for subsequent file operations.
-
-${buildNetworkSection('the IronCurtain MCP tools')}
+${buildWorkspaceAccessSection(context, 'built-in shell tools', 'IronCurtain MCP tools')}
 ${buildNestedDockerSection(context)}
 ${buildPolicySection('MCP tool call')}
 ${buildAttributionSection()}`;
@@ -207,7 +194,7 @@ export function createCodexAdapter(userConfig?: ResolvedUserConfig): AgentAdapte
     },
 
     buildSystemPrompt(context: OrientationContext): string {
-      const codeModePrompt = buildSystemPrompt(context.serverListings, context.hostSandboxDir);
+      const codeModePrompt = buildSystemPrompt(context.serverListings);
       const dockerPrompt = buildCodexDockerEnvironmentPrompt(context);
       return `${codeModePrompt}\n${dockerPrompt}`;
     },

--- a/src/docker/adapters/goose.ts
+++ b/src/docker/adapters/goose.ts
@@ -32,7 +32,7 @@ import { resolveApiKeyForProvider } from '../../config/model-provider.js';
 import {
   buildResizePtyScript,
   buildCheckPtySizeScript,
-  buildNetworkSection,
+  buildWorkspaceAccessSection,
   buildNestedDockerSection,
   buildPolicySection,
   buildAttributionSection,
@@ -137,20 +137,7 @@ export function escapeHeredoc(content: string): { delimiter: string } {
 function buildGooseDockerEnvironmentPrompt(context: OrientationContext): string {
   return `## Docker Environment
 
-### Workspace (\`${context.workspaceDir}\`)
-This is your workspace inside the container. You have full access here.
-For local file operations inside ${context.workspaceDir}, use your built-in tools.
-
-### External Operations (MCP tools)
-Use the IronCurtain MCP extension for operations that require external access:
-- Network requests (HTTP fetches, web searches, API calls)
-- Git remote operations (clone, push, pull, fetch)
-- Reading files outside ${context.workspaceDir}
-
-After cloning a repo or writing files via MCP tools, use your built-in
-tools for subsequent file operations.
-
-${buildNetworkSection('the IronCurtain MCP tools')}
+${buildWorkspaceAccessSection(context, 'built-in tools', 'IronCurtain MCP tools')}
 ${buildNestedDockerSection(context)}
 ${buildPolicySection('MCP tool call')}
 ${buildAttributionSection()}`;
@@ -268,7 +255,7 @@ export function createGooseAdapter(userConfig?: ResolvedUserConfig): AgentAdapte
     },
 
     buildSystemPrompt(context: OrientationContext): string {
-      const codeModePrompt = buildSystemPrompt(context.serverListings, context.hostSandboxDir);
+      const codeModePrompt = buildSystemPrompt(context.serverListings);
       const dockerPrompt = buildGooseDockerEnvironmentPrompt(context);
       return `${codeModePrompt}\n${dockerPrompt}`;
     },

--- a/src/docker/adapters/shared-scripts.ts
+++ b/src/docker/adapters/shared-scripts.ts
@@ -56,14 +56,21 @@ stty -F "$PTS" size 2>/dev/null || echo "0 0"
 
 // ─── Shared Docker Environment Prompt Sections ──────────────
 
-/**
- * Network restriction section. `toolReference` describes how to access network
- * (e.g. "the sandbox tools via `execute_code`" or "the IronCurtain MCP tools").
- */
-export function buildNetworkSection(toolReference: string): string {
-  return `### Network
-The container has NO direct internet access. All HTTP requests and
-git operations MUST go through ${toolReference}.`;
+/** Workspace and external-access orientation shared by every agent adapter. */
+export function buildWorkspaceAccessSection(
+  context: OrientationContext,
+  localTools: string,
+  externalTools: string,
+): string {
+  return `### Workspace
+Your workspace is \`${context.workspaceDir}\`. It is backed by the host workspace.
+Always refer to workspace files as \`${context.workspaceDir}/...\`.
+Use ${localTools} for all operations there, including after cloning or writing
+through ${externalTools}. Clone repositories into \`${context.workspaceDir}\`.
+
+### External operations
+The container has no direct internet access. Use ${externalTools} only for network
+requests, git remote operations, or files outside \`${context.workspaceDir}\`.`;
 }
 
 /**
@@ -103,11 +110,8 @@ Docker administrator authority over its bundle-local daemon.`;
  * (e.g. "tool call through `execute_code`" or "MCP tool call").
  */
 export function buildPolicySection(callType: string): string {
-  return `### Policy Enforcement
-Every ${callType} is evaluated against security policy rules:
-- **Allowed**: proceeds automatically
-- **Denied**: blocked -- do NOT retry denied operations
-- **Escalated**: requires human approval -- you will receive the result once approved`;
+  return `### Policy
+Each ${callType} may be allowed, denied, or escalated for human approval. Do not retry denials.`;
 }
 
 /**
@@ -115,6 +119,5 @@ Every ${callType} is evaluated against security policy rules:
  */
 export function buildAttributionSection(): string {
   return `### Attribution
-When adding attribution lines (e.g. Co-Authored-By, "Generated with"), include
-"running under IronCurtain" alongside the tool name.`;
+When adding attribution (for example, Co-Authored-By), say the tool ran under IronCurtain.`;
 }

--- a/src/docker/agent-adapter.ts
+++ b/src/docker/agent-adapter.ts
@@ -184,8 +184,6 @@ export interface AgentConfigFile {
 export interface OrientationContext {
   /** The sandbox directory path inside the container. */
   readonly workspaceDir: string;
-  /** The host-side path that is bind-mounted as workspaceDir. */
-  readonly hostSandboxDir: string;
   /** Server listings for progressive tool disclosure. */
   readonly serverListings: ServerListing[];
   /** Domains the agent may access via fetch MCP tool. */

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -962,15 +962,7 @@ export async function prepareDockerInfrastructure(
     const proxyHost = hostOnlyNetwork ? hostOnlyNetwork.gateway : DOCKER_HOST_GATEWAY;
     const proxyAddress = useTcp && proxy.port !== undefined ? `${proxyHost}:${proxy.port}` : undefined;
     const nestedDocker = dockerWorkload === undefined ? undefined : { networkName: APPLE_VM_DOCKER_WORKLOAD_NETWORK };
-    const { systemPrompt } = prepareSession(
-      adapter,
-      serverListings,
-      bundleDir,
-      config,
-      workspaceDir,
-      proxyAddress,
-      nestedDocker,
-    );
+    const { systemPrompt } = prepareSession(adapter, serverListings, bundleDir, config, proxyAddress, nestedDocker);
 
     const orientationDir = resolve(bundleDir, 'orientation');
     const runtimeTrust = stageRuntimeTrust(orientationDir, ca.certPem);

--- a/src/docker/orientation.ts
+++ b/src/docker/orientation.ts
@@ -58,7 +58,6 @@ export function prepareSession(
   serverListings: ServerListing[],
   sessionDir: string,
   config: IronCurtainConfig,
-  hostSandboxDir: string,
   proxyAddress?: string,
   nestedDocker?: OrientationContext['nestedDocker'],
 ): { systemPrompt: string } {
@@ -67,7 +66,6 @@ export function prepareSession(
 
   const context: OrientationContext = {
     workspaceDir: CONTAINER_WORKSPACE_DIR,
-    hostSandboxDir,
     serverListings,
     allowedDomains: extractAllowedDomains(config),
     networkMode: proxyAddress ? 'bridge' : 'none',

--- a/src/session/prompts.ts
+++ b/src/session/prompts.ts
@@ -97,10 +97,7 @@ return content;
  * Context injected into the system prompt for cron-initiated sessions.
  */
 export interface CronPromptContext {
-  /** The English task description from the job definition. */
-  readonly taskDescription: string;
-
-  /** Absolute path to the persistent workspace directory. */
+  /** Workspace path visible to the agent. */
   readonly workspacePath: string;
 }
 
@@ -113,16 +110,12 @@ export function buildCronSystemPromptAugmentation(context: CronPromptContext): s
 
 You are running as an automated scheduled task. There is no interactive user present.
 
-### Your Task
-
-${context.taskDescription}
-
 ### Workspace
 
 Your persistent workspace is: ${context.workspacePath}
 This directory persists across runs. Use it for cross-run state:
 
-- **workspace/last-run.md** -- Write a structured summary here before finishing. Include:
+- **last-run.md** -- Write a structured summary in the workspace root before finishing. Include:
   - Date and time of this run
   - Actions taken (with counts: "Labeled 12 issues, commented on 3, closed 1")
   - Any issues encountered or items skipped
@@ -133,5 +126,5 @@ This directory persists across runs. Use it for cross-run state:
 - If a tool call is denied, do NOT retry it. Note the denial in your summary and continue with other work.
 - If a tool call requires approval and no human responds in time, it will be auto-denied. Continue without that operation.
 - Work efficiently: this is a recurring job, not an exploration. Focus on the task.
-- Always write workspace/last-run.md before finishing, even if the task failed.`;
+- Always write last-run.md in the workspace root before finishing, even if the task failed.`;
 }

--- a/test/codex-adapter.test.ts
+++ b/test/codex-adapter.test.ts
@@ -10,7 +10,6 @@ import type { IronCurtainConfig } from '../src/config/types.js';
 
 const sampleContext: OrientationContext = {
   workspaceDir: CONTAINER_WORKSPACE_DIR,
-  hostSandboxDir: '/home/user/.ironcurtain/sessions/test/sandbox',
   serverListings: [{ name: 'filesystem', description: 'Read, write, and manage files' }],
   allowedDomains: ['example.com'],
   networkMode: 'none',
@@ -132,9 +131,11 @@ done
   it('builds system prompt with Docker and policy guidance', () => {
     const prompt = adapter.buildSystemPrompt(sampleContext);
     expect(prompt).toContain('help.help');
-    expect(prompt).toContain('/workspace');
-    expect(prompt).toContain('NO direct internet access');
-    expect(prompt).toContain('Policy Enforcement');
+    expect(prompt).toContain('Your workspace is `/workspace`');
+    expect(prompt).toContain('It is backed by the host workspace');
+    expect(prompt).not.toContain('Your sandbox directory is:');
+    expect(prompt).toContain('no direct internet access');
+    expect(prompt).toContain('### Policy');
     expect(prompt).not.toContain('IRONCURTAIN_DOCKER_NETWORK');
   });
 

--- a/test/cron-prompts.test.ts
+++ b/test/cron-prompts.test.ts
@@ -9,13 +9,12 @@ import type { CronPromptContext } from '../src/session/prompts.js';
 
 describe('buildCronSystemPromptAugmentation', () => {
   const baseContext: CronPromptContext = {
-    taskDescription: 'Label all open GitHub issues that are older than 7 days',
     workspacePath: '/home/user/.ironcurtain/jobs/label-issues/workspace',
   };
 
-  it('includes the task description', () => {
+  it('does not duplicate the task description sent as the user message', () => {
     const prompt = buildCronSystemPromptAugmentation(baseContext);
-    expect(prompt).toContain('Label all open GitHub issues that are older than 7 days');
+    expect(prompt).not.toContain('Your Task');
   });
 
   it('includes the workspace path', () => {
@@ -44,29 +43,27 @@ describe('buildCronSystemPromptAugmentation', () => {
 
   it('produces different output for different contexts', () => {
     const ctx1: CronPromptContext = {
-      taskDescription: 'Task A',
       workspacePath: '/path/a',
     };
     const ctx2: CronPromptContext = {
-      taskDescription: 'Task B',
       workspacePath: '/path/b',
     };
     const prompt1 = buildCronSystemPromptAugmentation(ctx1);
     const prompt2 = buildCronSystemPromptAugmentation(ctx2);
 
     expect(prompt1).not.toBe(prompt2);
-    expect(prompt1).toContain('Task A');
-    expect(prompt2).toContain('Task B');
+    expect(prompt1).toContain('/path/a');
+    expect(prompt2).toContain('/path/b');
   });
 
-  it('handles multi-line task descriptions', () => {
+  it('uses the container-visible workspace path when provided', () => {
     const ctx: CronPromptContext = {
-      taskDescription: 'Step 1: Do this\nStep 2: Do that\nStep 3: Report',
       workspacePath: '/workspace',
     };
     const prompt = buildCronSystemPromptAugmentation(ctx);
-    expect(prompt).toContain('Step 1: Do this');
-    expect(prompt).toContain('Step 3: Report');
+    expect(prompt).toContain('Your persistent workspace is: /workspace');
+    expect(prompt).toContain('last-run.md in the workspace root');
+    expect(prompt).not.toContain('workspace/last-run.md');
   });
 });
 

--- a/test/docker-agent-adapter.test.ts
+++ b/test/docker-agent-adapter.test.ts
@@ -15,7 +15,6 @@ const sampleServerListings: ServerListing[] = [{ name: 'filesystem', description
 
 const sampleContext: OrientationContext = {
   workspaceDir: CONTAINER_WORKSPACE_DIR,
-  hostSandboxDir: '/home/user/.ironcurtain/sessions/test/sandbox',
   serverListings: sampleServerListings,
   allowedDomains: ['example.com'],
   networkMode: 'none',
@@ -135,10 +134,12 @@ describe('Claude Code Adapter', () => {
     expect(prompt).toContain('synchronous');
 
     // Docker environment layer
-    expect(prompt).toContain('/workspace');
-    expect(prompt).toContain('NO direct internet access');
-    expect(prompt).toContain('When to use `execute_code`');
-    expect(prompt).toContain('Policy Enforcement');
+    expect(prompt).toContain('Your workspace is `/workspace`');
+    expect(prompt).toContain('It is backed by the host workspace');
+    expect(prompt).not.toContain('Your sandbox directory is:');
+    expect(prompt).toContain('no direct internet access');
+    expect(prompt).toContain('### External operations');
+    expect(prompt).toContain('### Policy');
     expect(prompt).not.toContain('IRONCURTAIN_DOCKER_NETWORK');
   });
 
@@ -663,13 +664,7 @@ describe('prepareSession', () => {
       userConfig: { anthropicApiKey: 'sk-test' },
     } as IronCurtainConfig;
 
-    const { systemPrompt } = prepareSession(
-      claudeCodeAdapter,
-      sampleServerListings,
-      sessionDir,
-      config,
-      '/host/sandbox',
-    );
+    const { systemPrompt } = prepareSession(claudeCodeAdapter, sampleServerListings, sessionDir, config);
 
     // Check that orientation dir was created with config file
     const orientationDir = join(sessionDir, 'orientation');
@@ -690,15 +685,9 @@ describe('prepareSession', () => {
       userConfig: { anthropicApiKey: 'sk-test' },
     } as IronCurtainConfig;
 
-    const { systemPrompt } = prepareSession(
-      claudeCodeAdapter,
-      sampleServerListings,
-      sessionDir,
-      config,
-      '/host/sandbox',
-      undefined,
-      { networkName: 'ironcurtain' },
-    );
+    const { systemPrompt } = prepareSession(claudeCodeAdapter, sampleServerListings, sessionDir, config, undefined, {
+      networkName: 'ironcurtain',
+    });
 
     expect(systemPrompt).toContain('IRONCURTAIN_DOCKER_NETWORK');
     expect(systemPrompt).toContain('`ironcurtain`');

--- a/test/goose-adapter.test.ts
+++ b/test/goose-adapter.test.ts
@@ -17,7 +17,6 @@ const sampleServerListings: ServerListing[] = [{ name: 'filesystem', description
 
 const sampleContext: OrientationContext = {
   workspaceDir: CONTAINER_WORKSPACE_DIR,
-  hostSandboxDir: '/home/user/.ironcurtain/sessions/test/sandbox',
   serverListings: sampleServerListings,
   allowedDomains: ['example.com'],
   networkMode: 'none',
@@ -223,9 +222,11 @@ describe('GooseAdapter.buildCommand', () => {
 describe('GooseAdapter.buildSystemPrompt', () => {
   const adapter = createGooseAdapter();
 
-  it('contains workspace path', () => {
+  it('contains only the container-visible workspace path', () => {
     const prompt = adapter.buildSystemPrompt(sampleContext);
-    expect(prompt).toContain('/workspace');
+    expect(prompt).toContain('Your workspace is `/workspace`');
+    expect(prompt).toContain('It is backed by the host workspace');
+    expect(prompt).not.toContain('Your sandbox directory is:');
   });
 
   it('contains MCP tool guidance', () => {
@@ -243,14 +244,14 @@ describe('GooseAdapter.buildSystemPrompt', () => {
 
   it('contains policy enforcement explanation', () => {
     const prompt = adapter.buildSystemPrompt(sampleContext);
-    expect(prompt).toContain('Policy Enforcement');
-    expect(prompt).toContain('Denied');
-    expect(prompt).toContain('Escalated');
+    expect(prompt).toContain('### Policy');
+    expect(prompt).toContain('denied');
+    expect(prompt).toContain('escalated');
   });
 
-  it('contains NO direct internet access warning', () => {
+  it('contains direct internet access warning', () => {
     const prompt = adapter.buildSystemPrompt(sampleContext);
-    expect(prompt).toContain('NO direct internet access');
+    expect(prompt).toContain('no direct internet access');
     expect(prompt).not.toContain('IRONCURTAIN_DOCKER_NETWORK');
   });
 


### PR DESCRIPTION
## Summary

- orient Claude, Codex, and Goose to the container-visible `/workspace` path without exposing the host mount source
- use `/workspace` in Docker cron prompts and place `last-run.md` at the workspace root
- reduce prompt size by sharing concise workspace guidance and removing the duplicated cron task description

## Validation

- `npm test -- test/docker-agent-adapter.test.ts test/codex-adapter.test.ts test/goose-adapter.test.ts test/cron-prompts.test.ts` (157 passed)
- `npm test -- test/cron-scheduler.test.ts` (30 passed)
- `npx tsc --noEmit`
- `npm run typecheck:scripts -- --pretty false`
- focused ESLint and Prettier checks
- pre-commit and circular-dependency checks