### PR TITLE
feat(web-ui): resume container sessions safely

### DIFF
--- a/packages/web-ui/e2e/sessions.spec.ts
+++ b/packages/web-ui/e2e/sessions.spec.ts
@@ -49,6 +49,19 @@ test.describe('Sessions', () => {
     await waitForPtyTerminal(page);
   });
 
+  test('resumes a saved session into a selected PTY terminal', async ({ page }) => {
+    await navigateTo(page, 'Sessions');
+    await page.getByRole('button', { name: 'Resume previous…' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Resume a session' });
+    await expect(dialog.getByText('Claude Code — ironcurtain')).toBeVisible();
+    await dialog.getByRole('button', { name: 'Resume Claude Code — ironcurtain' }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByTestId('session-sidebar').locator('[data-testid^="session-item-"]')).toHaveCount(1);
+    await waitForPtyTerminal(page);
+  });
+
   test('sends a trusted prompt and echoes it into the terminal', async ({ page }) => {
     await createDefaultSession(page);
     await waitForPtyTerminal(page);

--- a/packages/web-ui/scripts/mock-ws-server.ts
+++ b/packages/web-ui/scripts/mock-ws-server.ts
@@ -65,6 +65,17 @@ interface MockSession {
   lastAttachedAt?: string;
 }
 
+interface MockResumableSession {
+  sessionId: string;
+  displayName: string;
+  agent: string;
+  status: 'completed' | 'crashed' | 'auth-failure' | 'user-exit';
+  lastActivity: string;
+  workspaceLabel?: string;
+  persona?: string;
+  providerProfileName?: string;
+}
+
 interface MockWhitelistCandidate {
   description: string;
 }
@@ -219,6 +230,7 @@ let replayController: ReplayController | null = null;
 let nextLabel = 1;
 let eventSeq = 0;
 const sessions = new Map<number, MockSession>();
+const resumableSessions = new Map<string, MockResumableSession>();
 const escalations = new Map<string, MockEscalation>();
 const clients = new Set<WebSocket>();
 
@@ -1377,6 +1389,18 @@ const jobs = structuredClone(CANNED_JOBS);
 function resetState(opts?: ResetOptions): void {
   stopAllPtyFrames();
   sessions.clear();
+  resumableSessions.clear();
+  const resumable: MockResumableSession = {
+    sessionId: 'mock-saved-session',
+    displayName: 'Claude Code — ironcurtain',
+    agent: 'claude-code',
+    status: 'user-exit',
+    lastActivity: new Date(Date.now() - 12 * 60_000).toISOString(),
+    workspaceLabel: '~/src/ironcurtain',
+    persona: 'code-reviewer',
+    providerProfileName: 'native',
+  };
+  resumableSessions.set(resumable.sessionId, resumable);
   escalations.clear();
   nextLabel = 1;
   eventSeq = 0;
@@ -1709,6 +1733,31 @@ function handleMethod(ws: WebSocket, method: string, params: Record<string, unkn
 
     case 'sessions.list':
       return [...sessions.values()].map(buildSessionDto);
+
+    case 'sessions.listResumable':
+      return [...resumableSessions.values()].sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
+
+    case 'sessions.resume': {
+      const sessionId = params.sessionId as string;
+      const saved = resumableSessions.get(sessionId);
+      if (!saved) return errorResult('SESSION_NOT_RESUMABLE', `Session "${sessionId}" is not resumable`);
+      resumableSessions.delete(sessionId);
+      const label = nextLabel++;
+      const session: MockSession = {
+        label,
+        turnCount: 0,
+        createdAt: new Date().toISOString(),
+        status: 'ready',
+        persona: saved.persona,
+        totalTokens: 0,
+        stepCount: 0,
+        estimatedCostUsd: 0,
+        isPty: true,
+      };
+      sessions.set(label, session);
+      broadcast('session.created', buildSessionDto(session));
+      return { label };
+    }
 
     case 'sessions.create': {
       const label = nextLabel++;

--- a/packages/web-ui/src/lib/__tests__/stores-pty.test.ts
+++ b/packages/web-ui/src/lib/__tests__/stores-pty.test.ts
@@ -43,6 +43,8 @@ import {
   sendPtyResize,
   sendPtyPrompt,
   createSession,
+  listResumableSessions,
+  resumeSession,
   registerPtySink,
   unregisterPtySink,
   connectPtyTerminal,
@@ -80,6 +82,16 @@ describe('PTY store actions', () => {
   it('sendPtyPrompt sends sessions.ptyPrompt with PLAIN text (not base64)', async () => {
     await sendPtyPrompt(5, 'approve the write');
     expect(mockRequest).toHaveBeenCalledWith('sessions.ptyPrompt', { label: 5, text: 'approve the write' });
+  });
+
+  it('lists and resumes persisted sessions with the exact RPC contract', async () => {
+    mockRequest.mockResolvedValueOnce([]).mockResolvedValueOnce({ label: 9 });
+
+    await listResumableSessions();
+    await resumeSession('saved-session');
+
+    expect(mockRequest).toHaveBeenNthCalledWith(1, 'sessions.listResumable');
+    expect(mockRequest).toHaveBeenNthCalledWith(2, 'sessions.resume', { sessionId: 'saved-session' });
   });
 });
 

--- a/packages/web-ui/src/lib/components/features/message-log-timeline.svelte
+++ b/packages/web-ui/src/lib/components/features/message-log-timeline.svelte
@@ -106,10 +106,10 @@
   }
 
   // ------------------------------------------------------------------
-  // Relative-time helper. No codebase utility exists for this; keep it
-  // small and inline rather than introducing a new dependency.
+  // Message logs intentionally retain seconds-level detail for recent events;
+  // the shared compact formatter starts at minute granularity.
   // ------------------------------------------------------------------
-  function formatRelativeTime(iso: string, now: number = Date.now()): string {
+  function formatMessageRelativeTime(iso: string, now: number = Date.now()): string {
     const ts = Date.parse(iso);
     if (Number.isNaN(ts)) return iso;
     const deltaSec = Math.round((now - ts) / 1000);
@@ -160,7 +160,7 @@
         <div class="flex items-baseline gap-2 text-xs text-muted-foreground mb-1">
           <Badge variant={meta.badgeVariant} class="font-mono shrink-0">{meta.label}</Badge>
           <span class="font-mono text-foreground/70">{entry.state}</span>
-          <span class="ml-auto" title={formatAbsoluteTime(entry.ts)}>{formatRelativeTime(entry.ts)}</span>
+          <span class="ml-auto" title={formatAbsoluteTime(entry.ts)}>{formatMessageRelativeTime(entry.ts)}</span>
         </div>
 
         {#if isAgentMessage(entry)}

--- a/packages/web-ui/src/lib/components/features/resume-session-modal.svelte
+++ b/packages/web-ui/src/lib/components/features/resume-session-modal.svelte
@@ -42,7 +42,12 @@
 
     <div class="min-h-0 flex-1 overflow-y-auto p-4" aria-busy={loading || resumingId !== null}>
       {#if actionError}
-        <Alert variant="destructive" class="mb-3 items-start">{actionError}</Alert>
+        <Alert variant="destructive" class="mb-3 items-start">
+          <div class="flex flex-col items-start gap-3">
+            <span>{actionError}</span>
+            <Button variant="outline" size="sm" onclick={onretry}>Refresh sessions</Button>
+          </div>
+        </Alert>
       {/if}
       {#if loading}
         <div

--- a/packages/web-ui/src/lib/components/features/resume-session-modal.svelte
+++ b/packages/web-ui/src/lib/components/features/resume-session-modal.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import type { ResumableSessionDto } from '$lib/types.js';
+  import { formatRelativeTime } from '$lib/format.js';
+  import { Alert } from '$lib/components/ui/alert/index.js';
+  import { Badge } from '$lib/components/ui/badge/index.js';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { Modal } from '$lib/components/ui/modal/index.js';
+  import { Spinner } from '$lib/components/ui/spinner/index.js';
+
+  let {
+    open,
+    sessions,
+    loading,
+    loadError,
+    actionError,
+    resumingId,
+    onclose,
+    onretry,
+    onresume,
+  }: {
+    open: boolean;
+    sessions: readonly ResumableSessionDto[];
+    loading: boolean;
+    loadError: string;
+    actionError: string;
+    resumingId: string | null;
+    onclose: () => void;
+    onretry: () => void;
+    onresume: (sessionId: string) => void;
+  } = $props();
+
+  function close(): void {
+    if (resumingId === null) onclose();
+  }
+</script>
+
+<Modal {open} onclose={close} title="Resume a session" class="max-w-3xl">
+  <div class="flex max-h-[80dvh] min-h-56 flex-col">
+    <div class="border-b border-border px-5 py-3 text-sm text-muted-foreground">
+      Continue a previous container session with its original agent, workspace, profile, and persona.
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto p-4" aria-busy={loading || resumingId !== null}>
+      {#if actionError}
+        <Alert variant="destructive" class="mb-3 items-start">{actionError}</Alert>
+      {/if}
+      {#if loading}
+        <div
+          class="flex min-h-36 items-center justify-center gap-2 text-sm text-muted-foreground"
+          role="status"
+          aria-live="polite"
+        >
+          <Spinner size="md" />
+          Loading resumable sessions…
+        </div>
+      {:else if loadError}
+        <Alert variant="destructive" class="items-start">
+          <div class="flex flex-col items-start gap-3">
+            <span>{loadError}</span>
+            <Button variant="outline" size="sm" onclick={onretry}>Retry</Button>
+          </div>
+        </Alert>
+      {:else if sessions.length === 0}
+        <div class="flex min-h-40 flex-col items-center justify-center px-6 text-center">
+          <div class="text-sm font-semibold text-foreground">No resumable sessions</div>
+          <p class="mt-1 max-w-sm text-sm text-muted-foreground">
+            Completed sessions appear here when their agent supports continuing the conversation.
+          </p>
+        </div>
+      {:else}
+        <div class="space-y-2">
+          {#each sessions as session (session.sessionId)}
+            <article class="rounded-xl border border-border bg-background/40 p-3 transition-colors hover:bg-accent/20">
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div class="min-w-0 flex-1">
+                  <div class="flex min-w-0 flex-wrap items-center gap-2">
+                    <span class="truncate text-sm font-semibold" title={session.displayName}>{session.displayName}</span
+                    >
+                    <Badge
+                      variant={session.status === 'crashed' || session.status === 'auth-failure'
+                        ? 'warning'
+                        : 'secondary'}
+                    >
+                      {session.status}
+                    </Badge>
+                  </div>
+                  <div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <span class="font-mono" title={session.sessionId}>{session.sessionId.slice(0, 8)}</span>
+                    <span>{session.agent}</span>
+                    {#if session.persona}<span>Persona: {session.persona}</span>{/if}
+                    {#if session.providerProfileName}<span>Profile: {session.providerProfileName}</span>{/if}
+                    <time datetime={session.lastActivity} title={new Date(session.lastActivity).toLocaleString()}>
+                      {formatRelativeTime(session.lastActivity)}
+                    </time>
+                  </div>
+                  <div
+                    class="mt-1 truncate text-xs text-muted-foreground"
+                    title={session.workspaceLabel ?? 'Session sandbox'}
+                  >
+                    {session.workspaceLabel ?? 'Session sandbox'}
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  class="min-h-11 w-full sm:min-h-0 sm:w-auto"
+                  loading={resumingId === session.sessionId}
+                  disabled={resumingId !== null}
+                  aria-label={`Resume ${session.displayName}`}
+                  onclick={() => onresume(session.sessionId)}
+                >
+                  {resumingId === session.sessionId ? 'Resuming…' : 'Resume'}
+                </Button>
+              </div>
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <div class="flex justify-end border-t border-border px-5 py-3">
+      <Button variant="ghost" disabled={resumingId !== null} onclick={close}>Close</Button>
+    </div>
+  </div>
+</Modal>

--- a/packages/web-ui/src/lib/components/features/resume-session-modal.test.ts
+++ b/packages/web-ui/src/lib/components/features/resume-session-modal.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ResumeSessionModal from './resume-session-modal.svelte';
+import type { ResumableSessionDto } from '$lib/types.js';
+
+const saved: ResumableSessionDto[] = [
+  {
+    sessionId: 'saved-session-1234',
+    displayName: 'Claude Code session',
+    agent: 'claude-code',
+    status: 'user-exit',
+    lastActivity: '2026-08-24T12:00:00.000Z',
+    workspaceLabel: '~/src/ironcurtain',
+    persona: 'reviewer',
+    providerProfileName: 'work',
+  },
+  {
+    sessionId: 'another-session',
+    displayName: 'Goose session',
+    agent: 'goose',
+    status: 'crashed',
+    lastActivity: '2026-08-23T12:00:00.000Z',
+  },
+];
+
+function props(overrides: Record<string, unknown> = {}) {
+  return {
+    open: true,
+    sessions: saved,
+    loading: false,
+    loadError: '',
+    actionError: '',
+    resumingId: null,
+    onclose: vi.fn(),
+    onretry: vi.fn(),
+    onresume: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('ResumeSessionModal', () => {
+  it('presents persisted metadata and resumes the selected row', async () => {
+    const onresume = vi.fn();
+    render(ResumeSessionModal, { props: props({ onresume }) });
+
+    expect(screen.getByRole('dialog', { name: 'Resume a session' })).toBeTruthy();
+    expect(screen.getByText('~/src/ironcurtain')).toBeTruthy();
+    expect(screen.getByText('Persona: reviewer')).toBeTruthy();
+    expect(screen.getByText('Profile: work')).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume Goose session' }));
+    expect(onresume).toHaveBeenCalledWith('another-session');
+  });
+
+  it('uses an announced loading state and a clear empty state', async () => {
+    const rendered = render(ResumeSessionModal, { props: props({ sessions: [], loading: true }) });
+    expect(screen.getByRole('status').textContent).toContain('Loading resumable sessions');
+
+    await rendered.rerender(props({ sessions: [], loading: false }));
+    expect(screen.getByText('No resumable sessions')).toBeTruthy();
+  });
+
+  it('locks modal actions while a resume is in flight', () => {
+    render(ResumeSessionModal, { props: props({ resumingId: 'saved-session-1234' }) });
+
+    expect(screen.getByRole('button', { name: 'Resume Claude Code session' })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('button', { name: 'Resume Goose session' })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('button', { name: 'Close' })).toHaveProperty('disabled', true);
+  });
+
+  it('keeps valid rows visible when a resume action fails', () => {
+    render(ResumeSessionModal, { props: props({ actionError: 'That session is already active' }) });
+
+    expect(screen.getByRole('alert').textContent).toContain('already active');
+    expect(screen.getByText('Claude Code session')).toBeTruthy();
+  });
+});

--- a/packages/web-ui/src/lib/components/features/resume-session-modal.test.ts
+++ b/packages/web-ui/src/lib/components/features/resume-session-modal.test.ts
@@ -68,10 +68,13 @@ describe('ResumeSessionModal', () => {
     expect(screen.getByRole('button', { name: 'Close' })).toHaveProperty('disabled', true);
   });
 
-  it('keeps valid rows visible when a resume action fails', () => {
-    render(ResumeSessionModal, { props: props({ actionError: 'That session is already active' }) });
+  it('keeps valid rows visible and offers a refresh when a resume action fails', async () => {
+    const onretry = vi.fn();
+    render(ResumeSessionModal, { props: props({ actionError: 'That session is already active', onretry }) });
 
     expect(screen.getByRole('alert').textContent).toContain('already active');
     expect(screen.getByText('Claude Code session')).toBeTruthy();
+    await fireEvent.click(screen.getByRole('button', { name: 'Refresh sessions' }));
+    expect(onretry).toHaveBeenCalledOnce();
   });
 });

--- a/packages/web-ui/src/lib/components/features/session-sidebar.svelte
+++ b/packages/web-ui/src/lib/components/features/session-sidebar.svelte
@@ -14,6 +14,8 @@
     createError,
     loadPersonasFn,
     loadProviderProfilesFn,
+    onresumeopen,
+    resumeDisabledReason,
   }: {
     sessions: Map<number, SessionDto>;
     selectedLabel: number | null;
@@ -24,6 +26,8 @@
     loadPersonasFn: () => Promise<PersonaListItem[]>;
     /** Loads selectable provider-profile names for the launch options. */
     loadProviderProfilesFn?: () => Promise<string[]>;
+    onresumeopen?: () => void;
+    resumeDisabledReason?: string;
   } = $props();
 
   let personas = $state<PersonaListItem[]>([]);
@@ -84,12 +88,15 @@
   }
 </script>
 
-<div data-testid="session-sidebar" class="w-64 border-r border-border bg-sidebar flex flex-col shrink-0 min-h-0">
-  <div class="px-4 py-3 border-b border-border">
+<div
+  data-testid="session-sidebar"
+  class="flex max-h-[46dvh] min-h-0 w-full shrink-0 flex-col overflow-y-auto border-b border-border bg-sidebar md:max-h-none md:w-64 md:overflow-hidden md:border-b-0 md:border-r"
+>
+  <div class="shrink-0 px-4 py-3 border-b border-border">
     <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Sessions</h3>
   </div>
 
-  <div class="px-3 py-3 border-b border-border bg-card/40">
+  <div class="shrink-0 px-3 py-3 border-b border-border bg-card/40">
     <form data-testid="session-launch-form" class="space-y-2.5" onsubmit={handleLaunchSubmit}>
       <div class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Launch options</div>
       <label class="block">
@@ -151,6 +158,24 @@
       <Button data-testid="launch-start" type="submit" variant="default" size="sm" class="w-full" loading={creating}>
         {creating ? 'Starting...' : 'Start session'}
       </Button>
+      {#if onresumeopen}
+        <Button
+          data-testid="resume-open"
+          type="button"
+          variant="outline"
+          size="sm"
+          class="w-full"
+          disabled={creating || Boolean(resumeDisabledReason)}
+          title={resumeDisabledReason}
+          aria-describedby={resumeDisabledReason ? 'resume-disabled-reason' : undefined}
+          onclick={onresumeopen}
+        >
+          Resume previous…
+        </Button>
+        {#if resumeDisabledReason}
+          <p id="resume-disabled-reason" class="text-xs text-muted-foreground">{resumeDisabledReason}</p>
+        {/if}
+      {/if}
     </form>
   </div>
 
@@ -160,7 +185,7 @@
     </div>
   {/if}
 
-  <div class="flex-1 overflow-auto">
+  <div class="flex-none overflow-visible md:flex-1 md:overflow-auto">
     {#if creating}
       <div class="w-full text-left px-4 py-3 border-b border-border text-sm bg-accent/20 animate-pulse">
         <div class="flex items-center justify-between">

--- a/packages/web-ui/src/lib/format.ts
+++ b/packages/web-ui/src/lib/format.ts
@@ -1,0 +1,18 @@
+/**
+ * Formats an ISO timestamp as a compact relative string. Entries older than a
+ * week fall back to a locale date; invalid inputs use a neutral placeholder.
+ */
+export function formatRelativeTime(iso: string, now: number = Date.now()): string {
+  if (!iso) return '--';
+  const timestamp = new Date(iso).getTime();
+  if (Number.isNaN(timestamp)) return '--';
+  const seconds = Math.floor((now - timestamp) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}

--- a/packages/web-ui/src/lib/stores.svelte.ts
+++ b/packages/web-ui/src/lib/stores.svelte.ts
@@ -35,6 +35,7 @@ import type {
   DockerWorkloadSettingsDto,
   PtySink,
   CreateSessionOptions,
+  ResumableSessionDto,
   StatisticsCapabilitiesDto,
   StatisticsSummaryQuery,
   StatisticsMetricSummaryDto,
@@ -612,6 +613,14 @@ export async function createSession(opts?: CreateSessionOptions): Promise<{ labe
   if (opts?.providerProfileName) params.providerProfileName = opts.providerProfileName;
   if (opts?.model) params.model = opts.model;
   return getWsClient().request<{ label: number }>('sessions.create', params);
+}
+
+export async function listResumableSessions(): Promise<ResumableSessionDto[]> {
+  return getWsClient().request<ResumableSessionDto[]>('sessions.listResumable');
+}
+
+export async function resumeSession(sessionId: string): Promise<{ label: number }> {
+  return getWsClient().request<{ label: number }>('sessions.resume', { sessionId });
 }
 
 export async function endSession(label: number): Promise<void> {

--- a/packages/web-ui/src/lib/types.ts
+++ b/packages/web-ui/src/lib/types.ts
@@ -51,6 +51,18 @@ export interface SessionDto {
   readonly lastAttachedAt?: string;
 }
 
+/** Persisted Docker-agent session available to resume as a live terminal. */
+export interface ResumableSessionDto {
+  readonly sessionId: string;
+  readonly displayName: string;
+  readonly agent: string;
+  readonly status: 'completed' | 'crashed' | 'auth-failure' | 'user-exit';
+  readonly lastActivity: string;
+  readonly workspaceLabel?: string;
+  readonly persona?: string;
+  readonly providerProfileName?: string;
+}
+
 export interface ConversationTurn {
   readonly turnNumber: number;
   readonly userMessage: string;

--- a/packages/web-ui/src/routes/Sessions.svelte
+++ b/packages/web-ui/src/routes/Sessions.svelte
@@ -45,15 +45,20 @@
   const resumeDisabledReason = $derived(
     !appState.connected
       ? 'Connect to the daemon to resume a session.'
-      : appState.daemonStatus?.sessionMode !== 'container'
-        ? 'Session resume requires container mode.'
-        : undefined,
+      : !appState.daemonStatus
+        ? 'Daemon status is not available yet. Wait for the daemon connection to finish.'
+        : appState.daemonStatus.sessionMode === undefined
+          ? 'Session resume requires daemon session-mode support. Upgrade or restart the daemon, then refresh this page.'
+          : appState.daemonStatus.sessionMode !== 'container'
+            ? 'Session resume requires container mode.'
+            : undefined,
   );
 
   async function loadResumable(): Promise<void> {
     const generation = ++resumeLoadGeneration;
     loadingResumable = true;
     resumeLoadError = '';
+    resumeActionError = '';
     try {
       const sessions = await listResumableSessions();
       if (generation === resumeLoadGeneration && resumeModalOpen) resumableSessions = sessions;

--- a/packages/web-ui/src/routes/Sessions.svelte
+++ b/packages/web-ui/src/routes/Sessions.svelte
@@ -15,11 +15,14 @@
     connectPtyTerminal,
     disconnectPtyTerminal,
     getModelProviders,
+    listResumableSessions,
+    resumeSession,
   } from '../lib/stores.svelte.js';
-  import type { CreateSessionOptions } from '../lib/types.js';
+  import type { CreateSessionOptions, ResumableSessionDto } from '../lib/types.js';
 
   import SessionSidebar from '$lib/components/features/session-sidebar.svelte';
   import TerminalConsole from '$lib/components/features/terminal-console.svelte';
+  import ResumeSessionModal from '$lib/components/features/resume-session-modal.svelte';
   import { Button } from '$lib/components/ui/button/index.js';
   import { Badge } from '$lib/components/ui/badge/index.js';
   import { Input } from '$lib/components/ui/input/index.js';
@@ -30,6 +33,68 @@
   // Session creation state
   let creatingSession = $state(false);
   let createError = $state('');
+
+  let resumeModalOpen = $state(false);
+  let resumableSessions = $state<ResumableSessionDto[]>([]);
+  let loadingResumable = $state(false);
+  let resumeLoadError = $state('');
+  let resumeActionError = $state('');
+  let resumingId = $state<string | null>(null);
+  let resumeLoadGeneration = 0;
+
+  const resumeDisabledReason = $derived(
+    !appState.connected
+      ? 'Connect to the daemon to resume a session.'
+      : appState.daemonStatus?.sessionMode !== 'container'
+        ? 'Session resume requires container mode.'
+        : undefined,
+  );
+
+  async function loadResumable(): Promise<void> {
+    const generation = ++resumeLoadGeneration;
+    loadingResumable = true;
+    resumeLoadError = '';
+    try {
+      const sessions = await listResumableSessions();
+      if (generation === resumeLoadGeneration && resumeModalOpen) resumableSessions = sessions;
+    } catch (err) {
+      if (generation === resumeLoadGeneration && resumeModalOpen) {
+        resumeLoadError = err instanceof Error ? err.message : String(err);
+      }
+    } finally {
+      if (generation === resumeLoadGeneration && resumeModalOpen) loadingResumable = false;
+    }
+  }
+
+  function openResumeModal(): void {
+    if (resumeDisabledReason) return;
+    resumeModalOpen = true;
+    resumableSessions = [];
+    resumeActionError = '';
+    void loadResumable();
+  }
+
+  function closeResumeModal(): void {
+    if (resumingId !== null) return;
+    resumeModalOpen = false;
+    resumeLoadGeneration++;
+  }
+
+  async function handleResume(sessionId: string): Promise<void> {
+    if (resumingId !== null) return;
+    resumingId = sessionId;
+    resumeActionError = '';
+    try {
+      const result = await resumeSession(sessionId);
+      appState.selectedSessionLabel = result.label;
+      resumeModalOpen = false;
+      resumeLoadGeneration++;
+    } catch (err) {
+      resumeActionError = err instanceof Error ? err.message : String(err);
+    } finally {
+      resumingId = null;
+    }
+  }
 
   // Session end state
   let endingSession = $state<number | null>(null);
@@ -147,7 +212,7 @@
   });
 </script>
 
-<div class="flex h-full min-h-0 animate-fade-in">
+<div class="flex h-full min-h-0 flex-col animate-fade-in md:flex-row">
   <SessionSidebar
     sessions={appState.sessions}
     selectedLabel={appState.selectedSessionLabel}
@@ -157,6 +222,20 @@
     {createError}
     loadPersonasFn={listPersonas}
     loadProviderProfilesFn={loadProviderProfiles}
+    onresumeopen={openResumeModal}
+    {resumeDisabledReason}
+  />
+
+  <ResumeSessionModal
+    open={resumeModalOpen}
+    sessions={resumableSessions}
+    loading={loadingResumable}
+    loadError={resumeLoadError}
+    actionError={resumeActionError}
+    {resumingId}
+    onclose={closeResumeModal}
+    onretry={loadResumable}
+    onresume={handleResume}
   />
 
   {#if appState.selectedSession}

--- a/packages/web-ui/src/routes/Sessions.test.ts
+++ b/packages/web-ui/src/routes/Sessions.test.ts
@@ -165,7 +165,7 @@ describe('Sessions create flow guards', () => {
     await fireEvent.click(screen.getByTestId('launch-start'));
 
     expect(mockCreateSession).not.toHaveBeenCalled();
-    expect(screen.getByText(/daemon session-mode support/i)).toBeTruthy();
+    expect(screen.getByText(/web sessions require daemon session-mode support/i)).toBeTruthy();
     expect(screen.queryByText(/container mode enabled/i)).toBeNull();
   });
 
@@ -177,6 +177,27 @@ describe('Sessions create flow guards', () => {
 
     expect(mockCreateSession).not.toHaveBeenCalled();
     expect(screen.getByText(/container mode enabled/i)).toBeTruthy();
+  });
+
+  it('waits for daemon status before describing resume availability', () => {
+    mockAppState.daemonStatus = null;
+    render(Sessions);
+
+    expect(screen.getByTestId('resume-open')).toHaveProperty('disabled', true);
+    expect(screen.getByText(/daemon status is not available yet/i)).toBeTruthy();
+    expect(screen.queryByText(/session resume requires container mode/i)).toBeNull();
+  });
+
+  it('distinguishes unsupported and builtin daemon modes for resume', () => {
+    mockAppState.daemonStatus = makeStatus();
+    const rendered = render(Sessions);
+
+    expect(screen.getByText(/session resume requires daemon session-mode support/i)).toBeTruthy();
+
+    rendered.unmount();
+    mockAppState.daemonStatus = makeStatus('builtin');
+    render(Sessions);
+    expect(screen.getByText(/session resume requires container mode/i)).toBeTruthy();
   });
 
   it('loads resumable sessions on demand and selects the resumed terminal', async () => {
@@ -214,5 +235,30 @@ describe('Sessions create flow guards', () => {
 
     await waitFor(() => expect(mockListResumableSessions).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('No resumable sessions')).toBeTruthy();
+  });
+
+  it('clears a stale resume-action error when refreshing the saved-session list', async () => {
+    mockListResumableSessions
+      .mockResolvedValueOnce([
+        {
+          sessionId: 'stale-session',
+          displayName: 'Stale session',
+          agent: 'claude-code',
+          status: 'user-exit',
+          lastActivity: new Date().toISOString(),
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockResumeSession.mockRejectedValueOnce(new Error('That session is already active'));
+    render(Sessions);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume previous…' }));
+    await fireEvent.click(await screen.findByRole('button', { name: 'Resume Stale session' }));
+    expect((await screen.findByRole('alert')).textContent).toContain('already active');
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Refresh sessions' }));
+
+    expect(await screen.findByText('No resumable sessions')).toBeTruthy();
+    expect(screen.queryByText(/already active/i)).toBeNull();
   });
 });

--- a/packages/web-ui/src/routes/Sessions.test.ts
+++ b/packages/web-ui/src/routes/Sessions.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 
-const { mockAppState, mockCreateSession, mockListPersonas, mockGetModelProviders, mockSendPtyInput } = vi.hoisted(
-  () => ({
-    mockAppState: {
-      daemonStatus: null as Record<string, unknown> | null,
-      sessions: new Map(),
-      selectedSessionLabel: null as number | null,
-      selectedSession: null as {
-        label: number;
-        source: { kind: string };
-        status: string;
-        persona?: string;
-        turnCount: number;
-        budget: { estimatedCostUsd: number };
-      } | null,
-      escalationDismissedAt: 0,
-    },
-    mockCreateSession: vi.fn<(opts?: unknown) => Promise<{ label: number }>>(),
-    mockListPersonas: vi.fn<() => Promise<unknown[]>>(),
-    mockGetModelProviders: vi.fn<() => Promise<{ profiles: Record<string, unknown> }>>(),
-    mockSendPtyInput: vi.fn<(label: number, dataB64: string) => Promise<void>>(),
-  }),
-);
+const {
+  mockAppState,
+  mockCreateSession,
+  mockListPersonas,
+  mockGetModelProviders,
+  mockSendPtyInput,
+  mockListResumableSessions,
+  mockResumeSession,
+} = vi.hoisted(() => ({
+  mockAppState: {
+    connected: true,
+    daemonStatus: null as Record<string, unknown> | null,
+    sessions: new Map(),
+    selectedSessionLabel: null as number | null,
+    selectedSession: null as {
+      label: number;
+      source: { kind: string };
+      status: string;
+      persona?: string;
+      turnCount: number;
+      budget: { estimatedCostUsd: number };
+    } | null,
+    escalationDismissedAt: 0,
+  },
+  mockCreateSession: vi.fn<(opts?: unknown) => Promise<{ label: number }>>(),
+  mockListPersonas: vi.fn<() => Promise<unknown[]>>(),
+  mockGetModelProviders: vi.fn<() => Promise<{ profiles: Record<string, unknown> }>>(),
+  mockSendPtyInput: vi.fn<(label: number, dataB64: string) => Promise<void>>(),
+  mockListResumableSessions: vi.fn<() => Promise<unknown[]>>(),
+  mockResumeSession: vi.fn<(sessionId: string) => Promise<{ label: number }>>(),
+}));
 
 vi.mock('../lib/stores.svelte.js', () => ({
   appState: mockAppState,
@@ -39,6 +48,8 @@ vi.mock('../lib/stores.svelte.js', () => ({
   connectPtyTerminal: vi.fn(),
   disconnectPtyTerminal: vi.fn(),
   getModelProviders: mockGetModelProviders,
+  listResumableSessions: mockListResumableSessions,
+  resumeSession: mockResumeSession,
 }));
 
 vi.mock('$lib/components/features/terminal-console.svelte', async () => await import('../__test_stubs__/Stub.svelte'));
@@ -60,6 +71,7 @@ function makeStatus(sessionMode?: 'builtin' | 'container'): Record<string, unkno
 describe('Sessions create flow guards', () => {
   beforeEach(() => {
     mockAppState.daemonStatus = makeStatus('container');
+    mockAppState.connected = true;
     mockAppState.sessions = new Map();
     mockAppState.selectedSessionLabel = null;
     mockAppState.selectedSession = null;
@@ -72,6 +84,10 @@ describe('Sessions create flow guards', () => {
     mockGetModelProviders.mockResolvedValue({ profiles: { native: { type: 'native' } } });
     mockSendPtyInput.mockReset();
     mockSendPtyInput.mockResolvedValue(undefined);
+    mockListResumableSessions.mockReset();
+    mockListResumableSessions.mockResolvedValue([]);
+    mockResumeSession.mockReset();
+    mockResumeSession.mockResolvedValue({ label: 12 });
   });
 
   it('explains PTY shutdown and disables ending it again while stopping', () => {
@@ -161,5 +177,42 @@ describe('Sessions create flow guards', () => {
 
     expect(mockCreateSession).not.toHaveBeenCalled();
     expect(screen.getByText(/container mode enabled/i)).toBeTruthy();
+  });
+
+  it('loads resumable sessions on demand and selects the resumed terminal', async () => {
+    mockListResumableSessions.mockResolvedValue([
+      {
+        sessionId: 'saved-session-1234',
+        displayName: 'Claude Code session',
+        agent: 'claude-code',
+        status: 'user-exit',
+        lastActivity: new Date().toISOString(),
+        workspaceLabel: '~/src/project',
+        persona: 'reviewer',
+      },
+    ]);
+    render(Sessions);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume previous…' }));
+    expect(await screen.findByText('Claude Code session')).toBeTruthy();
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume Claude Code session' }));
+
+    expect(mockResumeSession).toHaveBeenCalledWith('saved-session-1234');
+    await waitFor(() => expect(mockAppState.selectedSessionLabel).toBe(12));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('keeps the resume dialog open with retry feedback after a failed request', async () => {
+    mockListResumableSessions
+      .mockRejectedValueOnce(new Error('Unable to read saved sessions'))
+      .mockResolvedValueOnce([]);
+    render(Sessions);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume previous…' }));
+    expect((await screen.findByRole('alert')).textContent).toContain('Unable to read saved sessions');
+    await fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(mockListResumableSessions).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('No resumable sessions')).toBeTruthy();
   });
 });

--- a/packages/web-ui/src/routes/workflows-helpers.ts
+++ b/packages/web-ui/src/routes/workflows-helpers.ts
@@ -210,25 +210,4 @@ export function formatDurationMs(ms: number | undefined): string {
   return `${s}s`;
 }
 
-/**
- * Formats an ISO timestamp as a compact relative string ("just now", "3m ago",
- * "2h ago", "5d ago"), falling back to a locale date for entries older than a
- * week. Returns '--' for empty / unparseable input. Pair with an absolute
- * `title` tooltip for the exact time. `now` is injectable for deterministic tests.
- */
-export function formatRelativeTime(iso: string, now: number = Date.now()): string {
-  if (!iso) return '--';
-  const t = new Date(iso).getTime();
-  if (Number.isNaN(t)) return '--';
-  // Floor each unit so we never round up across a boundary (e.g. 59m 31s must
-  // read "59m ago", not "1h ago"). The sub-minute window absorbs the floor=0 case.
-  const diffSec = Math.floor((now - t) / 1000);
-  if (diffSec < 60) return 'just now';
-  const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return new Date(t).toLocaleDateString();
-}
+export { formatRelativeTime } from '../lib/format.js';

--- a/src/docker/docker-resource-lifecycle.ts
+++ b/src/docker/docker-resource-lifecycle.ts
@@ -186,15 +186,17 @@ function defaultPidAlive(pid: number): boolean {
   }
 }
 
-function ownerIsAlive(
+type OwnerLeaseStatus = 'alive' | 'dead' | 'unattributed';
+
+function ownerLeaseStatus(
   labels: Readonly<Record<string, string>>,
   pidAlive: (pid: number) => boolean,
   processIdentity: (pid: number) => ProcessIdentity | undefined,
   root = leaseRoot(),
-): boolean {
+): OwnerLeaseStatus {
   const pid = Number(labels[IRONCURTAIN_OWNER_PID_LABEL]);
   const token = labels[IRONCURTAIN_OWNER_TOKEN_LABEL];
-  if (!Number.isSafeInteger(pid) || pid <= 0 || !token || !pidAlive(pid)) return false;
+  if (!Number.isSafeInteger(pid) || pid <= 0 || !token || !pidAlive(pid)) return 'dead';
   try {
     const lease = JSON.parse(readFileSync(resolve(root, `${token}.json`), 'utf8')) as {
       token?: unknown;
@@ -207,35 +209,37 @@ function ownerIsAlive(
       typeof lease.identity?.bootId !== 'string' ||
       typeof lease.identity.startedAt !== 'string'
     ) {
-      return false;
+      return 'unattributed';
     }
     const currentIdentity = processIdentity(pid);
-    return (
-      currentIdentity !== undefined &&
-      currentIdentity.bootId === lease.identity.bootId &&
-      currentIdentity.startedAt === lease.identity.startedAt
-    );
+    if (currentIdentity === undefined) return 'unattributed';
+    return currentIdentity.bootId === lease.identity.bootId && currentIdentity.startedAt === lease.identity.startedAt
+      ? 'alive'
+      : 'dead';
   } catch {
-    return false;
+    return 'unattributed';
   }
 }
 
 /**
- * Foreign-home resources are never ours to reclaim. Resources created before
- * the scope label existed are retained while their recorded PID is alive; this
- * conservative migration rule protects an already-running older IronCurtain
- * session from a newer test or installation using a different home.
+ * Foreign-home resources are never ours to reclaim.
  */
-function belongsToForeignScopeOrLiveLegacy(
-  labels: Readonly<Partial<Record<string, string>>>,
-  pidAlive: (pid: number) => boolean,
-  ownerScope: string,
-): boolean {
+function belongsToForeignScope(labels: Readonly<Partial<Record<string, string>>>, ownerScope: string): boolean {
   const scope = labels[IRONCURTAIN_OWNER_SCOPE_LABEL];
-  if (scope !== undefined) return scope !== ownerScope;
+  return scope !== undefined && scope !== ownerScope;
+}
 
-  const pid = Number(labels[IRONCURTAIN_OWNER_PID_LABEL]);
-  return Number.isSafeInteger(pid) && pid > 0 && pidAlive(pid);
+/**
+ * Conservatively protects a resource created before owner scopes were labeled
+ * when the current home cannot attribute it. A missing or unreadable lease may
+ * live under another IRONCURTAIN_HOME, so only a readable local lease with a
+ * mismatched process identity is proof that its PID was recycled.
+ */
+function legacyOwnerMayBeAlive(
+  labels: Readonly<Partial<Record<string, string>>>,
+  leaseStatus: OwnerLeaseStatus,
+): boolean {
+  return labels[IRONCURTAIN_OWNER_SCOPE_LABEL] === undefined && leaseStatus === 'unattributed';
 }
 
 interface ReconcileOptions {
@@ -319,11 +323,16 @@ export async function reconcileIronCurtainDockerResources(
 
     const managedContainers = await docker.listContainers?.({ labelFilter: `${IRONCURTAIN_MANAGED_LABEL}=true` });
     for (const container of managedContainers ?? []) {
-      if (belongsToForeignScopeOrLiveLegacy(container.labels, pidAlive, ownerScope)) {
+      if (belongsToForeignScope(container.labels, ownerScope)) {
         retainedActiveResources++;
         continue;
       }
-      if (ownerIsAlive(container.labels, pidAlive, processIdentity)) {
+      const leaseStatus = ownerLeaseStatus(container.labels, pidAlive, processIdentity);
+      if (leaseStatus === 'alive') {
+        retainedActiveResources++;
+        continue;
+      }
+      if (legacyOwnerMayBeAlive(container.labels, leaseStatus)) {
         retainedActiveResources++;
         continue;
       }
@@ -351,11 +360,16 @@ export async function reconcileIronCurtainDockerResources(
       const legacy = !managed && LEGACY_NETWORK_RE.test(network.name);
       if (!managed && !legacy) continue;
 
-      if (managed && belongsToForeignScopeOrLiveLegacy(network.labels, pidAlive, ownerScope)) {
+      if (managed && belongsToForeignScope(network.labels, ownerScope)) {
         retainedActiveResources++;
         continue;
       }
-      if (managed && ownerIsAlive(network.labels, pidAlive, processIdentity)) {
+      const leaseStatus = managed ? ownerLeaseStatus(network.labels, pidAlive, processIdentity) : 'dead';
+      if (managed && leaseStatus === 'alive') {
+        retainedActiveResources++;
+        continue;
+      }
+      if (managed && legacyOwnerMayBeAlive(network.labels, leaseStatus)) {
         retainedActiveResources++;
         continue;
       }

--- a/src/docker/docker-resource-lifecycle.ts
+++ b/src/docker/docker-resource-lifecycle.ts
@@ -11,7 +11,7 @@
 
 import { createHash, randomUUID } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, realpathSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { networkInterfaces, platform } from 'node:os';
 import { resolve } from 'node:path';
 import { getIronCurtainHome } from '../config/paths.js';
@@ -24,10 +24,11 @@ import { acquireProcessLock, ProcessLockBusyError } from '../docker-workload/pro
 export const IRONCURTAIN_MANAGED_LABEL = 'ironcurtain.managed';
 export const IRONCURTAIN_OWNER_PID_LABEL = 'ironcurtain.owner-pid';
 export const IRONCURTAIN_OWNER_TOKEN_LABEL = 'ironcurtain.owner-token';
+export const IRONCURTAIN_OWNER_SCOPE_LABEL = 'ironcurtain.owner-scope';
 export const IRONCURTAIN_CREATED_AT_LABEL = 'ironcurtain.created-at';
 export const IRONCURTAIN_RESOURCE_SCHEMA_LABEL = 'ironcurtain.resource-schema';
 const IRONCURTAIN_BUNDLE_LABEL = 'ironcurtain.bundle';
-const RESOURCE_SCHEMA = '2';
+const RESOURCE_SCHEMA = '3';
 // Current bundle slugs are 12 hex digits; pre-identity-refactor names used a
 // raw UUID substring and therefore contain a hyphen after eight digits.
 const LEGACY_NETWORK_RE = /^ironcurtain-(?:[a-f0-9]{12}|[a-f0-9]{8}-[a-f0-9]{3})$/;
@@ -91,6 +92,23 @@ function leaseRoot(): string {
   return resolve(getIronCurtainHome(), 'run', 'docker-owners');
 }
 
+/**
+ * Stable, non-sensitive namespace for one IronCurtain home. Docker inventory is
+ * host-global, while ownership leases live below IRONCURTAIN_HOME; without this
+ * label a test using a temporary home can mistake production resources for
+ * orphans because it cannot see their lease files.
+ */
+function currentOwnerScope(): string {
+  const resolvedHome = resolve(getIronCurtainHome());
+  let canonicalHome: string;
+  try {
+    canonicalHome = realpathSync(resolvedHome);
+  } catch {
+    canonicalHome = resolvedHome;
+  }
+  return createHash('sha256').update(canonicalHome).digest('hex').slice(0, 24);
+}
+
 function installExitHook(): void {
   if (exitHookInstalled) return;
   exitHookInstalled = true;
@@ -139,6 +157,7 @@ export function managedResourceLabels(bundleId: BundleId | string): Record<strin
     [IRONCURTAIN_BUNDLE_LABEL]: bundleId,
     [IRONCURTAIN_OWNER_PID_LABEL]: String(lease.pid),
     [IRONCURTAIN_OWNER_TOKEN_LABEL]: lease.token,
+    [IRONCURTAIN_OWNER_SCOPE_LABEL]: currentOwnerScope(),
     [IRONCURTAIN_CREATED_AT_LABEL]: new Date().toISOString(),
     [IRONCURTAIN_RESOURCE_SCHEMA_LABEL]: RESOURCE_SCHEMA,
   };
@@ -199,6 +218,24 @@ function ownerIsAlive(
   } catch {
     return false;
   }
+}
+
+/**
+ * Foreign-home resources are never ours to reclaim. Resources created before
+ * the scope label existed are retained while their recorded PID is alive; this
+ * conservative migration rule protects an already-running older IronCurtain
+ * session from a newer test or installation using a different home.
+ */
+function belongsToForeignScopeOrLiveLegacy(
+  labels: Readonly<Partial<Record<string, string>>>,
+  pidAlive: (pid: number) => boolean,
+  ownerScope: string,
+): boolean {
+  const scope = labels[IRONCURTAIN_OWNER_SCOPE_LABEL];
+  if (scope !== undefined) return scope !== ownerScope;
+
+  const pid = Number(labels[IRONCURTAIN_OWNER_PID_LABEL]);
+  return Number.isSafeInteger(pid) && pid > 0 && pidAlive(pid);
 }
 
 interface ReconcileOptions {
@@ -277,10 +314,15 @@ export async function reconcileIronCurtainDockerResources(
     const removedNetworks: string[] = [];
     const skippedUnsafeNetworks: string[] = [];
     const deadOwnerTokens = new Set<string>();
+    const ownerScope = currentOwnerScope();
     let retainedActiveResources = 0;
 
     const managedContainers = await docker.listContainers?.({ labelFilter: `${IRONCURTAIN_MANAGED_LABEL}=true` });
     for (const container of managedContainers ?? []) {
+      if (belongsToForeignScopeOrLiveLegacy(container.labels, pidAlive, ownerScope)) {
+        retainedActiveResources++;
+        continue;
+      }
       if (ownerIsAlive(container.labels, pidAlive, processIdentity)) {
         retainedActiveResources++;
         continue;
@@ -309,6 +351,10 @@ export async function reconcileIronCurtainDockerResources(
       const legacy = !managed && LEGACY_NETWORK_RE.test(network.name);
       if (!managed && !legacy) continue;
 
+      if (managed && belongsToForeignScopeOrLiveLegacy(network.labels, pidAlive, ownerScope)) {
+        retainedActiveResources++;
+        continue;
+      }
       if (managed && ownerIsAlive(network.labels, pidAlive, processIdentity)) {
         retainedActiveResources++;
         continue;

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -25,13 +25,14 @@ import { buildSessionConfig } from '../session/index.js';
 import { loadSessionMetadata, updateSessionMetadata } from '../session/session-metadata.js';
 import { validateWorkspacePath } from '../session/workspace-validation.js';
 import { CONTAINER_WORKSPACE_DIR } from './agent-adapter.js';
-import { PTY_SOCK_NAME, DEFAULT_PTY_PORT, APPLE_PTY_GUEST_SOCK } from './pty-types.js';
+import { PTY_SOCK_NAME, DEFAULT_PTY_PORT, APPLE_PTY_GUEST_SOCK, isSessionSnapshot } from './pty-types.js';
 import type { PtySessionRegistration, SessionSnapshot } from './pty-types.js';
 import type { ContainerRuntime } from './types.js';
 import { createEscalationWatcher, atomicWriteJsonSync } from '../escalation/escalation-watcher.js';
 import type { EscalationWatcher } from '../escalation/escalation-watcher.js';
 import { getSessionDir, getSessionCapturesDir, getPtyRegistryDir, SESSION_STATE_FILENAME } from '../config/paths.js';
 import * as logger from '../logger.js';
+import { acquireProcessLock, ProcessLockBusyError, type ProcessLockHandle } from '../docker-workload/process-lock.js';
 import { buildDockerClaudeMd } from './claude-md-seed.js';
 import { getInternalNetworkName } from './platform.js';
 import { destroyBundleOuterResources } from './container-lifecycle.js';
@@ -151,16 +152,22 @@ export function validateResumeSession(resumeSessionId: string, protectedPaths: s
     throw new Error(`Cannot resume session "${resumeSessionId}": no session state snapshot found`);
   }
 
-  let snapshot: SessionSnapshot;
+  let parsed: unknown;
   try {
-    snapshot = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as SessionSnapshot;
+    parsed = JSON.parse(readFileSync(snapshotPath, 'utf-8'));
   } catch {
     throw new Error(`Cannot resume session "${resumeSessionId}": session state snapshot is corrupted or invalid`);
   }
 
-  if (!snapshot.sessionId || snapshot.sessionId !== resumeSessionId) {
+  const parsedSessionId =
+    typeof parsed === 'object' && parsed !== null ? (parsed as { sessionId?: unknown }).sessionId : undefined;
+  if (parsedSessionId !== resumeSessionId) {
     throw new Error(`Cannot resume session "${resumeSessionId}": snapshot sessionId mismatch`);
   }
+  if (!isSessionSnapshot(parsed)) {
+    throw new Error(`Cannot resume session "${resumeSessionId}": session state snapshot is corrupted or invalid`);
+  }
+  const snapshot = parsed;
   if (!snapshot.resumable) {
     throw new Error(
       `Cannot resume session "${resumeSessionId}": session is not resumable (status: ${snapshot.status})`,
@@ -268,20 +275,44 @@ function writeSessionSnapshot(sessionDir: string, snapshot: SessionSnapshot): vo
  * Claude Code, attaches the terminal, and blocks until the session ends.
  */
 export async function runPtySession(options: PtySessionOptions): Promise<void> {
+  const resumeLock = options.resumeSessionId
+    ? acquireResumeSessionLock(options.resumeSessionId, options.config.protectedPaths)
+    : undefined;
   let retryDocker: ContainerRuntime | undefined;
-  await withInternalNetworkAllocationRetry(
-    {
-      maxAttempts: 4,
-      description: 'PTY internal Docker network',
-      reconcile: async () => {
-        if (retryDocker) await reconcileIronCurtainDockerResourcesBestEffort(retryDocker, 'PTY internal network retry');
+  try {
+    await withInternalNetworkAllocationRetry(
+      {
+        maxAttempts: 4,
+        description: 'PTY internal Docker network',
+        reconcile: async () => {
+          if (retryDocker)
+            await reconcileIronCurtainDockerResourcesBestEffort(retryDocker, 'PTY internal network retry');
+        },
       },
-    },
-    (excludedSubnets, attempt) =>
-      runPtySessionAttempt(options, excludedSubnets, attempt, (docker) => {
-        retryDocker = docker;
-      }),
-  );
+      (excludedSubnets, attempt) =>
+        runPtySessionAttempt(options, excludedSubnets, attempt, (docker) => {
+          retryDocker = docker;
+        }),
+    );
+  } finally {
+    resumeLock?.release();
+  }
+}
+
+const RESUME_SESSION_LOCK_FILENAME = 'resume.lock';
+
+/** Holds a session-global lock for the full resumed PTY lifecycle. */
+export function acquireResumeSessionLock(sessionId: string, protectedPaths: string[] = []): ProcessLockHandle {
+  validateResumeSession(sessionId, protectedPaths);
+  const lockPath = resolve(getSessionDir(sessionId), RESUME_SESSION_LOCK_FILENAME);
+  try {
+    return acquireProcessLock(lockPath);
+  } catch (error) {
+    if (error instanceof ProcessLockBusyError) {
+      throw new Error(`Cannot resume session "${sessionId}": session is already being resumed`, { cause: error });
+    }
+    throw error;
+  }
 }
 
 async function runPtySessionAttempt(

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -23,10 +23,10 @@ import type { IronCurtainConfig } from '../config/types.js';
 import { createSessionId, getBundleShortId, type BundleId, type SessionMode } from '../session/types.js';
 import { buildSessionConfig } from '../session/index.js';
 import { loadSessionMetadata, updateSessionMetadata } from '../session/session-metadata.js';
-import { validateWorkspacePath } from '../session/workspace-validation.js';
 import { CONTAINER_WORKSPACE_DIR } from './agent-adapter.js';
-import { PTY_SOCK_NAME, DEFAULT_PTY_PORT, APPLE_PTY_GUEST_SOCK, isSessionSnapshot } from './pty-types.js';
+import { PTY_SOCK_NAME, DEFAULT_PTY_PORT, APPLE_PTY_GUEST_SOCK } from './pty-types.js';
 import type { PtySessionRegistration, SessionSnapshot } from './pty-types.js';
+import { validateResumeSession } from '../pty/session-scanner.js';
 import type { ContainerRuntime } from './types.js';
 import { createEscalationWatcher, atomicWriteJsonSync } from '../escalation/escalation-watcher.js';
 import type { EscalationWatcher } from '../escalation/escalation-watcher.js';
@@ -138,63 +138,6 @@ const PTY_READINESS_TIMEOUT_REMAP_MS = 90_000;
 const PTY_READINESS_POLL_MS = 200;
 
 /**
- * Validates a session for resume and returns the loaded snapshot.
- * Throws descriptive errors for invalid resume attempts.
- */
-export function validateResumeSession(resumeSessionId: string, protectedPaths: string[] = []): SessionSnapshot {
-  const sessionDir = getSessionDir(resumeSessionId);
-  if (!existsSync(sessionDir)) {
-    throw new Error(`Cannot resume session "${resumeSessionId}": session directory not found`);
-  }
-
-  const snapshotPath = resolve(sessionDir, SESSION_STATE_FILENAME);
-  if (!existsSync(snapshotPath)) {
-    throw new Error(`Cannot resume session "${resumeSessionId}": no session state snapshot found`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(snapshotPath, 'utf-8'));
-  } catch {
-    throw new Error(`Cannot resume session "${resumeSessionId}": session state snapshot is corrupted or invalid`);
-  }
-
-  const parsedSessionId =
-    typeof parsed === 'object' && parsed !== null ? (parsed as { sessionId?: unknown }).sessionId : undefined;
-  if (parsedSessionId !== resumeSessionId) {
-    throw new Error(`Cannot resume session "${resumeSessionId}": snapshot sessionId mismatch`);
-  }
-  if (!isSessionSnapshot(parsed)) {
-    throw new Error(`Cannot resume session "${resumeSessionId}": session state snapshot is corrupted or invalid`);
-  }
-  const snapshot = parsed;
-  if (!snapshot.resumable) {
-    throw new Error(
-      `Cannot resume session "${resumeSessionId}": session is not resumable (status: ${snapshot.status})`,
-    );
-  }
-  if (!snapshot.agent) {
-    throw new Error(`Cannot resume session "${resumeSessionId}": agent configuration is missing`);
-  }
-
-  // Validate workspace path using the same checks as --workspace to prevent
-  // a tampered snapshot from expanding the sandbox to a sensitive directory.
-  if (!snapshot.workspacePath || typeof snapshot.workspacePath !== 'string') {
-    throw new Error(`Cannot resume session "${resumeSessionId}": workspace path is missing or invalid`);
-  }
-  try {
-    validateWorkspacePath(snapshot.workspacePath, protectedPaths);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`Cannot resume session "${resumeSessionId}": workspace path is unsafe: ${detail}`, {
-      cause: err,
-    });
-  }
-
-  return snapshot;
-}
-
-/**
  * Loads a session snapshot from disk.
  * Returns undefined if the snapshot file does not exist or is invalid.
  */
@@ -275,8 +218,8 @@ function writeSessionSnapshot(sessionDir: string, snapshot: SessionSnapshot): vo
  * Claude Code, attaches the terminal, and blocks until the session ends.
  */
 export async function runPtySession(options: PtySessionOptions): Promise<void> {
-  const resumeLock = options.resumeSessionId
-    ? acquireResumeSessionLock(options.resumeSessionId, options.config.protectedPaths)
+  const resumeClaim = options.resumeSessionId
+    ? acquireResumeSessionClaim(options.resumeSessionId, options.config.protectedPaths)
     : undefined;
   let retryDocker: ContainerRuntime | undefined;
   try {
@@ -290,33 +233,72 @@ export async function runPtySession(options: PtySessionOptions): Promise<void> {
         },
       },
       (excludedSubnets, attempt) =>
-        runPtySessionAttempt(options, excludedSubnets, attempt, (docker) => {
+        runPtySessionAttempt(options, resumeClaim?.snapshot, excludedSubnets, attempt, (docker) => {
           retryDocker = docker;
         }),
     );
   } finally {
-    resumeLock?.release();
+    releaseResumeSessionLock(resumeClaim?.lock);
   }
 }
 
 const RESUME_SESSION_LOCK_FILENAME = 'resume.lock';
 
-/** Holds a session-global lock for the full resumed PTY lifecycle. */
-export function acquireResumeSessionLock(sessionId: string, protectedPaths: string[] = []): ProcessLockHandle {
-  validateResumeSession(sessionId, protectedPaths);
-  const lockPath = resolve(getSessionDir(sessionId), RESUME_SESSION_LOCK_FILENAME);
+interface ResumeSessionClaim {
+  readonly lock: ProcessLockHandle;
+  readonly snapshot: SessionSnapshot;
+}
+
+function acquireResumeSessionClaim(sessionId: string, protectedPaths: string[]): ResumeSessionClaim {
+  const sessionDir = getSessionDir(sessionId);
+  if (!existsSync(sessionDir)) {
+    throw new Error(`Cannot resume session "${sessionId}": session directory not found`);
+  }
+  const lockPath = resolve(sessionDir, RESUME_SESSION_LOCK_FILENAME);
+  let lock: ProcessLockHandle;
   try {
-    return acquireProcessLock(lockPath);
+    lock = acquireProcessLock(lockPath);
   } catch (error) {
     if (error instanceof ProcessLockBusyError) {
       throw new Error(`Cannot resume session "${sessionId}": session is already being resumed`, { cause: error });
     }
     throw error;
   }
+
+  try {
+    return { lock, snapshot: validateResumeSession(sessionId, protectedPaths) };
+  } catch (error) {
+    releaseResumeSessionLock(lock);
+    throw error;
+  }
+}
+
+/** Holds a session-global lock for the full resumed PTY lifecycle. */
+export function acquireResumeSessionLock(sessionId: string, protectedPaths: string[] = []): ProcessLockHandle {
+  return acquireResumeSessionClaim(sessionId, protectedPaths).lock;
+}
+
+/**
+ * Releases the resume claim without allowing cleanup damage to replace the
+ * session's real outcome. The process-lock implementation deliberately throws
+ * when the published inode vanished or was replaced; at PTY teardown we log
+ * that integrity signal but never erase the primary Docker error or turn an
+ * otherwise completed interactive session into a fatal CLI failure.
+ */
+export function releaseResumeSessionLock(lock: ProcessLockHandle | undefined): void {
+  if (!lock) return;
+  try {
+    lock.release();
+  } catch (error) {
+    logger.error(
+      `[PTY] Failed to release resume-session lock ${lock.path}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 async function runPtySessionAttempt(
   options: PtySessionOptions,
+  resumeSnapshot: SessionSnapshot | undefined,
   excludedSubnets: ReadonlySet<string>,
   attempt: number,
   onDockerReady: (docker: ContainerRuntime) => void,
@@ -329,10 +311,9 @@ async function runPtySessionAttempt(
     checkInternalNetworkConnectivity,
   } = await import('./docker-infrastructure.js');
 
-  // When resuming, validate the snapshot and reuse the existing session directory
-  const resumeSnapshot = options.resumeSessionId
-    ? validateResumeSession(options.resumeSessionId, options.config.protectedPaths)
-    : undefined;
+  // A resumed session uses the snapshot validated under its process lock.
+  // Reuse it across network-allocation retries even if a failed attempt writes
+  // updated session state during teardown.
   const isResume = !!resumeSnapshot;
 
   // Use the original session ID when resuming, otherwise create a new one

--- a/src/docker/pty-types.ts
+++ b/src/docker/pty-types.ts
@@ -52,6 +52,28 @@ export interface SessionSnapshot {
   readonly resumable: boolean;
 }
 
+/** Runtime guard for snapshots loaded from mutable on-disk JSON. */
+export function isSessionSnapshot(value: unknown): value is SessionSnapshot {
+  if (typeof value !== 'object' || value === null) return false;
+  const snapshot = value as Partial<SessionSnapshot>;
+  return (
+    typeof snapshot.sessionId === 'string' &&
+    snapshot.sessionId.length > 0 &&
+    ['completed', 'crashed', 'auth-failure', 'user-exit'].includes(snapshot.status ?? '') &&
+    (snapshot.exitCode === null || typeof snapshot.exitCode === 'number') &&
+    typeof snapshot.lastActivity === 'string' &&
+    !Number.isNaN(Date.parse(snapshot.lastActivity)) &&
+    typeof snapshot.workspacePath === 'string' &&
+    snapshot.workspacePath.length > 0 &&
+    (snapshot.persona === undefined || typeof snapshot.persona === 'string') &&
+    (snapshot.providerProfileName === undefined || typeof snapshot.providerProfileName === 'string') &&
+    typeof snapshot.agent === 'string' &&
+    snapshot.agent.length > 0 &&
+    typeof snapshot.label === 'string' &&
+    typeof snapshot.resumable === 'boolean'
+  );
+}
+
 /** Well-known directory for PTY session registration files. */
 export const PTY_REGISTRY_DIR_NAME = 'pty-registry';
 

--- a/src/mux/mux-app.ts
+++ b/src/mux/mux-app.ts
@@ -16,7 +16,7 @@ import { writeTrustedUserContext } from '../escalation/trusted-input.js';
 import { createPasteInterceptor, type PasteInterceptor } from './paste-interceptor.js';
 import type { MuxTab, MuxAction } from './types.js';
 import { validateWorkspacePath } from '../session/workspace-validation.js';
-import { scanResumableSessions } from './session-scanner.js';
+import { scanResumableSessions } from '../pty/session-scanner.js';
 import { scanPersonas } from './persona-scanner.js';
 import type { ProviderProfileSnapshot } from './provider-profile-snapshot.js';
 import ora from 'ora';

--- a/src/mux/mux-app.ts
+++ b/src/mux/mux-app.ts
@@ -454,7 +454,7 @@ export function createMuxApp(options: MuxAppOptions): MuxApp {
         const directId = args[0];
         if (directId) {
           // Direct resume by session ID
-          const sessions = scanResumableSessions();
+          const sessions = scanResumableSessions(protectedPaths);
           const match = sessions.find((s) => s.sessionId.startsWith(directId));
           if (!match) {
             showMessage(`No resumable session matching "${directId}"`);
@@ -464,7 +464,7 @@ export function createMuxApp(options: MuxAppOptions): MuxApp {
           break;
         }
         // Open the resume picker
-        const sessions = scanResumableSessions();
+        const sessions = scanResumableSessions(protectedPaths);
         if (sessions.length === 0) {
           showMessage('No resumable sessions found');
           break;

--- a/src/mux/mux-input-handler.ts
+++ b/src/mux/mux-input-handler.ts
@@ -15,7 +15,7 @@ import { homedir } from 'node:os';
 import { expandTilde } from '../types/argument-roles.js';
 import { PASTE_START, PASTE_END } from './paste-interceptor.js';
 import type { InputMode, MuxAction } from './types.js';
-import type { SessionSnapshot } from './session-scanner.js';
+import type { SessionSnapshot } from '../pty/session-scanner.js';
 import type { PersonaSnapshot } from './persona-scanner.js';
 import type { ProviderProfileSnapshot } from './provider-profile-snapshot.js';
 import { hasSelectableProfiles } from './provider-profile-snapshot.js';

--- a/src/mux/mux-renderer.ts
+++ b/src/mux/mux-renderer.ts
@@ -33,7 +33,7 @@ import type {
   EscalationPickerState,
 } from './mux-input-handler.js';
 import { createSplashScreen, type SplashScreen } from './mux-splash.js';
-import { formatRelativeTime, getWorkspaceLabel } from './session-scanner.js';
+import { formatRelativeTime, getWorkspaceLabel } from '../pty/session-scanner.js';
 
 // -- xterm.js color mode constants (from IBufferCell.getFgColorMode/getBgColorMode) --
 const CM_DEFAULT = 0;

--- a/src/mux/session-scanner.ts
+++ b/src/mux/session-scanner.ts
@@ -10,9 +10,13 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { getSessionsDir, getSessionSandboxDir, SESSION_STATE_FILENAME } from '../config/paths.js';
-import type { SessionSnapshot } from '../docker/pty-types.js';
+import { isSessionSnapshot, type SessionSnapshot } from '../docker/pty-types.js';
 
 export type { SessionSnapshot } from '../docker/pty-types.js';
+
+function isResumableSnapshot(value: unknown, directoryName: string): value is SessionSnapshot {
+  return isSessionSnapshot(value) && value.resumable && value.sessionId === directoryName;
+}
 
 /**
  * Scans the sessions directory for resumable sessions.
@@ -34,8 +38,8 @@ export function scanResumableSessions(): SessionSnapshot[] {
     const statePath = resolve(sessionsDir, entry, SESSION_STATE_FILENAME);
     try {
       const raw = readFileSync(statePath, 'utf-8');
-      const snapshot = JSON.parse(raw) as SessionSnapshot;
-      if (snapshot.resumable && snapshot.sessionId) {
+      const snapshot: unknown = JSON.parse(raw);
+      if (isResumableSnapshot(snapshot, entry)) {
         snapshots.push(snapshot);
       }
     } catch {

--- a/src/pty/session-scanner.ts
+++ b/src/pty/session-scanner.ts
@@ -1,9 +1,8 @@
 /**
- * Session scanner -- discovers resumable sessions from disk.
+ * Session scanner -- discovers resumable PTY sessions from disk.
  *
- * Reads `session-state.json` files from the sessions directory,
- * filters for resumable sessions, and returns them sorted by
- * last activity (most recent first).
+ * This module is shared by the mux and Web UI layers, so neither interactive
+ * frontend needs to import the other.
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
@@ -75,9 +74,7 @@ export function getWorkspaceLabel(s: SessionSnapshot): string | undefined {
   return shortenHomePath(s.workspacePath);
 }
 
-/**
- * Formats a relative time description for display (e.g., "2h ago", "3d ago").
- */
+/** Formats a relative time description for display (e.g., "2h ago", "3d ago"). */
 export function formatRelativeTime(isoDate: string): string {
   const diff = Date.now() - new Date(isoDate).getTime();
   if (isNaN(diff)) return 'unknown';

--- a/src/pty/session-scanner.ts
+++ b/src/pty/session-scanner.ts
@@ -5,23 +5,74 @@
  * frontend needs to import the other.
  */
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
-import { getSessionsDir, getSessionSandboxDir, SESSION_STATE_FILENAME } from '../config/paths.js';
+import { getSessionDir, getSessionsDir, getSessionSandboxDir, SESSION_STATE_FILENAME } from '../config/paths.js';
 import { isSessionSnapshot, type SessionSnapshot } from '../docker/pty-types.js';
+import { validateWorkspacePath } from '../session/workspace-validation.js';
 
 export type { SessionSnapshot } from '../docker/pty-types.js';
 
-function isResumableSnapshot(value: unknown, directoryName: string): value is SessionSnapshot {
-  return isSessionSnapshot(value) && value.resumable && value.sessionId === directoryName;
+function validateParsedResumeSession(
+  parsed: unknown,
+  resumeSessionId: string,
+  protectedPaths: string[],
+): SessionSnapshot {
+  const parsedSessionId =
+    typeof parsed === 'object' && parsed !== null ? (parsed as { sessionId?: unknown }).sessionId : undefined;
+  if (parsedSessionId !== resumeSessionId) {
+    throw new Error(`Cannot resume session "${resumeSessionId}": snapshot sessionId mismatch`);
+  }
+  if (!isSessionSnapshot(parsed)) {
+    throw new Error(`Cannot resume session "${resumeSessionId}": session state snapshot is corrupted or invalid`);
+  }
+  if (!parsed.resumable) {
+    throw new Error(`Cannot resume session "${resumeSessionId}": session is not resumable (status: ${parsed.status})`);
+  }
+
+  try {
+    validateWorkspacePath(parsed.workspacePath, protectedPaths);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot resume session "${resumeSessionId}": workspace path is unsafe: ${detail}`, {
+      cause: error,
+    });
+  }
+
+  return parsed;
+}
+
+/**
+ * Loads and authoritatively validates one persisted session for resume.
+ * Direct launch callers must use this again even if the session was previously
+ * listed, because the mutable snapshot or workspace may have changed.
+ */
+export function validateResumeSession(resumeSessionId: string, protectedPaths: string[] = []): SessionSnapshot {
+  const sessionDir = getSessionDir(resumeSessionId);
+  if (!existsSync(sessionDir)) {
+    throw new Error(`Cannot resume session "${resumeSessionId}": session directory not found`);
+  }
+  const snapshotPath = resolve(sessionDir, SESSION_STATE_FILENAME);
+  if (!existsSync(snapshotPath)) {
+    throw new Error(`Cannot resume session "${resumeSessionId}": no session state snapshot found`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as unknown;
+  } catch {
+    throw new Error(`Cannot resume session "${resumeSessionId}": session state snapshot is corrupted or invalid`);
+  }
+  return validateParsedResumeSession(parsed, resumeSessionId, protectedPaths);
 }
 
 /**
  * Scans the sessions directory for resumable sessions.
+ * Applies the same snapshot and workspace checks as direct resume validation.
  * Returns snapshots sorted by lastActivity descending (most recent first).
  */
-export function scanResumableSessions(): SessionSnapshot[] {
+export function scanResumableSessions(protectedPaths: string[]): SessionSnapshot[] {
   const sessionsDir = getSessionsDir();
 
   let entries: string[];
@@ -34,13 +85,11 @@ export function scanResumableSessions(): SessionSnapshot[] {
   const snapshots: SessionSnapshot[] = [];
 
   for (const entry of entries) {
-    const statePath = resolve(sessionsDir, entry, SESSION_STATE_FILENAME);
     try {
+      const statePath = resolve(getSessionDir(entry), SESSION_STATE_FILENAME);
       const raw = readFileSync(statePath, 'utf-8');
       const snapshot: unknown = JSON.parse(raw);
-      if (isResumableSnapshot(snapshot, entry)) {
-        snapshots.push(snapshot);
-      }
+      snapshots.push(validateParsedResumeSession(snapshot, entry, protectedPaths));
     } catch {
       // Skip sessions without a valid state file
     }

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -19,6 +19,7 @@ import {
 import {
   type SessionDto,
   type SessionDetailDto,
+  type ResumableSessionDto,
   RpcError,
   SessionNotFoundError,
   MethodNotFoundError,
@@ -27,6 +28,8 @@ import { tokenStreamDispatch } from './token-stream-dispatch.js';
 import { ptyDispatch } from './pty-dispatch.js';
 import { WebSessionTransport } from '../web-session-transport.js';
 import { loadConfig } from '../../config/index.js';
+import { validateResumeSession } from '../../docker/pty-session.js';
+import { getWorkspaceLabel, scanResumableSessions } from '../../mux/session-scanner.js';
 import { createStandaloneSession } from '../../session/index.js';
 import { shouldAutoSaveMemory } from '../../memory/auto-save.js';
 import { BudgetExhaustedError } from '../../types/errors.js';
@@ -57,6 +60,13 @@ const sessionCreateSchema = z.object({
   model: z.string().min(1).optional(),
 });
 const sessionSendSchema = z.object({ label: z.number().int().positive(), text: z.string().min(1) });
+const sessionResumeSchema = z.object({
+  sessionId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid session ID'),
+});
 
 // ---------------------------------------------------------------------------
 // Session dispatch
@@ -87,6 +97,8 @@ export async function sessionDispatch(
   switch (method) {
     case 'sessions.list':
       return listSessions(ctx);
+    case 'sessions.listResumable':
+      return listResumableSessions(ctx);
     case 'sessions.get': {
       const { label } = validateParams(labelSchema, params);
       return getSession(ctx, label);
@@ -99,6 +111,10 @@ export async function sessionDispatch(
         return createPtySession(ctx, opts);
       }
       return createWebSession(ctx, opts.persona, opts.captureTraces);
+    }
+    case 'sessions.resume': {
+      const { sessionId } = validateParams(sessionResumeSchema, params);
+      return resumePtySession(ctx, sessionId);
     }
     case 'sessions.end': {
       const { label } = validateParams(labelSchema, params);
@@ -177,6 +193,31 @@ function listSessions(ctx: DispatchContext): SessionDto[] {
   return [...managed, ...pty];
 }
 
+function listResumableSessions(ctx: DispatchContext): ResumableSessionDto[] {
+  const protectedPaths = loadConfig().protectedPaths;
+  const result: ResumableSessionDto[] = [];
+  for (const candidate of scanResumableSessions()) {
+    if (ctx.ptySessionManager?.isResuming(candidate.sessionId)) continue;
+    try {
+      const snapshot = validateResumeSession(candidate.sessionId, protectedPaths);
+      const workspaceLabel = getWorkspaceLabel(snapshot);
+      result.push({
+        sessionId: snapshot.sessionId,
+        displayName: snapshot.label,
+        agent: snapshot.agent,
+        status: snapshot.status,
+        lastActivity: snapshot.lastActivity,
+        ...(workspaceLabel ? { workspaceLabel } : {}),
+        ...(snapshot.persona ? { persona: snapshot.persona } : {}),
+        ...(snapshot.providerProfileName ? { providerProfileName: snapshot.providerProfileName } : {}),
+      });
+    } catch {
+      // A stale, corrupted, or newly unsafe snapshot is not advertised.
+    }
+  }
+  return result;
+}
+
 function getSession(ctx: DispatchContext, label: number): SessionDetailDto {
   // PTY sessions have no turn history/diagnostics; return the DTO with empty
   // logs rather than throwing, since selecting one drives this call.
@@ -202,13 +243,7 @@ async function createPtySession(
   ctx: DispatchContext,
   opts: z.infer<typeof sessionCreateSchema>,
 ): Promise<{ label: number }> {
-  const manager = ctx.ptySessionManager;
-  if (!manager) {
-    throw new RpcError('INTERNAL_ERROR', 'PTY session manager not available');
-  }
-  if (manager.size >= ctx.maxConcurrentWebSessions) {
-    throw new RpcError('RATE_LIMITED', `PTY session limit reached (max ${ctx.maxConcurrentWebSessions})`);
-  }
+  const manager = requirePtyCapacity(ctx);
   return manager.create({
     ...(opts.persona ? { persona: opts.persona } : {}),
     ...(opts.captureTraces !== undefined ? { captureTraces: opts.captureTraces } : {}),
@@ -216,6 +251,37 @@ async function createPtySession(
     ...(opts.providerProfileName ? { providerProfileName: opts.providerProfileName } : {}),
     ...(opts.model ? { model: opts.model } : {}),
   });
+}
+
+async function resumePtySession(ctx: DispatchContext, sessionId: string): Promise<{ label: number }> {
+  if (ctx.mode.kind !== 'docker') {
+    throw new RpcError('SESSION_NOT_RESUMABLE', 'Session resume requires container mode');
+  }
+  const manager = requirePtyCapacity(ctx);
+
+  let snapshot;
+  try {
+    snapshot = validateResumeSession(sessionId, loadConfig().protectedPaths);
+  } catch (error) {
+    throw new RpcError('SESSION_NOT_RESUMABLE', error instanceof Error ? error.message : String(error));
+  }
+
+  return manager.create({
+    resume: {
+      sessionId: snapshot.sessionId,
+      agent: snapshot.agent,
+      ...(snapshot.persona ? { persona: snapshot.persona } : {}),
+    },
+  });
+}
+
+function requirePtyCapacity(ctx: DispatchContext): NonNullable<DispatchContext['ptySessionManager']> {
+  const manager = ctx.ptySessionManager;
+  if (!manager) throw new RpcError('INTERNAL_ERROR', 'PTY session manager not available');
+  if (manager.capacityUsed >= ctx.maxConcurrentWebSessions) {
+    throw new RpcError('RATE_LIMITED', `PTY session limit reached (max ${ctx.maxConcurrentWebSessions})`);
+  }
+  return manager;
 }
 
 async function createWebSession(

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -29,7 +29,7 @@ import { ptyDispatch } from './pty-dispatch.js';
 import { WebSessionTransport } from '../web-session-transport.js';
 import { loadConfig } from '../../config/index.js';
 import { validateResumeSession } from '../../docker/pty-session.js';
-import { getWorkspaceLabel, scanResumableSessions } from '../../mux/session-scanner.js';
+import { getWorkspaceLabel, scanResumableSessions } from '../../pty/session-scanner.js';
 import { createStandaloneSession } from '../../session/index.js';
 import { shouldAutoSaveMemory } from '../../memory/auto-save.js';
 import { BudgetExhaustedError } from '../../types/errors.js';

--- a/src/web-ui/dispatch/session-dispatch.ts
+++ b/src/web-ui/dispatch/session-dispatch.ts
@@ -28,8 +28,7 @@ import { tokenStreamDispatch } from './token-stream-dispatch.js';
 import { ptyDispatch } from './pty-dispatch.js';
 import { WebSessionTransport } from '../web-session-transport.js';
 import { loadConfig } from '../../config/index.js';
-import { validateResumeSession } from '../../docker/pty-session.js';
-import { getWorkspaceLabel, scanResumableSessions } from '../../pty/session-scanner.js';
+import { getWorkspaceLabel, scanResumableSessions, validateResumeSession } from '../../pty/session-scanner.js';
 import { createStandaloneSession } from '../../session/index.js';
 import { shouldAutoSaveMemory } from '../../memory/auto-save.js';
 import { BudgetExhaustedError } from '../../types/errors.js';
@@ -194,26 +193,24 @@ function listSessions(ctx: DispatchContext): SessionDto[] {
 }
 
 function listResumableSessions(ctx: DispatchContext): ResumableSessionDto[] {
+  if (ctx.mode.kind !== 'docker') {
+    throw new RpcError('SESSION_NOT_RESUMABLE', 'Session resume requires container mode');
+  }
   const protectedPaths = loadConfig().protectedPaths;
   const result: ResumableSessionDto[] = [];
-  for (const candidate of scanResumableSessions()) {
-    if (ctx.ptySessionManager?.isResuming(candidate.sessionId)) continue;
-    try {
-      const snapshot = validateResumeSession(candidate.sessionId, protectedPaths);
-      const workspaceLabel = getWorkspaceLabel(snapshot);
-      result.push({
-        sessionId: snapshot.sessionId,
-        displayName: snapshot.label,
-        agent: snapshot.agent,
-        status: snapshot.status,
-        lastActivity: snapshot.lastActivity,
-        ...(workspaceLabel ? { workspaceLabel } : {}),
-        ...(snapshot.persona ? { persona: snapshot.persona } : {}),
-        ...(snapshot.providerProfileName ? { providerProfileName: snapshot.providerProfileName } : {}),
-      });
-    } catch {
-      // A stale, corrupted, or newly unsafe snapshot is not advertised.
-    }
+  for (const snapshot of scanResumableSessions(protectedPaths)) {
+    if (ctx.ptySessionManager?.isResuming(snapshot.sessionId)) continue;
+    const workspaceLabel = getWorkspaceLabel(snapshot);
+    result.push({
+      sessionId: snapshot.sessionId,
+      displayName: snapshot.label,
+      agent: snapshot.agent,
+      status: snapshot.status,
+      lastActivity: snapshot.lastActivity,
+      ...(workspaceLabel ? { workspaceLabel } : {}),
+      ...(snapshot.persona ? { persona: snapshot.persona } : {}),
+      ...(snapshot.providerProfileName ? { providerProfileName: snapshot.providerProfileName } : {}),
+    });
   }
   return result;
 }

--- a/src/web-ui/pty-session-manager.ts
+++ b/src/web-ui/pty-session-manager.ts
@@ -480,6 +480,7 @@ export class PtySessionManager {
     }
     if (resumeSessionId) this.activeResumeIds.add(resumeSessionId);
     this.pendingCreates++;
+    let claimTransferredToSession = false;
 
     try {
       await this.preflight();
@@ -529,8 +530,18 @@ export class PtySessionManager {
       // idle backstop guards against a browser that crashes between create and
       // attach; the first attach cancels it.
       this.sessions.set(label, session);
+      claimTransferredToSession = true;
       this.startIdleTimer(label);
-      this.eventBus.emit('session.created', toPtySessionDto(session));
+      try {
+        this.eventBus.emit('session.created', toPtySessionDto(session));
+      } catch (error) {
+        // Event delivery is observational: a broken WebSocket/subscriber must
+        // not unwind registration, release the resume claim, or orphan a live
+        // child before its exit handler is installed.
+        logger.error(
+          `[WebUI] PTY session #${label}: session.created delivery failed (${error instanceof Error ? error.message : String(error)})`,
+        );
+      }
 
       bridge.onData((chunk) => session.pushChunk(chunk));
       bridge.onExit(() => this.handleExit(label));
@@ -543,7 +554,7 @@ export class PtySessionManager {
       });
       return { label };
     } catch (error) {
-      if (resumeSessionId) this.activeResumeIds.delete(resumeSessionId);
+      if (resumeSessionId && !claimTransferredToSession) this.activeResumeIds.delete(resumeSessionId);
       throw error;
     } finally {
       this.pendingCreates--;

--- a/src/web-ui/pty-session-manager.ts
+++ b/src/web-ui/pty-session-manager.ts
@@ -164,6 +164,30 @@ export interface PtySessionManagerOptions {
   readonly idleTtlMs?: number;
 }
 
+interface FreshPtySessionOptions {
+  readonly persona?: string;
+  readonly captureTraces?: boolean;
+  /** Workspace dir passed as `--workspace` (the child validates containment). */
+  readonly workspacePath?: string;
+  /** Provider-profile name passed as `--provider-profile`. */
+  readonly providerProfileName?: string;
+  /** Model ID override passed as `--model`. */
+  readonly model?: string;
+  readonly resume?: never;
+}
+
+interface ResumePtySessionOptions {
+  /** Trusted, validated persisted session descriptor. Never browser-supplied directly. */
+  readonly resume: { sessionId: string; agent: string; persona?: string };
+  readonly persona?: never;
+  readonly captureTraces?: never;
+  readonly workspacePath?: never;
+  readonly providerProfileName?: never;
+  readonly model?: never;
+}
+
+type PtySessionCreateOptions = FreshPtySessionOptions | ResumePtySessionOptions;
+
 // ---------------------------------------------------------------------------
 // PtyWebSession -- one bridge + its subscriber set + the coalescing streamer
 // ---------------------------------------------------------------------------
@@ -195,6 +219,7 @@ export class PtyWebSession {
     readonly bridge: PtyBridge,
     private readonly sender: PtyStreamSender,
     readonly persona: string | undefined,
+    readonly resumeSessionId?: string,
   ) {}
 
   get alive(): boolean {
@@ -391,6 +416,7 @@ export class PtyWebSession {
 
 export class PtySessionManager {
   private readonly sessions = new Map<number, PtyWebSession>();
+  private readonly activeResumeIds = new Set<string>();
   private readonly idleTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private readonly sender: PtyStreamSender;
   private readonly sessionManager: SessionManager;
@@ -403,6 +429,9 @@ export class PtySessionManager {
   private readonly runPreflight: () => Promise<void>;
   private readonly idleTtlMs: number;
   private preflightPromise: Promise<void> | undefined;
+  private pendingCreates = 0;
+  private closing = false;
+  private readonly pendingCreateWaiters = new Set<() => void>();
 
   constructor(options: PtySessionManagerOptions) {
     this.sender = options.sender;
@@ -422,8 +451,17 @@ export class PtySessionManager {
     return this.sessions.size;
   }
 
+  /** Live sessions plus creates that have reserved capacity but not registered yet. */
+  get capacityUsed(): number {
+    return this.sessions.size + this.pendingCreates;
+  }
+
   has(label: number): boolean {
     return this.sessions.has(label);
+  }
+
+  isResuming(sessionId: string): boolean {
+    return this.activeResumeIds.has(sessionId);
   }
 
   /**
@@ -432,64 +470,82 @@ export class PtySessionManager {
    * borrowed label. The initial size is a sane 80x24 default; the first browser
    * attach re-sizes it (§11 D1).
    */
-  async create(
-    options: {
-      persona?: string;
-      captureTraces?: boolean;
-      /** Workspace dir passed as `--workspace` (the child validates containment). */
-      workspacePath?: string;
-      /** Provider-profile name passed as `--provider-profile`. */
-      providerProfileName?: string;
-      /** Model ID override passed as `--model`. */
-      model?: string;
-    } = {},
-  ): Promise<{ label: number }> {
-    await this.preflight();
+  async create(options: PtySessionCreateOptions = {}): Promise<{ label: number }> {
+    if (this.closing) throw new RpcError('INTERNAL_ERROR', 'PTY session manager is shutting down');
+    const resumeSessionId = options.resume?.sessionId;
+    if (resumeSessionId && this.activeResumeIds.has(resumeSessionId)) {
+      throw new RpcError('SESSION_BUSY', `Session "${resumeSessionId}" is already being resumed`);
+    }
+    if (resumeSessionId) this.activeResumeIds.add(resumeSessionId);
+    this.pendingCreates++;
 
-    const label = this.sessionManager.reserveLabel();
-    const { bin, prefixArgs } = resolveIroncurtainBin();
-    const agent = this.mode.kind === 'docker' ? this.mode.agent : 'claude-code';
-    const captureTraces = options.captureTraces ?? this.captureTracesDefault;
+    try {
+      await this.preflight();
+      if (this.isClosing()) throw new RpcError('INTERNAL_ERROR', 'PTY session manager is shutting down');
 
-    const bridge = await this.createBridge({
-      cols: PTY_INITIAL_COLS,
-      rows: PTY_INITIAL_ROWS,
-      ironcurtainBin: bin,
-      prefixArgs,
-      agent,
-      ...(options.persona ? { persona: options.persona } : {}),
-      ...(options.workspacePath ? { workspacePath: options.workspacePath } : {}),
-      ...(options.providerProfileName ? { providerProfileName: options.providerProfileName } : {}),
-      ...(options.model ? { model: options.model } : {}),
-      captureTraces,
-      muxId: this.ownerId,
-      muxPid: this.ownerPid,
-    });
+      const label = this.sessionManager.reserveLabel();
+      const { bin, prefixArgs } = resolveIroncurtainBin();
+      const agent = options.resume?.agent ?? (this.mode.kind === 'docker' ? this.mode.agent : 'claude-code');
+      const captureTraces = options.captureTraces ?? this.captureTracesDefault;
 
-    const session = new PtyWebSession(label, bridge, this.sender, options.persona);
+      const bridge = await this.createBridge({
+        cols: PTY_INITIAL_COLS,
+        rows: PTY_INITIAL_ROWS,
+        ironcurtainBin: bin,
+        prefixArgs,
+        agent,
+        ...(options.resume
+          ? { resumeSessionId: options.resume.sessionId }
+          : {
+              ...(options.persona ? { persona: options.persona } : {}),
+              ...(options.workspacePath ? { workspacePath: options.workspacePath } : {}),
+              ...(options.providerProfileName ? { providerProfileName: options.providerProfileName } : {}),
+              ...(options.model ? { model: options.model } : {}),
+            }),
+        captureTraces,
+        muxId: this.ownerId,
+        muxPid: this.ownerPid,
+      });
 
-    // Register + announce the session BEFORE wiring the bridge handlers. A child
-    // that already exited by now makes `bridge.onExit` fire its callback
-    // synchronously; if the session were not yet in the map, `handleExit` would
-    // no-op and leak the entry (armed idle timer, `session.created` with no
-    // matching `session.ended`). Registering first makes that a clean
-    // created -> ended. A freshly created session has no subscribers yet, so the
-    // idle backstop guards against a browser that crashes between create and
-    // attach; the first attach cancels it.
-    this.sessions.set(label, session);
-    this.startIdleTimer(label);
-    this.eventBus.emit('session.created', toPtySessionDto(session));
+      if (this.isClosing()) {
+        bridge.kill();
+        throw new RpcError('INTERNAL_ERROR', 'PTY session manager is shutting down');
+      }
 
-    bridge.onData((chunk) => session.pushChunk(chunk));
-    bridge.onExit(() => this.handleExit(label));
-    // Phase 4: capture the escalation dir and start bridging its escalations
-    // to the structured Escalations UI over the WebEventBus.
-    bridge.onSessionDiscovered((reg) => {
-      if (!reg) return;
-      session.escalationDir = reg.escalationDir;
-      this.startEscalationWatcher(session, reg.escalationDir);
-    });
-    return { label };
+      const persona = options.resume?.persona ?? options.persona;
+      const session = new PtyWebSession(label, bridge, this.sender, persona, resumeSessionId);
+
+      // Register + announce the session BEFORE wiring the bridge handlers. A child
+      // that already exited by now makes `bridge.onExit` fire its callback
+      // synchronously; if the session were not yet in the map, `handleExit` would
+      // no-op and leak the entry (armed idle timer, `session.created` with no
+      // matching `session.ended`). Registering first makes that a clean
+      // created -> ended. A freshly created session has no subscribers yet, so the
+      // idle backstop guards against a browser that crashes between create and
+      // attach; the first attach cancels it.
+      this.sessions.set(label, session);
+      this.startIdleTimer(label);
+      this.eventBus.emit('session.created', toPtySessionDto(session));
+
+      bridge.onData((chunk) => session.pushChunk(chunk));
+      bridge.onExit(() => this.handleExit(label));
+      // Phase 4: capture the escalation dir and start bridging its escalations
+      // to the structured Escalations UI over the WebEventBus.
+      bridge.onSessionDiscovered((reg) => {
+        if (!reg) return;
+        session.escalationDir = reg.escalationDir;
+        this.startEscalationWatcher(session, reg.escalationDir);
+      });
+      return { label };
+    } catch (error) {
+      if (resumeSessionId) this.activeResumeIds.delete(resumeSessionId);
+      throw error;
+    } finally {
+      this.pendingCreates--;
+      if (this.pendingCreates === 0) {
+        for (const settle of [...this.pendingCreateWaiters]) settle();
+      }
+    }
   }
 
   /**
@@ -577,8 +633,11 @@ export class PtySessionManager {
 
   /** Kills all bridges with a bounded await (mirrors mux doShutdown). */
   async close(): Promise<void> {
+    this.closing = true;
+    await this.waitForPendingCreates();
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
+    this.activeResumeIds.clear();
     for (const timer of this.idleTimers.values()) clearTimeout(timer);
     this.idleTimers.clear();
 
@@ -694,6 +753,7 @@ export class PtySessionManager {
     const session = this.sessions.get(label);
     if (!session) return;
     this.sessions.delete(label);
+    if (session.resumeSessionId) this.activeResumeIds.delete(session.resumeSessionId);
     this.clearIdleTimer(label);
     session.dispose();
     const reason = session.endReason ?? 'pty_exited';
@@ -745,6 +805,24 @@ export class PtySessionManager {
       clearTimeout(timer);
       this.idleTimers.delete(label);
     }
+  }
+
+  private waitForPendingCreates(): Promise<void> {
+    if (this.pendingCreates === 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      const settle = (): void => {
+        this.pendingCreateWaiters.delete(settle);
+        clearTimeout(timer);
+        resolve();
+      };
+      this.pendingCreateWaiters.add(settle);
+      const timer = setTimeout(settle, PTY_CLOSE_TIMEOUT_MS);
+      timer.unref();
+    });
+  }
+
+  private isClosing(): boolean {
+    return this.closing;
   }
 
   private preflight(): Promise<void> {

--- a/src/web-ui/pty-session-manager.ts
+++ b/src/web-ui/pty-session-manager.ts
@@ -417,6 +417,8 @@ export class PtyWebSession {
 export class PtySessionManager {
   private readonly sessions = new Map<number, PtyWebSession>();
   private readonly activeResumeIds = new Set<string>();
+  /** Exit waits for bridges that spawned after close() began and were never registered. */
+  private readonly closingBridgeExits = new Set<Promise<void>>();
   private readonly idleTimers = new Map<number, ReturnType<typeof setTimeout>>();
   private readonly sender: PtyStreamSender;
   private readonly sessionManager: SessionManager;
@@ -508,7 +510,10 @@ export class PtySessionManager {
       });
 
       if (this.isClosing()) {
-        bridge.kill();
+        // Own cleanup here even if close() has already exhausted its timeout.
+        // When close() is still waiting, pendingCreates keeps this exit promise
+        // inside the same bounded shutdown window.
+        this.trackClosingBridge(bridge);
         throw new RpcError('INTERNAL_ERROR', 'PTY session manager is shutting down');
       }
 
@@ -634,14 +639,18 @@ export class PtySessionManager {
   /** Kills all bridges with a bounded await (mirrors mux doShutdown). */
   async close(): Promise<void> {
     this.closing = true;
-    await this.waitForPendingCreates();
     const sessions = [...this.sessions.values()];
     this.sessions.clear();
     this.activeResumeIds.clear();
     for (const timer of this.idleTimers.values()) clearTimeout(timer);
     this.idleTimers.clear();
 
-    const exits = sessions.map(
+    const pendingCreateExits = (async (): Promise<void> => {
+      await this.waitForPendingCreates();
+      await Promise.allSettled([...this.closingBridgeExits]);
+    })();
+
+    const exits: Promise<void>[] = sessions.map(
       (session) =>
         new Promise<void>((resolve) => {
           session.bridge.onExit(() => resolve());
@@ -649,6 +658,7 @@ export class PtySessionManager {
           session.bridge.kill();
         }),
     );
+    exits.push(pendingCreateExits);
     let closeTimeout: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<void>((resolve) => {
       const timer = setTimeout(resolve, PTY_CLOSE_TIMEOUT_MS);
@@ -812,13 +822,27 @@ export class PtySessionManager {
     return new Promise((resolve) => {
       const settle = (): void => {
         this.pendingCreateWaiters.delete(settle);
-        clearTimeout(timer);
         resolve();
       };
       this.pendingCreateWaiters.add(settle);
-      const timer = setTimeout(settle, PTY_CLOSE_TIMEOUT_MS);
-      timer.unref();
     });
+  }
+
+  private trackClosingBridge(bridge: PtyBridge): void {
+    const exit = new Promise<void>((resolve) => {
+      bridge.onExit(() => resolve());
+      try {
+        bridge.kill();
+      } catch (error) {
+        // A thrown termination request is not evidence that the child exited;
+        // keep tracking it until onExit (while close remains globally bounded).
+        logger.error(
+          `[WebUI] PTY child pid=${bridge.pid}: shutdown request failed (${error instanceof Error ? error.message : String(error)})`,
+        );
+      }
+    });
+    this.closingBridgeExits.add(exit);
+    void exit.finally(() => this.closingBridgeExits.delete(exit));
   }
 
   private isClosing(): boolean {

--- a/src/web-ui/web-ui-types.ts
+++ b/src/web-ui/web-ui-types.ts
@@ -38,8 +38,10 @@ export type MethodName =
   | 'jobs.run'
   | 'jobs.logs'
   | 'sessions.list'
+  | 'sessions.listResumable'
   | 'sessions.get'
   | 'sessions.create'
+  | 'sessions.resume'
   | 'sessions.end'
   | 'sessions.send'
   | 'sessions.budget'
@@ -132,6 +134,7 @@ export interface EventFrame {
 export type ErrorCode =
   | 'AUTH_REQUIRED'
   | 'SESSION_NOT_FOUND'
+  | 'SESSION_NOT_RESUMABLE'
   | 'JOB_NOT_FOUND'
   | 'ESCALATION_NOT_FOUND'
   | 'ESCALATION_EXPIRED'
@@ -188,6 +191,18 @@ export interface SessionDto {
    * kinds. Additive/optional — existing consumers ignore it.
    */
   readonly lastAttachedAt?: string;
+}
+
+/** Persisted Docker-agent session that can be resumed into a new web PTY. */
+export interface ResumableSessionDto {
+  readonly sessionId: string;
+  readonly displayName: string;
+  readonly agent: string;
+  readonly status: 'completed' | 'crashed' | 'auth-failure' | 'user-exit';
+  readonly lastActivity: string;
+  readonly workspaceLabel?: string;
+  readonly persona?: string;
+  readonly providerProfileName?: string;
 }
 
 export interface BudgetSummaryDto {

--- a/test/docker-resource-lifecycle.test.ts
+++ b/test/docker-resource-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -7,6 +7,7 @@ import {
   InternalNetworkConnectivityError,
   IRONCURTAIN_MANAGED_LABEL,
   IRONCURTAIN_OWNER_PID_LABEL,
+  IRONCURTAIN_OWNER_SCOPE_LABEL,
   IRONCURTAIN_OWNER_TOKEN_LABEL,
   managedResourceLabels,
   reconcileIronCurtainDockerResources,
@@ -83,6 +84,84 @@ describe('Docker resource crash reconciliation', () => {
     expect(result.retainedActiveResources).toBe(2);
     expect(docker.remove).not.toHaveBeenCalled();
     expect(docker.removeNetwork).not.toHaveBeenCalled();
+  });
+
+  it('does not reclaim live resources owned by another IronCurtain home', async () => {
+    const productionHome = mkdtempSync(resolve(tmpdir(), 'ironcurtain-production-home-'));
+    process.env.IRONCURTAIN_HOME = productionHome;
+    const labels = managedResourceLabels('production-bundle');
+
+    process.env.IRONCURTAIN_HOME = home;
+    const docker = runtimeWithInventory({
+      containers: [container({ labels })],
+      networks: [network({ labels, containerIds: ['container-id'] })],
+    });
+
+    try {
+      const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => true });
+
+      expect(labels[IRONCURTAIN_OWNER_SCOPE_LABEL]).toBeTruthy();
+      expect(result.retainedActiveResources).toBe(2);
+      expect(docker.remove).not.toHaveBeenCalled();
+      expect(docker.removeNetwork).not.toHaveBeenCalled();
+    } finally {
+      process.env.IRONCURTAIN_HOME = productionHome;
+      releaseManagedResourceLease('production-bundle');
+      process.env.IRONCURTAIN_HOME = home;
+      rmSync(productionHome, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the same owner scope for symlink aliases of one IronCurtain home', () => {
+    const alias = `${home}-alias`;
+    symlinkSync(home, alias, 'dir');
+    process.env.IRONCURTAIN_HOME = alias;
+    const aliasLabels = managedResourceLabels('alias-bundle');
+    process.env.IRONCURTAIN_HOME = home;
+    const directLabels = managedResourceLabels('direct-bundle');
+
+    try {
+      expect(aliasLabels[IRONCURTAIN_OWNER_SCOPE_LABEL]).toBe(directLabels[IRONCURTAIN_OWNER_SCOPE_LABEL]);
+    } finally {
+      process.env.IRONCURTAIN_HOME = alias;
+      releaseManagedResourceLease('alias-bundle');
+      process.env.IRONCURTAIN_HOME = home;
+      releaseManagedResourceLease('direct-bundle');
+      rmSync(alias, { force: true });
+    }
+  });
+
+  it('never reclaims foreign-home resources even when their recorded owner is dead', async () => {
+    const foreignHome = mkdtempSync(resolve(tmpdir(), 'ironcurtain-foreign-home-'));
+    process.env.IRONCURTAIN_HOME = foreignHome;
+    const labels = managedResourceLabels('foreign-bundle');
+    process.env.IRONCURTAIN_HOME = home;
+    const docker = runtimeWithInventory({ containers: [container({ labels })] });
+
+    try {
+      await reconcileIronCurtainDockerResources(docker, { pidAlive: () => false });
+      expect(docker.remove).not.toHaveBeenCalled();
+    } finally {
+      process.env.IRONCURTAIN_HOME = foreignHome;
+      releaseManagedResourceLease('foreign-bundle');
+      process.env.IRONCURTAIN_HOME = home;
+      rmSync(foreignHome, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves live managed resources created before owner scopes were labeled', async () => {
+    const labels = {
+      [IRONCURTAIN_MANAGED_LABEL]: 'true',
+      [IRONCURTAIN_OWNER_PID_LABEL]: '424242',
+      [IRONCURTAIN_OWNER_TOKEN_LABEL]: 'legacy-live-owner',
+      'ironcurtain.bundle': 'legacy-live-bundle',
+    };
+    const docker = runtimeWithInventory({ containers: [container({ labels })] });
+
+    const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => true });
+
+    expect(result.retainedActiveResources).toBe(1);
+    expect(docker.remove).not.toHaveBeenCalled();
   });
 
   it('force-removes managed containers and networks after owner death', async () => {

--- a/test/docker-resource-lifecycle.test.ts
+++ b/test/docker-resource-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createIronCurtainInternalNetwork,
   InternalNetworkConnectivityError,
+  IRONCURTAIN_CREATED_AT_LABEL,
   IRONCURTAIN_MANAGED_LABEL,
   IRONCURTAIN_OWNER_PID_LABEL,
   IRONCURTAIN_OWNER_SCOPE_LABEL,
@@ -154,14 +155,78 @@ describe('Docker resource crash reconciliation', () => {
       [IRONCURTAIN_MANAGED_LABEL]: 'true',
       [IRONCURTAIN_OWNER_PID_LABEL]: '424242',
       [IRONCURTAIN_OWNER_TOKEN_LABEL]: 'legacy-live-owner',
+      [IRONCURTAIN_CREATED_AT_LABEL]: '2026-08-24T12:00:00.000Z',
       'ironcurtain.bundle': 'legacy-live-bundle',
+    };
+    const docker = runtimeWithInventory({
+      containers: [container({ labels })],
+      networks: [network({ labels, containerIds: ['container-id'] })],
+    });
+
+    const result = await reconcileIronCurtainDockerResources(docker, {
+      pidAlive: () => true,
+      processIdentity: () => ({ bootId: 'same-boot', startedAt: '2026-08-24T11:59:00.000Z' }),
+    });
+
+    expect(result.retainedActiveResources).toBe(2);
+    expect(docker.remove).not.toHaveBeenCalled();
+    expect(docker.removeNetwork).not.toHaveBeenCalled();
+  });
+
+  it('preserves a live pre-scope resource when process identity is unavailable', async () => {
+    const labels = {
+      [IRONCURTAIN_MANAGED_LABEL]: 'true',
+      [IRONCURTAIN_OWNER_PID_LABEL]: '424242',
+      [IRONCURTAIN_OWNER_TOKEN_LABEL]: 'legacy-unknown-owner',
+      [IRONCURTAIN_CREATED_AT_LABEL]: '2026-08-24T12:00:00.000Z',
+      'ironcurtain.bundle': 'legacy-unknown-bundle',
     };
     const docker = runtimeWithInventory({ containers: [container({ labels })] });
 
-    const result = await reconcileIronCurtainDockerResources(docker, { pidAlive: () => true });
+    const result = await reconcileIronCurtainDockerResources(docker, {
+      pidAlive: () => true,
+      processIdentity: (pid) => (pid === process.pid ? { bootId: 'same-boot', startedAt: 'test-process' } : undefined),
+    });
 
     expect(result.retainedActiveResources).toBe(1);
     expect(docker.remove).not.toHaveBeenCalled();
+  });
+
+  it('reclaims pre-scope resources when their recorded PID was recycled', async () => {
+    const labels = {
+      [IRONCURTAIN_MANAGED_LABEL]: 'true',
+      [IRONCURTAIN_OWNER_PID_LABEL]: '424242',
+      [IRONCURTAIN_OWNER_TOKEN_LABEL]: 'legacy-recycled-owner',
+      [IRONCURTAIN_CREATED_AT_LABEL]: '2026-08-24T12:00:00.000Z',
+      'ironcurtain.bundle': 'legacy-recycled-bundle',
+    };
+    const docker = runtimeWithInventory({
+      containers: [container({ labels })],
+      networks: [network({ labels, containerIds: ['container-id'] })],
+    });
+    const leaseDir = resolve(home, 'run', 'docker-owners');
+    mkdirSync(leaseDir, { recursive: true });
+    writeFileSync(
+      resolve(leaseDir, 'legacy-recycled-owner.json'),
+      JSON.stringify({
+        token: 'legacy-recycled-owner',
+        pid: 424242,
+        identity: { bootId: 'same-boot', startedAt: 'original-process' },
+      }),
+    );
+
+    const result = await reconcileIronCurtainDockerResources(docker, {
+      pidAlive: () => true,
+      processIdentity: (pid) => ({
+        bootId: 'same-boot',
+        startedAt: pid === 424242 ? 'recycled-process' : 'test-process',
+      }),
+    });
+
+    expect(result.removedContainers).toEqual(['ironcurtain-1234567890ab']);
+    expect(result.removedNetworks).toEqual(['ironcurtain-1234567890ab']);
+    expect(docker.remove).toHaveBeenCalledWith('container-id');
+    expect(docker.removeNetwork).toHaveBeenCalledWith('ironcurtain-1234567890ab');
   });
 
   it('force-removes managed containers and networks after owner death', async () => {

--- a/test/pty-entrypoint.integration.test.ts
+++ b/test/pty-entrypoint.integration.test.ts
@@ -196,6 +196,8 @@ describe.skipIf(!dockerReady)('PTY container entrypoint UDS→TCP bridge (via ru
         },
         autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
         auditRedaction: { enabled: true },
+        modelProviders: { default: 'native', profiles: { native: { type: 'native' } } },
+        statistics: { enabled: false, retentionDays: null },
         memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
         packageInstall: {
           enabled: false,

--- a/test/pty/pty-session-manager.test.ts
+++ b/test/pty/pty-session-manager.test.ts
@@ -727,7 +727,7 @@ describe('PtySessionManager', () => {
 
     it('close() waits for an in-flight bridge and prevents it from registering', async () => {
       let resolveBridge: ((bridge: PtyBridge) => void) | undefined;
-      const bridge = new StubBridge();
+      const bridge = new NonExitingBridge();
       const h = makeHarness({
         createBridge: () =>
           new Promise((resolve) => {
@@ -739,13 +739,84 @@ describe('PtySessionManager', () => {
       for (let attempt = 0; attempt < 5 && !resolveBridge; attempt++) await Promise.resolve();
       expect(resolveBridge).toBeDefined();
       const close = h.manager.close();
+      let closeResolved = false;
+      void close.then(() => {
+        closeResolved = true;
+      });
       resolveBridge?.(bridge as unknown as PtyBridge);
 
       await expect(create).rejects.toThrow('shutting down');
+      await Promise.resolve();
+      expect(closeResolved).toBe(false);
+      expect(bridge.kill).toHaveBeenCalledTimes(1);
+
+      bridge.emitExit(0);
       await close;
+      expect(closeResolved).toBe(true);
+      expect(h.manager.size).toBe(0);
+      expect(h.events.filter((event) => event.event === 'session.created')).toHaveLength(0);
+    });
+
+    it('kills an in-flight bridge even when it resolves after close() times out', async () => {
+      let resolveBridge: ((bridge: PtyBridge) => void) | undefined;
+      const bridge = new NonExitingBridge();
+      const h = makeHarness({
+        createBridge: () =>
+          new Promise((resolve) => {
+            resolveBridge = resolve;
+          }),
+      });
+
+      const create = h.manager.create();
+      const rejectedCreate = expect(create).rejects.toThrow('shutting down');
+      for (let attempt = 0; attempt < 5 && !resolveBridge; attempt++) await Promise.resolve();
+      expect(resolveBridge).toBeDefined();
+
+      const close = h.manager.close();
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS + 5_000);
+      await close;
+
+      resolveBridge?.(bridge as unknown as PtyBridge);
+      await rejectedCreate;
       expect(bridge.kill).toHaveBeenCalledTimes(1);
       expect(h.manager.size).toBe(0);
       expect(h.events.filter((event) => event.event === 'session.created')).toHaveLength(0);
+
+      bridge.emitExit(0);
+    });
+
+    it('does not treat a thrown in-flight kill request as a completed exit', async () => {
+      let resolveBridge: ((bridge: PtyBridge) => void) | undefined;
+      const bridge = new NonExitingBridge();
+      bridge.kill.mockImplementationOnce(() => {
+        throw new Error('signal unavailable');
+      });
+      const h = makeHarness({
+        createBridge: () =>
+          new Promise((resolve) => {
+            resolveBridge = resolve;
+          }),
+      });
+
+      const create = h.manager.create();
+      for (let attempt = 0; attempt < 5 && !resolveBridge; attempt++) await Promise.resolve();
+      expect(resolveBridge).toBeDefined();
+
+      let closeResolved = false;
+      const close = h.manager.close().then(() => {
+        closeResolved = true;
+      });
+      resolveBridge?.(bridge as unknown as PtyBridge);
+
+      await expect(create).rejects.toThrow('shutting down');
+      await Promise.resolve();
+      expect(closeResolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(PTY_KILL_GRACE_MS + 5_000);
+      await close;
+      expect(closeResolved).toBe(true);
+
+      bridge.emitExit(0);
     });
 
     it('attempts later bridge kills when an earlier kill throws', async () => {

--- a/test/pty/pty-session-manager.test.ts
+++ b/test/pty/pty-session-manager.test.ts
@@ -277,6 +277,23 @@ describe('PtySessionManager', () => {
       await expect(h.manager.create(resume)).resolves.toEqual({ label: 2 });
     });
 
+    it('keeps the resume claim and exit wiring when session.created delivery throws', async () => {
+      const h = makeHarness();
+      h.eventBus.subscribe((event) => {
+        if (event === 'session.created') throw new Error('broadcast failed');
+      });
+      const resume = { resume: { sessionId: 'saved-session', agent: 'claude-code' } };
+
+      const first = await h.manager.create(resume);
+
+      expect(h.manager.has(first.label)).toBe(true);
+      await expect(h.manager.create(resume)).rejects.toMatchObject({ code: 'SESSION_BUSY' });
+
+      h.lastBridge().emitExit(0);
+      expect(h.manager.has(first.label)).toBe(false);
+      await expect(h.manager.create(resume)).resolves.toEqual({ label: 2 });
+    });
+
     it('releases a resume claim when bridge creation fails', async () => {
       const createBridge = vi
         .fn<(options: PtyBridgeOptions) => Promise<PtyBridge>>()
@@ -1284,6 +1301,9 @@ describe('sessions resume RPC', () => {
     const ctx = makeResumeContext();
     const builtinCtx = { ...ctx, mode: { kind: 'builtin' } as const };
 
+    await expect(sessionDispatch(builtinCtx, 'sessions.listResumable', {})).rejects.toMatchObject({
+      code: 'SESSION_NOT_RESUMABLE',
+    });
     await expect(
       sessionDispatch(builtinCtx, 'sessions.resume', { sessionId: 'missing-session' }),
     ).rejects.toMatchObject({

--- a/test/pty/pty-session-manager.test.ts
+++ b/test/pty/pty-session-manager.test.ts
@@ -245,6 +245,50 @@ describe('PtySessionManager', () => {
       expect(seen[0].rows).toBe(24);
     });
 
+    it('resumes with the persisted agent and persona without fresh-launch flags', async () => {
+      const seen: PtyBridgeOptions[] = [];
+      const h = makeHarness({
+        createBridge: async (opts) => {
+          seen.push(opts);
+          return new StubBridge() as unknown as PtyBridge;
+        },
+      });
+
+      const result = await h.manager.create({
+        resume: { sessionId: 'saved-session', agent: 'goose', persona: 'saved-persona' },
+      });
+
+      expect(seen[0]).toMatchObject({ resumeSessionId: 'saved-session', agent: 'goose' });
+      expect(seen[0]).not.toHaveProperty('workspacePath');
+      expect(seen[0]).not.toHaveProperty('providerProfileName');
+      expect(seen[0]).not.toHaveProperty('model');
+      expect(seen[0]).not.toHaveProperty('persona');
+      expect(h.manager.getDto(result.label)?.persona).toBe('saved-persona');
+    });
+
+    it('rejects duplicate resume claims until the first resumed PTY exits', async () => {
+      const h = makeHarness();
+      const resume = { resume: { sessionId: 'saved-session', agent: 'claude-code' } };
+
+      await h.manager.create(resume);
+      await expect(h.manager.create(resume)).rejects.toMatchObject({ code: 'SESSION_BUSY' });
+
+      h.lastBridge().emitExit(0);
+      await expect(h.manager.create(resume)).resolves.toEqual({ label: 2 });
+    });
+
+    it('releases a resume claim when bridge creation fails', async () => {
+      const createBridge = vi
+        .fn<(options: PtyBridgeOptions) => Promise<PtyBridge>>()
+        .mockRejectedValueOnce(new Error('spawn failed'))
+        .mockResolvedValueOnce(new StubBridge() as unknown as PtyBridge);
+      const h = makeHarness({ createBridge });
+      const resume = { resume: { sessionId: 'retryable-session', agent: 'claude-code' } };
+
+      await expect(h.manager.create(resume)).rejects.toThrow('spawn failed');
+      await expect(h.manager.create(resume)).resolves.toEqual({ label: 2 });
+    });
+
     it('threads workspace / provider-profile / model options to the bridge factory', async () => {
       const seen: PtyBridgeOptions[] = [];
       const h = makeHarness({
@@ -681,6 +725,29 @@ describe('PtySessionManager', () => {
       expect(h.manager.size).toBe(0);
     });
 
+    it('close() waits for an in-flight bridge and prevents it from registering', async () => {
+      let resolveBridge: ((bridge: PtyBridge) => void) | undefined;
+      const bridge = new StubBridge();
+      const h = makeHarness({
+        createBridge: () =>
+          new Promise((resolve) => {
+            resolveBridge = resolve;
+          }),
+      });
+
+      const create = h.manager.create();
+      for (let attempt = 0; attempt < 5 && !resolveBridge; attempt++) await Promise.resolve();
+      expect(resolveBridge).toBeDefined();
+      const close = h.manager.close();
+      resolveBridge?.(bridge as unknown as PtyBridge);
+
+      await expect(create).rejects.toThrow('shutting down');
+      await close;
+      expect(bridge.kill).toHaveBeenCalledTimes(1);
+      expect(h.manager.size).toBe(0);
+      expect(h.events.filter((event) => event.event === 'session.created')).toHaveLength(0);
+    });
+
     it('attempts later bridge kills when an earlier kill throws', async () => {
       const first = new StubBridge();
       first.kill.mockImplementationOnce(() => {
@@ -995,5 +1062,161 @@ describe('sessions.create (docker) concurrency cap', () => {
     expect(manager.size).toBe(2);
 
     await expect(sessionDispatch(ctx, 'sessions.create', {})).rejects.toThrow('PTY session limit reached (max 2)');
+  });
+
+  it('counts an in-flight create before its bridge has registered', async () => {
+    let resolveBridge: ((bridge: PtyBridge) => void) | undefined;
+    const eventBus = new WebEventBus();
+    const sessionManager = new SessionManager();
+    const manager = new PtySessionManager({
+      sender: { sendToSubscribers: () => {} },
+      sessionManager,
+      eventBus,
+      mode: { kind: 'docker', agent: 'claude-code' },
+      daemonId: 'test',
+      daemonPid: 1,
+      createBridge: () =>
+        new Promise((resolve) => {
+          resolveBridge = resolve;
+        }),
+      preflight: async () => {},
+    });
+    const ctx: DispatchContext = {
+      handler: makeHandler(),
+      sessionManager,
+      mode: { kind: 'docker', agent: 'claude-code' },
+      eventBus,
+      maxConcurrentWebSessions: 1,
+      sessionQueues: new Map(),
+      ptySessionManager: manager,
+    };
+
+    const first = sessionDispatch(ctx, 'sessions.create', {});
+    expect(manager.capacityUsed).toBe(1);
+    await expect(sessionDispatch(ctx, 'sessions.create', {})).rejects.toThrow('PTY session limit reached (max 1)');
+
+    resolveBridge?.(new StubBridge() as unknown as PtyBridge);
+    await expect(first).resolves.toMatchObject({ label: 1 });
+  });
+});
+
+describe('sessions resume RPC', () => {
+  let home: string;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    previousHome = process.env.IRONCURTAIN_HOME;
+    home = mkdtempSync(join(tmpdir(), 'ironcurtain-web-resume-'));
+    process.env.IRONCURTAIN_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.IRONCURTAIN_HOME;
+    else process.env.IRONCURTAIN_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeSnapshot(sessionId: string, overrides: Record<string, unknown> = {}): void {
+    const sessionDir = join(home, 'sessions', sessionId);
+    const workspacePath = join(sessionDir, 'sandbox');
+    mkdirSync(workspacePath, { recursive: true });
+    writeFileSync(
+      join(sessionDir, 'session-state.json'),
+      JSON.stringify({
+        sessionId,
+        status: 'user-exit',
+        exitCode: 0,
+        lastActivity: '2026-08-24T12:00:00.000Z',
+        workspacePath,
+        persona: 'saved-persona',
+        providerProfileName: 'work',
+        agent: 'goose',
+        label: 'Saved Goose session',
+        resumable: true,
+        ...overrides,
+      }),
+    );
+  }
+
+  function makeResumeContext(seen: PtyBridgeOptions[] = []): DispatchContext {
+    const eventBus = new WebEventBus();
+    const sessionManager = new SessionManager();
+    const manager = new PtySessionManager({
+      sender: { sendToSubscribers: () => {} },
+      sessionManager,
+      eventBus,
+      mode: { kind: 'docker', agent: 'claude-code' },
+      daemonId: 'test',
+      daemonPid: 1,
+      createBridge: async (options) => {
+        seen.push(options);
+        return new StubBridge() as unknown as PtyBridge;
+      },
+      preflight: async () => {},
+    });
+    return {
+      handler: makeHandler(),
+      sessionManager,
+      mode: { kind: 'docker', agent: 'claude-code' },
+      eventBus,
+      maxConcurrentWebSessions: 2,
+      sessionQueues: new Map(),
+      ptySessionManager: manager,
+    };
+  }
+
+  it('lists safe resumable metadata and resumes with the validated snapshot identity', async () => {
+    writeSnapshot('saved-session');
+    const seen: PtyBridgeOptions[] = [];
+    const ctx = makeResumeContext(seen);
+
+    const list = (await sessionDispatch(ctx, 'sessions.listResumable', {})) as Array<Record<string, unknown>>;
+    expect(list).toEqual([
+      expect.objectContaining({
+        sessionId: 'saved-session',
+        displayName: 'Saved Goose session',
+        agent: 'goose',
+        persona: 'saved-persona',
+      }),
+    ]);
+    expect(list[0]).not.toHaveProperty('workspacePath');
+
+    await expect(sessionDispatch(ctx, 'sessions.resume', { sessionId: 'saved-session' })).resolves.toEqual({
+      label: 1,
+    });
+    expect(seen[0]).toMatchObject({ resumeSessionId: 'saved-session', agent: 'goose' });
+
+    await expect(sessionDispatch(ctx, 'sessions.listResumable', {})).resolves.toEqual([]);
+    ctx.ptySessionManager?.end(1);
+    await expect(sessionDispatch(ctx, 'sessions.listResumable', {})).resolves.toHaveLength(1);
+  });
+
+  it('returns SESSION_NOT_RESUMABLE for a stale or invalid saved session', async () => {
+    writeSnapshot('finished-session', { resumable: false, status: 'completed' });
+    writeSnapshot('unsafe-session', { workspacePath: '/' });
+    const ctx = makeResumeContext();
+
+    await expect(sessionDispatch(ctx, 'sessions.listResumable', {})).resolves.toEqual([]);
+
+    await expect(sessionDispatch(ctx, 'sessions.resume', { sessionId: 'finished-session' })).rejects.toMatchObject({
+      code: 'SESSION_NOT_RESUMABLE',
+    });
+    await expect(sessionDispatch(ctx, 'sessions.resume', { sessionId: 'unsafe-session' })).rejects.toMatchObject({
+      code: 'SESSION_NOT_RESUMABLE',
+    });
+    await expect(sessionDispatch(ctx, 'sessions.resume', { sessionId: 'missing-session' })).rejects.toMatchObject({
+      code: 'SESSION_NOT_RESUMABLE',
+    });
+  });
+
+  it('rejects resume outside container mode before touching the saved session', async () => {
+    const ctx = makeResumeContext();
+    const builtinCtx = { ...ctx, mode: { kind: 'builtin' } as const };
+
+    await expect(
+      sessionDispatch(builtinCtx, 'sessions.resume', { sessionId: 'missing-session' }),
+    ).rejects.toMatchObject({
+      code: 'SESSION_NOT_RESUMABLE',
+    });
   });
 });

--- a/test/session-resume-security.test.ts
+++ b/test/session-resume-security.test.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionSnapshot } from '../src/docker/pty-types.js';
-import { validateResumeSession } from '../src/docker/pty-session.js';
+import { acquireResumeSessionLock, validateResumeSession } from '../src/docker/pty-session.js';
 import { prepareConversationStateDir } from '../src/docker/docker-infrastructure.js';
 import type { ConversationStateConfig } from '../src/docker/agent-adapter.js';
 import { scanResumableSessions } from '../src/mux/session-scanner.js';
@@ -119,6 +119,42 @@ describe('snapshot tampering resistance', () => {
     writeFileSync(join(sessionDir, SESSION_STATE_FILENAME), '{not valid json!!!');
 
     expect(() => validateResumeSession('corrupt-session')).toThrow('corrupted or invalid');
+  });
+
+  it('rejects malformed snapshot metadata on the direct resume path', () => {
+    const sessionDir = join(baseDir, 'sessions', 'malformed-session');
+    const workspaceDir = join(sessionDir, 'sandbox');
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, SESSION_STATE_FILENAME),
+      JSON.stringify(
+        makeSnapshot({
+          sessionId: 'malformed-session',
+          workspacePath: workspaceDir,
+          agent: { name: 'claude-code' } as unknown as string,
+          persona: { name: 'reviewer' } as unknown as string,
+        }),
+      ),
+    );
+
+    expect(() => validateResumeSession('malformed-session')).toThrow('corrupted or invalid');
+  });
+
+  it('holds a crash-recoverable lock for one resumed session at a time', () => {
+    const sessionDir = join(baseDir, 'sessions', 'locked-session');
+    const workspaceDir = join(sessionDir, 'sandbox');
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, SESSION_STATE_FILENAME),
+      JSON.stringify(makeSnapshot({ sessionId: 'locked-session', workspacePath: workspaceDir })),
+    );
+
+    const first = acquireResumeSessionLock('locked-session');
+    expect(() => acquireResumeSessionLock('locked-session')).toThrow('already being resumed');
+    first.release();
+
+    const retry = acquireResumeSessionLock('locked-session');
+    retry.release();
   });
 
   it('handles extra unexpected fields in snapshot gracefully', () => {

--- a/test/session-resume-security.test.ts
+++ b/test/session-resume-security.test.ts
@@ -11,10 +11,10 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionSnapshot } from '../src/docker/pty-types.js';
-import { acquireResumeSessionLock, validateResumeSession } from '../src/docker/pty-session.js';
+import { acquireResumeSessionLock, releaseResumeSessionLock } from '../src/docker/pty-session.js';
 import { prepareConversationStateDir } from '../src/docker/docker-infrastructure.js';
 import type { ConversationStateConfig } from '../src/docker/agent-adapter.js';
-import { scanResumableSessions } from '../src/pty/session-scanner.js';
+import { scanResumableSessions, validateResumeSession } from '../src/pty/session-scanner.js';
 import { getSessionDir, SESSION_STATE_FILENAME } from '../src/config/paths.js';
 
 function makeSnapshot(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {
@@ -98,7 +98,7 @@ describe('snapshot tampering resistance', () => {
     expect(() => validateResumeSession('no-id-session')).toThrow('sessionId mismatch');
 
     // scanResumableSessions also requires sessionId to be truthy
-    const sessions = scanResumableSessions();
+    const sessions = scanResumableSessions([]);
     expect(sessions).toHaveLength(0);
   });
 
@@ -155,6 +155,36 @@ describe('snapshot tampering resistance', () => {
 
     const retry = acquireResumeSessionLock('locked-session');
     retry.release();
+  });
+
+  it('releases the resume lock when validation fails under the claim', () => {
+    const sessionDir = join(baseDir, 'sessions', 'invalid-then-fixed-session');
+    const workspaceDir = join(sessionDir, 'sandbox');
+    mkdirSync(workspaceDir, { recursive: true });
+
+    expect(() => acquireResumeSessionLock('invalid-then-fixed-session')).toThrow('no session state snapshot');
+
+    writeFileSync(
+      join(sessionDir, SESSION_STATE_FILENAME),
+      JSON.stringify(makeSnapshot({ sessionId: 'invalid-then-fixed-session', workspacePath: workspaceDir })),
+    );
+    const retry = acquireResumeSessionLock('invalid-then-fixed-session');
+    retry.release();
+  });
+
+  it('does not let lost-lock cleanup replace the resumed session outcome', () => {
+    const sessionDir = join(baseDir, 'sessions', 'lost-lock-session');
+    const workspaceDir = join(sessionDir, 'sandbox');
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, SESSION_STATE_FILENAME),
+      JSON.stringify(makeSnapshot({ sessionId: 'lost-lock-session', workspacePath: workspaceDir })),
+    );
+
+    const lock = acquireResumeSessionLock('lost-lock-session');
+    rmSync(lock.path);
+
+    expect(() => releaseResumeSessionLock(lock)).not.toThrow();
   });
 
   it('handles extra unexpected fields in snapshot gracefully', () => {
@@ -300,19 +330,21 @@ describe('session isolation', () => {
     // Create two sessions
     for (const id of ['session-a', 'session-b']) {
       const dir = join(sessionsDir, id);
+      const workspacePath = join(dir, 'sandbox');
       mkdirSync(dir, { recursive: true });
+      mkdirSync(workspacePath, { recursive: true });
       writeFileSync(
         join(dir, SESSION_STATE_FILENAME),
         JSON.stringify(
           makeSnapshot({
             sessionId: id,
-            workspacePath: `/tmp/${id}/sandbox`,
+            workspacePath,
           }),
         ),
       );
     }
 
-    const sessions = scanResumableSessions();
+    const sessions = scanResumableSessions([]);
     expect(sessions).toHaveLength(2);
 
     // Each session has its own workspace path

--- a/test/session-resume-security.test.ts
+++ b/test/session-resume-security.test.ts
@@ -14,7 +14,7 @@ import type { SessionSnapshot } from '../src/docker/pty-types.js';
 import { acquireResumeSessionLock, validateResumeSession } from '../src/docker/pty-session.js';
 import { prepareConversationStateDir } from '../src/docker/docker-infrastructure.js';
 import type { ConversationStateConfig } from '../src/docker/agent-adapter.js';
-import { scanResumableSessions } from '../src/mux/session-scanner.js';
+import { scanResumableSessions } from '../src/pty/session-scanner.js';
 import { getSessionDir, SESSION_STATE_FILENAME } from '../src/config/paths.js';
 
 function makeSnapshot(overrides: Partial<SessionSnapshot> = {}): SessionSnapshot {

--- a/test/session-scanner.test.ts
+++ b/test/session-scanner.test.ts
@@ -7,9 +7,9 @@ import {
   formatRelativeTime,
   shortenHomePath,
   getWorkspaceLabel,
-} from '../src/mux/session-scanner.js';
+} from '../src/pty/session-scanner.js';
 import { getSessionSandboxDir, SESSION_STATE_FILENAME } from '../src/config/paths.js';
-import type { SessionSnapshot } from '../src/mux/session-scanner.js';
+import type { SessionSnapshot } from '../src/pty/session-scanner.js';
 
 describe('session-scanner', () => {
   const testDir = resolve('/tmp', `ironcurtain-scanner-test-${process.pid}`);

--- a/test/session-scanner.test.ts
+++ b/test/session-scanner.test.ts
@@ -28,28 +28,31 @@ describe('session-scanner', () => {
   function writeSnapshot(sessionId: string, snapshot: SessionSnapshot): void {
     const dir = resolve(sessionsDir, sessionId);
     mkdirSync(dir, { recursive: true });
-    writeFileSync(resolve(dir, SESSION_STATE_FILENAME), JSON.stringify(snapshot));
+    const persisted =
+      snapshot.workspacePath === '/workspace' ? { ...snapshot, workspacePath: resolve(dir, 'sandbox') } : snapshot;
+    mkdirSync(persisted.workspacePath, { recursive: true });
+    writeFileSync(resolve(dir, SESSION_STATE_FILENAME), JSON.stringify(persisted));
   }
 
   it('returns empty array when sessions dir does not exist', () => {
     rmSync(sessionsDir, { recursive: true, force: true });
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('returns empty array when sessions dir is empty', () => {
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('skips sessions without session-state.json', () => {
     mkdirSync(resolve(sessionsDir, 'orphan-session'), { recursive: true });
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('skips sessions with invalid JSON', () => {
     const dir = resolve(sessionsDir, 'bad-json');
     mkdirSync(dir, { recursive: true });
     writeFileSync(resolve(dir, 'session-state.json'), 'not json');
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('skips snapshots whose session ID does not match their directory', () => {
@@ -64,7 +67,22 @@ describe('session-scanner', () => {
       resumable: true,
     });
 
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
+  });
+
+  it('skips snapshots stored under an invalid session directory name', () => {
+    writeSnapshot('invalid id', {
+      sessionId: 'invalid id',
+      status: 'user-exit',
+      exitCode: 0,
+      lastActivity: '2026-03-10T12:00:00Z',
+      workspacePath: '/workspace',
+      agent: 'claude-code',
+      label: 'Invalid directory',
+      resumable: true,
+    });
+
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('skips resumable-looking snapshots with malformed required metadata', () => {
@@ -83,7 +101,7 @@ describe('session-scanner', () => {
       }),
     );
 
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('skips non-resumable sessions', () => {
@@ -98,7 +116,7 @@ describe('session-scanner', () => {
       label: 'Claude Code (interactive)',
       resumable: false,
     });
-    expect(scanResumableSessions()).toEqual([]);
+    expect(scanResumableSessions([])).toEqual([]);
   });
 
   it('returns resumable sessions', () => {
@@ -114,7 +132,7 @@ describe('session-scanner', () => {
       resumable: true,
     });
 
-    const results = scanResumableSessions();
+    const results = scanResumableSessions([]);
     expect(results).toHaveLength(1);
     expect(results[0].sessionId).toBe('session-1');
     expect(results[0].resumable).toBe(true);
@@ -145,7 +163,7 @@ describe('session-scanner', () => {
       resumable: true,
     });
 
-    const results = scanResumableSessions();
+    const results = scanResumableSessions([]);
     expect(results).toHaveLength(2);
     expect(results[0].sessionId).toBe('new-session');
     expect(results[1].sessionId).toBe('old-session');
@@ -176,7 +194,7 @@ describe('session-scanner', () => {
       resumable: false,
     });
 
-    const results = scanResumableSessions();
+    const results = scanResumableSessions([]);
     expect(results).toHaveLength(1);
     expect(results[0].sessionId).toBe('resumable');
   });

--- a/test/session-scanner.test.ts
+++ b/test/session-scanner.test.ts
@@ -52,6 +52,40 @@ describe('session-scanner', () => {
     expect(scanResumableSessions()).toEqual([]);
   });
 
+  it('skips snapshots whose session ID does not match their directory', () => {
+    writeSnapshot('expected-session', {
+      sessionId: 'different-session',
+      status: 'user-exit',
+      exitCode: 0,
+      lastActivity: '2026-03-10T12:00:00Z',
+      workspacePath: '/workspace',
+      agent: 'claude-code',
+      label: 'Mismatched session',
+      resumable: true,
+    });
+
+    expect(scanResumableSessions()).toEqual([]);
+  });
+
+  it('skips resumable-looking snapshots with malformed required metadata', () => {
+    const dir = resolve(sessionsDir, 'malformed-session');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      resolve(dir, SESSION_STATE_FILENAME),
+      JSON.stringify({
+        sessionId: 'malformed-session',
+        status: 'made-up-status',
+        lastActivity: 42,
+        workspacePath: '/workspace',
+        agent: '',
+        label: 'Malformed',
+        resumable: true,
+      }),
+    );
+
+    expect(scanResumableSessions()).toEqual([]);
+  });
+
   it('skips non-resumable sessions', () => {
     writeSnapshot('session-1', {
       sessionId: 'session-1',

--- a/test/session-snapshot.test.ts
+++ b/test/session-snapshot.test.ts
@@ -4,7 +4,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { SessionSnapshot } from '../src/docker/pty-types.js';
 import { SESSION_STATE_FILENAME } from '../src/config/paths.js';
-import { validateResumeSession, loadSessionSnapshot, resolveSnapshotResumability } from '../src/docker/pty-session.js';
+import { loadSessionSnapshot, resolveSnapshotResumability } from '../src/docker/pty-session.js';
+import { validateResumeSession } from '../src/pty/session-scanner.js';
 
 /**
  * These tests verify session snapshot I/O and resume validation

--- a/test/skills-end-to-end.integration.test.ts
+++ b/test/skills-end-to-end.integration.test.ts
@@ -488,6 +488,8 @@ function buildDockerSessionConfig(workspaceDir: string, generatedDir: string): I
       },
       autoApprove: { enabled: false, modelId: 'anthropic:claude-haiku-4-5' },
       auditRedaction: { enabled: false },
+      modelProviders: { default: 'native', profiles: { native: { type: 'native' } } },
+      statistics: { enabled: false, retentionDays: null },
       memory: { enabled: false, llmBaseUrl: undefined, llmApiKey: undefined },
       packageInstall: {
         enabled: false,


### PR DESCRIPTION
## Summary

- add resumable container-session discovery and launch RPCs to the Web UI
- add an accessible, responsive resume dialog with loading, retry, empty, and action-error states
- harden snapshot validation, duplicate resume locking, and PTY shutdown races
- namespace Docker resource ownership by canonical IronCurtain home so temporary-home integration tests cannot reclaim production sessions

## Validation

- 147 focused backend lifecycle and security tests
- 550 Web UI unit tests
- 8 Playwright session flows, including resume to live terminal
- TypeScript, ESLint, Prettier, Svelte checks, production Web UI build, and circular dependency check

The Docker ownership regression uses a fake runtime and does not touch live Docker resources.
