### PR TITLE
Support offline nested Docker and repair CA storage

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -91,13 +91,13 @@ to `offline` to use only images already available to the private runtime:
 }
 ```
 
-| Field                          | Type            | Default when enabled     | Description                                                                             |
-| ------------------------------ | --------------- | ------------------------ | --------------------------------------------------------------------------------------- |
-| `dockerWorkload.enabled`       | boolean         | `false`                  | Enable private nested Docker for Docker Agent sessions.                                 |
-| `dockerWorkload.networkAccess` | string          | Fresh enable: `packages` | `packages`, `images`, or `offline`; changes apply only to new sessions.                 |
-| `containerRuntime`             | string          | `auto`                   | `auto`, `docker`, or `apple-container`; the current nested-Docker slice requires Apple. |
-| `dockerResources.memoryMb`     | integer \| null | `8192`                   | Ordinary container memory ceiling; numeric values are inherited by nested Docker.       |
-| `dockerResources.cpus`         | number \| null  | `4`                      | Ordinary container CPU ceiling; numeric values are inherited by nested Docker.          |
+| Field                          | Type            | Default when enabled     | Description                                                                        |
+| ------------------------------ | --------------- | ------------------------ | ---------------------------------------------------------------------------------- |
+| `dockerWorkload.enabled`       | boolean         | `false`                  | Enable private nested Docker for Docker Agent sessions.                            |
+| `dockerWorkload.networkAccess` | string          | Fresh enable: `packages` | `packages`, `images`, or `offline`; changes apply only to new sessions.            |
+| `containerRuntime`             | string          | `auto`                   | `auto`, `docker`, or `apple-container`; nested Docker with `docker` is macOS-only. |
+| `dockerResources.memoryMb`     | integer \| null | `8192`                   | Ordinary container memory ceiling; numeric values are inherited by nested Docker.  |
+| `dockerResources.cpus`         | number \| null  | `4`                      | Ordinary container CPU ceiling; numeric values are inherited by nested Docker.     |
 
 For backward compatibility, an existing enabled block with no old or new network choice migrates to
 `images`; old `imageIngress: "public-registry"` also becomes `images`, while `preloaded-only` becomes
@@ -105,11 +105,13 @@ For backward compatibility, an existing enabled block with no old or new network
 with no prior choice remains unchanged until the first CLI or web enable, which explicitly writes
 `packages`.
 
-The current admitted implementation is the Apple Container developer slice. `containerRuntime` may
-remain `auto` when Apple Container is available; unsupported runtime resolutions fail before nested
-Docker is provisioned. If an ordinary Docker resource is `null`, nested Docker keeps its safe fallback
-instead of inheriting an unlimited value. The setting is global for Docker Agent execution: standalone
-sessions and each workflow infrastructure bundle receive their own private nested daemon when enabled.
+On macOS, nested Docker admits a resolved Docker Desktop or Apple Container runtime and checks that the
+selected runtime is available before provisioning. Docker Desktop currently supports only `offline`;
+`images` and `packages` fail before a sidecar is created until the separate DD-PROXY mediation topology is
+implemented. A Docker resolution on another host fails closed. If an ordinary Docker resource is `null`,
+nested Docker keeps its safe fallback instead of inheriting an unlimited value. The setting is global for
+Docker Agent execution: standalone sessions and each workflow infrastructure bundle receive their own
+private nested daemon when enabled.
 
 ### Connecting nested containers
 

--- a/config/docker-workload/profile-ceiling.json
+++ b/config/docker-workload/profile-ceiling.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "status": "probe-only-dd-h1-h2-supported-not-qualified",
+  "status": "reviewed-dd-h3-sidecar-supported-not-qualified",
   "maximumArtifactsPerCategory": 1,
   "categories": {
     "idMap": {
@@ -42,7 +42,8 @@
           "setns",
           "umount",
           "umount2"
-        ]
+        ],
+        "nestedUtsLifecycle": ["sethostname"]
       },
       "forbidden": [
         "bpf",
@@ -60,7 +61,7 @@
       },
       "artifact": {
         "path": "config/docker-workload/seccomp/desktop-p2-userns.json",
-        "sha256": "e5be04f5d37728c4c863768deea26eae3e64c07437e11c7363cb6e5ee27f983f"
+        "sha256": "5693eddf4a993ba182346c7570def97b49d5b97c02b961f2329f47e5a629a5f5"
       },
       "additions": [
         {
@@ -104,6 +105,20 @@
             "source": "https://github.com/moby/moby/blob/11ee7e07df4203b65b9cb23302aed9f8d81af0b6/daemon/internal/mounttree/switchroot_linux.go"
           },
           "namespaceInterpretation": "PivotRoot is available only to Moby's unpack helper inside RootlessKit's nested user/mount namespace; chroot remains denied and outside the ceiling.",
+          "reviewerDisposition": "Eligible for the cumulative P2 probe only; this is not qualification approval."
+        },
+        {
+          "syscall": "sethostname",
+          "arguments": "all",
+          "group": "nestedUtsLifecycle",
+          "denialEvidence": {
+            "runId": "codex-dd-functional-systempaths-0001",
+            "rootManifestSha256": "045d36989eded7c5048a838e23e4ff20404e4dd12cf0ec8af617cfa4c9838ccb",
+            "commandPath": "commands/45-inner-run-main.json",
+            "commandSha256": "3cf1f3f21ee573cfedb9b0f69189f40549ff9e568e741a7c384fae6cad3becd9",
+            "observation": "After the reviewed sidecar-only mount-mask exception allowed nested procfs creation, the first inner container failed at sethostname with EPERM under the prior P2 artifact"
+          },
+          "namespaceInterpretation": "SetHostname initializes only the inner container's UTS namespace inside the rootless daemon sidecar; the sidecar retains its private outer UTS namespace and no host namespace or capability is added.",
           "reviewerDisposition": "Eligible for the cumulative P2 probe only; this is not qualification approval."
         },
         {
@@ -157,9 +172,34 @@
       "additions": []
     },
     "mountMask": {
-      "eligibleEntryClasses": ["exact-bundle-private-run-or-data", "namespaced-nonsensitive-guest-proc-sys"],
+      "eligibleEntryClasses": [
+        "exact-bundle-private-run-or-data",
+        "namespaced-nonsensitive-guest-proc-sys",
+        "nested-daemon-sidecar-procfs"
+      ],
       "artifact": null,
-      "additions": []
+      "additions": [
+        {
+          "option": "systempaths=unconfined",
+          "scope": "docker-desktop-nested-daemon-sidecar-only",
+          "denialEvidence": {
+            "runId": "codex-dd-functional-baseline-0001",
+            "rootManifestSha256": "85b8d2ad16826d47450acff6fab2f769253895734452bfdbec5af0a2530ab8c1",
+            "commandPath": "commands/45-inner-run-main.json",
+            "commandSha256": "7ad475a45d6ca765d6c93645aee18acf512a9452a645d210764e107905701e3a",
+            "observation": "The first inner container failed because Docker's outer masked and read-only proc paths made the nested user-namespace procfs mount too revealing"
+          },
+          "positiveEvidence": {
+            "runId": "codex-dd-functional-systempaths-0008",
+            "rootManifestSha256": "f9eab292db802ea42b626a936e63b83d31c1642a823b3307bc2ee21a6e3869be",
+            "summaryPath": "summary.json",
+            "summarySha256": "98794ef41d7fd8d70ff23a835a9df74b1c9515735420debfd56f396624c28e8f",
+            "observation": "The functional sidecar probe passed staged load, run, exec, offline build, bind, volume, internal-network exchange, negative pull, and exact cleanup"
+          },
+          "boundary": "This exception applies only to the dedicated rootless nested-daemon sidecar with no outer network, host namespace, host runtime socket, device, SYS_ADMIN, NET_ADMIN, or broad bind. Agent containers retain Docker's default masked and read-only system paths.",
+          "reviewerDisposition": "Reviewed exception for the version-scoped Docker Desktop nested-daemon sidecar only; forbidden for agent and other containers."
+        }
+      ]
     }
   },
   "versionScope": {
@@ -179,7 +219,7 @@
     "device-or-fuse",
     "seccomp-unconfined",
     "apparmor-unconfined-or-complain",
-    "systempaths-unconfined",
+    "systempaths-unconfined-outside-reviewed-nested-daemon-sidecar",
     "direct-external-network"
   ]
 }

--- a/config/docker-workload/seccomp/desktop-p2-userns.json
+++ b/config/docker-workload/seccomp/desktop-p2-userns.json
@@ -912,6 +912,13 @@
       ],
       "action": "SCMP_ACT_ALLOW",
       "comment": "IronCurtain P2: denial-proven detached unmount of the old root after nested image-unpack pivot"
+    },
+    {
+      "names": [
+        "sethostname"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "comment": "IronCurtain P2: denial-proven inner UTS namespace hostname initialization"
     }
   ]
 }

--- a/docker/nested-daemon/Dockerfile
+++ b/docker/nested-daemon/Dockerfile
@@ -1,3 +1,12 @@
+# Reuse the same pinned builder as the fixed relay. The tiny wrapper adds
+# runc's --no-new-keyring option for ordinary runs and integrated BuildKit RUN
+# without admitting the keyctl syscall to the outer sidecar profile.
+FROM golang:1.24-bookworm@sha256:1a6d4452c65dea36aac2e2d606b01b4a029ec90cc1ae53890540ce6173ea77ac AS shim-build
+WORKDIR /src
+COPY runtime-shim/main.go ./main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/runc ./main.go \
+    && install -d -o 1000 -g 1000 -m 0700 /out/api
+
 # The stock rootless image is input bytes only. A scratch final stage clears
 # its inherited anonymous VOLUME declarations and exposed TCP ports so every
 # writable state root is explicitly named, leased, watched, and deleted by the
@@ -6,6 +15,12 @@ FROM docker@sha256:67c4114553192e9072969fc347426048cfe4192385dc762d8eb449c05e904
 
 FROM scratch
 COPY --from=stock / /
+
+# Docker named-volume copy-up preserves this image-owned directory metadata.
+# The daemon sidecar therefore receives a private API root already owned by
+# the rootless UID without an initializer container or CAP_CHOWN.
+COPY --from=shim-build --chown=1000:1000 --chmod=0700 /out/api/ /run/ironcurtain-docker/
+COPY --from=shim-build --chown=0:0 --chmod=0555 /out/runc /usr/local/lib/ironcurtain/runc
 
 ARG IRONCURTAIN_BUILD_HASH_SCHEMA=""
 ARG IRONCURTAIN_BUILD_HASH=""

--- a/docker/nested-daemon/runtime-shim/main.go
+++ b/docker/nested-daemon/runtime-shim/main.go
@@ -11,7 +11,7 @@ const realRunc = "/usr/local/bin/runc"
 func main() {
 	args := append([]string{"runc"}, os.Args[1:]...)
 	for index, argument := range args {
-		if argument != "create" {
+		if argument != "create" && argument != "run" {
 			continue
 		}
 		if !contains(args[index+1:], "--no-new-keyring") {

--- a/docs/designs/secure-nested-runtime-implementation-plan.md
+++ b/docs/designs/secure-nested-runtime-implementation-plan.md
@@ -1,8 +1,10 @@
 # Secure Nested Docker Runtime Implementation Plan
 
 **Date:** 2026-07-19
-**Status:** Phase 0A is implemented and self-tested. Phase 0B baseline Docker Desktop reached its
-frozen-topology stop gate at the inner procfs mount. Independent Apple evidence supports guest
+**Status:** Phase 0A is implemented and self-tested. A later Docker Desktop H3 probe resolved the
+earlier inner-procfs stop with a reviewed, sidecar-only mount-mask exception and passed staged image
+load, ordinary run/exec, bind and named-volume mounts, offline BuildKit RUN, internal target/scanner
+exchange, egress negatives, and exact cleanup. Independent Apple evidence supports guest
 prerequisites, a rootless `vfs` daemon, the functional offline matrix, sampled VM-boundary and
 publication negatives, resource accounting/peer survival, sparse-disk observation, and scoped
 fault cleanup, exact workspace/dependency paths, and a fixed per-file proxy relay with fail-closed
@@ -23,10 +25,11 @@ readiness and egress negatives, immutable-image checks, and exact cleanup on Doc
 that verifies its stopped and running effective profiles; a live Engine-28 check proved fixed-target
 forwarding, uplink-peer exclusion, relay-loss failure, and exact cleanup on an isolated dual-stack
 network. The Apple same-VM rootless daemon lifecycle and selected same-agent private-Docker image
-bootstrap are implemented. A fail-closed resolved-variant guard now admits only the exact Apple
-developer-only, selected-current-agent, ephemeral slice defined in §12, with either offline ingress or
-the fixed public-registry path, after a live Apple-availability
-preflight. `npm run smoke:nested:apple` exercises the built CLI session/bootstrap/activation path,
+bootstrap are implemented. A fail-closed resolved-variant guard admits the exact Apple slice defined
+in §12 and the macOS Docker Desktop offline-only developer slice: a dedicated rootless daemon sidecar,
+selected-current-agent transport, reviewed P2 seccomp and mount-mask exception, bounded aggregate
+resources, and lease-owned API volume. Both paths require live runtime-availability preflight.
+`npm run smoke:nested:apple` exercises the built Apple CLI session/bootstrap/activation path,
 then an exact lease-bound private-Docker child and teardown. The complementary, manually invoked
 `npm run smoke:nested:apple:pty` drives the built `start --pty` entrypoint through the same node-pty
 bridge as mux and requires a post-activation Claude TUI redraw plus private-Docker evidence and exact
@@ -37,9 +40,15 @@ path. The replacement selected-current public-registry product-entrypoint gate p
 IP/public-DNS negatives, no published ports, and exact teardown. A newer deterministic production
 workflow gate passed both public (28 checks) and offline (17 checks) modes without an LLM, with exact
 cleanup after each run and graceful second-session admission in one isolated home. These smokes are not
-agent-turn/provider, full 0C, or preview qualification. Docker Desktop, native Linux,
-build-egress, enforced-PID, bounded-disk, and preview variants remain rejected. No backend is
+agent-turn/provider, full 0C, or preview qualification. Docker Desktop `images`/`packages`, native Linux,
+enforced-PID, bounded-disk, and preview variants remain rejected. No backend is
 implementation-qualified or preview-ready.
+**Amendment (2026-08-25, Docker Desktop offline developer slice):** explicit opt-in on macOS may use
+the reviewed H3 sidecar topology before formal 0C/preview qualification. This is narrowly supported,
+not qualified: only `networkAccess: "offline"` is admitted, the outer sidecar remains `network=none`,
+and the agent receives only the read-only private API volume. Earlier statements that all Docker
+Desktop sessions were rejected or that the sidecar was unbuilt are superseded by this amendment.
+DD-PROXY and native Linux remain fail-closed future work.
 **Amendment (2026-07-21, user-approved; image-class disposition superseded by §16.16):** workload-image
 registry egress is promoted from Phase 3 into 0F/0C scope. See §6.4, §7.1, and §16.5.
 **Amendment (2026-07-21, user-approved):** workload-registry mediation gates request and derived-
@@ -153,7 +162,7 @@ Therefore:
 - do not treat the name `dind-rootless` as proof of a safe outer profile;
 - build a purpose-specific daemon image and begin with the normal outer restrictions;
 - permit only narrow, recorded changes shown necessary by the spike;
-- do not add `SYS_ADMIN`, `NET_ADMIN`, `/dev/fuse`, host namespaces, `seccomp=unconfined`, `apparmor=unconfined`, `systempaths=unconfined`, or outer `--privileged` during the Docker Desktop spike;
+- do not add `SYS_ADMIN`, `NET_ADMIN`, `/dev/fuse`, host namespaces, `seccomp=unconfined`, `apparmor=unconfined`, or outer `--privileged`; `systempaths=unconfined` is permitted only by the version-scoped, reviewed nested-daemon-sidecar exception recorded in §9.3 and remains forbidden for the agent container;
 - if a bounded non-privileged daemon cannot start, Docker Desktop support is infeasible under this topology and fails closed.
 
 Apple `container` is different: each outer workload has a dedicated lightweight VM. Rootful Docker inside that VM may be acceptable because it controls the disposable bundle VM rather than a shared host kernel. That is a separately named and separately proven topology, not a fallback that weakens Docker Desktop or Linux.
@@ -646,7 +655,7 @@ Never mount a host runtime socket, Mac home/root, SSH material, real credentials
 9. **Resources:** run bounded memory, CPU, process, and disk fixtures; sample outer runtime and host state; prove the declared aggregate behavior.
 10. **Fault cleanup:** kill nested child, daemon, agent, and sidecar at separate points during build and target/scanner execution. Delete exact outer resources and capture two empty owned inventories.
 
-Exploratory evidence establishes DD-H1 and DD-H2 but falsifies DD-H3 under the frozen baseline
+Exploratory evidence establishes DD-H1 and DD-H2 and initially falsifies DD-H3 under the baseline
 ceiling. `dd-p0-run-0002` falsifies P0 user-namespace creation. Fresh cumulative
 `dd-p2-capsetid-0005`, `dd-p2-capsetid-daemon-0006`, and `dd-h2-private-api-0006` support namespace
 creation, UDS-only daemon boot, and private sibling access with `NoNewPrivs=false`, only outer
@@ -655,27 +664,32 @@ eligible `pivot_root` and `umount2` syscalls and used a hash-recorded runtime sh
 `--no-new-keyring` mode rather than admit the forbidden `keyctl` syscall. `dd-h3-functional-0004`
 successfully loads the staged image but the first inner container fails while mounting procfs.
 
-This DD-H3 result reaches the Track DD stop gate, rather than P4. The outer container's default
+That DD-H3 result reached the Track DD stop gate. The outer container's default
 masked and read-only `/proc/*` overmounts cause Linux `mount_too_revealing` to reject a new procfs
 mount from the nested user namespace. This is a kernel rule, not a further seccomp denial: an
 unconditional `mount` rule is already present and earlier nested mounts succeed. Primary runc
 analysis demonstrates that removing a single entry is insufficient; the mount namespace needs at
 least one fully visible procfs. Docker's supported control is an empty `MaskedPaths` and
-`ReadonlyPaths` override, exposed by `systempaths=unconfined`. That would unmask sensitive proc
-entries and is explicitly outside P4 and the absolute-stop list. A host/VM procfs bind would instead
-expose a host namespace and is also forbidden. Consequently baseline Docker Desktop is currently
-**not feasible under the frozen topology**. DD-PROXY cannot repair this local mount prerequisite and
-is not run for this candidate. ECI/Sysbox may still be assessed only as their separately named
-environments.
+`ReadonlyPaths` override, exposed by `systempaths=unconfined`. Review accepted that override only for
+the dedicated, networkless rootless-daemon sidecar: it has no host namespace, host runtime socket,
+device, `SYS_ADMIN`, `NET_ADMIN`, or broad bind. The agent container and every other outer container
+retain Docker's default masks. A host/VM procfs bind remains forbidden.
+
+The first reviewed-exception run, `codex-dd-functional-systempaths-0001`, advanced to an independent
+`sethostname` seccomp denial. Its manifest-bound command denial justified the one additional P2 rule,
+which operates only for inner UTS initialization inside the rootless sidecar. With that hash-bound
+artifact, `codex-dd-functional-systempaths-0008` passes staged image load, run/exec, offline build,
+bind/volume, internal-network target/scanner exchange, negative pull, and exact cleanup. This closes
+the local DD-H3 functional blocker for the version-scoped sidecar profile; it does not qualify
+DD-PROXY, the product entrypoint, native Linux, or preview support.
 
 Every cited successful or falsifying run has a verified manifest and exact cleanup with two empty
-inventories. These stock-image probes do not qualify Docker Desktop. Proceed independently with
-Track AC; revisiting baseline Desktop requires an explicit reviewed change to the profile ceiling
-and a complete P0-P4 restart, not an exploratory fallback.
+inventories. These stock-image probes do not qualify Docker Desktop. The reviewed exception is
+recorded in the checked-in profile ceiling and cannot be reused outside the dedicated sidecar.
 
 #### Track DD stop gates
 
-Stop and record **not feasible under the baseline topology** if rootless Docker requires outer `--privileged`, `SYS_ADMIN`, `NET_ADMIN`, `/dev/fuse`, the host cgroup namespace/mount, writable cgroup control above its delegated subtree, migration outside its immutable ancestor, any other host namespace/device, a host runtime socket, broad unconfined profiles, direct external networking, unconfined host mounts, or untrusted cleanup access to the host daemon. Also stop for external egress, sidecar-cgroup escape, host port exposure, sibling/runtime access, or incomplete exact cleanup.
+Stop and record **not feasible under the baseline topology** if rootless Docker requires outer `--privileged`, `SYS_ADMIN`, `NET_ADMIN`, `/dev/fuse`, the host cgroup namespace/mount, writable cgroup control above its delegated subtree, migration outside its immutable ancestor, any other host namespace/device, a host runtime socket, broad unconfined profiles beyond the reviewed nested-daemon-sidecar system-path exception, direct external networking, unconfined host mounts, or untrusted cleanup access to the host daemon. Also stop for external egress, sidecar-cgroup escape, host port exposure, sibling/runtime access, or incomplete exact cleanup.
 
 ### 9.4 Phase 0B Track AC: Apple primitive falsification
 
@@ -807,7 +821,7 @@ Phase 0B classifies each primitive hypothesis as `supported`, `falsified`, or `b
 Implementation slices may land behind a fail-closed resolved-variant guard before their phase exit.
 That makes one exact topology testable without claiming broader support. The ordering of phase exits,
 backend qualification, product-entrypoint reruns, and preview remains normative; admitting the narrow
-Apple developer slice satisfies none of those later gates by itself.
+Apple or Docker Desktop offline developer slice satisfies none of those later gates by itself.
 
 Current 0F foundations are catalog-independent. Checked-in images are CA-neutral; trusted bootstrap
 stages only public trust, provider/registry forwarding uses destination-bound transport, and the
@@ -1006,7 +1020,10 @@ unbound, or non-ready; reconciliation fencing alone is not treated as cleanup pr
 
 ### Phase 2-DD — Docker Desktop product slice (independent)
 
-Proceed only if Track DD becomes an implementation-qualified candidate in 0C. Implement its minimal recorded profile, separate named-volume API/exchange roots, identical workspace paths, DD-STRICT `network=none`, evidence-gated DD-PROXY isolated-gateway network plus independently pinned fixed relay, selected-current-agent transport, and resource declarations.
+The explicit-opt-in DD-STRICT developer slice is implemented with its minimal recorded profile,
+lease-owned named-volume API/data root, `network=none`, selected-current-agent transport, and aggregate
+resource partition. It remains supported-not-qualified. DD-PROXY still requires its isolated-gateway
+network, independently pinned fixed relay, and complete network-policy evidence before admission.
 
 **Exit:** the actual CLI, web/CLI launch, session-creation, agent entrypoint, and resume/rejection paths rerun the Desktop release suite and G1-G10 before Desktop preview. Every Phase 0 stop condition is a regression test. Failed preflight disables the capability without fallback.
 
@@ -1062,7 +1079,7 @@ Each requires its own threat model and gates.
 
 - `src/docker-workload/config.ts` — requested and resolved capability types.
 - `src/docker-workload/infrastructure.ts` — common bundle lifecycle and budget partition.
-- `src/docker-workload/rootless-sidecar.ts` — Linux/Desktop bootstrap, health, profile record, and UDS paths. Not built: no Linux/Desktop backend is qualified, and §9.3 classifies baseline Desktop as infeasible under the frozen topology.
+- [`src/docker-workload/docker-desktop-sidecar.ts`](../../src/docker-workload/docker-desktop-sidecar.ts) — implemented Docker Desktop rootless sidecar bootstrap, health, frozen-profile binding, activation canaries, API-volume handoff, and rollback.
 - `src/docker-workload/client-toolchain.ts` — qualification-recorded Docker CLI/Buildx/Compose installation manifest and API compatibility preflight; its guest result is advisory.
 - [`src/docker-workload/apple-vm-daemon.ts`](../../src/docker-workload/apple-vm-daemon.ts) — frozen same-VM rootless bootstrap argv and the fail-closed readiness adjudication (§4.4 variant 1). Pure logic over an injected exec seam; variants 2 and 3 are unbuilt.
 - [`src/docker-workload/session-daemon.ts`](../../src/docker-workload/session-daemon.ts) — backend implementation assert (`assertNestedDaemonBackendImplemented`) and the per-session decision of whether a create launches the nested daemon component.
@@ -1144,7 +1161,7 @@ Operators who require no live registry access opt out explicitly:
 ```yaml
 dockerWorkload:
   enabled: true
-  imageIngress: preloaded-only
+  networkAccess: offline
 ```
 
 Qualification, offline, and PTY-only gates must use that explicit opt-out. The remaining internal
@@ -1152,7 +1169,7 @@ fields are implementation invariants, not ordinary UI choices. The following are
 unsupported and rejected before feature-attributable runtime, image transport, proxy, lease, or
 filesystem provisioning:
 
-- Docker Desktop and native Linux outer runtimes;
+- native Linux outer runtimes, and Docker Desktop `images` or `packages` network access;
 - `tier: preview`, current-Dockerfile build egress, persistent daemon state,
   or host-port publishing;
 - `pids.required: true`, a numeric disk limit, or explicitly disabling acceptance of the admitted

--- a/scripts/spikes/secure-nested-docker/README.md
+++ b/scripts/spikes/secure-nested-docker/README.md
@@ -4,15 +4,17 @@ This directory contains only the platform probes and capture tools that still ha
 It is not a second test suite and no result here qualifies a backend. Product behavior belongs in
 `src/docker-workload`, product tests, and `npm run qualify:apple`.
 
-The Apple developer slice is currently admitted with this minimal operator configuration:
+The macOS developer slices are currently admitted with this minimal operator configuration:
 
 ```json
 { "dockerWorkload": { "enabled": true } }
 ```
 
 That enabled state defaults to mediated Docker Hub/GHCR pulls. Deterministic offline and PTY-only
-qualification gates set `imageIngress: "preloaded-only"` explicitly. Nothing in this retained-probe
-directory changes either product default or the preview qualification state.
+qualification gates set `imageIngress: "preloaded-only"` explicitly. Docker Desktop uses the
+version-scoped reviewed rootless sidecar profile recorded below; Apple Container uses its separate VM
+profile. Nothing in this retained-probe directory changes either product default or the preview
+qualification state.
 
 ## Retention ledger
 
@@ -20,7 +22,7 @@ directory changes either product default or the preview qualification state.
 | ---------------------------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Phase 0A fake-runtime ledger, recovery, redaction, and tamper harness        | Retired       | The real lease, lock, reconciliation, lifecycle-evidence, and watchdog paths now have production tests. The design also rejects commit/hash-bound qualification bookkeeping (§16.12).                      |
 | Apple 0B inventory, rootless, path, relay, resource, disk, and fault runners | Retired       | They were one-off executors for a completed primitive study, used superseded CA-baked images, and cannot qualify the current product topology. The durable results and evidence IDs remain in design §9.4. |
-| Docker Desktop P0/P2 and private-API/functional probes                       | Retained      | Baseline Desktop is unsupported at a documented stop gate. These are the exact replay tools required if a future decision explicitly reopens the profile ceiling.                                          |
+| Docker Desktop P0/P2 and private-API/functional probes                       | Retained      | These bind the reviewed sidecar-only profile exception and replay the functional result; they do not qualify Docker Desktop or authorize the exception for agent containers.                               |
 | Docker Desktop runtime shim                                                  | Retained      | The functional Desktop probe uses it to select runc's `--no-new-keyring` mode without admitting `keyctl`.                                                                                                  |
 | Profile-ceiling and probe-evidence verifiers                                 | Retained      | They validate the retained Desktop replay inputs and outputs.                                                                                                                                              |
 | Current-Dockerfile build-egress capture                                      | Retired       | Source/hash pinning and the generic-public experiment are not product authority. Git history retains the deleted capture tooling; the governing package-only design owns future work.                      |
@@ -30,21 +32,25 @@ directory changes either product default or the preview qualification state.
 Deleted executors are intentionally not kept as historical code. The design is the record of their
 findings; source control is the record of their implementation.
 
-## Docker Desktop: retained stop-gate replay
+## Docker Desktop: reviewed sidecar-profile replay
 
-Do not run these probes to make an unsupported backend appear supported. The existing result is:
+The retained sequence records both the original stop gate and the explicitly reviewed sidecar-only
+exception:
 
 - P0 denies unprivileged user-namespace creation.
 - P2 plus only outer `SETUID`/`SETGID` and `NoNewPrivs=false` boots the rootless daemon.
 - A named-volume UDS gives the authorized sibling private daemon access while excluding a sibling
   without the volume.
-- The functional probe loads the staged image, then runc fails to mount procfs because the outer
-  Docker container's masked/read-only proc paths make the nested procfs too revealing.
-- Docker's `systempaths=unconfined` override is outside the frozen ceiling, so baseline Docker
-  Desktop stopped before DD-PROXY.
+- With Docker's default system paths, the functional probe loads the staged image, then runc fails to
+  mount procfs because the outer container's masked/read-only proc paths make nested procfs too
+  revealing.
+- Review admitted `systempaths=unconfined` only for the dedicated rootless daemon sidecar. The first
+  rerun then denial-proved `sethostname`; the updated P2 artifact admits it only for inner UTS setup.
+- `codex-dd-functional-systempaths-0008` passes the functional matrix and exact cleanup under that
+  version-scoped profile. Agent containers retain Docker's default masked/read-only system paths.
 
-The detailed evidence IDs and adjudication are in design §9.3. Reopening this track requires an
-explicit review of the ceiling followed by a fresh P0-P4 sequence, not another ad hoc delta.
+The detailed evidence IDs and adjudication are in design §9.3. This is functional sidecar evidence,
+not 0C qualification or authority to broaden another container's profile.
 
 First verify the checked-in ceiling against its canonical Moby baseline:
 
@@ -66,6 +72,7 @@ node scripts/spikes/secure-nested-docker/phase0b-dd-private-api.mjs \
 
 node scripts/spikes/secure-nested-docker/phase0b-dd-private-api.mjs \
   --probe functional \
+  --systempaths-unconfined true \
   --run-id dd-functional-review-0001 \
   --evidence-dir /absolute/outside-workspace/dd-functional-review-0001
 

--- a/scripts/spikes/secure-nested-docker/phase0b-dd-p0.mjs
+++ b/scripts/spikes/secure-nested-docker/phase0b-dd-p0.mjs
@@ -36,7 +36,10 @@ if (!['p0', 'p2'].includes(profileLevel)) throw new Error('--profile-level must 
 const profilePath =
   profileLevel === 'p2' ? path.join(workspaceRoot, 'config/docker-workload/seccomp/desktop-p2-userns.json') : undefined;
 const profileHash = profilePath ? sha256File(profilePath) : 'docker-builtin';
-const expectedProfileHash = 'e5be04f5d37728c4c863768deea26eae3e64c07437e11c7363cb6e5ee27f983f';
+const ceiling = JSON.parse(
+  readFileSync(path.join(workspaceRoot, 'config/docker-workload/profile-ceiling.json'), 'utf8'),
+);
+const expectedProfileHash = ceiling.categories?.seccomp?.artifact?.sha256;
 if (profilePath && profileHash !== expectedProfileHash) {
   throw new Error(
     `P2 seccomp artifact hash mismatch: expected ${expectedProfileHash}, received ${profileHash} at ${profilePath}`,

--- a/scripts/spikes/secure-nested-docker/phase0b-dd-private-api.mjs
+++ b/scripts/spikes/secure-nested-docker/phase0b-dd-private-api.mjs
@@ -30,6 +30,7 @@ const probe = (parsed.probe ?? 'private-api').toLowerCase();
 if (!['functional', 'private-api'].includes(probe)) {
   throw new Error('--probe must be functional or private-api');
 }
+const systempathsUnconfined = parsed['systempaths-unconfined'] === 'true';
 const daemonImage =
   parsed['daemon-image'] ?? 'docker@sha256:67c4114553192e9072969fc347426048cfe4192385dc762d8eb449c05e904255';
 const helperImage =
@@ -60,9 +61,9 @@ const stageRoot = '/run/ironcurtain-staged';
 const stagingDir = path.join(evidenceDir, 'staging');
 const stagedArchiveHostPath = path.join(stagingDir, 'alpine.tar');
 const stagedArchiveGuestPath = `${stageRoot}/alpine.tar`;
-const runtimeShimSourcePath = path.join(scriptDir, 'runtime-shim/main.go');
-const runtimeShimHostPath = path.join(stagingDir, 'runc-no-new-keyring');
-const runtimeShimGuestPath = `${stageRoot}/runc-no-new-keyring`;
+const runtimeShimSourcePath = path.join(workspaceRoot, 'docker/nested-daemon/runtime-shim/main.go');
+const runtimeShimHostPath = path.join(stagingDir, 'runc');
+const runtimeShimGuestPath = `${stageRoot}/runc`;
 const requestedNames = {
   authorized: `ic-nested-spike-${runId}-authorized`,
   daemon: `ic-nested-spike-${runId}-daemon`,
@@ -232,7 +233,7 @@ function prepareStagedImage() {
   appendLedger(evidenceDir, {
     event: 'artifact-intent',
     generation,
-    path: 'staging/runc-no-new-keyring',
+    path: 'staging/runc',
     runId,
     source: path.relative(workspaceRoot, runtimeShimSourcePath),
     time: new Date().toISOString(),
@@ -261,7 +262,7 @@ function prepareStagedImage() {
   ].join('\n');
   writeFileSync(path.join(stagingDir, 'Dockerfile'), dockerfile, { mode: 0o600, flag: 'wx' });
   writeFileSync(path.join(stagingDir, 'payload.txt'), 'offline-build-ok\n', { mode: 0o600, flag: 'wx' });
-  writeFileSync(path.join(stagingDir, '.dockerignore'), 'alpine.tar\nrunc-no-new-keyring\n', {
+  writeFileSync(path.join(stagingDir, '.dockerignore'), 'alpine.tar\nrunc\n', {
     mode: 0o600,
     flag: 'wx',
   });
@@ -276,7 +277,7 @@ function prepareStagedImage() {
     source: helperImage,
   });
   writeJsonAtomic(path.join(evidenceDir, 'runtime-shim.json'), {
-    binaryPath: 'staging/runc-no-new-keyring',
+    binaryPath: 'staging/runc',
     binarySha256: sha256File(runtimeShimHostPath),
     build: {
       cgoEnabled: false,
@@ -318,7 +319,7 @@ function createApiVolume() {
 function initializeApiVolume() {
   const initCommand =
     probe === 'functional'
-      ? 'chmod 0700 /api && chown 1000:1000 /api && chown 0:0 /staged/.dockerignore /staged/alpine.tar /staged/Dockerfile /staged/payload.txt /staged/runc-no-new-keyring && chmod 0444 /staged/.dockerignore /staged/alpine.tar /staged/Dockerfile /staged/payload.txt && chmod 0555 /staged/runc-no-new-keyring'
+      ? 'chmod 0700 /api && chown 1000:1000 /api && chown 0:0 /staged/.dockerignore /staged/alpine.tar /staged/Dockerfile /staged/payload.txt /staged/runc && chmod 0444 /staged/.dockerignore /staged/alpine.tar /staged/Dockerfile /staged/payload.txt && chmod 0555 /staged/runc'
       : 'chmod 0700 /api && chown 1000:1000 /api';
   const init = createTrackedContainer('init', [
     'docker',
@@ -387,6 +388,7 @@ function createDaemon() {
     'SETGID',
     '--security-opt',
     `seccomp=${profilePath}`,
+    ...(systempathsUnconfined ? ['--security-opt', 'systempaths=unconfined'] : []),
     '--read-only',
     '--pids-limit',
     '128',
@@ -398,6 +400,8 @@ function createDaemon() {
     '/run:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000',
     '--tmpfs',
     '/tmp:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000',
+    '--tmpfs',
+    '/home/rootless/.docker:rw,nosuid,nodev,noexec,size=16m,uid=1000,gid=1000',
     '--mount',
     `type=volume,src=${apiVolumeName},dst=${apiRoot},volume-nocopy`,
     ...(probe === 'functional'
@@ -409,6 +413,8 @@ function createDaemon() {
     'DOCKERD_ROOTLESS_ROOTLESSKIT_NET=none',
     '--env',
     `XDG_RUNTIME_DIR=${apiRoot}`,
+    '--env',
+    `PATH=${stageRoot}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
     daemonImage,
     'dockerd',
     ...(probe === 'functional' ? ['--debug'] : []),
@@ -484,6 +490,10 @@ function runFunctionalPrimitives(daemon) {
   if (JSON.parse(loadedInspect.stdout)[0]?.Id !== helperImageId) {
     throw new ProbeFailure('loaded image immutable ID differs from the staged image');
   }
+  assertInnerSucceeded(
+    innerDocker(daemon, 'inner-tag-loaded-image', ['image', 'tag', helperImageId, 'alpine:latest']),
+    'loaded image could not be tagged for the offline build',
+  );
 
   const main = innerDocker(daemon, 'inner-run-main', [
     'run',
@@ -613,11 +623,23 @@ function runFunctionalPrimitives(daemon) {
     helperImageId,
     '/bin/sh',
     '-c',
-    'printf vulnerable-marker > /www/index.html; exec httpd -f -p 8080 -h /www',
+    "while :; do printf 'HTTP/1.1 200 OK\\r\\nContent-Length: 17\\r\\nConnection: close\\r\\n\\r\\nvulnerable-marker' | nc -l -p 8080; done",
   ]);
   assertInnerSucceeded(server, 'nested target start failed');
   const serverId = server.stdout.trim();
   if (!/^[a-f0-9]{64}$/.test(serverId)) throw new ProbeFailure('nested target returned an invalid ID');
+
+  const serverRunning = innerDocker(daemon, 'inner-target-readiness', [
+    'inspect',
+    '--format',
+    '{{.State.Running}}',
+    serverId,
+  ]);
+  assertInnerSucceeded(serverRunning, 'nested target readiness inspect failed');
+  if (serverRunning.stdout.trim() !== 'true') {
+    const serverLogs = innerDocker(daemon, 'inner-target-failed-logs', ['logs', serverId]);
+    throw new ProbeFailure(`nested target exited before readiness: ${serverLogs.stderr || serverLogs.stdout}`);
+  }
 
   assertInnerSucceeded(
     innerDocker(daemon, 'inner-run-scanner', [

--- a/scripts/spikes/secure-nested-docker/verify-profile-ceiling.mjs
+++ b/scripts/spikes/secure-nested-docker/verify-profile-ceiling.mjs
@@ -10,8 +10,13 @@ const workspaceRoot = path.resolve(scriptDir, '../../..');
 const ceilingPath = path.join(workspaceRoot, 'config/docker-workload/profile-ceiling.json');
 const ceiling = readJson(ceilingPath);
 const seccomp = ceiling.categories?.seccomp;
+const mountMask = ceiling.categories?.mountMask;
 
 assert(ceiling.schemaVersion === 1, 'unsupported profile-ceiling schema');
+assert(
+  ceiling.status === 'reviewed-dd-h3-sidecar-supported-not-qualified',
+  'profile-ceiling status does not describe the reviewed sidecar result',
+);
 assert(ceiling.maximumArtifactsPerCategory === 1, 'profile ceiling must permit exactly one artifact per category');
 assert(seccomp?.artifact?.path, 'seccomp artifact path is missing');
 assertHash(seccomp.artifact.sha256, 'seccomp artifact sha256');
@@ -80,8 +85,41 @@ for (const entry of taggedEntries) {
 assert(emitted.size === declared.size, 'artifact and declared addition counts differ');
 for (const syscall of declared.keys())
   assert(emitted.has(syscall), `declared syscall is absent from artifact: ${syscall}`);
+assert(declared.has('sethostname'), 'denial-proven sethostname addition is absent');
 
-process.stdout.write(`verified P2 subset: ${[...emitted].sort().join(', ')}; artifact ${seccomp.artifact.sha256}\n`);
+const mountMaskAdditions = mountMask?.additions ?? [];
+assert(mountMaskAdditions.length === 1, 'profile ceiling must contain exactly one mount-mask exception');
+const [sidecarSystemPaths] = mountMaskAdditions;
+assert(sidecarSystemPaths.option === 'systempaths=unconfined', 'reviewed mount-mask option is missing');
+assert(
+  sidecarSystemPaths.scope === 'docker-desktop-nested-daemon-sidecar-only',
+  'systempaths exception is not confined to the Docker Desktop nested-daemon sidecar',
+);
+assertEvidence(sidecarSystemPaths.denialEvidence, 'systempaths=unconfined');
+assertPositiveEvidence(sidecarSystemPaths.positiveEvidence, 'systempaths=unconfined');
+assert(
+  sidecarSystemPaths.reviewerDisposition ===
+    'Reviewed exception for the version-scoped Docker Desktop nested-daemon sidecar only; forbidden for agent and other containers.',
+  'systempaths exception lacks the sidecar-only reviewer disposition',
+);
+assert(
+  /Agent containers retain Docker's default masked and read-only system paths\./u.test(
+    sidecarSystemPaths.boundary ?? '',
+  ),
+  'systempaths exception does not preserve the agent-container mount-mask policy',
+);
+assert(
+  ceiling.absoluteStops?.includes('systempaths-unconfined-outside-reviewed-nested-daemon-sidecar'),
+  'absolute stops do not reject systempaths=unconfined outside the reviewed sidecar',
+);
+assert(
+  !ceiling.absoluteStops?.includes('systempaths-unconfined'),
+  'absolute stops still contradict the reviewed sidecar-only systempaths exception',
+);
+
+process.stdout.write(
+  `verified P2 subset: ${[...emitted].sort().join(', ')}; sidecar mount-mask exception: ${sidecarSystemPaths.option}; artifact ${seccomp.artifact.sha256}\n`,
+);
 
 function assertEvidence(evidence, syscall) {
   assert(evidence && typeof evidence === 'object', `denial evidence is missing: ${syscall}`);
@@ -95,6 +133,18 @@ function assertEvidence(evidence, syscall) {
   assert(
     typeof evidence.observation === 'string' && evidence.observation.length > 0,
     `denial observation is missing: ${syscall}`,
+  );
+}
+
+function assertPositiveEvidence(evidence, label) {
+  assert(evidence && typeof evidence === 'object', `positive evidence is missing: ${label}`);
+  assert(/^[a-z0-9][a-z0-9-]{0,127}$/.test(evidence.runId ?? ''), `invalid positive run ID: ${label}`);
+  assert(evidence.summaryPath === 'summary.json', `invalid positive summary path: ${label}`);
+  assertHash(evidence.rootManifestSha256, `positive manifest hash: ${label}`);
+  assertHash(evidence.summarySha256, `positive summary hash: ${label}`);
+  assert(
+    typeof evidence.observation === 'string' && evidence.observation.length > 0,
+    `positive observation is missing: ${label}`,
   );
 }
 

--- a/src/docker-workload/bundle-lease.ts
+++ b/src/docker-workload/bundle-lease.ts
@@ -32,11 +32,12 @@ const labelKeySchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/u);
  * so downstream readers (lifecycle evidence) never restate the numbers.
  */
 export const cleanupInventoryGapMsSchema = z.number().int().min(100).max(60_000);
+export const outerResourceKindSchema = z.enum(['container', 'network', 'volume']);
 
 const outerResourceSchema = z
   .object({
     requestId: identifierSchema,
-    kind: z.enum(['container', 'network']),
+    kind: outerResourceKindSchema,
     role: identifierSchema,
     requestedName: resourceNameSchema,
     ownershipLabelKey: labelKeySchema,

--- a/src/docker-workload/bundle-revocation.ts
+++ b/src/docker-workload/bundle-revocation.ts
@@ -48,8 +48,11 @@ export async function revokeDockerWorkloadOuterResources(
     if (current.kind === 'container') {
       const removed = await revokeContainer(runtime, leasePath, generation, current, now, assertBudget);
       removedResourceIds.push(removed);
-    } else {
+    } else if (current.kind === 'network') {
       const removed = await revokeNetwork(runtime, leasePath, generation, current, now, assertBudget);
+      removedResourceIds.push(removed);
+    } else {
+      const removed = await revokeVolume(runtime, leasePath, generation, current, now, assertBudget);
       removedResourceIds.push(removed);
     }
   }
@@ -102,6 +105,25 @@ export async function inventoryOwnedResourceIds(
           }),
         )
         .map((network) => network.id),
+    );
+  }
+  if (lease.resources.some((resource) => resource.kind === 'volume')) {
+    if (runtime.listVolumes === undefined) {
+      throw new Error('selected outer runtime cannot inventory volumes for cleanup proof');
+    }
+    assertBudget();
+    const volumes = await runtime.listVolumes();
+    assertBudget();
+    assertUniqueInventory(volumes, 'volume');
+    ids.push(
+      ...volumes
+        .filter((volume) =>
+          [...ownershipTuples].some((tuple) => {
+            const [key, value] = tuple.split('\0');
+            return volume.labels[key] === value;
+          }),
+        )
+        .map((volume) => volume.id),
     );
   }
   return [...ids].sort();
@@ -183,15 +205,69 @@ async function revokeNetwork(
   if (runtime.listNetworks === undefined) {
     throw new Error('selected outer runtime cannot inventory networks for exact revocation');
   }
-  assertBudget();
-  const inventory = await runtime.listNetworks();
-  assertBudget();
-  assertUniqueInventory(inventory, 'network');
+  const listNetworks = runtime.listNetworks.bind(runtime);
+  return revokeNamedResource({
+    kind: 'network',
+    leasePath,
+    generation,
+    resource,
+    now,
+    assertBudget,
+    list: listNetworks,
+    remove: (id) => runtime.removeNetwork(id),
+  });
+}
+
+async function revokeVolume(
+  runtime: ContainerRuntime,
+  leasePath: string,
+  generation: string,
+  resource: DockerWorkloadOuterResource,
+  now: () => Date,
+  assertBudget: () => void,
+): Promise<string> {
+  if (runtime.listVolumes === undefined || runtime.removeVolume === undefined) {
+    throw new Error('selected outer runtime cannot inventory and remove volumes for exact revocation');
+  }
+  const listVolumes = runtime.listVolumes.bind(runtime);
+  const removeVolume = runtime.removeVolume.bind(runtime);
+  return revokeNamedResource({
+    kind: 'volume',
+    leasePath,
+    generation,
+    resource,
+    now,
+    assertBudget,
+    list: listVolumes,
+    remove: removeVolume,
+  });
+}
+
+interface RevokeNamedResourceOptions {
+  readonly kind: 'network' | 'volume';
+  readonly leasePath: string;
+  readonly generation: string;
+  readonly resource: DockerWorkloadOuterResource;
+  readonly now: () => Date;
+  readonly assertBudget: () => void;
+  readonly list: () => Promise<readonly NamedResourceInfo[]>;
+  readonly remove: (id: string) => Promise<void>;
+}
+
+interface NamedResourceInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly labels: Readonly<Record<string, string>>;
+}
+
+async function revokeNamedResource(options: RevokeNamedResourceOptions): Promise<string> {
+  const { kind, leasePath, generation, resource, now, assertBudget, list, remove } = options;
+  const inventory = await requiredNamedResourceInventory(kind, list, assertBudget);
   let observedId = resource.observedId;
   if (observedId === null) {
-    const matching = inventory.filter((network) => network.name === resource.requestedName);
+    const matching = inventory.filter((candidate) => candidate.name === resource.requestedName);
     if (matching.length > 1)
-      throw new Error(`outer runtime returned duplicate network name: ${resource.requestedName}`);
+      throw new Error(`outer runtime returned duplicate ${kind} name: ${resource.requestedName}`);
     const discovered = matching.at(0);
     if (discovered === undefined) {
       recordDockerWorkloadOuterResourceRemoval(
@@ -207,7 +283,7 @@ async function revokeNetwork(
     observedId = discovered.id;
     observeDockerWorkloadOuterResource(leasePath, generation, resource.requestId, observedId, now());
   } else {
-    const observed = inventory.find((network) => network.id === observedId);
+    const observed = inventory.find((candidate) => candidate.id === observedId);
     if (observed === undefined) {
       recordDockerWorkloadOuterResourceRemoval(
         leasePath,
@@ -219,19 +295,16 @@ async function revokeNetwork(
       return observedId;
     }
     if (observed.name !== resource.requestedName) {
-      throw new Error(`observed network name changed for immutable ID ${observedId}`);
+      throw new Error(`observed ${kind} name changed for runtime identity ${observedId}`);
     }
     assertOwnership(observed, resource);
   }
 
   assertBudget();
-  await runtime.removeNetwork(observedId);
-  assertBudget();
-  const after = await runtime.listNetworks();
-  assertBudget();
-  assertUniqueInventory(after, 'network');
-  if (after.some((network) => network.id === observedId)) {
-    throw new Error(`exact outer network still exists after revocation: ${observedId}`);
+  await remove(observedId);
+  const after = await requiredNamedResourceInventory(kind, list, assertBudget);
+  if (after.some((candidate) => candidate.id === observedId)) {
+    throw new Error(`exact outer ${kind} still exists after revocation: ${observedId}`);
   }
   recordDockerWorkloadOuterResourceRemoval(
     leasePath,
@@ -252,6 +325,18 @@ async function requiredContainerInventory(
   const inventory = await runtime.listContainers();
   assertBudget();
   assertUniqueInventory(inventory, 'container');
+  return inventory;
+}
+
+async function requiredNamedResourceInventory(
+  kind: 'network' | 'volume',
+  list: () => Promise<readonly NamedResourceInfo[]>,
+  assertBudget: () => void,
+): Promise<readonly NamedResourceInfo[]> {
+  assertBudget();
+  const inventory = await list();
+  assertBudget();
+  assertUniqueInventory(inventory, kind);
   return inventory;
 }
 
@@ -283,7 +368,8 @@ function requiredResource(lease: DockerWorkloadLease, requestId: string): Docker
 }
 
 function compareRevocationOrder(left: DockerWorkloadOuterResource, right: DockerWorkloadOuterResource): number {
-  if (left.kind !== right.kind) return left.kind === 'container' ? -1 : 1;
+  const kindPriority = { container: 0, volume: 1, network: 2 } as const;
+  if (left.kind !== right.kind) return kindPriority[left.kind] - kindPriority[right.kind];
   const priorities = new Map([
     ['agent', 0],
     ['nested-daemon', 1],

--- a/src/docker-workload/config.ts
+++ b/src/docker-workload/config.ts
@@ -75,7 +75,7 @@ export const dockerWorkloadRequestedSchema = z
         code: 'custom',
         path: ['backend'],
         message:
-          'legacy nested-Docker backend "docker" is not supported; remove dockerWorkload.backend and use the current Apple Container developer slice',
+          'legacy dockerWorkload.backend is no longer supported; remove it and set containerRuntime to "docker" to select Docker Desktop',
       });
     }
     if (request.buildEgress === 'ironcurtain-dockerfiles') {
@@ -224,36 +224,45 @@ export function dockerWorkloadConfigHash(config: ResolvedDockerWorkloadConfig): 
 }
 
 /**
- * Admit only the Mac developer slice whose complete runtime path is currently
- * implemented. The caller resolves `auto` first, then invokes this guard before
- * any feature-attributable runtime, image, proxy, lease, or filesystem
- * provisioning. Operational artifacts are verified later by their owning
- * seams; this guard deliberately contains no release/commit bookkeeping.
+ * Admit only a supported developer slice. The caller resolves `auto` first,
+ * then invokes this guard before any feature-attributable runtime, image,
+ * proxy, lease, or filesystem provisioning. Docker Desktop is admitted only
+ * on Darwin; Apple Container performs its platform/version checks in the
+ * runtime-availability preflight below. Operational artifacts are verified
+ * later by their owning seams; this guard deliberately contains no
+ * release/commit bookkeeping.
  */
 export function assertDockerWorkloadVariantAdmitted(
   config: ResolvedDockerWorkloadConfig | undefined,
   resolvedRuntimeKind: 'docker' | 'apple-container',
+  hostPlatform: NodeJS.Platform = process.platform,
 ): void {
   if (config?.enabled !== true) return;
-  const admitted =
-    resolvedRuntimeKind === 'apple-container' &&
-    !config.resources.pids.required &&
-    config.resources.diskMb === null &&
-    config.acceptObservedDiskRisk;
-  if (!admitted) {
+  if (config.resources.pids.required || config.resources.diskMb !== null || !config.acceptObservedDiskRisk) {
     throw new Error(
-      'secure nested Docker currently admits only the Apple Container developer slice with offline, mediated images-only, or fixed public package access; no image, relay, daemon, or lease action was performed',
+      'secure nested Docker does not admit the requested resource policy; no image, relay, daemon, or lease action was performed',
+    );
+  }
+  if (resolvedRuntimeKind === 'docker' && hostPlatform !== 'darwin') {
+    throw new Error(
+      `secure nested Docker with the Docker runtime is supported only on macOS (Darwin), not ${hostPlatform}; no image, relay, daemon, or lease action was performed`,
     );
   }
 }
 
-/** Read-only platform preflight required after the supported variant is selected. */
-export async function assertAdmittedDockerWorkloadRuntimeAvailable(): Promise<void> {
-  const { checkAppleContainerAvailable } = await import('../docker/apple-container-manager.js');
-  const availability = await checkAppleContainerAvailable();
+/** Read-only runtime preflight required after the supported variant is selected. */
+export async function assertAdmittedDockerWorkloadRuntimeAvailable(
+  resolvedRuntimeKind: 'docker' | 'apple-container',
+): Promise<void> {
+  const checkAvailability =
+    resolvedRuntimeKind === 'docker'
+      ? (await import('../docker/docker-probe.js')).checkDockerAvailable
+      : (await import('../docker/apple-container-manager.js')).checkAppleContainerAvailable;
+  const availability = await checkAvailability();
   if (!availability.available) {
+    const runtimeName = resolvedRuntimeKind === 'docker' ? 'Docker' : 'Apple';
     throw new Error(
-      `secure nested Docker Apple runtime is unavailable: ${availability.reason}` +
+      `secure nested Docker ${runtimeName} runtime is unavailable: ${availability.reason}` +
         (availability.detailedMessage ? ` (${availability.detailedMessage})` : ''),
     );
   }

--- a/src/docker-workload/docker-desktop-sidecar.ts
+++ b/src/docker-workload/docker-desktop-sidecar.ts
@@ -1,0 +1,780 @@
+/**
+ * Rootless nested-Docker daemon sidecar for the macOS Docker Desktop backend.
+ *
+ * The outer runtime remains the authority for isolation: the sidecar has no
+ * outer network, host runtime socket, host namespace, device, or broad bind.
+ * Its only writable shared authority is a randomly named API volume, mounted
+ * read-only into the agent before final lease activation. The selected agent archive
+ * arrives through one lease-private, read-only staging directory. The runc
+ * compatibility wrapper is part of the immutable daemon image and selected
+ * from one fixed PATH prefix.
+ *
+ * This module deliberately does not own lease implementation details. The
+ * caller supplies one ledgered-create capability so volume/container
+ * precommit, watchdog freshness, immutable-ID observation, and crash recovery
+ * remain in the common Docker-workload lifecycle.
+ */
+
+import { dirname, resolve } from 'node:path';
+import { z } from 'zod';
+import type {
+  ContainerRuntime,
+  DockerContainerConfig,
+  DockerExecResult,
+  DockerNamedVolumeMount,
+  DockerVolumeInfo,
+} from '../docker/types.js';
+import { getFrozenProfileCeilingPath, getIronCurtainPackageRoot } from '../docker/docker-workload-paths.js';
+import { computeHash, sha256HexSchema } from '../hash.js';
+import { loadImmutableHostJson } from '../hardened-fs.js';
+import {
+  APPLE_VM_DAEMON_API_DIR,
+  APPLE_VM_DAEMON_DOCKER_HOST,
+  APPLE_VM_DAEMON_LOG_TAIL_ARGV,
+  APPLE_VM_DAEMON_TOOLCHAIN_DIR,
+  waitForAppleVmDaemonReady,
+  type AppleVmDaemonExec,
+  type AppleVmDaemonReadiness,
+} from './apple-vm-daemon.js';
+import {
+  appleVmDockerWorkloadArtifactMount,
+  createAppleVmDockerWorkloadNetwork,
+  provisionAppleVmDockerWorkload,
+  type AppleVmDockerWorkloadBootstrapConfig,
+  type AppleVmDockerWorkloadNetwork,
+  type AppleVmDockerWorkloadProvisioning,
+} from './apple-private-docker.js';
+import type { DockerWorkloadBundleHandle } from './infrastructure.js';
+import type { ExpandedOuterCreate } from './lifecycle-evidence.js';
+
+export const DOCKER_DESKTOP_SIDECAR_API_ROOT = APPLE_VM_DAEMON_API_DIR;
+export const DOCKER_DESKTOP_SIDECAR_DOCKER_HOST = APPLE_VM_DAEMON_DOCKER_HOST;
+export const DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT = '/home/rootless/.local/share/docker';
+export const DOCKER_DESKTOP_SIDECAR_DATA_ROOT = `${DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT}/data`;
+export const DOCKER_DESKTOP_RUNC_SHIM_PATH = '/usr/local/lib/ironcurtain/runc';
+export const DOCKER_DESKTOP_RUNC_VERSION_PREFIX = 'runc version 1.3.4';
+
+const DAEMON_IMAGE_ROLE_LABEL = 'com.ironcurtain.docker-workload.image-role';
+const DAEMON_IMAGE_ROLE = 'nested-daemon';
+const ROOTLESS_USER = 'rootless';
+const APPLE_RUNTIME_USER = 'codespace';
+const RUNC_SHIM_RUNTIME_NAME = 'ic-no-new-keyring';
+const DEFAULT_READINESS_TIMEOUT_MS = 120_000;
+const EXEC_TIMEOUT_MS = 30_000;
+const BUILD_TIMEOUT_MS = 5 * 60_000;
+const MAX_DIAGNOSTIC_BYTES = 2048;
+const DEFAULT_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+const PROFILE_RELATIVE_PATH = 'config/docker-workload/seccomp/desktop-p2-userns.json';
+const DESKTOP_CEILING_STATUS = 'reviewed-dd-h3-sidecar-supported-not-qualified';
+const SYSTEM_PATHS_SECURITY_OPTION = 'systempaths=unconfined';
+const SYSTEM_PATHS_SCOPE = 'docker-desktop-nested-daemon-sidecar-only';
+const PROFILE_MAX_BYTES = 1024 * 1024;
+const IMMUTABLE_ID = /^sha256:[a-f0-9]{64}$/u;
+const CONTAINER_ID = /^[a-f0-9]{64}$/u;
+const CONTROL_CHARACTERS = /[^\P{Cc}\n\t]/gu;
+
+const profileCeilingSchema = z
+  .object({
+    status: z.literal(DESKTOP_CEILING_STATUS),
+    categories: z
+      .object({
+        seccomp: z
+          .object({
+            artifact: z
+              .object({
+                path: z.literal(PROFILE_RELATIVE_PATH),
+                sha256: sha256HexSchema,
+              })
+              .strict(),
+          })
+          .loose(),
+        mountMask: z
+          .object({
+            additions: z.tuple([
+              z
+                .object({
+                  option: z.literal(SYSTEM_PATHS_SECURITY_OPTION),
+                  scope: z.literal(SYSTEM_PATHS_SCOPE),
+                })
+                .loose(),
+            ]),
+          })
+          .loose(),
+      })
+      .loose(),
+  })
+  .loose();
+
+const seccompRuleSchema = z
+  .object({
+    names: z.array(z.string().min(1)),
+    action: z.string().min(1),
+    args: z.unknown().optional(),
+    includes: z.unknown().optional(),
+    excludes: z.unknown().optional(),
+  })
+  .loose();
+
+const seccompProfileSchema = z
+  .object({
+    defaultAction: z.string().min(1),
+    syscalls: z.array(seccompRuleSchema).min(1),
+  })
+  .loose();
+
+export interface DockerDesktopP2SeccompProfile {
+  readonly path: string;
+  readonly sha256: string;
+  readonly systemPathsSecurityOption: typeof SYSTEM_PATHS_SECURITY_OPTION;
+}
+
+export function parseDockerDesktopProfileCeiling(value: unknown): z.infer<typeof profileCeilingSchema> {
+  return profileCeilingSchema.parse(value);
+}
+
+/** The minimal runtime surface the focused sidecar lifecycle consumes. */
+export type DockerDesktopSidecarRuntime = Pick<
+  ContainerRuntime,
+  'preflight' | 'inspectImage' | 'create' | 'start' | 'exec' | 'stop' | 'remove'
+> & {
+  readonly createVolume: NonNullable<ContainerRuntime['createVolume']>;
+  readonly inspectVolume: NonNullable<ContainerRuntime['inspectVolume']>;
+  readonly removeVolume: NonNullable<ContainerRuntime['removeVolume']>;
+};
+
+export function requireDockerDesktopSidecarRuntime(runtime: ContainerRuntime): DockerDesktopSidecarRuntime {
+  if (runtime.createVolume === undefined || runtime.inspectVolume === undefined || runtime.removeVolume === undefined) {
+    throw new Error('Docker Desktop nested-Docker requires exact named-volume create/inspect/remove runtime APIs');
+  }
+  return runtime as DockerDesktopSidecarRuntime;
+}
+
+export interface DockerDesktopSidecarOuterCreateSpec {
+  readonly kind: 'container' | 'volume';
+  readonly role: 'nested-daemon' | 'daemon-api';
+  readonly launchesNestedDaemon?: boolean;
+}
+
+export type DockerDesktopSidecarCreateAuthority = (
+  spec: DockerDesktopSidecarOuterCreateSpec,
+  create: (
+    requestedName: string,
+    ownershipLabels: Readonly<Record<string, string>>,
+  ) => Promise<{ readonly id: string; readonly expanded?: ExpandedOuterCreate }>,
+) => Promise<{ readonly id: string; readonly requestedName: string }>;
+
+export interface DockerDesktopSidecarResources {
+  readonly memoryMb: number;
+  readonly cpus: number;
+  readonly pidsLimit: number;
+}
+
+type DockerDesktopActivationHandle = Pick<
+  DockerWorkloadBundleHandle,
+  'generation' | 'recordDaemonReady' | 'recordPrivateDockerBootstrap'
+>;
+
+export interface StartDockerDesktopSidecarOptions {
+  readonly runtime: DockerDesktopSidecarRuntime;
+  readonly sidecarImage: string;
+  readonly bootstrap: AppleVmDockerWorkloadBootstrapConfig;
+  readonly resources: DockerDesktopSidecarResources;
+  readonly createOuterResource: DockerDesktopSidecarCreateAuthority;
+  readonly activation: DockerDesktopActivationHandle;
+  readonly readinessTimeoutMs?: number;
+  readonly pollIntervalMs?: number;
+  /** Test-only deterministic readiness clock. */
+  readonly now?: () => number;
+  /** Test-only deterministic readiness sleeper. */
+  readonly sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export interface DockerDesktopSidecarHandle {
+  readonly containerId: string;
+  readonly apiVolumeName: string;
+  readonly dockerHost: typeof DOCKER_DESKTOP_SIDECAR_DOCKER_HOST;
+  /** Exact read-only capability mounted into the agent container. */
+  readonly agentApiMount: DockerNamedVolumeMount;
+  readonly readiness: AppleVmDaemonReadiness;
+  readonly provisioning: AppleVmDockerWorkloadProvisioning;
+  readonly network: AppleVmDockerWorkloadNetwork;
+  readonly seccompProfile: DockerDesktopP2SeccompProfile;
+}
+
+/** Load and bind the one reviewed P2 artifact named by the frozen ceiling. */
+export function loadDockerDesktopP2SeccompProfile(): DockerDesktopP2SeccompProfile {
+  const loadedCeiling = loadImmutableHostJson(getFrozenProfileCeilingPath(), {
+    label: 'Docker-workload profile ceiling',
+    schema: z.unknown(),
+    maxBytes: PROFILE_MAX_BYTES,
+  });
+  const ceiling = parseDockerDesktopProfileCeiling(loadedCeiling.value);
+  const artifact = ceiling.categories.seccomp.artifact;
+  const profilePath = resolve(getIronCurtainPackageRoot(), artifact.path);
+  const expectedPath = resolve(getIronCurtainPackageRoot(), PROFILE_RELATIVE_PATH);
+  if (profilePath !== expectedPath)
+    throw new Error('Docker Desktop P2 seccomp artifact resolved outside its fixed path');
+  const profile = loadImmutableHostJson(profilePath, {
+    label: 'Docker Desktop P2 seccomp profile',
+    schema: seccompProfileSchema,
+    maxBytes: PROFILE_MAX_BYTES,
+  });
+  if (profile.sha256 !== artifact.sha256) {
+    throw new Error(
+      `Docker Desktop P2 seccomp artifact hash mismatch: expected ${artifact.sha256}, got ${profile.sha256}`,
+    );
+  }
+  const unconditionalAllows = (name: string): boolean =>
+    profile.value.syscalls.some(
+      (rule) =>
+        rule.action === 'SCMP_ACT_ALLOW' &&
+        rule.names.includes(name) &&
+        rule.args === undefined &&
+        rule.includes === undefined &&
+        rule.excludes === undefined,
+    );
+  if (!unconditionalAllows('sethostname')) {
+    throw new Error('Docker Desktop P2 seccomp profile lacks the denial-proven sethostname allowance');
+  }
+  if (unconditionalAllows('keyctl')) {
+    throw new Error('Docker Desktop P2 seccomp profile must not admit keyctl; use the pinned runc compatibility shim');
+  }
+  return {
+    path: profile.path,
+    sha256: profile.sha256,
+    systemPathsSecurityOption: ceiling.categories.mountMask.additions[0].option,
+  };
+}
+
+/**
+ * Create, adjudicate, and qualify one sidecar. Every failure before a successful
+ * handoff removes the exact sidecar and API volume best-effort; the common lease
+ * remains the crash-recovery authority and performs final activation only after
+ * the agent has been ledgered and created with the returned API mount.
+ */
+export async function startDockerDesktopSidecar(
+  options: StartDockerDesktopSidecarOptions,
+): Promise<DockerDesktopSidecarHandle> {
+  validateResources(options.resources);
+  const profile = loadDockerDesktopP2SeccompProfile();
+  await options.runtime.preflight(options.sidecarImage);
+  const inspectedSidecarImage = await options.runtime.inspectImage(options.sidecarImage);
+  if (inspectedSidecarImage === undefined)
+    throw new Error(`Docker Desktop daemon image is absent: ${options.sidecarImage}`);
+  if (!IMMUTABLE_ID.test(inspectedSidecarImage.id)) {
+    throw new Error('Docker Desktop daemon image resolved to an invalid immutable ID');
+  }
+  if (inspectedSidecarImage.labels[DAEMON_IMAGE_ROLE_LABEL] !== DAEMON_IMAGE_ROLE) {
+    throw new Error('Docker Desktop daemon image is missing its exact nested-daemon role label');
+  }
+
+  let apiVolumeName: string | undefined;
+  let containerId: string | undefined;
+  try {
+    const volume = await options.createOuterResource({ kind: 'volume', role: 'daemon-api' }, async (name, labels) => {
+      const id = await options.runtime.createVolume(name, { labels });
+      if (id !== name) throw new Error('Docker Desktop API volume returned an unexpected runtime identity');
+      // Retain the exact runtime-confirmed identity before post-create
+      // inspection/ledger observation so either failure can roll it back.
+      apiVolumeName = name;
+      const inspected = await options.runtime.inspectVolume(id);
+      assertApiVolume(inspected, name, labels);
+      return { id };
+    });
+    if (apiVolumeName === undefined || volume.id !== apiVolumeName || volume.requestedName !== apiVolumeName) {
+      throw new Error('Docker Desktop API volume grant identity changed');
+    }
+    const ownedApiVolumeName = apiVolumeName;
+
+    const sidecar = await options.createOuterResource(
+      { kind: 'container', role: 'nested-daemon', launchesNestedDaemon: true },
+      async (name, labels) => {
+        const config = buildSidecarConfig({
+          imageId: inspectedSidecarImage.id,
+          name,
+          labels,
+          apiVolumeName: ownedApiVolumeName,
+          bootstrap: options.bootstrap,
+          profile,
+          resources: options.resources,
+        });
+        const id = await options.runtime.create(config);
+        if (!CONTAINER_ID.test(id)) throw new Error('Docker Desktop sidecar create returned an invalid container ID');
+        // As with the volume, keep the immutable runtime identity before the
+        // outer ledger records it so an observation failure cannot leak it.
+        containerId = id;
+        return {
+          id,
+          expanded: {
+            mounts: [
+              { source: ownedApiVolumeName, target: DOCKER_DESKTOP_SIDECAR_API_ROOT, readonly: false },
+              { source: ownedApiVolumeName, target: DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT, readonly: false },
+              ...config.mounts,
+            ],
+            limits: {
+              memoryMb: options.resources.memoryMb,
+              cpus: options.resources.cpus,
+              pidsLimit: options.resources.pidsLimit,
+            },
+            profileRef: `${profile.path}#sha256=${profile.sha256}`,
+          },
+        };
+      },
+    );
+    if (containerId === undefined || sidecar.id !== containerId) {
+      throw new Error('Docker Desktop sidecar grant identity changed');
+    }
+    await options.runtime.start(containerId);
+
+    const appleCompatibleExec = appleCompatibleSidecarExec(options.runtime, containerId);
+    const readiness = await waitForAppleVmDaemonReady(appleCompatibleExec, {
+      timeoutMs: options.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS,
+      pollIntervalMs: options.pollIntervalMs,
+      now: options.now,
+      sleep: options.sleep,
+    });
+    options.activation.recordDaemonReady(readiness);
+    await preflightRuntimeShim(options.runtime, containerId);
+
+    const translatedRuntime: Pick<ContainerRuntime, 'exec'> = {
+      exec: async (_containerId, argv, timeoutMs, execUser) => {
+        if (_containerId !== containerId) throw new Error('Docker Desktop private-Docker container ID mismatch');
+        if (execUser !== APPLE_RUNTIME_USER) throw new Error('Docker Desktop private-Docker adapter user mismatch');
+        const result = await appleCompatibleExec(argv, {
+          user: APPLE_RUNTIME_USER,
+          timeoutMs: timeoutMs ?? EXEC_TIMEOUT_MS,
+        });
+        return { stdout: result.stdout, stderr: result.stderr ?? '', exitCode: result.exitCode };
+      },
+    };
+    const provisioning = await provisionAppleVmDockerWorkload({
+      outerRuntime: translatedRuntime,
+      containerId,
+      config: options.bootstrap,
+    });
+    const network = await createAppleVmDockerWorkloadNetwork({
+      outerRuntime: translatedRuntime,
+      containerId,
+    });
+    await runDockerDesktopActivationCanary({
+      runtime: options.runtime,
+      containerId,
+      selectedImageId: provisioning.image.immutableImageId,
+      networkName: network.name,
+      generation: options.activation.generation,
+    });
+
+    options.activation.recordPrivateDockerBootstrap(provisioning, network);
+    return {
+      containerId,
+      apiVolumeName,
+      dockerHost: DOCKER_DESKTOP_SIDECAR_DOCKER_HOST,
+      agentApiMount: {
+        name: apiVolumeName,
+        target: DOCKER_DESKTOP_SIDECAR_API_ROOT,
+        readonly: true,
+        noCopy: true,
+      },
+      readiness,
+      provisioning,
+      network,
+      seccompProfile: profile,
+    };
+  } catch (error) {
+    const cleanupFailures = await rollbackSidecar(options.runtime, containerId, apiVolumeName);
+    if (cleanupFailures.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupFailures],
+        'Docker Desktop sidecar qualification and rollback failed',
+        {
+          cause: error,
+        },
+      );
+    }
+    throw error;
+  }
+}
+
+function buildSidecarConfig(options: {
+  readonly imageId: string;
+  readonly name: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly apiVolumeName: string;
+  readonly bootstrap: AppleVmDockerWorkloadBootstrapConfig;
+  readonly profile: DockerDesktopP2SeccompProfile;
+  readonly resources: DockerDesktopSidecarResources;
+}): DockerContainerConfig {
+  return {
+    image: options.imageId,
+    name: options.name,
+    mounts: [appleVmDockerWorkloadArtifactMount(options.bootstrap)],
+    network: 'none',
+    env: {
+      DOCKER_TLS_CERTDIR: '',
+      DOCKERD_ROOTLESS_ROOTLESSKIT_NET: 'none',
+      XDG_RUNTIME_DIR: DOCKER_DESKTOP_SIDECAR_API_ROOT,
+      PATH: `${dirname(DOCKER_DESKTOP_RUNC_SHIM_PATH)}:${DEFAULT_PATH}`,
+    },
+    command: [
+      'dockerd',
+      `--add-runtime=${RUNC_SHIM_RUNTIME_NAME}=${DOCKER_DESKTOP_RUNC_SHIM_PATH}`,
+      `--default-runtime=${RUNC_SHIM_RUNTIME_NAME}`,
+      `--host=${DOCKER_DESKTOP_SIDECAR_DOCKER_HOST}`,
+      '--storage-driver=vfs',
+      `--data-root=${DOCKER_DESKTOP_SIDECAR_DATA_ROOT}`,
+      `--exec-root=${DOCKER_DESKTOP_SIDECAR_API_ROOT}/exec`,
+      `--pidfile=${DOCKER_DESKTOP_SIDECAR_API_ROOT}/docker.pid`,
+      '--iptables=false',
+      '--bridge=none',
+      '--ip-forward=false',
+      '--ip-masq=false',
+    ],
+    labels: options.labels,
+    resources: { memoryMb: options.resources.memoryMb, cpus: options.resources.cpus },
+    capAdd: ['SETUID', 'SETGID'],
+    trustedCreateOptions: {
+      namedVolumeMounts: [
+        {
+          name: options.apiVolumeName,
+          target: DOCKER_DESKTOP_SIDECAR_API_ROOT,
+          readonly: false,
+          // Copy-up is required: the image supplies this directory as
+          // uid/gid 1000, mode 0700 without CAP_CHOWN.
+          noCopy: false,
+        },
+        {
+          name: options.apiVolumeName,
+          target: DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT,
+          readonly: false,
+          // The API-root mount already initialized this same volume. Do not
+          // copy stock daemon state into it again through the second target.
+          noCopy: true,
+        },
+      ],
+      tmpfs: [
+        '/run:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000',
+        '/tmp:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000',
+        '/home/rootless/.docker:rw,nosuid,nodev,noexec,size=16m,uid=1000,gid=1000',
+      ],
+      readOnlyRootfs: true,
+      securityOptions: [options.profile.systemPathsSecurityOption],
+      seccompProfile: options.profile.path,
+      pidsLimit: options.resources.pidsLimit,
+    },
+  };
+}
+
+function validateResources(resources: DockerDesktopSidecarResources): void {
+  if (!Number.isSafeInteger(resources.memoryMb) || resources.memoryMb < 512) {
+    throw new Error('Docker Desktop sidecar memory must be an integer of at least 512 MiB');
+  }
+  if (!Number.isFinite(resources.cpus) || resources.cpus < 0.25) {
+    throw new Error('Docker Desktop sidecar CPUs must be at least 0.25');
+  }
+  if (!Number.isSafeInteger(resources.pidsLimit) || resources.pidsLimit < 16) {
+    throw new Error('Docker Desktop sidecar PID limit must be an integer of at least 16');
+  }
+}
+
+function assertApiVolume(
+  volume: DockerVolumeInfo | undefined,
+  expectedName: string,
+  expectedLabels: Readonly<Record<string, string>>,
+): asserts volume is DockerVolumeInfo {
+  if (
+    volume === undefined ||
+    volume.id !== expectedName ||
+    volume.name !== expectedName ||
+    volume.driver !== 'local' ||
+    volume.mountpoint === '' ||
+    Object.keys(volume.labels).length !== Object.keys(expectedLabels).length ||
+    Object.entries(expectedLabels).some(([key, value]) => volume.labels[key] !== value)
+  ) {
+    throw new Error('Docker Desktop API volume did not inspect as the exact owned local volume');
+  }
+}
+
+/** Translate only the fixed Apple private-Docker command prefix to the stock sidecar client path. */
+function appleCompatibleSidecarExec(runtime: DockerDesktopSidecarRuntime, containerId: string): AppleVmDaemonExec {
+  const appleDockerClient = `${APPLE_VM_DAEMON_TOOLCHAIN_DIR}/docker`;
+  return async (argv, execOptions) => {
+    if (execOptions.user !== APPLE_RUNTIME_USER) throw new Error('Docker Desktop daemon exec user mismatch');
+    const translated =
+      argv[0] === appleDockerClient && argv[1] === '--host' && argv[2] === APPLE_VM_DAEMON_DOCKER_HOST
+        ? ['docker', '--host', DOCKER_DESKTOP_SIDECAR_DOCKER_HOST, ...argv.slice(3)]
+        : exactArgv(argv, APPLE_VM_DAEMON_LOG_TAIL_ARGV)
+          ? argv
+          : (() => {
+              throw new Error('Docker Desktop daemon adapter rejected an unknown Apple command');
+            })();
+    return runtime.exec(containerId, translated, execOptions.timeoutMs, ROOTLESS_USER);
+  };
+}
+
+async function preflightRuntimeShim(runtime: DockerDesktopSidecarRuntime, containerId: string): Promise<void> {
+  const resolved = await runtime.exec(
+    containerId,
+    ['/bin/sh', '-c', 'command -v runc'],
+    EXEC_TIMEOUT_MS,
+    ROOTLESS_USER,
+  );
+  if (resolved.exitCode !== 0 || resolved.stdout.trim() !== DOCKER_DESKTOP_RUNC_SHIM_PATH) {
+    throw new Error(
+      `Docker Desktop daemon PATH did not select the baked runc shim at ${DOCKER_DESKTOP_RUNC_SHIM_PATH}`,
+    );
+  }
+  const version = await runtime.exec(
+    containerId,
+    [DOCKER_DESKTOP_RUNC_SHIM_PATH, '--version'],
+    EXEC_TIMEOUT_MS,
+    ROOTLESS_USER,
+  );
+  if (version.exitCode !== 0 || !version.stdout.startsWith(DOCKER_DESKTOP_RUNC_VERSION_PREFIX)) {
+    throw new Error('Docker Desktop baked runc shim did not hand off to the pinned runc version');
+  }
+}
+
+interface ActivationCanaryOptions {
+  readonly runtime: DockerDesktopSidecarRuntime;
+  readonly containerId: string;
+  readonly selectedImageId: string;
+  readonly networkName: string;
+  readonly generation: string;
+}
+
+/** Prove both ordinary inner OCI start and an integrated BuildKit RUN before activation. */
+async function runDockerDesktopActivationCanary(options: ActivationCanaryOptions): Promise<void> {
+  if (!IMMUTABLE_ID.test(options.selectedImageId))
+    throw new Error('Docker Desktop canary received an invalid image ID');
+  const suffix = computeHash({ containerId: options.containerId, generation: options.generation }).slice(0, 16);
+  const runName = `ironcurtain-desktop-run-${suffix}`;
+  const baseTag = `ironcurtain-desktop-base:${suffix}`;
+  const outputTag = `ironcurtain-desktop-build:${suffix}`;
+  const contextRoot = `/tmp/ironcurtain-desktop-build-${suffix}`;
+  const dockerfilePath = `${contextRoot}/Dockerfile`;
+  const execDocker = (args: readonly string[], timeoutMs = EXEC_TIMEOUT_MS): Promise<DockerExecResult> =>
+    options.runtime.exec(
+      options.containerId,
+      ['docker', '--host', DOCKER_DESKTOP_SIDECAR_DOCKER_HOST, ...args],
+      timeoutMs,
+      ROOTLESS_USER,
+    );
+
+  let failure: unknown;
+  let baseTagged = false;
+  let outputImageId: string | undefined;
+  try {
+    if (
+      (await inspectImage(execDocker, baseTag)) !== undefined ||
+      (await inspectImage(execDocker, outputTag)) !== undefined
+    ) {
+      throw new Error('Docker Desktop activation canary reserved image tag already exists');
+    }
+    if ((await inspectContainer(execDocker, runName)) !== undefined) {
+      throw new Error('Docker Desktop activation canary reserved container already exists');
+    }
+    const run = await execDocker([
+      'run',
+      '--rm',
+      '--name',
+      runName,
+      '--network',
+      options.networkName,
+      '--read-only',
+      '--cap-drop',
+      'ALL',
+      '--security-opt',
+      'no-new-privileges=true',
+      '--entrypoint',
+      '/bin/true',
+      options.selectedImageId,
+    ]);
+    assertDockerSuccess(run, 'ordinary inner-container activation canary');
+    if ((await inspectContainer(execDocker, runName)) !== undefined) {
+      throw new Error('Docker Desktop ordinary activation canary container remained after --rm');
+    }
+
+    assertDockerSuccess(await execDocker(['image', 'tag', options.selectedImageId, baseTag]), 'activation base tag');
+    baseTagged = true;
+    if ((await inspectImage(execDocker, baseTag)) !== options.selectedImageId) {
+      throw new Error('Docker Desktop activation canary base tag changed immutable identity');
+    }
+    const prepare = await options.runtime.exec(
+      options.containerId,
+      [
+        '/bin/sh',
+        '-c',
+        'set -eu; umask 077; mkdir -p "$1"; printf "%s" "$2" > "$3"',
+        'ironcurtain-desktop-build-canary',
+        contextRoot,
+        `FROM ${baseTag}\nRUN /bin/true\n`,
+        dockerfilePath,
+      ],
+      EXEC_TIMEOUT_MS,
+      ROOTLESS_USER,
+    );
+    assertDockerSuccess(prepare, 'activation canary context preparation');
+    const built = await execDocker(
+      [
+        'build',
+        '--pull=false',
+        '--network=none',
+        '--no-cache',
+        '--progress=plain',
+        '--tag',
+        outputTag,
+        '--file',
+        dockerfilePath,
+        contextRoot,
+      ],
+      BUILD_TIMEOUT_MS,
+    );
+    assertDockerSuccess(built, 'integrated BuildKit RUN activation canary');
+    outputImageId = await inspectImage(execDocker, outputTag);
+    if (outputImageId === undefined || outputImageId === options.selectedImageId) {
+      throw new Error('Docker Desktop BuildKit canary did not create a distinct immutable image');
+    }
+  } catch (error) {
+    failure = error;
+  }
+
+  const cleanupFailures: Error[] = [];
+  const cleanup = async (description: string, operation: () => Promise<void>): Promise<void> => {
+    try {
+      await operation();
+    } catch (error) {
+      cleanupFailures.push(new Error(description, { cause: error }));
+    }
+  };
+  await cleanup('Docker Desktop BuildKit canary output cleanup failed', async () => {
+    const current = await inspectImage(execDocker, outputTag);
+    if (current === undefined) return;
+    if (outputImageId !== undefined && current !== outputImageId) {
+      throw new Error('reserved BuildKit output tag was replaced; refusing deletion');
+    }
+    if (current === options.selectedImageId) throw new Error('BuildKit output tag aliases the selected image');
+    assertDockerSuccess(await execDocker(['image', 'rm', '--force', current]), 'activation output image cleanup');
+  });
+  await cleanup('Docker Desktop activation base-tag cleanup failed', async () => {
+    const current = await inspectImage(execDocker, baseTag);
+    if (current === undefined) return;
+    if (!baseTagged || current !== options.selectedImageId) {
+      throw new Error('reserved activation base tag was replaced; refusing deletion');
+    }
+    assertDockerSuccess(await execDocker(['image', 'rm', baseTag]), 'activation base tag cleanup');
+  });
+  await cleanup('Docker Desktop activation context cleanup failed', async () => {
+    const removed = await options.runtime.exec(
+      options.containerId,
+      ['/bin/rm', '-rf', contextRoot],
+      EXEC_TIMEOUT_MS,
+      ROOTLESS_USER,
+    );
+    assertDockerSuccess(removed, 'activation context cleanup');
+  });
+  await cleanup('Docker Desktop activation residue check failed', async () => {
+    const [runResidue, baseResidue, outputResidue, selected] = await Promise.all([
+      inspectContainer(execDocker, runName),
+      inspectImage(execDocker, baseTag),
+      inspectImage(execDocker, outputTag),
+      inspectImage(execDocker, options.selectedImageId),
+    ]);
+    if (runResidue !== undefined || baseResidue !== undefined || outputResidue !== undefined) {
+      throw new Error('Docker Desktop activation canary left container or image residue');
+    }
+    if (selected !== options.selectedImageId)
+      throw new Error('Docker Desktop activation canary changed the selected image');
+  });
+
+  if (cleanupFailures.length > 0) {
+    throw new AggregateError(
+      [...(failure === undefined ? [] : [failure]), ...cleanupFailures],
+      'Docker Desktop activation canary cleanup verification failed',
+      { cause: failure },
+    );
+  }
+  if (failure !== undefined) {
+    throw failure instanceof Error ? failure : new Error('Docker Desktop activation canary failed', { cause: failure });
+  }
+}
+
+async function inspectImage(
+  execDocker: (args: readonly string[], timeoutMs?: number) => Promise<DockerExecResult>,
+  reference: string,
+): Promise<string | undefined> {
+  const result = await execDocker(['image', 'inspect', '--format', '{{.Id}}', reference]);
+  return parseInspectIdentity(result, 'image', reference);
+}
+
+async function inspectContainer(
+  execDocker: (args: readonly string[], timeoutMs?: number) => Promise<DockerExecResult>,
+  reference: string,
+): Promise<string | undefined> {
+  const result = await execDocker(['container', 'inspect', '--format', '{{.Id}}', reference]);
+  const parsed = parseInspectIdentity(result, 'container', reference);
+  if (parsed === undefined) return undefined;
+  return parsed.slice('sha256:'.length);
+}
+
+function parseInspectIdentity(result: DockerExecResult, kind: string, reference: string): string | undefined {
+  if (result.exitCode === 0) {
+    const value = result.stdout.trim();
+    const normalized = kind === 'container' && CONTAINER_ID.test(value) ? `sha256:${value}` : value;
+    if (!IMMUTABLE_ID.test(normalized)) throw new Error(`Docker Desktop ${kind} inspect returned an invalid ID`);
+    return normalized;
+  }
+  if (result.exitCode === 1 && /(?:no such|not found)/iu.test(`${result.stdout}\n${result.stderr}`)) return undefined;
+  throw new Error(
+    `Docker Desktop ${kind} inspect failed for ${reference} with exit code ${result.exitCode}: ${boundedDiagnostic(
+      result,
+    )}`,
+  );
+}
+
+function assertDockerSuccess(result: DockerExecResult, operation: string): void {
+  if (result.exitCode !== 0) {
+    throw new Error(`${operation} failed with exit code ${result.exitCode}: ${boundedDiagnostic(result)}`);
+  }
+}
+
+function boundedDiagnostic(result: Pick<DockerExecResult, 'stdout' | 'stderr'>): string {
+  const text = (result.stderr.trim() || result.stdout.trim() || 'no diagnostic output')
+    .replace(CONTROL_CHARACTERS, '')
+    .replace(/[\n\t]/gu, ' ');
+  const bytes = Buffer.from(text, 'utf8');
+  return bytes.byteLength <= MAX_DIAGNOSTIC_BYTES
+    ? text
+    : `${bytes.subarray(0, MAX_DIAGNOSTIC_BYTES).toString('utf8')}…`;
+}
+
+async function rollbackSidecar(
+  runtime: DockerDesktopSidecarRuntime,
+  containerId: string | undefined,
+  apiVolumeName: string | undefined,
+): Promise<readonly Error[]> {
+  const failures: Error[] = [];
+  if (containerId !== undefined) {
+    try {
+      await runtime.stop(containerId);
+    } catch (error) {
+      failures.push(new Error('Docker Desktop sidecar rollback stop failed', { cause: error }));
+    }
+    try {
+      await runtime.remove(containerId);
+    } catch (error) {
+      failures.push(new Error('Docker Desktop sidecar rollback removal failed', { cause: error }));
+    }
+  }
+  if (apiVolumeName !== undefined) {
+    try {
+      await runtime.removeVolume(apiVolumeName);
+    } catch (error) {
+      failures.push(new Error('Docker Desktop API volume rollback removal failed', { cause: error }));
+    }
+  }
+  return failures;
+}
+
+function exactArgv(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}

--- a/src/docker-workload/infrastructure.ts
+++ b/src/docker-workload/infrastructure.ts
@@ -39,6 +39,7 @@ import {
   returnDockerWorkloadLeaseRecoveryToIncident,
   requestDockerWorkloadOuterResource,
   type DockerWorkloadCleanupProof,
+  type DockerWorkloadOuterResource,
 } from './bundle-lease.js';
 import type { DockerWorkloadRevocationResult } from './bundle-revocation.js';
 import {
@@ -88,8 +89,8 @@ const POST_CREATE_SAMPLE_POLL_MS = 50;
 const ADMISSION_LOCK_ACQUIRE_ATTEMPTS = 16;
 
 export type DockerWorkloadRuntimeKind = ContainerRuntimeKind;
-export type OuterResourceKind = 'container' | 'network';
-export type OuterResourceRole = 'agent' | 'nested-daemon' | 'fixed-relay' | 'proxy' | 'network';
+export type OuterResourceKind = DockerWorkloadOuterResource['kind'];
+export type OuterResourceRole = 'agent' | 'nested-daemon' | 'daemon-api' | 'fixed-relay' | 'proxy' | 'network';
 
 /**
  * A precommitted outer-resource ledger entry. The caller creates the runtime

--- a/src/docker-workload/lifecycle-evidence.ts
+++ b/src/docker-workload/lifecycle-evidence.ts
@@ -37,6 +37,7 @@ import { APPLE_VM_DAEMON_READINESS_TEXT_BOUNDS as READINESS_TEXT_BOUNDS } from '
 import {
   assertCleanupInventoryGap,
   cleanupInventoryGapMsSchema,
+  outerResourceKindSchema,
   type DockerWorkloadCleanupProof,
 } from './bundle-lease.js';
 
@@ -83,7 +84,7 @@ const dockerWorkloadAuditEventSchema = z.discriminatedUnion('kind', [
       ...baseEventShape,
       kind: z.literal('outer-create'),
       requestId: identifierSchema,
-      resourceKind: z.enum(['container', 'network']),
+      resourceKind: outerResourceKindSchema,
       role: z.string().min(1).max(128),
       requestedName: resourceNameSchema,
       immutableId: runtimeIdentitySchema,

--- a/src/docker-workload/session-daemon.ts
+++ b/src/docker-workload/session-daemon.ts
@@ -5,10 +5,10 @@
  * own per-session VM, so there is no separate daemon container: the agent
  * container create IS the §8.2 step-4 "daemon component" create, and the in-VM
  * bootstrap happens between that container's start and the agent process. This
- * module owns the three consequences of that topology so neither session mode
- * has to re-derive them:
+ * module owns the Apple-specific consequences of that topology so neither
+ * session mode has to re-derive them:
  *
- *  - which backend currently implements the topology (Apple `container` only),
+ *  - selecting the same-VM topology only for Apple `container`,
  *  - the `ContainerRuntime.exec` -> {@link AppleVmDaemonExec} adaptation plus
  *    the bootstrap/adjudicate/record sequence,
  *  - the private socket and managed-network environment the agent receives.
@@ -83,23 +83,28 @@ export interface AppleVmDockerWorkloadEgressLedgers {
 }
 
 /**
- * The same-VM topology is implemented behind the resolved-variant guard on Apple
- * `container` only: the daemon needs a per-session VM to live in. This is an
- * implementation check, not a qualification or enablement claim.
+ * Both macOS product backends have a nested-daemon implementation. Apple runs
+ * the daemon inside the agent VM; Docker Desktop uses a separate rootless
+ * sidecar. This is an implementation check, not a qualification or enablement
+ * claim.
  */
 export function assertNestedDaemonBackendImplemented(runtimeKind: ContainerRuntimeKind): void {
-  if (runtimeKind === 'apple-container') return;
-  throw new Error(
-    `secure nested Docker is not implemented on the ${runtimeKind} backend: ` +
-      'the nested Docker daemon runs inside the agent VM, which only the apple-container runtime provides',
-  );
+  switch (runtimeKind) {
+    case 'apple-container':
+    case 'docker':
+      return;
+    default: {
+      const unsupported: never = runtimeKind;
+      throw new Error(`nested Docker is not implemented for runtime ${String(unsupported)}`);
+    }
+  }
 }
 
 /**
  * The admitted bundle whose agent container IS the nested-daemon component, or
- * `undefined` for an ordinary session. Returning the handle rather than a
- * boolean keeps the "daemon wiring applies" decision and the handle the wiring
- * needs from ever disagreeing.
+ * `undefined` for an ordinary session and for the separate Docker Desktop
+ * sidecar topology. Returning the handle rather than a boolean keeps the
+ * Apple same-VM wiring decision and the handle it needs from ever disagreeing.
  *
  * @throws when a bundle was admitted on a backend where the topology is not
  * implemented — a create that silently produced no daemon would be worse.
@@ -110,7 +115,7 @@ export function resolveNestedDaemonBundle(
 ): DockerWorkloadBundleHandle | undefined {
   if (dockerWorkload === undefined) return undefined;
   assertNestedDaemonBackendImplemented(runtimeKind);
-  return dockerWorkload;
+  return runtimeKind === 'apple-container' ? dockerWorkload : undefined;
 }
 
 /**

--- a/src/docker/ca.ts
+++ b/src/docker/ca.ts
@@ -5,6 +5,7 @@ import {
   chmodSync,
   closeSync,
   constants,
+  fchmodSync,
   fstatSync,
   fsyncSync,
   lstatSync,
@@ -18,7 +19,7 @@ import {
   writeFileSync,
   type Stats,
 } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import * as tls from 'node:tls';
 import forge from 'node-forge';
 import * as logger from '../logger.js';
@@ -32,6 +33,22 @@ export interface CertificateAuthority {
   readonly certPath: string;
   readonly keyPath: string;
 }
+
+export type CertificateAuthorityInspection =
+  | { readonly state: 'uninitialized'; readonly directory: string }
+  | { readonly state: 'migration-required'; readonly directory: string; readonly generation?: string }
+  | { readonly state: 'ready'; readonly directory: string; readonly generation: string };
+
+export type CertificateAuthorityRepair =
+  | { readonly state: 'not-needed'; readonly directory: string; readonly generation?: string }
+  | { readonly state: 'hardened'; readonly directory: string; readonly generation?: string }
+  | { readonly state: 'migrated'; readonly directory: string; readonly generation: string }
+  | {
+      readonly state: 'rotated';
+      readonly directory: string;
+      readonly generation: string;
+      readonly quarantineDirectory: string;
+    };
 
 type CertificateAuthorityFiles = Omit<CertificateAuthority, 'generation'>;
 
@@ -53,6 +70,7 @@ const GENERATION_KEY_FILENAME = 'ca-key.pem';
 const GENERATION_MANIFEST_FILENAME = 'manifest.json';
 const CURRENT_FILENAME = 'current.json';
 const LOCK_FILENAME = '.ca.lock';
+const PARENT_LOCK_FILENAME = '.ca-repair.lock';
 const CERT_MODE = 0o644;
 const KEY_MODE = 0o600;
 const MANIFEST_MODE = 0o600;
@@ -69,11 +87,32 @@ const BASIC_CONSTRAINTS_OID = '2.5.29.19';
 const KEY_USAGE_OID = '2.5.29.15';
 const SUBJECT_KEY_IDENTIFIER_OID = '2.5.29.14';
 const AUTHORITY_KEY_IDENTIFIER_OID = '2.5.29.35';
+const TRANSIENT_FILESYSTEM_ERROR_CODES = new Set(['EBUSY', 'EIO', 'EMFILE', 'ENFILE', 'ENOMEM', 'ENOSPC', 'ESTALE']);
 
 interface FileIdentity {
   readonly dev: number;
   readonly ino: number;
 }
+
+interface PreparedAuthorityParent {
+  readonly path: string;
+  readonly identity: FileIdentity;
+  readonly wasBroad: boolean;
+  readonly wasWritable: boolean;
+}
+
+type CertificateAuthorityStorage =
+  | { readonly state: 'uninitialized' }
+  | { readonly state: 'legacy'; readonly authority: VerifiedCertificateAuthorityFiles }
+  | { readonly state: 'current'; readonly authority: VerifiedCertificateAuthority };
+
+type CertificateAuthorityRepairAssessment =
+  | {
+      readonly action: 'none';
+      readonly inspection: CertificateAuthorityInspection;
+      readonly directoryWasBroad: boolean;
+    }
+  | { readonly action: 'rotate' };
 
 interface GenerationManifest {
   readonly schemaVersion: 1;
@@ -101,16 +140,30 @@ interface CurrentManifest {
  * atomically renamed into place.
  */
 export function loadOrCreateCA(caDir: string): CertificateAuthority {
-  const directory = prepareAuthorityDirectory(caDir);
+  const directory = resolve(caDir);
+  const parent = prepareAuthorityParent(directory, false);
+  const parentLock = acquireProcessLock(join(parent.path, PARENT_LOCK_FILENAME), {
+    attempts: 8,
+    processIdentityForPid: livePidIdentity,
+  });
+  try {
+    return loadOrCreateCAWithParentLock(directory);
+  } finally {
+    parentLock.release();
+  }
+}
+
+function loadOrCreateCAWithParentLock(directory: string): CertificateAuthority {
+  prepareAuthorityDirectory(directory);
   const lock = acquireProcessLock(join(directory, LOCK_FILENAME), {
     attempts: 8,
     processIdentityForPid: livePidIdentity,
   });
   try {
     cleanupInterruptedCurrentTemps(directory);
-    const currentPath = join(directory, CURRENT_FILENAME);
-    if (pathExistsNoFollow(currentPath)) {
-      const authority = loadCurrentAuthority(directory, currentPath);
+    const storage = analyzeCertificateAuthorityStorage(directory);
+    if (storage.state === 'current') {
+      const authority = storage.authority;
       if (authority.profile === 'legacy-v1') {
         cleanupLegacyMigrationRemainder(directory, authority);
         const migrated = publishStrictAuthorityWithExistingKey(directory, authority.keyPem, true);
@@ -120,19 +173,9 @@ export function loadOrCreateCA(caDir: string): CertificateAuthority {
       return withoutProfile(authority);
     }
 
-    const legacyCertPath = join(directory, LEGACY_CERT_FILENAME);
-    const legacyKeyPath = join(directory, LEGACY_KEY_FILENAME);
-    const certExists = pathExistsNoFollow(legacyCertPath);
-    const keyExists = pathExistsNoFollow(legacyKeyPath);
-    if (certExists !== keyExists) {
-      throw new Error(
-        'IronCurtain CA is incomplete: legacy ca-cert.pem and ca-key.pem must either both exist or both be absent',
-      );
-    }
-
     cleanupUnreachableGenerations(directory);
-    if (certExists) {
-      const legacy = loadAndVerifyAuthorityFiles(legacyCertPath, legacyKeyPath);
+    if (storage.state === 'legacy') {
+      const legacy = storage.authority;
       const authority =
         legacy.profile === 'legacy-v1'
           ? publishStrictAuthorityWithExistingKey(directory, legacy.keyPem, false)
@@ -145,6 +188,189 @@ export function loadOrCreateCA(caDir: string): CertificateAuthority {
   } finally {
     lock.release();
   }
+}
+
+/**
+ * Explicitly repair CA storage. Safe legacy/current state is hardened or
+ * migrated in place. State whose integrity or key confidentiality cannot be
+ * established is renamed to a quarantine sibling and replaced with a newly
+ * generated authority; quarantined contents are never opened or traversed.
+ */
+export function repairCertificateAuthority(caDir: string): CertificateAuthorityRepair {
+  const directory = resolve(caDir);
+  const parentCreated = createAuthorityParentIfMissing(directory);
+  const parent = prepareAuthorityParent(directory, true);
+  const parentLock = acquireProcessLock(join(parent.path, PARENT_LOCK_FILENAME), {
+    attempts: 8,
+    processIdentityForPid: livePidIdentity,
+  });
+  try {
+    assertPathIdentity(parent.path, parent.identity, 'parent directory');
+    const entry = lstatIfPresent(directory);
+    if (entry === undefined) {
+      return { state: parentCreated || parent.wasBroad ? 'hardened' : 'not-needed', directory };
+    }
+
+    const assessment = assessCertificateAuthorityForRepair(directory, entry, parent.wasWritable);
+    if (assessment.action === 'rotate') {
+      return rotateQuarantinedAuthority(directory, parent.path, parent.identity);
+    }
+
+    const { inspection, directoryWasBroad } = assessment;
+    if (inspection.state === 'uninitialized') {
+      prepareAuthorityDirectory(directory);
+      return {
+        state: parentCreated || parent.wasBroad || directoryWasBroad ? 'hardened' : 'not-needed',
+        directory,
+      };
+    }
+
+    const authority = loadOrCreateCAWithParentLock(directory);
+    if (inspection.state === 'migration-required') {
+      return { state: 'migrated', directory, generation: authority.generation };
+    }
+    return {
+      state: parentCreated || parent.wasBroad || directoryWasBroad ? 'hardened' : 'not-needed',
+      directory,
+      generation: authority.generation,
+    };
+  } finally {
+    parentLock.release();
+  }
+}
+
+function assessCertificateAuthorityForRepair(
+  directory: string,
+  entry: Stats,
+  parentWasWritable: boolean,
+): CertificateAuthorityRepairAssessment {
+  const expectedUid = process.getuid?.();
+  if (!entry.isDirectory() || entry.isSymbolicLink()) {
+    throw new Error(`IronCurtain CA repair refuses to replace non-directory path ${directory}`);
+  }
+  if (expectedUid !== undefined && entry.uid !== expectedUid) {
+    throw new Error(`IronCurtain CA repair refuses to replace directory not owned by the current user: ${directory}`);
+  }
+  if (parentWasWritable) return { action: 'rotate' };
+  if ((entry.mode & 0o022) !== 0) return { action: 'rotate' };
+
+  try {
+    return {
+      action: 'none',
+      inspection: inspectCertificateAuthority(directory),
+      directoryWasBroad: (entry.mode & 0o777) !== DIRECTORY_MODE,
+    };
+  } catch (error) {
+    if (isTransientFilesystemFailure(error)) throw error;
+    return { action: 'rotate' };
+  }
+}
+
+function isTransientFilesystemFailure(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code !== undefined && TRANSIENT_FILESYSTEM_ERROR_CODES.has(code);
+}
+
+function rotateQuarantinedAuthority(
+  directory: string,
+  parent: string,
+  parentIdentity: FileIdentity,
+): CertificateAuthorityRepair {
+  const id = randomUUID();
+  const stagingDirectory = join(parent, `.${basename(directory)}.repair-staging-${id}`);
+  const quarantineDirectory = join(
+    parent,
+    `${basename(directory)}.quarantine-${new Date().toISOString().replace(/[^0-9]/gu, '')}-${id}`,
+  );
+  assertPathIdentity(parent, parentIdentity, 'parent directory');
+  mkdirSync(stagingDirectory, { mode: DIRECTORY_MODE });
+  let stagingPublished = false;
+  let oldQuarantined = false;
+  try {
+    validateAuthorityDirectory(lstatSync(stagingDirectory), stagingDirectory, true);
+    const authority = generateAndPublishCA(stagingDirectory);
+    assertPathIdentity(parent, parentIdentity, 'parent directory');
+    renameSync(directory, quarantineDirectory);
+    oldQuarantined = true;
+    fsyncDirectory(parent);
+    renameSync(stagingDirectory, directory);
+    stagingPublished = true;
+    fsyncDirectory(parent);
+    return {
+      state: 'rotated',
+      directory,
+      generation: authority.generation,
+      quarantineDirectory,
+    };
+  } catch (error) {
+    if (oldQuarantined && !stagingPublished) {
+      try {
+        assertPathIdentity(parent, parentIdentity, 'parent directory');
+        if (lstatIfPresent(directory) === undefined) {
+          renameSync(quarantineDirectory, directory);
+          oldQuarantined = false;
+          fsyncDirectory(parent);
+        }
+      } catch (restoreError) {
+        throw new Error(
+          `IronCurtain CA repair failed (${String(error)}); old state remains at ${quarantineDirectory} and the fresh replacement at ${stagingDirectory}`,
+          { cause: restoreError },
+        );
+      }
+    }
+    if (oldQuarantined) {
+      throw new Error(`IronCurtain CA repair failed after preserving old state at ${quarantineDirectory}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    if (!stagingPublished && !oldQuarantined) rmSync(stagingDirectory, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Verify that the CA storage can be consumed by {@link loadOrCreateCA}
+ * without creating, migrating, hardening, or cleaning any filesystem state.
+ * Valid legacy storage is reported separately so diagnostics can explain that
+ * the next container session will migrate it.
+ */
+export function inspectCertificateAuthority(caDir: string): CertificateAuthorityInspection {
+  const { directory, exists } = inspectAuthorityDirectory(caDir);
+  if (!exists) return { state: 'uninitialized', directory };
+
+  const storage = analyzeCertificateAuthorityStorage(directory);
+  if (storage.state === 'uninitialized') return { state: 'uninitialized', directory };
+  if (storage.state === 'legacy') return { state: 'migration-required', directory };
+  return {
+    state: storage.authority.profile === 'legacy-v1' ? 'migration-required' : 'ready',
+    directory,
+    generation: storage.authority.generation,
+  };
+}
+
+function analyzeCertificateAuthorityStorage(directory: string): CertificateAuthorityStorage {
+  validateInterruptedCurrentTemps(directory);
+  const currentPath = join(directory, CURRENT_FILENAME);
+  if (pathExistsNoFollow(currentPath)) {
+    const authority = loadCurrentAuthority(directory, currentPath);
+    validateLegacyMigrationRemainder(directory, authority);
+    return { state: 'current', authority };
+  }
+
+  const legacyCertPath = join(directory, LEGACY_CERT_FILENAME);
+  const legacyKeyPath = join(directory, LEGACY_KEY_FILENAME);
+  const certExists = pathExistsNoFollow(legacyCertPath);
+  const keyExists = pathExistsNoFollow(legacyKeyPath);
+  if (certExists !== keyExists) {
+    throw new Error(
+      'IronCurtain CA is incomplete: legacy ca-cert.pem and ca-key.pem must either both exist or both be absent',
+    );
+  }
+
+  validateUnreachableGenerations(directory);
+  if (!certExists) return { state: 'uninitialized' };
+  return { state: 'legacy', authority: loadAndVerifyAuthorityFiles(legacyCertPath, legacyKeyPath) };
 }
 
 function livePidIdentity(pid: number): string | undefined {
@@ -187,10 +413,89 @@ function prepareAuthorityDirectory(input: string): string {
   return directory;
 }
 
+function prepareAuthorityParent(directory: string, allowWritable: boolean): PreparedAuthorityParent {
+  const path = dirname(directory);
+  const descriptor = openSync(path, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  try {
+    const before = fstatSync(descriptor);
+    validateAuthorityDirectory(before, path, false);
+    if (!allowWritable) validateHardenableDirectoryMode(before, path);
+    const mode = before.mode & 0o777;
+    if (mode !== DIRECTORY_MODE) {
+      fchmodSync(descriptor, DIRECTORY_MODE);
+      fsyncSync(descriptor);
+    }
+    const after = fstatSync(descriptor);
+    const published = lstatSync(path);
+    validateAuthorityDirectory(after, path, true);
+    if (!sameIdentity(before, after) || !sameIdentity(after, published)) {
+      throw new Error(`IronCurtain CA parent directory changed while it was being hardened: ${path}`);
+    }
+    return {
+      path,
+      identity: identity(after),
+      wasBroad: mode !== DIRECTORY_MODE,
+      wasWritable: (mode & 0o022) !== 0,
+    };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function inspectAuthorityDirectory(input: string): { readonly directory: string; readonly exists: boolean } {
+  const directory = resolve(input);
+  const parent = dirname(directory);
+  const parentStats = lstatIfPresent(parent);
+  if (parentStats === undefined) return { directory, exists: false };
+  validateAuthorityDirectory(parentStats, parent, false);
+  validateHardenableDirectoryMode(parentStats, parent);
+  try {
+    const existing = lstatSync(directory);
+    validateAuthorityDirectory(existing, directory, false);
+    validateHardenableDirectoryMode(existing, directory);
+    return { directory, exists: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    return { directory, exists: false };
+  }
+}
+
+function createAuthorityParentIfMissing(directory: string): boolean {
+  const parent = dirname(directory);
+  if (lstatIfPresent(parent) !== undefined) return false;
+
+  const ancestor = dirname(parent);
+  const ancestorStats = lstatSync(ancestor);
+  validateAuthorityDirectory(ancestorStats, ancestor, false);
+  validateHardenableDirectoryMode(ancestorStats, ancestor);
+  try {
+    mkdirSync(parent, { mode: DIRECTORY_MODE });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+  validateAuthorityDirectory(lstatSync(parent), parent, true);
+  return true;
+}
+
+function lstatIfPresent(path: string): Stats | undefined {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
 function hardenDirectoryMode(stats: Stats, path: string): void {
+  validateHardenableDirectoryMode(stats, path);
   const mode = stats.mode & 0o777;
-  if ((mode & 0o022) !== 0) throw new Error(`IronCurtain CA directory ${path} is group- or world-writable`);
   if (mode !== DIRECTORY_MODE) chmodSync(path, DIRECTORY_MODE);
+}
+
+function validateHardenableDirectoryMode(stats: Stats, path: string): void {
+  if ((stats.mode & 0o022) !== 0) {
+    throw new Error(`IronCurtain CA directory ${path} is group- or world-writable`);
+  }
 }
 
 function validateAuthorityDirectory(stats: Stats, path: string, requireExactMode: boolean): void {
@@ -518,6 +823,12 @@ function isSha256(value: unknown): value is string {
 }
 
 function cleanupInterruptedCurrentTemps(directory: string): void {
+  for (const path of validateInterruptedCurrentTemps(directory)) unlinkSync(path);
+  fsyncDirectory(directory);
+}
+
+function validateInterruptedCurrentTemps(directory: string): string[] {
+  const paths: string[] = [];
   for (const name of readdirSync(directory)) {
     if (!CURRENT_TEMP_PATTERN.test(name)) continue;
     const path = join(directory, name);
@@ -525,26 +836,39 @@ function cleanupInterruptedCurrentTemps(directory: string): void {
     if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
       throw new Error(`IronCurtain CA interrupted current publication is not a regular file: ${path}`);
     }
-    unlinkSync(path);
+    paths.push(path);
   }
-  fsyncDirectory(directory);
+  return paths;
 }
 
 function cleanupUnreachableGenerations(directory: string): void {
+  for (const path of validateUnreachableGenerations(directory)) removeGenerationDirectory(path);
   const generationsDirectory = join(directory, GENERATIONS_DIRECTORY);
-  if (!pathExistsNoFollow(generationsDirectory)) return;
+  if (pathExistsNoFollow(generationsDirectory)) fsyncDirectory(generationsDirectory);
+}
+
+function validateUnreachableGenerations(directory: string): string[] {
+  const generationsDirectory = join(directory, GENERATIONS_DIRECTORY);
+  if (!pathExistsNoFollow(generationsDirectory)) return [];
   validateAuthorityDirectory(lstatSync(generationsDirectory), generationsDirectory, true);
+  const paths: string[] = [];
   for (const name of readdirSync(generationsDirectory)) {
     const path = join(generationsDirectory, name);
     if (!GENERATION_PATTERN.test(name)) {
       throw new Error(`IronCurtain CA generations directory contains an unknown entry: ${name}`);
     }
-    removeGenerationDirectory(path);
+    validateRemovableGenerationDirectory(path);
+    paths.push(path);
   }
-  fsyncDirectory(generationsDirectory);
+  return paths;
 }
 
 function removeGenerationDirectory(path: string): void {
+  validateRemovableGenerationDirectory(path);
+  rmSync(path, { recursive: true });
+}
+
+function validateRemovableGenerationDirectory(path: string): void {
   const stats = lstatSync(path);
   validateAuthorityDirectory(stats, path, true);
   for (const name of readdirSync(path)) {
@@ -557,15 +881,24 @@ function removeGenerationDirectory(path: string): void {
       throw new Error(`IronCurtain CA unreachable generation contains an unsafe entry: ${child}`);
     }
   }
-  rmSync(path, { recursive: true });
 }
 
 function cleanupLegacyMigrationRemainder(directory: string, current: CertificateAuthority): void {
+  const remainder = validateLegacyMigrationRemainder(directory, current);
+  if (remainder.certPath !== undefined) unlinkSync(remainder.certPath);
+  if (remainder.keyPath !== undefined) unlinkSync(remainder.keyPath);
+  fsyncDirectory(directory);
+}
+
+function validateLegacyMigrationRemainder(
+  directory: string,
+  current: CertificateAuthority,
+): { readonly certPath?: string; readonly keyPath?: string } {
   const certPath = join(directory, LEGACY_CERT_FILENAME);
   const keyPath = join(directory, LEGACY_KEY_FILENAME);
   const certExists = pathExistsNoFollow(certPath);
   const keyExists = pathExistsNoFollow(keyPath);
-  if (!certExists && !keyExists) return;
+  if (!certExists && !keyExists) return {};
   if (certExists) {
     const legacyCertPem = readExactFile(certPath, CERT_MODE, 'legacy certificate', MAX_CA_FILE_BYTES).toString('utf8');
     if (legacyCertPem !== current.certPem) {
@@ -586,9 +919,10 @@ function cleanupLegacyMigrationRemainder(directory: string, current: Certificate
   ) {
     throw new Error('IronCurtain CA legacy private key conflicts with the current generation');
   }
-  if (certExists) unlinkSync(certPath);
-  if (keyExists) unlinkSync(keyPath);
-  fsyncDirectory(directory);
+  return {
+    ...(certExists ? { certPath } : {}),
+    ...(keyExists ? { keyPath } : {}),
+  };
 }
 
 function removeExactLegacyPair(authority: CertificateAuthorityFiles): void {
@@ -660,6 +994,12 @@ function sha256(contents: Buffer): string {
 
 function identity(stats: Stats): FileIdentity {
   return { dev: stats.dev, ino: stats.ino };
+}
+
+function assertPathIdentity(path: string, expected: FileIdentity, label: string): void {
+  if (!sameIdentity(lstatSync(path), expected)) {
+    throw new Error(`IronCurtain CA ${label} changed during repair: ${path}`);
+  }
 }
 
 function sameIdentity(left: Pick<Stats, 'dev' | 'ino'>, right: Pick<Stats, 'dev' | 'ino'>): boolean {

--- a/src/docker/docker-infrastructure.ts
+++ b/src/docker/docker-infrastructure.ts
@@ -46,8 +46,8 @@ import type { DockerProxy } from './code-mode-proxy.js';
 import type { MitmProxy } from './mitm-proxy.js';
 import type { TrajectoryCaptureWriter } from './trajectory-capture.js';
 import type { CertificateAuthority } from './ca.js';
-import type { ContainerRuntime } from './types.js';
-import { createContainerRuntime, type ContainerRuntimeKind } from './container-runtime.js';
+import type { ContainerRuntime, DockerNamedVolumeMount } from './types.js';
+import { createContainerRuntime, resolveRuntimeKind, type ContainerRuntimeKind } from './container-runtime.js';
 import type { HostOnlyNetwork, NetworkTopology } from './network-topology.js';
 import type { ProviderKeyMapping } from './mitm-proxy.js';
 import { parseUpstreamBaseUrl, type AgentKind, type ProviderConfig, type UpstreamTarget } from './provider-config.js';
@@ -62,7 +62,7 @@ import {
   withInternalNetworkAllocationRetry,
 } from './docker-resource-lifecycle.js';
 import { clampDockerResources } from './resource-limits.js';
-import type { HostResources } from './resource-limits.js';
+import type { EffectiveDockerResources, HostResources } from './resource-limits.js';
 import { errorMessage } from '../utils/error-message.js';
 import { createCachedStager } from '../skills/staging.js';
 import type { ResolvedSkill } from '../skills/types.js';
@@ -76,6 +76,8 @@ import {
 import { getFrozenWatchdogPolicyTemplatePath, getIronCurtainPackageRoot } from './docker-workload-paths.js';
 import { prepareSelectedAgentArtifact, type SelectedAgentArtifact } from './selected-agent-artifact.js';
 import {
+  assertAdmittedDockerWorkloadRuntimeAvailable,
+  assertDockerWorkloadVariantAdmitted,
   formatDockerWorkloadStatus,
   type DockerWorkloadNetworkAccess,
   type ResolvedDockerWorkloadConfig,
@@ -86,6 +88,7 @@ import type {
   OuterResourceRole,
 } from '../docker-workload/infrastructure.js';
 import {
+  assertNestedDaemonBackendImplemented,
   nestedDaemonAgentEnv,
   resolveNestedDaemonBundle,
   startAppleVmDockerWorkload,
@@ -100,10 +103,15 @@ import { acquireLlmMetricsRuntime, type LlmMetricsRuntimeLease } from '../llm-me
 import { hasMetricsCapableCompletionEndpoint } from './llm-observation/completion-endpoint.js';
 import {
   APPLE_VM_DOCKER_WORKLOAD_NETWORK,
+  APPLE_VM_DOCKER_WORKLOAD_NETWORK_ENV,
   appleVmDockerWorkloadArtifactMount,
   stageAppleVmDockerWorkloadBootstrap,
   type AppleVmDockerWorkloadBootstrapConfig,
 } from '../docker-workload/apple-private-docker.js';
+import type {
+  DockerDesktopSidecarHandle,
+  DockerDesktopSidecarResources,
+} from '../docker-workload/docker-desktop-sidecar.js';
 import type { ExpandedOuterCreate } from '../docker-workload/lifecycle-evidence.js';
 import {
   DOCKER_BUILD_PROXY_CONFIG_PATH,
@@ -417,6 +425,15 @@ export function stageDockerBuildShim(
  * `createDockerInfrastructure()` instead, which extends this with a
  * running container.
  */
+export type DockerDesktopAgentAccess = Pick<DockerDesktopSidecarHandle, 'dockerHost' | 'agentApiMount'> & {
+  readonly networkName: string;
+};
+
+export interface DockerDesktopResourcePartition {
+  readonly sidecar: DockerDesktopSidecarResources;
+  readonly agent: EffectiveDockerResources;
+}
+
 export interface PreContainerInfrastructure {
   /**
    * Stable key for this bundle. Used by:
@@ -620,14 +637,18 @@ export interface PreContainerInfrastructure {
    * (docs/designs/secure-nested-runtime-implementation-plan.md §8.2–8.3).
    * The host-owned lease handle: `createSessionContainers` / the PTY path
    * ledger every outer resource through it before create and observe it
-   * after (§8.2 step 1); the same-VM bootstrap activates it after private
-   * Docker is fully provisioned; `destroyDockerInfrastructure` tears it down
-   * first (§8.3). Undefined for every ordinary session. The resolved-variant
-   * guard currently admits only the explicit Apple developer slice.
+   * after (§8.2 step 1); the selected backend activates it after private
+   * Docker and the agent create are fully adjudicated;
+   * `destroyDockerInfrastructure` tears it down first (§8.3). Undefined for
+   * every ordinary session.
    */
   readonly dockerWorkload?: DockerWorkloadBundleHandle;
-  /** Immutable per-lease selected-agent artifact used only by an admitted Apple Docker workload. */
+  /** Immutable per-lease selected-agent artifact consumed by the selected nested-daemon backend. */
   readonly dockerWorkloadBootstrap?: AppleVmDockerWorkloadBootstrapConfig;
+  /** Private Docker Desktop API capability exposed to the agent after sidecar adjudication. */
+  readonly dockerDesktopAgentAccess?: DockerDesktopAgentAccess;
+  /** One aggregate Docker Desktop envelope partitioned between sidecar and agent. */
+  readonly dockerDesktopResources?: DockerDesktopResourcePartition;
   /** Exact per-bundle nested-Docker egress authorities, absent when offline. */
   readonly dockerWorkloadEgress?: DockerWorkloadEgressCollection;
   /** Package-only Docker shim, build-trust wrapper/contract, and credential-free client config. */
@@ -695,6 +716,23 @@ const CODEX_CHATGPT_HOSTS = new Set(['chatgpt.com', 'auth.openai.com']);
 
 /** Prefix for container/sidecar names. Keep in sync with `docker ps` filters. */
 const CONTAINER_NAME_PREFIX = 'ironcurtain-';
+
+const DOCKER_DESKTOP_SIDECAR_IMAGE = 'ironcurtain-nested-daemon:latest';
+const DOCKER_DESKTOP_SIDECAR_MEMORY_MB = 512;
+const DOCKER_DESKTOP_SIDECAR_CPUS = 0.25;
+const DOCKER_DESKTOP_MIN_AGGREGATE_MEMORY_MB = 1024;
+const DOCKER_DESKTOP_MIN_AGGREGATE_CPUS = 0.5;
+
+function assertDockerDesktopNetworkModeImplemented(
+  runtimeKind: ContainerRuntimeKind,
+  config: ResolvedDockerWorkloadConfig,
+): void {
+  if (runtimeKind !== 'docker' || !config.enabled || config.networkAccess === 'offline') return;
+  throw new Error(
+    'secure nested Docker on Docker Desktop currently supports only networkAccess "offline"; ' +
+      'DD-PROXY image and package mediation is not yet implemented and no sidecar was provisioned',
+  );
+}
 
 /** Host gateway alias used by Docker containers on macOS/Windows. */
 const DOCKER_HOST_GATEWAY = 'host.docker.internal';
@@ -788,14 +826,12 @@ export async function prepareDockerInfrastructure(
   // proxy, lease, or filesystem provisioning. Runtime resolution is a
   // read-only probe; ordinary CLI credential preflight is outside this seam.
   // Keep the feature-off path's historical profile/adapter/runtime ordering.
-  let admittedRuntimeKind: ContainerRuntimeKind | undefined;
-  if (config.userConfig.dockerWorkload?.enabled === true) {
-    const { resolveRuntimeKind } = await import('./container-runtime.js');
-    admittedRuntimeKind = await resolveRuntimeKind(config.userConfig.containerRuntime);
-    const { assertDockerWorkloadVariantAdmitted, assertAdmittedDockerWorkloadRuntimeAvailable } =
-      await import('../docker-workload/config.js');
-    assertDockerWorkloadVariantAdmitted(config.userConfig.dockerWorkload, admittedRuntimeKind);
-    await assertAdmittedDockerWorkloadRuntimeAvailable();
+  const admittedRuntimeKind = await resolveAdmittedDockerWorkloadRuntimeKind(config.userConfig);
+  let dockerDesktopResources: DockerDesktopResourcePartition | undefined;
+  if (admittedRuntimeKind !== undefined) {
+    if (admittedRuntimeKind === 'docker') {
+      dockerDesktopResources = selectDockerDesktopResourcePartition(config.userConfig);
+    }
     const nestedDockerStatus = formatDockerWorkloadStatus(config.userConfig.dockerWorkload);
     if (nestedDockerStatus) logger.info(nestedDockerStatus);
   }
@@ -913,16 +949,20 @@ export async function prepareDockerInfrastructure(
   // host-owned lease before any proxy or outer resource is created. Placed
   // here (after the runtime is resolved, before proxy startup) so the §8.2
   // ordering "lease -> proxies -> watchdog attestation" holds. The
-  // resolved-variant guard above limits this production path to the admitted
-  // Apple developer slice. `attestWatchdog()` (§8.2 step 3) is driven after
-  // the proxies start, below.
+  // resolved-variant guard above limits this production path to an admitted
+  // backend/mode. `attestWatchdog()` (§8.2 step 3) is driven after the proxies
+  // start, below.
   const dockerWorkloadConfig = config.userConfig.dockerWorkload;
   let dockerWorkloadAgentImage: string | undefined;
   let dockerWorkloadImageResolution: AgentImageResolution | undefined;
+  let dockerDesktopSidecarImage: string | undefined;
   let admittedDockerWorkload:
     | { readonly handle: DockerWorkloadBundleHandle; readonly bootstrap: AppleVmDockerWorkloadBootstrapConfig }
     | undefined;
   if (dockerWorkloadConfig?.enabled === true) {
+    if (runtimeKind === 'docker') {
+      dockerDesktopSidecarImage = await ensureDockerDesktopSidecarImage(docker);
+    }
     dockerWorkloadAgentImage = await adapter.getImage();
     dockerWorkloadImageResolution = preparedImageResolution;
     if (dockerWorkloadImageResolution === undefined) {
@@ -960,6 +1000,7 @@ export async function prepareDockerInfrastructure(
   let metricsRuntime: LlmMetricsRuntimeLease | undefined;
   let dockerWorkloadEgress: DockerWorkloadEgressCollection | undefined;
   let dockerBuildShim: DockerBuildShimStaging | undefined;
+  let dockerDesktopAgentAccess: DockerDesktopAgentAccess | undefined;
   try {
     // tcp-hostonly: create the per-bundle host-only network BEFORE the
     // proxies are constructed. The gateway address feeds the container env,
@@ -1266,6 +1307,31 @@ export async function prepareDockerInfrastructure(
     // reconciliation cannot be relied on for a post-attestation failure.
     await dockerWorkload?.attestWatchdog();
 
+    if (runtimeKind === 'docker' && dockerWorkload !== undefined) {
+      if (
+        dockerWorkloadBootstrap === undefined ||
+        dockerDesktopSidecarImage === undefined ||
+        dockerDesktopResources === undefined
+      ) {
+        throw new Error('Docker Desktop nested-Docker preparation is missing its staged artifact, image, or resources');
+      }
+      const { requireDockerDesktopSidecarRuntime, startDockerDesktopSidecar } =
+        await import('../docker-workload/docker-desktop-sidecar.js');
+      const sidecar = await startDockerDesktopSidecar({
+        runtime: requireDockerDesktopSidecarRuntime(docker),
+        sidecarImage: dockerDesktopSidecarImage,
+        bootstrap: dockerWorkloadBootstrap,
+        resources: dockerDesktopResources.sidecar,
+        createOuterResource: (spec, create) => ledgerOuterResourceCreate(dockerWorkload, spec, create),
+        activation: dockerWorkload,
+      });
+      dockerDesktopAgentAccess = {
+        dockerHost: sidecar.dockerHost,
+        networkName: sidecar.network.name,
+        agentApiMount: sidecar.agentApiMount,
+      };
+    }
+
     // Build orientation
     const helpData = proxy.getHelpData();
     const serverListings = Object.entries(helpData.serverDescriptions).map(([name, description]) => ({
@@ -1293,7 +1359,7 @@ export async function prepareDockerInfrastructure(
         throw new Error('admitted nested-Docker handle is missing its resolved enabled configuration');
       }
       nestedDocker = {
-        networkName: APPLE_VM_DOCKER_WORKLOAD_NETWORK,
+        networkName: dockerDesktopAgentAccess?.networkName ?? APPLE_VM_DOCKER_WORKLOAD_NETWORK,
         networkAccess: dockerWorkloadConfig.networkAccess,
       };
     }
@@ -1397,6 +1463,8 @@ export async function prepareDockerInfrastructure(
       ...workflowDependencyMounts,
       dockerWorkload,
       dockerWorkloadBootstrap,
+      dockerDesktopAgentAccess,
+      dockerDesktopResources,
       dockerWorkloadEgress,
       dockerBuildShim,
       restageSkills,
@@ -1948,6 +2016,45 @@ export function selectOuterContainerResources(
   return clampDockerResources(configured, hostResources).effective;
 }
 
+/**
+ * Partition one aggregate Docker Desktop nested-workload envelope. The fixed
+ * daemon reserve is deliberately small but nonzero; the agent receives the
+ * exact remainder, so the two outer `--memory`/`--cpus` declarations never
+ * exceed the operator-selected total. Apple keeps its existing single-VM
+ * envelope and does not call this helper.
+ */
+export function selectDockerDesktopResourcePartition(
+  userConfig: Pick<ResolvedUserConfig, 'dockerResources' | 'dockerWorkload'>,
+  hostResources?: HostResources,
+): DockerDesktopResourcePartition {
+  if (userConfig.dockerWorkload?.enabled !== true) {
+    throw new Error('Docker Desktop resource partition requires an enabled nested-Docker workload');
+  }
+  const aggregate = selectOuterContainerResources(userConfig, hostResources);
+  const memoryMb = aggregate.memoryMb;
+  const cpus = aggregate.cpus;
+  if (memoryMb === undefined || cpus === undefined) {
+    throw new Error('Docker Desktop nested Docker requires finite aggregate memory and CPU limits');
+  }
+  if (memoryMb < DOCKER_DESKTOP_MIN_AGGREGATE_MEMORY_MB || cpus < DOCKER_DESKTOP_MIN_AGGREGATE_CPUS) {
+    throw new Error(
+      `Docker Desktop nested Docker requires at least ${DOCKER_DESKTOP_MIN_AGGREGATE_MEMORY_MB} MiB and ` +
+        `${DOCKER_DESKTOP_MIN_AGGREGATE_CPUS} CPU in dockerWorkload.resources`,
+    );
+  }
+  return {
+    sidecar: {
+      memoryMb: DOCKER_DESKTOP_SIDECAR_MEMORY_MB,
+      cpus: DOCKER_DESKTOP_SIDECAR_CPUS,
+      pidsLimit: userConfig.dockerWorkload.resources.pids.desired,
+    },
+    agent: {
+      memoryMb: memoryMb - DOCKER_DESKTOP_SIDECAR_MEMORY_MB,
+      cpus: cpus - DOCKER_DESKTOP_SIDECAR_CPUS,
+    },
+  };
+}
+
 interface DockerWorkloadAdmissionForSessionOptions {
   readonly dockerWorkload: Extract<ResolvedDockerWorkloadConfig, { enabled: true }>;
   readonly runtime: ContainerRuntime;
@@ -1972,8 +2079,6 @@ async function admitDockerWorkloadForSession(options: DockerWorkloadAdmissionFor
   const { admitDockerWorkloadBundle } = await import('../docker-workload/infrastructure.js');
   const { createJsonlDockerWorkloadAuditSink } = await import('../docker-workload/lifecycle-evidence.js');
   const { dockerWorkloadConfigHash } = await import('../docker-workload/config.js');
-  const { assertNestedDaemonBackendImplemented } = await import('../docker-workload/session-daemon.js');
-
   assertNestedDaemonBackendImplemented(options.runtimeKind);
   const configHash = dockerWorkloadConfigHash(options.dockerWorkload);
   const packageRoot = getIronCurtainPackageRoot();
@@ -2072,6 +2177,69 @@ export function buildUdsSocketMounts(
   return [{ source: socketsDir, target: CONTAINER_SOCKETS_DIR, readonly: false }];
 }
 
+export interface NestedDockerAgentWiring {
+  readonly appleNestedDaemon: DockerWorkloadBundleHandle | undefined;
+  readonly env: Readonly<Record<string, string>>;
+  readonly namedVolumeMounts: readonly DockerNamedVolumeMount[];
+}
+
+/** Resolve the backend-specific private-Docker capability exposed to an agent. */
+export function resolveNestedDockerAgentWiring(
+  core: Pick<
+    PreContainerInfrastructure,
+    'runtimeKind' | 'dockerWorkload' | 'dockerWorkloadBootstrap' | 'dockerDesktopAgentAccess'
+  >,
+): NestedDockerAgentWiring {
+  const appleNestedDaemon = resolveNestedDaemonBundle(core.dockerWorkload, core.runtimeKind);
+  if (core.dockerWorkload === undefined) {
+    if (core.dockerWorkloadBootstrap !== undefined || core.dockerDesktopAgentAccess !== undefined) {
+      throw new Error('nested-Docker staging or API access exists without an admitted workload');
+    }
+    return { appleNestedDaemon, env: {}, namedVolumeMounts: [] };
+  }
+  if (core.dockerWorkloadBootstrap === undefined) {
+    throw new Error('admitted nested Docker is missing its staged selected-agent artifact');
+  }
+
+  if (core.runtimeKind === 'apple-container') {
+    if (core.dockerDesktopAgentAccess !== undefined) {
+      throw new Error('Apple nested Docker received a Docker Desktop API capability');
+    }
+    return {
+      appleNestedDaemon,
+      env: nestedDaemonAgentEnv(appleNestedDaemon),
+      namedVolumeMounts: [],
+    };
+  }
+
+  const access = core.dockerDesktopAgentAccess;
+  if (access === undefined) throw new Error('Docker Desktop nested Docker is missing its qualified sidecar API');
+  if (access.agentApiMount.readonly !== true || access.agentApiMount.noCopy !== true) {
+    throw new Error('Docker Desktop agent API volume must be an exact read-only no-copy capability');
+  }
+  return {
+    appleNestedDaemon: undefined,
+    env: {
+      DOCKER_HOST: access.dockerHost,
+      [APPLE_VM_DOCKER_WORKLOAD_NETWORK_ENV]: access.networkName,
+    },
+    namedVolumeMounts: [access.agentApiMount],
+  };
+}
+
+/** Pin Docker Desktop's outer agent create to the same captured immutable image. */
+export function resolveNestedDockerOuterAgentImage(
+  core: Pick<PreContainerInfrastructure, 'runtimeKind' | 'dockerWorkload' | 'imageResolution'>,
+  fallbackImage: string,
+): string {
+  if (core.runtimeKind !== 'docker' || core.dockerWorkload === undefined) return fallbackImage;
+  const selectedImageId = core.imageResolution?.immutableImageId;
+  if (selectedImageId === undefined || SHA256_IMAGE_ID.exec(selectedImageId) === null) {
+    throw new Error('Docker Desktop nested Docker is missing its selected immutable outer-agent image');
+  }
+  return selectedImageId;
+}
+
 /** Exact Apple-only mounts for the per-bundle nested-Docker egress capabilities. */
 export function buildDockerWorkloadEgressMounts(
   core: Pick<PreContainerInfrastructure, 'runtimeKind' | 'dockerWorkloadEgress'>,
@@ -2121,16 +2289,33 @@ export function dockerWorkloadEgressNetworkAccess(
  * Keeping this assembly here prevents the two container-creation paths from
  * drifting on network mode, trust artifacts, or egress-ledger witnesses.
  */
-export async function activateAppleVmDockerWorkload(options: {
+export async function activateNestedDockerWorkload(options: {
   readonly runtime: ContainerRuntime;
+  readonly runtimeKind: ContainerRuntimeKind;
   readonly containerId: string;
-  readonly nestedDaemon: DockerWorkloadBundleHandle | undefined;
+  readonly dockerWorkload: DockerWorkloadBundleHandle | undefined;
+  readonly dockerDesktopAgentAccess: DockerDesktopAgentAccess | undefined;
   readonly bootstrap: AppleVmDockerWorkloadBootstrapConfig | undefined;
   readonly dockerWorkloadEgress: DockerWorkloadEgressCollection | undefined;
   readonly dockerBuildShim: DockerBuildShimStaging | undefined;
 }): Promise<void> {
-  const { nestedDaemon, bootstrap, dockerWorkloadEgress, dockerBuildShim } = options;
-  if (nestedDaemon === undefined || bootstrap === undefined) return;
+  const { dockerWorkload, bootstrap, dockerWorkloadEgress, dockerBuildShim } = options;
+  if (dockerWorkload === undefined) return;
+  if (bootstrap === undefined) throw new Error('admitted nested Docker is missing its staged selected-agent artifact');
+
+  if (options.runtimeKind === 'docker') {
+    if (options.dockerDesktopAgentAccess === undefined) {
+      throw new Error('Docker Desktop nested Docker is missing its qualified sidecar API');
+    }
+    await dockerWorkload.activate();
+    return;
+  }
+
+  if (options.dockerDesktopAgentAccess !== undefined) {
+    throw new Error('Apple nested Docker received a Docker Desktop API capability');
+  }
+  const nestedDaemon = resolveNestedDaemonBundle(dockerWorkload, options.runtimeKind);
+  if (nestedDaemon === undefined) throw new Error('Apple nested Docker is missing its same-VM daemon handle');
 
   await startAppleVmDockerWorkload({
     runtime: options.runtime,
@@ -2249,10 +2434,16 @@ async function createSessionContainersAttempt(
     // nested egress listeners before any outer cleanup can run.
     await core.docker.removeStaleContainer(mainContainerName);
 
-    const mainImage =
+    const resumableBaseImage =
       options?.baseImageOverride && (await core.docker.imageExists(options.baseImageOverride))
         ? options.baseImageOverride
-        : core.image;
+        : undefined;
+    // Docker can create directly from the selected immutable ID, closing the
+    // tag-replacement window between artifact capture and the ledgered create.
+    // Apple cannot, so its stopped-create adjudication below remains the
+    // equivalent backend-specific defense. An immutable workflow snapshot,
+    // when present, continues to take precedence for resume.
+    const mainImage = resumableBaseImage ?? resolveNestedDockerOuterAgentImage(core, core.image);
 
     // Base mounts shared by TCP and UDS modes: the sandbox as the
     // workspace and the orientation dir. Mode-specific mounts (apt proxy
@@ -2265,19 +2456,17 @@ async function createSessionContainersAttempt(
     // Docker-workload bundle, in which case this agent container both hosts the
     // daemon and reaches it at the VM-local socket. Resolved once here and
     // reused for the env, the ledgered create, and the post-start bootstrap.
-    const nestedDaemon = resolveNestedDaemonBundle(core.dockerWorkload, core.runtimeKind);
+    const nestedDockerWiring = resolveNestedDockerAgentWiring(core);
+    const nestedDaemon = nestedDockerWiring.appleNestedDaemon;
     const dockerWorkloadBootstrap = core.dockerWorkloadBootstrap;
-    if ((nestedDaemon === undefined) !== (dockerWorkloadBootstrap === undefined)) {
-      throw new Error('Docker-workload lease and selected-agent artifact staging must be present together');
-    }
-    if (dockerWorkloadBootstrap !== undefined) {
+    if (nestedDaemon !== undefined && dockerWorkloadBootstrap !== undefined) {
       mounts.push(appleVmDockerWorkloadArtifactMount(dockerWorkloadBootstrap));
     }
     let env = {
       ...core.adapter.buildEnv(config, core.fakeKeys),
       ...core.adapter.buildBatchEnv?.(config, core.fakeKeys),
       ...buildRuntimeTrustEnv(),
-      ...nestedDaemonAgentEnv(nestedDaemon),
+      ...nestedDockerWiring.env,
     };
     let network: string | null;
     let extraHosts: string[] | undefined;
@@ -2469,7 +2658,7 @@ async function createSessionContainersAttempt(
     // Resource ceilings come from userConfig (defaults: 8 GB / 4 cpus) and
     // are clamped to fit the host. `null` in either field is preserved as
     // "no flag emitted" (see clampDockerResources docs).
-    const containerResources = selectOuterContainerResources(config.userConfig);
+    const containerResources = core.dockerDesktopResources?.agent ?? selectOuterContainerResources(config.userConfig);
 
     // Build the agent container create args for a given name + resolved labels.
     // `labels` is the base bundle labels in the ordinary case and the base merged
@@ -2512,6 +2701,10 @@ async function createSessionContainersAttempt(
         // nested daemon boot AND lets its runc mount procfs for inner
         // containers.
         fullyVisibleProc: nestedDaemon !== undefined,
+        trustedCreateOptions:
+          nestedDockerWiring.namedVolumeMounts.length === 0
+            ? undefined
+            : { namedVolumeMounts: nestedDockerWiring.namedVolumeMounts },
       });
 
     // §8.2 step 1: ledger the agent container before create when a
@@ -2524,12 +2717,36 @@ async function createSessionContainersAttempt(
       expectedImageId: core.imageResolution?.immutableImageId,
       deterministicName: mainContainerName,
       baseLabels: bundleLabels.labels,
-      mounts,
+      mounts: [
+        ...mounts,
+        ...nestedDockerWiring.namedVolumeMounts.map((mount) => ({
+          source: mount.name,
+          target: mount.target,
+          readonly: mount.readonly === true,
+        })),
+      ],
       create: createMainContainer,
     });
 
     await core.docker.start(mainContainerId);
     logger.info(`Container started: ${mainContainerId.substring(0, 12)}`);
+
+    // The Desktop sidecar is already adjudicated. Finalize the lease as soon
+    // as the ledgered agent has started, before even trusted diagnostic execs
+    // can cross the release boundary. Apple activation remains below because
+    // its daemon bootstrap itself runs inside this container.
+    if (core.runtimeKind === 'docker') {
+      await activateNestedDockerWorkload({
+        runtime: core.docker,
+        runtimeKind: core.runtimeKind,
+        containerId: mainContainerId,
+        dockerWorkload: core.dockerWorkload,
+        dockerDesktopAgentAccess: core.dockerDesktopAgentAccess,
+        bootstrap: dockerWorkloadBootstrap,
+        dockerWorkloadEgress: core.dockerWorkloadEgress,
+        dockerBuildShim: core.dockerBuildShim,
+      });
+    }
 
     if (core.runtimeKind === 'docker') {
       await checkDockerContainerWritableStorage(core.docker, mainContainerId);
@@ -2565,14 +2782,18 @@ async function createSessionContainersAttempt(
     // component. Bootstrap/adjudicate dockerd, preflight the pinned client,
     // provision the selected prepared inner image, record observations, and
     // activate the lease before any agent process is exec'd into it.
-    await activateAppleVmDockerWorkload({
-      runtime: core.docker,
-      containerId: mainContainerId,
-      nestedDaemon,
-      bootstrap: dockerWorkloadBootstrap,
-      dockerWorkloadEgress: core.dockerWorkloadEgress,
-      dockerBuildShim: core.dockerBuildShim,
-    });
+    if (core.runtimeKind === 'apple-container') {
+      await activateNestedDockerWorkload({
+        runtime: core.docker,
+        runtimeKind: core.runtimeKind,
+        containerId: mainContainerId,
+        dockerWorkload: core.dockerWorkload,
+        dockerDesktopAgentAccess: core.dockerDesktopAgentAccess,
+        bootstrap: dockerWorkloadBootstrap,
+        dockerWorkloadEgress: core.dockerWorkloadEgress,
+        dockerBuildShim: core.dockerBuildShim,
+      });
+    }
 
     return {
       containerId: mainContainerId,
@@ -2878,15 +3099,7 @@ export async function ensureDockerImage(
   agentId: AgentId,
   userConfig: ResolvedUserConfig,
 ): Promise<AgentImageResolution> {
-  let admittedRuntimeKind: ContainerRuntimeKind | undefined;
-  if (userConfig.dockerWorkload?.enabled === true) {
-    const { resolveRuntimeKind } = await import('./container-runtime.js');
-    admittedRuntimeKind = await resolveRuntimeKind(userConfig.containerRuntime);
-    const { assertDockerWorkloadVariantAdmitted, assertAdmittedDockerWorkloadRuntimeAvailable } =
-      await import('../docker-workload/config.js');
-    assertDockerWorkloadVariantAdmitted(userConfig.dockerWorkload, admittedRuntimeKind);
-    await assertAdmittedDockerWorkloadRuntimeAvailable();
-  }
+  const admittedRuntimeKind = await resolveAdmittedDockerWorkloadRuntimeKind(userConfig);
   const { registerBuiltinAdapters, getAgent } = await import('./agent-registry.js');
   const { createContainerRuntime, resolveRuntimeKind } = await import('./container-runtime.js');
 
@@ -2895,6 +3108,10 @@ export async function ensureDockerImage(
   const image = await adapter.getImage();
   const runtimeKind = admittedRuntimeKind ?? (await resolveRuntimeKind(userConfig.containerRuntime));
   const docker = createContainerRuntime(runtimeKind);
+  if (userConfig.dockerWorkload?.enabled === true && runtimeKind === 'docker') {
+    selectDockerDesktopResourcePartition(userConfig);
+    await ensureDockerDesktopSidecarImage(docker);
+  }
   const resolved = await resolveAgentImage(image, docker);
   if (userConfig.dockerWorkload?.enabled === true) {
     const artifact = await prepareSelectedAgentArtifact({
@@ -2905,6 +3122,19 @@ export async function ensureDockerImage(
     return selectedAgentImageResolution(resolved, artifact);
   }
   return resolved;
+}
+
+async function resolveAdmittedDockerWorkloadRuntimeKind(
+  userConfig: Pick<ResolvedUserConfig, 'containerRuntime' | 'dockerWorkload'>,
+): Promise<ContainerRuntimeKind | undefined> {
+  const workload = userConfig.dockerWorkload;
+  if (workload?.enabled !== true) return undefined;
+
+  const runtimeKind = await resolveRuntimeKind(userConfig.containerRuntime);
+  assertDockerWorkloadVariantAdmitted(workload, runtimeKind);
+  await assertAdmittedDockerWorkloadRuntimeAvailable(runtimeKind);
+  assertDockerDesktopNetworkModeImplemented(runtimeKind, workload);
+  return runtimeKind;
 }
 
 function selectedAgentImageResolution(
@@ -3024,6 +3254,25 @@ export async function resolveAgentImage(image: string, docker: ContainerRuntime)
   const spec = computeAgentImageBuildSpec(image);
   const buildHash = await ensureImageFromSpec(image, docker, spec);
   return { mode: 'build-if-stale', logicalName: image, imageRef: image, buildHash };
+}
+
+/** Resolve the purpose-built Desktop daemon image through the normal hash-label cache. */
+export async function ensureDockerDesktopSidecarImage(runtime: ContainerRuntime): Promise<string> {
+  const contextDirectory = resolve(getIronCurtainPackageRoot(), 'docker', 'nested-daemon');
+  const dockerfilePath = resolve(contextDirectory, 'Dockerfile');
+  const runtimeShimPath = resolve(contextDirectory, 'runtime-shim', 'main.go');
+  const runtimeShimHash = createHash('sha256').update(readFileSync(runtimeShimPath)).digest('hex');
+  const buildHash = computeDockerBuildHash(contextDirectory, ['Dockerfile'], runtimeShimHash);
+  if (!(await isImageStale(DOCKER_DESKTOP_SIDECAR_IMAGE, runtime, buildHash))) {
+    return DOCKER_DESKTOP_SIDECAR_IMAGE;
+  }
+
+  logger.info('Building Docker Desktop nested-daemon image...');
+  await runtime.buildImage(DOCKER_DESKTOP_SIDECAR_IMAGE, dockerfilePath, contextDirectory, {
+    'ironcurtain.build-hash': buildHash,
+  });
+  logger.info('Docker Desktop nested-daemon image built successfully');
+  return DOCKER_DESKTOP_SIDECAR_IMAGE;
 }
 
 function computeAgentImageBuildSpec(image: string): AgentImageBuildSpec {

--- a/src/docker/docker-manager.ts
+++ b/src/docker/docker-manager.ts
@@ -20,6 +20,8 @@ import type {
   DockerImageInfo,
   DockerNetworkCreateOptions,
   DockerNetworkInfo,
+  DockerVolumeCreateOptions,
+  DockerVolumeInfo,
 } from './types.js';
 import { parseDockerImageInfo } from './docker-image-inspect.js';
 import * as logger from '../logger.js';
@@ -90,7 +92,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function inspectDockerObjects(
   exec: ExecFileFn,
-  kind: 'network' | 'container',
+  kind: 'network' | 'container' | 'volume',
   ids: readonly string[],
 ): Promise<readonly Record<string, unknown>[]> {
   if (ids.length === 0) return [];
@@ -103,7 +105,8 @@ async function inspectDockerObjects(
     if (!Array.isArray(parsed)) throw new Error(`Unexpected docker ${kind} inspect result: expected array`);
     return parsed.filter(isRecord);
   } catch (error) {
-    const disappeared = isExecError(error) && /not found|no such (?:network|container|object)/i.test(error.stderr);
+    const disappeared =
+      isExecError(error) && /not found|no such (?:network|container|volume|object)/i.test(error.stderr);
     if (!disappeared) throw error;
     if (ids.length === 1) return [];
 
@@ -128,6 +131,18 @@ function parseDockerImageId(stdout: string): string {
 
 function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function parseDockerVolumeInfo(entry: Record<string, unknown>): DockerVolumeInfo {
+  const name = typeof entry.Name === 'string' ? entry.Name : '';
+  return {
+    id: name,
+    name,
+    created: typeof entry.CreatedAt === 'string' ? entry.CreatedAt : '',
+    labels: stringRecord(entry.Labels),
+    driver: typeof entry.Driver === 'string' ? entry.Driver : '',
+    mountpoint: typeof entry.Mountpoint === 'string' ? entry.Mountpoint : '',
+  };
 }
 
 /**
@@ -277,6 +292,39 @@ export function buildCreateArgs(config: DockerContainerConfig): string[] {
   for (const mount of config.mounts) {
     const opts = mount.readonly ? ':ro' : '';
     args.push('-v', `${mount.source}:${mount.target}${opts}`);
+  }
+
+  const trusted = config.trustedCreateOptions;
+  for (const mount of trusted?.namedVolumeMounts ?? []) {
+    const options = [
+      `type=volume`,
+      `src=${mount.name}`,
+      `dst=${mount.target}`,
+      ...(mount.readonly === true ? ['readonly'] : []),
+      ...(mount.noCopy === true ? ['volume-nocopy'] : []),
+    ];
+    args.push('--mount', options.join(','));
+  }
+  for (const tmpfs of trusted?.tmpfs ?? []) {
+    args.push('--tmpfs', tmpfs);
+  }
+  if (trusted?.readOnlyRootfs === true) {
+    args.push('--read-only');
+  }
+  for (const securityOption of trusted?.securityOptions ?? []) {
+    if (/^seccomp=/u.test(securityOption)) {
+      throw new Error('trusted securityOptions must use the dedicated seccompProfile field for seccomp');
+    }
+    args.push('--security-opt', securityOption);
+  }
+  if (trusted?.seccompProfile !== undefined) {
+    args.push('--security-opt', `seccomp=${trusted.seccompProfile}`);
+  }
+  if (trusted?.pidsLimit !== undefined) {
+    if (!Number.isSafeInteger(trusted.pidsLimit) || trusted.pidsLimit <= 0) {
+      throw new Error('trusted pidsLimit must be a positive safe integer');
+    }
+    args.push('--pids-limit', String(trusted.pidsLimit));
   }
 
   for (const [key, value] of Object.entries(config.env)) {
@@ -628,6 +676,17 @@ export function createDockerManager(
       }
     },
 
+    async tagImage(sourceRef: string, targetRef: string): Promise<void> {
+      await exec('docker', ['image', 'tag', sourceRef, targetRef], { timeout: 30_000 });
+    },
+
+    async saveImageArchive(ref: string, archivePath: string, platform?: 'linux/amd64' | 'linux/arm64'): Promise<void> {
+      const args = ['image', 'save', '--output', archivePath];
+      if (platform !== undefined) args.push('--platform', platform);
+      args.push(ref);
+      await exec('docker', args, { timeout: DEFAULT_COMMIT_TIMEOUT_MS, maxBuffer: 1024 * 1024 });
+    },
+
     async loadImageArchive(archivePath: string): Promise<void> {
       await runStreamed({
         operation: 'docker image load',
@@ -785,6 +844,67 @@ export function createDockerManager(
         return true;
       } catch {
         return false;
+      }
+    },
+
+    async createVolume(name: string, options?: DockerVolumeCreateOptions): Promise<string> {
+      const args = ['volume', 'create'];
+      if (options?.driver !== undefined) args.push('--driver', options.driver);
+      for (const [key, value] of Object.entries(options?.driverOptions ?? {})) {
+        args.push('--opt', `${key}=${value}`);
+      }
+      for (const [key, value] of Object.entries(options?.labels ?? {})) {
+        args.push('--label', `${key}=${value}`);
+      }
+      args.push(name);
+      const { stdout } = await exec('docker', args, { timeout: 10_000, maxBuffer: 1024 * 1024 });
+      const createdName = stdout.trim();
+      if (createdName !== name) {
+        throw new Error(`Docker returned an unexpected volume identity for ${name}: ${createdName || '(empty)'}`);
+      }
+      const inspected = await inspectDockerObjects(exec, 'volume', [createdName]);
+      const created = inspected.at(0);
+      if (created === undefined) throw new Error(`Docker-created volume disappeared before ownership check: ${name}`);
+      const info = parseDockerVolumeInfo(created);
+      if (info.name !== name) {
+        throw new Error(`Docker returned mismatched volume inspect identity for ${name}: ${info.name || '(empty)'}`);
+      }
+      for (const [key, value] of Object.entries(options?.labels ?? {})) {
+        if (info.labels[key] !== value) {
+          throw new Error(`Docker volume ${name} does not carry requested ownership label ${key}`);
+        }
+      }
+      return info.id;
+    },
+
+    async inspectVolume(name: string): Promise<DockerVolumeInfo | undefined> {
+      const inspected = await inspectDockerObjects(exec, 'volume', [name]);
+      const entry = inspected.at(0);
+      return entry === undefined ? undefined : parseDockerVolumeInfo(entry);
+    },
+
+    async listVolumes(options?: { readonly labelFilter?: string }): Promise<readonly DockerVolumeInfo[]> {
+      const args = ['volume', 'ls', '--quiet'];
+      if (options?.labelFilter !== undefined) args.push('--filter', `label=${options.labelFilter}`);
+      const { stdout } = await exec('docker', args, { timeout: 10_000, maxBuffer: 10 * 1024 * 1024 });
+      const names = [
+        ...new Set(
+          stdout
+            .split(/\r?\n/u)
+            .map((line) => line.trim())
+            .filter(Boolean),
+        ),
+      ];
+      const inspected = await inspectDockerObjects(exec, 'volume', names);
+      return inspected.map(parseDockerVolumeInfo);
+    },
+
+    async removeVolume(name: string): Promise<void> {
+      try {
+        await exec('docker', ['volume', 'rm', name], { timeout: 10_000 });
+      } catch (err: unknown) {
+        if (isExecError(err) && /not found|no such volume/i.test(err.stderr)) return;
+        throw err;
       }
     },
 

--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -40,15 +40,16 @@ import {
   buildDockerBuildShimMounts,
   buildDockerWorkloadEgressMounts,
   buildUdsSocketMounts,
-  activateAppleVmDockerWorkload,
+  activateNestedDockerWorkload,
   createLedgeredAgentContainer,
   dockerWorkloadSessionMetadata,
   removeBundleRuntimeRoot,
+  resolveNestedDockerAgentWiring,
+  resolveNestedDockerOuterAgentImage,
   selectOuterContainerResources,
   stopDockerWorkloadEgress,
   type AgentImageResolution,
 } from './docker-infrastructure.js';
-import { nestedDaemonAgentEnv, resolveNestedDaemonBundle } from '../docker-workload/session-daemon.js';
 import { appleVmDockerWorkloadArtifactMount } from '../docker-workload/apple-private-docker.js';
 import type { DockerWorkloadBundleHandle } from '../docker-workload/infrastructure.js';
 import { buildRuntimeTrustEnv, renderAptProxyConfig } from './runtime-trust.js';
@@ -579,11 +580,10 @@ async function runPtySessionAttempt(
     } else {
       throw new Error(`Agent ${adapter.id} does not support PTY mode.`);
     }
-    const nestedDaemon = resolveNestedDaemonBundle(dockerWorkload, infra.runtimeKind);
+    const nestedDockerWiring = resolveNestedDockerAgentWiring(infra);
+    const nestedDaemon = nestedDockerWiring.appleNestedDaemon;
     const dockerWorkloadBootstrap = infra.dockerWorkloadBootstrap;
-    if ((nestedDaemon === undefined) !== (dockerWorkloadBootstrap === undefined)) {
-      throw new Error('Docker-workload lease and selected-agent artifact staging must be present together');
-    }
+    const outerAgentImage = resolveNestedDockerOuterAgentImage(infra, image);
 
     // Build container configuration
     const shortId = getBundleShortId(bundleId);
@@ -762,7 +762,7 @@ async function runPtySessionAttempt(
     mounts.push(...buildDockerWorkloadEgressMounts(infra));
     mounts.push(...buildDockerBuildShimMounts(infra));
 
-    if (dockerWorkloadBootstrap !== undefined) {
+    if (nestedDaemon !== undefined && dockerWorkloadBootstrap !== undefined) {
       mounts.push(appleVmDockerWorkloadArtifactMount(dockerWorkloadBootstrap));
     }
 
@@ -786,7 +786,7 @@ async function runPtySessionAttempt(
     // docker-infrastructure.ts::createSessionContainersAttempt. Present only
     // for an admitted Docker-workload bundle; §8.2 step 6 gives the agent the
     // VM-local `DOCKER_HOST`, and the bootstrap runs after `docker.start`.
-    Object.assign(env, nestedDaemonAgentEnv(nestedDaemon));
+    Object.assign(env, nestedDockerWiring.env);
 
     // Pass initial terminal size so start-claude.sh can set PTY dimensions
     // before Claude starts, eliminating the resize race condition.
@@ -819,7 +819,7 @@ async function runPtySessionAttempt(
     // Resource ceilings come from userConfig (defaults: 8 GB / 4 cpus) and
     // are clamped to fit the host. `null` in either field is preserved as
     // "no flag emitted" (see clampDockerResources docs).
-    const ptyResources = selectOuterContainerResources(sessionConfig.userConfig);
+    const ptyResources = infra.dockerDesktopResources?.agent ?? selectOuterContainerResources(sessionConfig.userConfig);
 
     // Build the PTY agent container create args for a given name + resolved
     // labels. `labels` is the base resource labels in the ordinary case and the
@@ -827,7 +827,7 @@ async function runPtySessionAttempt(
     // ledgered — the merge lives in createLedgeredAgentContainer.
     const createPtyContainer = (name: string, labels: Readonly<Record<string, string>> | undefined): Promise<string> =>
       infra.docker.create({
-        image,
+        image: outerAgentImage,
         name,
         network: network ?? 'none',
         mounts,
@@ -854,6 +854,10 @@ async function runPtySessionAttempt(
         // nested daemon boot AND lets its runc mount procfs for inner
         // containers.
         fullyVisibleProc: nestedDaemon !== undefined,
+        trustedCreateOptions:
+          nestedDockerWiring.namedVolumeMounts.length === 0
+            ? undefined
+            : { namedVolumeMounts: nestedDockerWiring.namedVolumeMounts },
         // Apple Container allocates the agent TTY on `container exec -it`;
         // the outer `sleep infinity` process does not need a second TTY.
         tty: nativePtyCommand === undefined,
@@ -869,11 +873,34 @@ async function runPtySessionAttempt(
       expectedImageId: infra.imageResolution?.immutableImageId,
       deterministicName: mainContainerName,
       baseLabels: resourceLabels,
-      mounts,
+      mounts: [
+        ...mounts,
+        ...nestedDockerWiring.namedVolumeMounts.map((mount) => ({
+          source: mount.name,
+          target: mount.target,
+          readonly: mount.readonly === true,
+        })),
+      ],
       create: createPtyContainer,
     });
     await docker.start(containerId);
     logger.info(`PTY container started: ${containerId.substring(0, 12)}`);
+
+    // Docker Desktop's daemon sidecar is already adjudicated. Activate the
+    // bundle immediately after the ledgered agent starts and before any exec.
+    // Apple activation stays after its in-agent daemon bootstrap below.
+    if (infra.runtimeKind === 'docker') {
+      await activateNestedDockerWorkload({
+        runtime: docker,
+        runtimeKind: infra.runtimeKind,
+        containerId,
+        dockerWorkload,
+        dockerDesktopAgentAccess: infra.dockerDesktopAgentAccess,
+        bootstrap: dockerWorkloadBootstrap,
+        dockerWorkloadEgress,
+        dockerBuildShim: infra.dockerBuildShim,
+      });
+    }
 
     if (infra.runtimeKind === 'docker') {
       await checkDockerContainerWritableStorage(docker, containerId);
@@ -905,14 +932,18 @@ async function runPtySessionAttempt(
     // lease. The untrusted agent is not launched until the host attaches below,
     // so completing activation before attach preserves the release boundary
     // without delaying Apple Container's published-socket listener.
-    await activateAppleVmDockerWorkload({
-      runtime: docker,
-      containerId,
-      nestedDaemon,
-      bootstrap: dockerWorkloadBootstrap,
-      dockerWorkloadEgress,
-      dockerBuildShim: infra.dockerBuildShim,
-    });
+    if (infra.runtimeKind === 'apple-container') {
+      await activateNestedDockerWorkload({
+        runtime: docker,
+        runtimeKind: infra.runtimeKind,
+        containerId,
+        dockerWorkload,
+        dockerDesktopAgentAccess: infra.dockerDesktopAgentAccess,
+        bootstrap: dockerWorkloadBootstrap,
+        dockerWorkloadEgress,
+        dockerBuildShim: infra.dockerBuildShim,
+      });
+    }
 
     // Write session registration for the escalation listener
     registrationPath = writeRegistration(effectiveSessionId, escalationDir, adapter.displayName);

--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -100,6 +100,14 @@ export interface DockerContainerConfig {
   readonly capAdd?: readonly string[];
 
   /**
+   * Host-coordinator-selected controls for trusted infrastructure containers.
+   * These values must never be populated from agent or user configuration.
+   * Keeping them behind one explicit trust-boundary field prevents the more
+   * permissive sidecar profile from leaking into ordinary agent containers.
+   */
+  readonly trustedCreateOptions?: DockerTrustedCreateOptions;
+
+  /**
    * Leave `/proc` fully visible inside the container by opting out of the OCI
    * masked-path and read-only-path sets (`container create --masked-path NONE
    * --read-only-path NONE`).
@@ -171,6 +179,32 @@ export interface DockerMount {
   readonly readonly: boolean;
 }
 
+/** A Docker named-volume mount selected by the trusted host coordinator. */
+export interface DockerNamedVolumeMount {
+  readonly name: string;
+  readonly target: string;
+  readonly readonly?: boolean;
+  /** Suppress Docker's initial copy-up from the image into an empty volume. */
+  readonly noCopy?: boolean;
+}
+
+/**
+ * Docker-only create controls for trusted infrastructure containers.
+ * Callers must supply frozen, coordinator-owned values rather than forwarding
+ * configuration or agent input.
+ */
+export interface DockerTrustedCreateOptions {
+  readonly namedVolumeMounts?: readonly DockerNamedVolumeMount[];
+  /** Exact Docker tmpfs specifications, for example `/run:rw,nosuid,size=64m`. */
+  readonly tmpfs?: readonly string[];
+  readonly readOnlyRootfs?: boolean;
+  /** Exact `--security-opt` values other than the separately pinned seccomp profile. */
+  readonly securityOptions?: readonly string[];
+  /** Host path or Docker literal used as `--security-opt seccomp=<value>`. */
+  readonly seccompProfile?: string;
+  readonly pidsLimit?: number;
+}
+
 /** Result of a docker exec command. */
 export interface DockerExecResult {
   readonly exitCode: number;
@@ -219,6 +253,24 @@ export interface DockerContainerInfo {
   readonly created: string;
   readonly running: boolean;
   readonly labels: Readonly<Record<string, string>>;
+}
+
+/** Docker named-volume state used by exact bundle cleanup. */
+export interface DockerVolumeInfo {
+  /** Docker volumes have no separate immutable ID; the random exact name is their runtime identity. */
+  readonly id: string;
+  readonly name: string;
+  readonly created: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly driver: string;
+  readonly mountpoint: string;
+}
+
+export interface DockerVolumeCreateOptions {
+  readonly labels?: Readonly<Record<string, string>>;
+  readonly driver?: string;
+  /** Exact trusted driver options; never populated from agent input. */
+  readonly driverOptions?: Readonly<Record<string, string>>;
 }
 
 export interface DockerNetworkCreateOptions {
@@ -373,6 +425,18 @@ export interface ContainerRuntime {
 
   /** Check whether a named network still exists. Optional for non-Docker runtimes. */
   networkExists?(name: string): Promise<boolean>;
+
+  /** Create a named Docker volume and return its exact runtime identity. Optional for non-Docker runtimes. */
+  createVolume?(name: string, options?: DockerVolumeCreateOptions): Promise<string>;
+
+  /** Inspect one named Docker volume. Optional for non-Docker runtimes. */
+  inspectVolume?(name: string): Promise<DockerVolumeInfo | undefined>;
+
+  /** Enumerate named Docker volumes, optionally filtered by label. Optional for non-Docker runtimes. */
+  listVolumes?(options?: { readonly labelFilter?: string }): Promise<readonly DockerVolumeInfo[]>;
+
+  /** Remove a named Docker volume. Already-absent volumes are ignored. Optional for non-Docker runtimes. */
+  removeVolume?(name: string): Promise<void>;
 
   /** Pull a Docker image from a registry. */
   pullImage(image: string): Promise<void>;

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -9,9 +9,11 @@
 
 import { spawnSync } from 'node:child_process';
 import { arch, platform } from 'node:os';
+import { resolve } from 'node:path';
 import { checkSandboxViability } from '../utils/preflight-checks.js';
 import { checkDockerAvailable, type DockerAvailability } from '../docker/docker-probe.js';
 import { checkAppleContainerAvailable } from '../docker/apple-container-manager.js';
+import { inspectCertificateAuthority, repairCertificateAuthority } from '../docker/ca.js';
 import { resolveRuntimeKind, type ContainerRuntimeKind } from '../docker/container-runtime.js';
 import { detectAuthMethod, readOnlyCredentialSources } from '../docker/oauth-credentials.js';
 import {
@@ -33,7 +35,7 @@ import {
   type ProviderId,
 } from '../config/model-provider.js';
 import { loadGeneratedPolicy, getPackageGeneratedDir, findAnnotationServerDrift, loadConfig } from '../config/index.js';
-import { computeConstitutionHash } from '../config/paths.js';
+import { computeConstitutionHash, getIronCurtainHome } from '../config/paths.js';
 import type { IronCurtainConfig, MCPServerConfig } from '../config/types.js';
 import { isObjectWithProp } from '../utils/is-plain-object.js';
 import { probeServer, type ProbeResult } from './mcp-liveness.js';
@@ -127,6 +129,77 @@ export async function checkSandbox(): Promise<CheckResult> {
     message: result.message,
     hint: result.details,
   };
+}
+
+/**
+ * Verifies the host CA storage without generating or migrating it. The
+ * inspection shares the strict filesystem, manifest, and certificate
+ * validators used by container-session startup.
+ */
+export function checkCertificateAuthority(caDir = resolve(getIronCurtainHome(), 'ca')): CheckResult {
+  try {
+    const inspection = inspectCertificateAuthority(caDir);
+    if (inspection.state === 'uninitialized') {
+      return {
+        name: 'MITM CA storage',
+        status: 'ok',
+        message: 'not initialized — will be created by the first container session',
+      };
+    }
+    if (inspection.state === 'migration-required') {
+      return {
+        name: 'MITM CA storage',
+        status: 'warn',
+        message: 'valid legacy storage — will be migrated by the next container session',
+      };
+    }
+    return {
+      name: 'MITM CA storage',
+      status: 'ok',
+      message: `verified generation ${inspection.generation}`,
+    };
+  } catch (error) {
+    return {
+      name: 'MITM CA storage',
+      status: 'fail',
+      message: error instanceof Error ? error.message : String(error),
+      hint: `Run ironcurtain doctor --repair to quarantine unsafe state under ${caDir} and rotate any exposed CA key.`,
+    };
+  }
+}
+
+/** Repair CA storage only when explicitly requested by the doctor command. */
+export function repairCertificateAuthorityStorage(caDir = resolve(getIronCurtainHome(), 'ca')): CheckResult {
+  try {
+    const repair = repairCertificateAuthority(caDir);
+    if (repair.state === 'rotated') {
+      return {
+        name: 'MITM CA repair',
+        status: 'ok',
+        message:
+          `generated ${repair.generation}; quarantined previous state at ${repair.quarantineDirectory}. ` +
+          'Restart active container sessions so they trust the replacement CA.',
+      };
+    }
+    if (repair.state === 'migrated') {
+      return {
+        name: 'MITM CA repair',
+        status: 'ok',
+        message: `migrated valid legacy storage to generation ${repair.generation}`,
+      };
+    }
+    if (repair.state === 'hardened') {
+      return { name: 'MITM CA repair', status: 'ok', message: 'hardened storage permissions' };
+    }
+    return { name: 'MITM CA repair', status: 'ok', message: 'no repair needed' };
+  } catch (error) {
+    return {
+      name: 'MITM CA repair',
+      status: 'fail',
+      message: error instanceof Error ? error.message : String(error),
+      hint: `Preserve all CA and quarantine directories under ${resolve(caDir, '..')} for inspection.`,
+    };
+  }
 }
 
 /**

--- a/src/doctor/doctor-command.ts
+++ b/src/doctor/doctor-command.ts
@@ -18,6 +18,7 @@ import {
   checkAgentApiRoundtrip,
   checkAnnotationDrift,
   checkAppleContainer,
+  checkCertificateAuthority,
   checkConfigLoad,
   checkConstitutionDrift,
   checkDocker,
@@ -30,6 +31,7 @@ import {
   checkSandbox,
   checkServerCredentials,
   collectDeclaredEnvVars,
+  repairCertificateAuthorityStorage,
   type CheckResult,
 } from './checks.js';
 import { checkAnthropicCredentials, checkOAuthRefresh } from './oauth-checks.js';
@@ -43,6 +45,8 @@ import { printCheck, printSection, printSummary } from './output.js';
  */
 export interface DoctorDeps {
   readonly probeMcpServer?: typeof probeServer;
+  readonly checkCertificateAuthority?: typeof checkCertificateAuthority;
+  readonly repairCertificateAuthorityStorage?: typeof repairCertificateAuthorityStorage;
 }
 
 const DOCTOR_HELP: CommandSpec = {
@@ -51,13 +55,15 @@ const DOCTOR_HELP: CommandSpec = {
   usage: ['ironcurtain doctor [options]'],
   options: [
     { flag: 'check-api', description: 'Also run an agent-model API round-trip and OAuth refresh probe' },
+    { flag: 'repair', description: 'Repair MITM CA storage, quarantining unsafe state and rotating its key' },
     { flag: 'help', short: 'h', description: 'Show this help message' },
   ],
-  examples: ['ironcurtain doctor', 'ironcurtain doctor --check-api'],
+  examples: ['ironcurtain doctor', 'ironcurtain doctor --check-api', 'ironcurtain doctor --repair'],
 };
 
 export interface DoctorCliArgs {
   readonly checkApi: boolean;
+  readonly repair: boolean;
   readonly help: boolean;
 }
 
@@ -66,12 +72,14 @@ export function parseDoctorArgs(argv: string[]): DoctorCliArgs {
     args: argv,
     options: {
       'check-api': { type: 'boolean' },
+      repair: { type: 'boolean' },
       help: { type: 'boolean', short: 'h' },
     },
     strict: true,
   });
   return {
     checkApi: values['check-api'] === true,
+    repair: values.repair === true,
     help: values.help === true,
   };
 }
@@ -129,6 +137,21 @@ export async function runDoctorCommand(argv: string[], deps: DoctorDeps = {}): P
   const configCheck = checkConfigLoad();
   printCheck(configCheck.result);
   collected.push(configCheck.result);
+
+  const checkCa = deps.checkCertificateAuthority ?? checkCertificateAuthority;
+  let shouldCheckCa = true;
+  if (args.repair) {
+    const repairCa = deps.repairCertificateAuthorityStorage ?? repairCertificateAuthorityStorage;
+    const repairResult = repairCa();
+    printCheck(repairResult);
+    collected.push(repairResult);
+    shouldCheckCa = repairResult.status !== 'fail';
+  }
+  if (shouldCheckCa) {
+    const caResult = checkCa();
+    printCheck(caResult);
+    collected.push(caResult);
+  }
 
   if (!configCheck.config) {
     // Without a config we can't proceed past the basic environment.

--- a/test/ca.test.ts
+++ b/test/ca.test.ts
@@ -22,7 +22,14 @@ import { createHash } from 'node:crypto';
 import { createServer as createTlsServer } from 'node:tls';
 import { pathToFileURL } from 'node:url';
 import forge from 'node-forge';
-import { createLeafSecureContextCache, loadOrCreateCA, randomSerialNumber } from '../src/docker/ca.js';
+import {
+  createLeafSecureContextCache,
+  inspectCertificateAuthority,
+  loadOrCreateCA,
+  randomSerialNumber,
+  repairCertificateAuthority,
+} from '../src/docker/ca.js';
+import { acquireProcessLock } from '../src/docker-workload/process-lock.js';
 
 describe('loadOrCreateCA', () => {
   let tempDir: string;
@@ -46,6 +53,156 @@ describe('loadOrCreateCA', () => {
     expect(loadOrCreateCA(caDir).generation).toBe(ca.generation);
     expect(ca.certPath).toMatch(new RegExp(`^${escapeRegExp(join(caDir, 'generations', 'gen-'))}`));
     expect(ca.keyPath).toBe(join(join(ca.certPath, '..'), 'ca-key.pem'));
+  });
+
+  it('inspects uninitialized storage without creating or hardening it', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    mkdirSync(caDir, { mode: 0o755 });
+    chmodSync(caDir, 0o755);
+
+    expect(inspectCertificateAuthority(caDir)).toEqual({ state: 'uninitialized', directory: caDir });
+    expect(readdirSync(caDir)).toEqual([]);
+    expect(statSync(caDir).mode & 0o777).toBe(0o755);
+  });
+
+  it('inspects valid legacy storage without migrating it', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const legacy = createLegacyAuthority();
+    mkdirSync(caDir, { mode: 0o700 });
+    writeFileSync(join(caDir, 'ca-cert.pem'), legacy.certPem, { mode: 0o644 });
+    writeFileSync(join(caDir, 'ca-key.pem'), legacy.keyPem, { mode: 0o600 });
+
+    expect(inspectCertificateAuthority(caDir)).toEqual({ state: 'migration-required', directory: caDir });
+    expect(readdirSync(caDir).sort()).toEqual(['ca-cert.pem', 'ca-key.pem']);
+  });
+
+  it('inspects the published generation with the startup validators', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const authority = loadOrCreateCA(caDir);
+
+    expect(inspectCertificateAuthority(caDir)).toEqual({
+      state: 'ready',
+      directory: caDir,
+      generation: authority.generation,
+    });
+
+    chmodSync(authority.keyPath, 0o644);
+    expect(() => inspectCertificateAuthority(caDir)).toThrow(/private key .* mode 644, expected 600/u);
+  });
+
+  it('hardens safe broad parent and CA modes without rotating the key', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const original = loadOrCreateCA(caDir);
+    chmodSync(caDir, 0o755);
+    chmodSync(tempDir, 0o755);
+
+    const repair = repairCertificateAuthority(caDir);
+
+    expect(repair.state).toBe('hardened');
+    expect(statSync(tempDir).mode & 0o777).toBe(0o700);
+    expect(statSync(caDir).mode & 0o777).toBe(0o700);
+    const loaded = loadOrCreateCA(caDir);
+    expect(loaded.generation).toBe(original.generation);
+    expect(loaded.keyPem).toBe(original.keyPem);
+    expect(readdirSync(tempDir).filter((name) => name.includes('.quarantine-'))).toEqual([]);
+  });
+
+  it('rotates a valid CA when its parent was writable and preserves the old tree', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const original = loadOrCreateCA(caDir);
+    chmodSync(tempDir, 0o770);
+
+    const repair = repairCertificateAuthority(caDir);
+
+    expect(repair.state).toBe('rotated');
+    if (repair.state !== 'rotated') throw new Error('expected rotation');
+    expect(statSync(tempDir).mode & 0o777).toBe(0o700);
+    expect(statSync(caDir).mode & 0o777).toBe(0o700);
+    expect(existsSync(repair.quarantineDirectory)).toBe(true);
+    expect(readFileSync(original.keyPath.replace(caDir, repair.quarantineDirectory), 'utf8')).toBe(original.keyPem);
+    const replacement = loadOrCreateCA(caDir);
+    expect(replacement.keyPem).not.toBe(original.keyPem);
+    expect(statSync(replacement.keyPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('rotates an exposed key and leaves all quarantined evidence untouched', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const original = loadOrCreateCA(caDir);
+    const evidence = join(caDir, 'forensic-marker');
+    writeFileSync(evidence, 'preserve me', { mode: 0o600 });
+    chmodSync(original.keyPath, 0o644);
+
+    const repair = repairCertificateAuthority(caDir);
+
+    expect(repair.state).toBe('rotated');
+    if (repair.state !== 'rotated') throw new Error('expected rotation');
+    expect(readFileSync(join(repair.quarantineDirectory, 'forensic-marker'), 'utf8')).toBe('preserve me');
+    expect(statSync(original.keyPath.replace(caDir, repair.quarantineDirectory)).mode & 0o777).toBe(0o644);
+    const replacement = loadOrCreateCA(caDir);
+    expect(replacement.keyPem).not.toBe(original.keyPem);
+    expect(statSync(replacement.keyPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('rotates storage whose published generation is missing', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const original = loadOrCreateCA(caDir);
+    rmSync(join(caDir, 'generations', original.generation), { recursive: true });
+
+    const repair = repairCertificateAuthority(caDir);
+
+    expect(repair.state).toBe('rotated');
+    if (repair.state !== 'rotated') throw new Error('expected rotation');
+    expect(existsSync(join(repair.quarantineDirectory, 'current.json'))).toBe(true);
+    expect(loadOrCreateCA(caDir).keyPem).not.toBe(original.keyPem);
+  });
+
+  it('rotates storage containing a symlink without following it', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const original = loadOrCreateCA(caDir);
+    const outside = join(tempDir, 'outside-current.json');
+    writeFileSync(outside, 'forensic evidence', { mode: 0o600 });
+    rmSync(join(caDir, 'current.json'));
+    symlinkSync(outside, join(caDir, 'current.json'));
+
+    const repair = repairCertificateAuthority(caDir);
+
+    expect(repair.state).toBe('rotated');
+    if (repair.state !== 'rotated') throw new Error('expected rotation');
+    expect(lstatSync(join(repair.quarantineDirectory, 'current.json')).isSymbolicLink()).toBe(true);
+    expect(readFileSync(outside, 'utf8')).toBe('forensic evidence');
+    expect(loadOrCreateCA(caDir).keyPem).not.toBe(original.keyPem);
+  });
+
+  it('serializes loads and repairs through the shared parent lock', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    const lock = acquireProcessLock(join(tempDir, '.ca-repair.lock'), {
+      processIdentityForPid: () => `live-pid:${process.pid}`,
+    });
+    try {
+      expect(() => loadOrCreateCA(caDir)).toThrow(/process lock is busy/u);
+      expect(() => repairCertificateAuthority(caDir)).toThrow(/process lock is busy/u);
+    } finally {
+      lock.release();
+    }
+  });
+
+  it('refuses to replace a non-directory CA path', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ca-test-'));
+    const caDir = join(tempDir, 'ca');
+    writeFileSync(caDir, 'not a directory', { mode: 0o600 });
+
+    expect(() => repairCertificateAuthority(caDir)).toThrow(/refuses to replace non-directory path/u);
+    expect(readFileSync(caDir, 'utf8')).toBe('not a directory');
+    expect(readdirSync(tempDir).filter((name) => name.includes('.quarantine-'))).toEqual([]);
   });
 
   it('returns valid PEM content', () => {

--- a/test/docker-manager.test.ts
+++ b/test/docker-manager.test.ts
@@ -352,6 +352,47 @@ describe('DockerManager', () => {
       );
       expect(() => buildCreateArgs({ ...sampleConfig, ipv4Address: 'relay.internal' })).toThrow(/IPv4 literal/u);
     });
+
+    it('emits the frozen trusted sidecar profile without changing ordinary container defaults', () => {
+      const args = buildCreateArgs({
+        ...sampleConfig,
+        trustedCreateOptions: {
+          namedVolumeMounts: [
+            { name: 'ic-api-volume', target: '/run/user/1000', noCopy: true },
+            { name: 'ic-stage-volume', target: '/staged', readonly: true, noCopy: true },
+          ],
+          tmpfs: ['/tmp:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000'],
+          readOnlyRootfs: true,
+          securityOptions: ['no-new-privileges=true'],
+          seccompProfile: '/trusted/profiles/rootless-sidecar.json',
+          pidsLimit: 128,
+        },
+      });
+
+      expect(args).toContain('type=volume,src=ic-api-volume,dst=/run/user/1000,volume-nocopy');
+      expect(args).toContain('type=volume,src=ic-stage-volume,dst=/staged,readonly,volume-nocopy');
+      expect(args).toContain('/tmp:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000');
+      expect(args).toContain('--read-only');
+      expect(args).toContain('no-new-privileges=true');
+      expect(args).toContain('seccomp=/trusted/profiles/rootless-sidecar.json');
+      expect(args[args.indexOf('--pids-limit') + 1]).toBe('128');
+      expect(buildCreateArgs(sampleConfig)).not.toContain('--read-only');
+    });
+
+    it('rejects ambiguous or invalid trusted sidecar limits', () => {
+      expect(() =>
+        buildCreateArgs({
+          ...sampleConfig,
+          trustedCreateOptions: { securityOptions: ['seccomp=unconfined'] },
+        }),
+      ).toThrow(/dedicated seccompProfile/u);
+      expect(() =>
+        buildCreateArgs({
+          ...sampleConfig,
+          trustedCreateOptions: { pidsLimit: 0 },
+        }),
+      ).toThrow(/positive safe integer/u);
+    });
   });
 
   describe('preflight', () => {
@@ -776,6 +817,111 @@ describe('DockerManager', () => {
     });
   });
 
+  describe('named volume lifecycle', () => {
+    it('creates an exactly named, labeled volume', async () => {
+      mock.setSequence([
+        { stdout: 'ic-api-volume\n' },
+        {
+          stdout: JSON.stringify([
+            {
+              Name: 'ic-api-volume',
+              Driver: 'local',
+              Labels: { 'com.ironcurtain.docker-workload.generation': 'generation-001' },
+            },
+          ]),
+        },
+      ]);
+      const manager = createDockerManager(mock.mockExec);
+
+      await expect(
+        manager.createVolume?.('ic-api-volume', {
+          driver: 'local',
+          driverOptions: { type: 'none' },
+          labels: { 'com.ironcurtain.docker-workload.generation': 'generation-001' },
+        }),
+      ).resolves.toBe('ic-api-volume');
+      expect(mock.calls[0].args).toEqual([
+        'volume',
+        'create',
+        '--driver',
+        'local',
+        '--opt',
+        'type=none',
+        '--label',
+        'com.ironcurtain.docker-workload.generation=generation-001',
+        'ic-api-volume',
+      ]);
+      expect(mock.calls[1].args).toEqual(['volume', 'inspect', 'ic-api-volume']);
+    });
+
+    it('fails closed when Docker returns a different volume identity', async () => {
+      mock.setResponse('foreign-volume\n');
+      const manager = createDockerManager(mock.mockExec);
+      await expect(manager.createVolume?.('ic-api-volume')).rejects.toThrow(/unexpected volume identity/u);
+    });
+
+    it('fails closed when an existing volume name carries a foreign ownership label', async () => {
+      mock.setSequence([
+        { stdout: 'ic-api-volume\n' },
+        {
+          stdout: JSON.stringify([
+            {
+              Name: 'ic-api-volume',
+              Driver: 'local',
+              Labels: { 'com.ironcurtain.docker-workload.generation': 'foreign-generation' },
+            },
+          ]),
+        },
+      ]);
+      const manager = createDockerManager(mock.mockExec);
+      await expect(
+        manager.createVolume?.('ic-api-volume', {
+          labels: { 'com.ironcurtain.docker-workload.generation': 'generation-001' },
+        }),
+      ).rejects.toThrow(/does not carry requested ownership label/u);
+    });
+
+    it('lists and inspects exact volume ownership metadata', async () => {
+      const inspected = {
+        Name: 'ic-api-volume',
+        CreatedAt: '2026-08-25T01:02:03Z',
+        Driver: 'local',
+        Mountpoint: '/var/lib/docker/volumes/ic-api-volume/_data',
+        Labels: { 'com.ironcurtain.docker-workload.generation': 'generation-001' },
+      };
+      mock.setSequence([
+        { stdout: 'ic-api-volume\n' },
+        { stdout: JSON.stringify([inspected]) },
+        { stdout: JSON.stringify([inspected]) },
+      ]);
+      const manager = createDockerManager(mock.mockExec);
+
+      await expect(
+        manager.listVolumes?.({ labelFilter: 'com.ironcurtain.docker-workload.generation=generation-001' }),
+      ).resolves.toEqual([
+        {
+          id: 'ic-api-volume',
+          name: 'ic-api-volume',
+          created: '2026-08-25T01:02:03Z',
+          driver: 'local',
+          mountpoint: '/var/lib/docker/volumes/ic-api-volume/_data',
+          labels: { 'com.ironcurtain.docker-workload.generation': 'generation-001' },
+        },
+      ]);
+      await expect(manager.inspectVolume?.('ic-api-volume')).resolves.toMatchObject({ id: 'ic-api-volume' });
+      expect(mock.calls[0].args).toContain('label=com.ironcurtain.docker-workload.generation=generation-001');
+    });
+
+    it('removes by exact name and ignores an already-absent volume', async () => {
+      mock.setSequence([{ stdout: '' }, { error: true, code: 1, stderr: 'Error: No such volume: ic-api-volume' }]);
+      const manager = createDockerManager(mock.mockExec);
+
+      await expect(manager.removeVolume?.('ic-api-volume')).resolves.toBeUndefined();
+      await expect(manager.removeVolume?.('ic-api-volume')).resolves.toBeUndefined();
+      expect(mock.calls[0].args).toEqual(['volume', 'rm', 'ic-api-volume']);
+    });
+  });
+
   describe('buildImage', () => {
     it('passes labels as --label flags', async () => {
       const spawnMock = createMockSpawn();
@@ -854,6 +1000,27 @@ describe('DockerManager', () => {
       spawnMock.handles[0].exit(1);
 
       await expect(promise).rejects.toThrow(/docker build .*exited with code 1.*Dockerfile syntax error/s);
+    });
+  });
+
+  describe('selected image artifact primitives', () => {
+    it('tags and saves an exact platform image through Docker', async () => {
+      mock.setResponse('');
+      const manager = createDockerManager(mock.mockExec);
+
+      await manager.tagImage?.('sha256:source', 'ironcurtain-capture:latest');
+      await manager.saveImageArchive?.('ironcurtain-capture:latest', '/trusted/artifacts/agent.tar', 'linux/arm64');
+
+      expect(mock.calls[0].args).toEqual(['image', 'tag', 'sha256:source', 'ironcurtain-capture:latest']);
+      expect(mock.calls[1].args).toEqual([
+        'image',
+        'save',
+        '--output',
+        '/trusted/artifacts/agent.tar',
+        '--platform',
+        'linux/arm64',
+        'ironcurtain-capture:latest',
+      ]);
     });
   });
 

--- a/test/docker-workload/config.test.ts
+++ b/test/docker-workload/config.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  assertAdmittedDockerWorkloadRuntimeAvailable,
+  assertDockerWorkloadVariantAdmitted,
   dockerWorkloadConfigHash,
   dockerWorkloadRequestedSchema,
   formatDockerWorkloadStatus,
   resolveDockerWorkloadConfig,
 } from '../../src/docker-workload/config.js';
+
+const checkAppleContainerAvailable = vi.fn();
+const checkDockerAvailable = vi.fn();
+
+vi.mock('../../src/docker/apple-container-manager.js', () => ({ checkAppleContainerAvailable }));
+vi.mock('../../src/docker/docker-probe.js', () => ({ checkDockerAvailable }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  checkAppleContainerAvailable.mockResolvedValue({ available: true });
+  checkDockerAvailable.mockResolvedValue({ available: true });
+});
 
 describe('secure nested Docker configuration', () => {
   it('resolves absence, an empty object, and explicit false to the same authority-free value', () => {
@@ -99,7 +113,7 @@ describe('secure nested Docker configuration', () => {
 
   it('rejects unsupported legacy intent with an actionable replacement', () => {
     for (const [request, replacement] of [
-      [{ enabled: true, backend: 'docker' }, 'Apple Container'],
+      [{ enabled: true, backend: 'docker' }, 'containerRuntime'],
       [{ enabled: true, buildEgress: 'ironcurtain-dockerfiles' }, 'build egress'],
       [{ enabled: true, acceptObservedDiskRisk: false }, 'observed-disk policy'],
       [{ enabled: true, resources: { memoryMb: 8192 } }, 'dockerResources.memoryMb'],
@@ -113,6 +127,54 @@ describe('secure nested Docker configuration', () => {
       if (result.success) throw new Error('expected unsupported legacy intent to fail');
       expect(result.error.issues.map((issue) => issue.message).join('\n')).toContain(replacement);
     }
+  });
+
+  it('admits the resolved Apple runtime and Docker only on Darwin', () => {
+    const enabled = resolveDockerWorkloadConfig({ enabled: true });
+    expect(() => assertDockerWorkloadVariantAdmitted(enabled, 'apple-container', 'darwin')).not.toThrow();
+    expect(() => assertDockerWorkloadVariantAdmitted(enabled, 'docker', 'darwin')).not.toThrow();
+    expect(() => assertDockerWorkloadVariantAdmitted(enabled, 'docker', 'linux')).toThrow(
+      /Docker runtime is supported only on macOS \(Darwin\), not linux/u,
+    );
+  });
+
+  it('preserves feature-off without applying the runtime or platform admission gate', () => {
+    expect(() => assertDockerWorkloadVariantAdmitted(undefined, 'docker', 'linux')).not.toThrow();
+    expect(() =>
+      assertDockerWorkloadVariantAdmitted(resolveDockerWorkloadConfig({ enabled: false }), 'docker', 'linux'),
+    ).not.toThrow();
+  });
+
+  it('preflights only the selected runtime', async () => {
+    await expect(assertAdmittedDockerWorkloadRuntimeAvailable('docker')).resolves.toBeUndefined();
+    expect(checkDockerAvailable).toHaveBeenCalledOnce();
+    expect(checkAppleContainerAvailable).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    checkAppleContainerAvailable.mockResolvedValue({ available: true });
+    await expect(assertAdmittedDockerWorkloadRuntimeAvailable('apple-container')).resolves.toBeUndefined();
+    expect(checkAppleContainerAvailable).toHaveBeenCalledOnce();
+    expect(checkDockerAvailable).not.toHaveBeenCalled();
+  });
+
+  it('reports selected-runtime availability failures with probe detail', async () => {
+    checkDockerAvailable.mockResolvedValueOnce({
+      available: false,
+      reason: 'Docker not available',
+      detailedMessage: 'Start Docker Desktop.',
+    });
+    await expect(assertAdmittedDockerWorkloadRuntimeAvailable('docker')).rejects.toThrow(
+      /Docker runtime is unavailable: Docker not available \(Start Docker Desktop\.\)/u,
+    );
+
+    checkAppleContainerAvailable.mockResolvedValueOnce({
+      available: false,
+      reason: 'container services not running',
+      detailedMessage: 'Start them first.',
+    });
+    await expect(assertAdmittedDockerWorkloadRuntimeAvailable('apple-container')).rejects.toThrow(
+      /Apple runtime is unavailable: container services not running \(Start them first\.\)/u,
+    );
   });
 
   it('rejects raw runtime authority', () => {

--- a/test/docker-workload/docker-desktop-sidecar.test.ts
+++ b/test/docker-workload/docker-desktop-sidecar.test.ts
@@ -1,0 +1,391 @@
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DOCKER_DESKTOP_RUNC_SHIM_PATH,
+  DOCKER_DESKTOP_SIDECAR_API_ROOT,
+  DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT,
+  DOCKER_DESKTOP_SIDECAR_DATA_ROOT,
+  DOCKER_DESKTOP_SIDECAR_DOCKER_HOST,
+  loadDockerDesktopP2SeccompProfile,
+  parseDockerDesktopProfileCeiling,
+  startDockerDesktopSidecar,
+  type DockerDesktopSidecarCreateAuthority,
+  type DockerDesktopSidecarRuntime,
+  type StartDockerDesktopSidecarOptions,
+} from '../../src/docker-workload/docker-desktop-sidecar.js';
+import {
+  APPLE_VM_DAEMON_DOCKER_HOST,
+  APPLE_VM_DAEMON_TOOLCHAIN_DIR,
+} from '../../src/docker-workload/apple-vm-daemon.js';
+import type {
+  DockerContainerConfig,
+  DockerExecResult,
+  DockerImageInfo,
+  DockerVolumeInfo,
+} from '../../src/docker/types.js';
+import { sha256Hex } from '../../src/hash.js';
+import type { ExpandedOuterCreate } from '../../src/docker-workload/lifecycle-evidence.js';
+import {
+  createTestAppleVmDockerWorkloadBootstrap,
+  respondHealthyAppleVmDaemon,
+} from './helpers/infrastructure-harness.js';
+
+const SIDECAR_IMAGE_ID = `sha256:${'d'.repeat(64)}`;
+const SIDECAR_CONTAINER_ID = 'c'.repeat(64);
+const API_VOLUME_NAME = 'ic-desktop-api-test';
+const SIDECAR_NAME = 'ic-desktop-daemon-test';
+const OWNERSHIP_LABELS = { 'com.ironcurtain.docker-workload.generation': 'gen-test' } as const;
+
+let tempDirectory: string;
+
+beforeEach(() => {
+  tempDirectory = realpathSync(mkdtempSync(join(tmpdir(), 'desktop-sidecar-')));
+});
+
+afterEach(() => {
+  rmSync(tempDirectory, { recursive: true, force: true });
+});
+
+interface RuntimeFixture {
+  readonly runtime: DockerDesktopSidecarRuntime;
+  readonly events: string[];
+  readonly configs: DockerContainerConfig[];
+  readonly execs: (readonly string[])[];
+  readonly volumeLabels: Map<string, Readonly<Record<string, string>>>;
+  readonly expandedCreates: ExpandedOuterCreate[];
+}
+
+function runtimeFixture(
+  options: { readonly failBuild?: boolean; readonly failShim?: boolean; readonly wrongVolumeLabels?: boolean } = {},
+): RuntimeFixture {
+  const events: string[] = [];
+  const configs: DockerContainerConfig[] = [];
+  const execs: (readonly string[])[] = [];
+  const volumeLabels = new Map<string, Readonly<Record<string, string>>>();
+  const expandedCreates: ExpandedOuterCreate[] = [];
+  const runtime: DockerDesktopSidecarRuntime = {
+    async preflight(image) {
+      events.push(`preflight:${image}`);
+    },
+    async inspectImage(reference): Promise<DockerImageInfo | undefined> {
+      events.push(`outer-image-inspect:${reference}`);
+      return {
+        id: SIDECAR_IMAGE_ID,
+        repoTags: [reference],
+        labels: { 'com.ironcurtain.docker-workload.image-role': 'nested-daemon' },
+        created: '2026-08-25T00:00:00.000Z',
+      };
+    },
+    async create(config) {
+      events.push('container:create');
+      configs.push(config);
+      return SIDECAR_CONTAINER_ID;
+    },
+    async start(id) {
+      events.push(`container:start:${id}`);
+    },
+    async exec(_id, argv): Promise<DockerExecResult> {
+      execs.push([...argv]);
+      if (argv[0] === '/bin/sh' && argv[1] === '-c' && argv[2] === 'command -v runc') {
+        events.push('shim:path');
+        return {
+          exitCode: 0,
+          stdout: `${options.failShim === true ? '/usr/local/bin/runc' : DOCKER_DESKTOP_RUNC_SHIM_PATH}\n`,
+          stderr: '',
+        };
+      }
+      if (argv[0] === DOCKER_DESKTOP_RUNC_SHIM_PATH && argv[1] === '--version') {
+        events.push('shim:version');
+        return { exitCode: 0, stdout: 'runc version 1.3.4\ncommit: d6d73eb\n', stderr: '' };
+      }
+      if (argv[0] === 'docker' && argv[1] === '--host' && argv[2] === DOCKER_DESKTOP_SIDECAR_DOCKER_HOST) {
+        const operation = argv.slice(3);
+        if (operation[0] === 'container' && operation[1] === 'inspect') {
+          return { exitCode: 1, stdout: '', stderr: `Error: No such container: ${operation.at(-1) ?? ''}` };
+        }
+        if (operation[0] === 'run') events.push('canary:run');
+        if (operation[0] === 'build') {
+          events.push('canary:build');
+          if (options.failBuild === true) {
+            return { exitCode: 1, stdout: '', stderr: 'runc create failed: keyring denied' };
+          }
+        }
+        return respondHealthyAppleVmDaemon([
+          `${APPLE_VM_DAEMON_TOOLCHAIN_DIR}/docker`,
+          '--host',
+          APPLE_VM_DAEMON_DOCKER_HOST,
+          ...operation,
+        ]);
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    async stop(id) {
+      events.push(`container:stop:${id}`);
+    },
+    async remove(id) {
+      events.push(`container:remove:${id}`);
+    },
+    async createVolume(name, createOptions) {
+      events.push(`volume:create:${name}`);
+      volumeLabels.set(name, createOptions?.labels ?? {});
+      return name;
+    },
+    async inspectVolume(name): Promise<DockerVolumeInfo | undefined> {
+      events.push(`volume:inspect:${name}`);
+      const labels = volumeLabels.get(name);
+      return labels === undefined
+        ? undefined
+        : {
+            id: name,
+            name,
+            created: '2026-08-25T00:00:00.000Z',
+            labels: options.wrongVolumeLabels === true ? { unexpected: 'owner' } : labels,
+            driver: 'local',
+            mountpoint: `/var/lib/docker/volumes/${name}/_data`,
+          };
+    },
+    async removeVolume(name) {
+      events.push(`volume:remove:${name}`);
+      volumeLabels.delete(name);
+    },
+  };
+  return { runtime, events, configs, execs, volumeLabels, expandedCreates };
+}
+
+function resourceAuthority(
+  events: string[],
+  expandedCreates: ExpandedOuterCreate[],
+): DockerDesktopSidecarCreateAuthority {
+  return async (spec, create) => {
+    events.push(`ledger:${spec.kind}:${spec.role}:${spec.launchesNestedDaemon === true}`);
+    const requestedName = spec.kind === 'volume' ? API_VOLUME_NAME : SIDECAR_NAME;
+    const created = await create(requestedName, OWNERSHIP_LABELS);
+    if (created.expanded !== undefined) expandedCreates.push(created.expanded);
+    events.push(`observed:${spec.kind}:${created.id}`);
+    return { id: created.id, requestedName };
+  };
+}
+
+function startOptions(fixture: RuntimeFixture): StartDockerDesktopSidecarOptions {
+  const bootstrap = createTestAppleVmDockerWorkloadBootstrap(tempDirectory);
+  const events = fixture.events;
+  return {
+    runtime: fixture.runtime,
+    sidecarImage: 'ironcurtain-nested-daemon:latest',
+    bootstrap,
+    resources: { memoryMb: 4096, cpus: 2, pidsLimit: 512 },
+    createOuterResource: resourceAuthority(events, fixture.expandedCreates),
+    activation: {
+      generation: 'gen-desktop-test',
+      recordDaemonReady() {
+        events.push('record:daemon-ready');
+      },
+      recordPrivateDockerBootstrap() {
+        events.push('record:private-docker');
+      },
+    },
+  };
+}
+
+describe('Docker Desktop sidecar frozen artifacts', () => {
+  it('loads the hash-bound P2 profile with the measured sethostname rule and no keyctl allowance', () => {
+    const profile = loadDockerDesktopP2SeccompProfile();
+    const bytes = readFileSync(profile.path);
+    const parsed = JSON.parse(bytes.toString('utf8')) as {
+      readonly syscalls: readonly { readonly names: readonly string[]; readonly action: string }[];
+    };
+
+    expect(profile.sha256).toBe(sha256Hex(bytes));
+    expect(profile.systemPathsSecurityOption).toBe('systempaths=unconfined');
+    expect(profile.path).toMatch(/config\/docker-workload\/seccomp\/desktop-p2-userns\.json$/u);
+    expect(parsed.syscalls).toContainEqual(
+      expect.objectContaining({ names: ['sethostname'], action: 'SCMP_ACT_ALLOW' }),
+    );
+    expect(parsed.syscalls).not.toContainEqual(
+      expect.objectContaining({ names: ['keyctl'], action: 'SCMP_ACT_ALLOW' }),
+    );
+  });
+
+  it('fails closed when the reviewed sidecar-only mount-mask exception drifts', () => {
+    const ceiling = JSON.parse(
+      readFileSync(join(process.cwd(), 'config/docker-workload/profile-ceiling.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(() => parseDockerDesktopProfileCeiling(ceiling)).not.toThrow();
+
+    const wrongScope = structuredClone(ceiling) as {
+      categories: { mountMask: { additions: Array<{ scope: string }> } };
+    };
+    wrongScope.categories.mountMask.additions[0].scope = 'all-containers';
+    expect(() => parseDockerDesktopProfileCeiling(wrongScope)).toThrow();
+
+    const wrongStatus = structuredClone(ceiling) as { status: string };
+    wrongStatus.status = 'qualified';
+    expect(() => parseDockerDesktopProfileCeiling(wrongStatus)).toThrow();
+  });
+});
+
+describe('Docker Desktop sidecar lifecycle', () => {
+  it('creates the exact bounded profile and returns only after run and BuildKit canaries', async () => {
+    const fixture = runtimeFixture();
+    const options = startOptions(fixture);
+    const result = await startDockerDesktopSidecar(options);
+
+    expect(result).toMatchObject({
+      containerId: SIDECAR_CONTAINER_ID,
+      apiVolumeName: API_VOLUME_NAME,
+      dockerHost: DOCKER_DESKTOP_SIDECAR_DOCKER_HOST,
+      agentApiMount: {
+        name: API_VOLUME_NAME,
+        target: DOCKER_DESKTOP_SIDECAR_API_ROOT,
+        readonly: true,
+        noCopy: true,
+      },
+      readiness: { driver: 'vfs', serverVersion: '29.2.1' },
+      network: { name: 'ironcurtain' },
+    });
+    expect(fixture.configs).toHaveLength(1);
+    const config = fixture.configs[0];
+    expect(config).toMatchObject({
+      image: SIDECAR_IMAGE_ID,
+      name: SIDECAR_NAME,
+      network: 'none',
+      capAdd: ['SETUID', 'SETGID'],
+      resources: { memoryMb: 4096, cpus: 2 },
+      trustedCreateOptions: {
+        namedVolumeMounts: [
+          { name: API_VOLUME_NAME, target: DOCKER_DESKTOP_SIDECAR_API_ROOT, readonly: false, noCopy: false },
+          { name: API_VOLUME_NAME, target: DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT, readonly: false, noCopy: true },
+        ],
+        readOnlyRootfs: true,
+        securityOptions: ['systempaths=unconfined'],
+        pidsLimit: 512,
+      },
+    });
+    expect(config.trustedCreateOptions?.seccompProfile).toBe(result.seccompProfile.path);
+    expect(config.trustedCreateOptions?.tmpfs).toEqual([
+      '/run:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000',
+      '/tmp:rw,nosuid,nodev,noexec,size=64m,uid=1000,gid=1000',
+      '/home/rootless/.docker:rw,nosuid,nodev,noexec,size=16m,uid=1000,gid=1000',
+    ]);
+    expect(config.mounts).toEqual([
+      {
+        source: options.bootstrap.hostArtifactDirectory,
+        target: options.bootstrap.guestArtifactDirectory,
+        readonly: true,
+      },
+    ]);
+    expect(fixture.expandedCreates).toHaveLength(1);
+    expect(fixture.expandedCreates[0]?.mounts).toEqual([
+      { source: API_VOLUME_NAME, target: DOCKER_DESKTOP_SIDECAR_API_ROOT, readonly: false },
+      { source: API_VOLUME_NAME, target: DOCKER_DESKTOP_SIDECAR_DATA_MOUNT_ROOT, readonly: false },
+      {
+        source: options.bootstrap.hostArtifactDirectory,
+        target: options.bootstrap.guestArtifactDirectory,
+        readonly: true,
+      },
+    ]);
+    expect(config.env).toEqual({
+      DOCKER_TLS_CERTDIR: '',
+      DOCKERD_ROOTLESS_ROOTLESSKIT_NET: 'none',
+      XDG_RUNTIME_DIR: DOCKER_DESKTOP_SIDECAR_API_ROOT,
+      PATH: '/usr/local/lib/ironcurtain:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    });
+    expect(config.command).toEqual([
+      'dockerd',
+      `--add-runtime=ic-no-new-keyring=${DOCKER_DESKTOP_RUNC_SHIM_PATH}`,
+      '--default-runtime=ic-no-new-keyring',
+      `--host=${DOCKER_DESKTOP_SIDECAR_DOCKER_HOST}`,
+      '--storage-driver=vfs',
+      `--data-root=${DOCKER_DESKTOP_SIDECAR_DATA_ROOT}`,
+      `--exec-root=${DOCKER_DESKTOP_SIDECAR_API_ROOT}/exec`,
+      `--pidfile=${DOCKER_DESKTOP_SIDECAR_API_ROOT}/docker.pid`,
+      '--iptables=false',
+      '--bridge=none',
+      '--ip-forward=false',
+      '--ip-masq=false',
+    ]);
+    expect(config.ports).toBeUndefined();
+    expect(config.extraHosts).toBeUndefined();
+
+    const build = fixture.events.indexOf('canary:build');
+    const privateEvidence = fixture.events.indexOf('record:private-docker');
+    expect(fixture.events.indexOf('canary:run')).toBeGreaterThan(fixture.events.indexOf('record:daemon-ready'));
+    expect(build).toBeGreaterThan(fixture.events.indexOf('canary:run'));
+    expect(privateEvidence).toBeGreaterThan(build);
+    expect(fixture.events).not.toContain(`container:stop:${SIDECAR_CONTAINER_ID}`);
+    expect(fixture.events.slice(0, 10)).toEqual([
+      'preflight:ironcurtain-nested-daemon:latest',
+      'outer-image-inspect:ironcurtain-nested-daemon:latest',
+      'ledger:volume:daemon-api:false',
+      `volume:create:${API_VOLUME_NAME}`,
+      `volume:inspect:${API_VOLUME_NAME}`,
+      `observed:volume:${API_VOLUME_NAME}`,
+      'ledger:container:nested-daemon:true',
+      'container:create',
+      `observed:container:${SIDECAR_CONTAINER_ID}`,
+      `container:start:${SIDECAR_CONTAINER_ID}`,
+    ]);
+    expect(fixture.execs).toContainEqual(['/bin/sh', '-c', 'command -v runc']);
+    expect(fixture.execs).toContainEqual([DOCKER_DESKTOP_RUNC_SHIM_PATH, '--version']);
+  });
+
+  it('fails closed and rolls back when PATH does not select the baked no-new-keyring shim', async () => {
+    const fixture = runtimeFixture({ failShim: true });
+
+    await expect(startDockerDesktopSidecar(startOptions(fixture))).rejects.toThrow(
+      /PATH did not select the baked runc shim/u,
+    );
+    expect(fixture.events).not.toContain('record:private-docker');
+    expect(fixture.events.slice(-3)).toEqual([
+      `container:stop:${SIDECAR_CONTAINER_ID}`,
+      `container:remove:${SIDECAR_CONTAINER_ID}`,
+      `volume:remove:${API_VOLUME_NAME}`,
+    ]);
+  });
+
+  it('removes an API volume whose post-create inspection does not preserve exact ownership', async () => {
+    const fixture = runtimeFixture({ wrongVolumeLabels: true });
+
+    await expect(startDockerDesktopSidecar(startOptions(fixture))).rejects.toThrow(
+      /did not inspect as the exact owned local volume/u,
+    );
+    expect(fixture.events).not.toContain('container:create');
+    expect(fixture.events.slice(-2)).toEqual([`volume:inspect:${API_VOLUME_NAME}`, `volume:remove:${API_VOLUME_NAME}`]);
+  });
+
+  it('removes the exact created objects when ledger observation rejects after container create', async () => {
+    const fixture = runtimeFixture();
+    const options = startOptions(fixture);
+    const createOuterResource: DockerDesktopSidecarCreateAuthority = async (spec, create) => {
+      const requestedName = spec.kind === 'volume' ? API_VOLUME_NAME : SIDECAR_NAME;
+      const created = await create(requestedName, OWNERSHIP_LABELS);
+      if (spec.kind === 'container') throw new Error('ledger observation rejected');
+      return { id: created.id, requestedName };
+    };
+
+    await expect(startDockerDesktopSidecar({ ...options, createOuterResource })).rejects.toThrow(
+      /ledger observation rejected/u,
+    );
+    expect(fixture.events.slice(-3)).toEqual([
+      `container:stop:${SIDECAR_CONTAINER_ID}`,
+      `container:remove:${SIDECAR_CONTAINER_ID}`,
+      `volume:remove:${API_VOLUME_NAME}`,
+    ]);
+  });
+
+  it('does not record qualified bootstrap evidence and removes the exact objects when BuildKit fails', async () => {
+    const fixture = runtimeFixture({ failBuild: true });
+
+    await expect(startDockerDesktopSidecar(startOptions(fixture))).rejects.toThrow(
+      /integrated BuildKit RUN activation canary failed/u,
+    );
+    expect(fixture.events).not.toContain('record:private-docker');
+    expect(fixture.events.slice(-3)).toEqual([
+      `container:stop:${SIDECAR_CONTAINER_ID}`,
+      `container:remove:${SIDECAR_CONTAINER_ID}`,
+      `volume:remove:${API_VOLUME_NAME}`,
+    ]);
+  });
+});

--- a/test/docker/bundle-revocation.test.ts
+++ b/test/docker/bundle-revocation.test.ts
@@ -14,7 +14,7 @@ import {
   requestDockerWorkloadOuterResource,
   type CreateDockerWorkloadLeaseOptions,
 } from '../../src/docker-workload/bundle-lease.js';
-import type { DockerContainerInfo, DockerNetworkInfo } from '../../src/docker/types.js';
+import type { DockerContainerInfo, DockerNetworkInfo, DockerVolumeInfo } from '../../src/docker/types.js';
 import { createMockDocker } from '../helpers/docker-mocks.js';
 
 const temporaryDirectories: string[] = [];
@@ -24,13 +24,15 @@ afterEach(() => {
 });
 
 describe('Docker-workload exact outer-resource revocation', () => {
-  it('deletes observed immutable IDs in container-before-network order and preserves foreign resources', async () => {
+  it('deletes observed identities in container-volume-network order and preserves foreign resources', async () => {
     const fixture = leaseFixture();
     createDockerWorkloadLease(fixture.path, fixture.options);
     request(fixture, 'daemon-sidecar', 'container', 'nested-daemon', 'ic-daemon');
     request(fixture, 'isolated-network', 'network', 'daemon-isolation', 'ic-network');
+    request(fixture, 'api-volume', 'volume', 'daemon-api', 'ic-api-volume');
     observeDockerWorkloadOuterResource(fixture.path, fixture.options.generation, 'daemon-sidecar', 'container-owned');
     observeDockerWorkloadOuterResource(fixture.path, fixture.options.generation, 'isolated-network', 'network-owned');
+    observeDockerWorkloadOuterResource(fixture.path, fixture.options.generation, 'api-volume', 'ic-api-volume');
     activateDockerWorkloadLease(fixture.path, fixture.options.generation);
 
     const state = runtimeState(
@@ -43,15 +45,22 @@ describe('Docker-workload exact outer-resource revocation', () => {
         network('network-owned', 'ic-network', fixture.options.generation),
         network('network-foreign', 'unrelated-network', 'foreign-generation'),
       ],
+      [volume('ic-api-volume', fixture.options.generation), volume('foreign-volume', 'foreign-generation')],
     );
     const result = await revokeDockerWorkloadOuterResources(state.runtime, fixture.path, fixture.options.generation);
     expect(result).toEqual({
-      removedResourceIds: ['container-owned', 'network-owned'],
+      removedResourceIds: ['container-owned', 'ic-api-volume', 'network-owned'],
       finalOwnedResourceIds: [],
     });
-    expect(state.calls).toEqual(['stop:container-owned', 'remove:container-owned', 'remove-network:network-owned']);
+    expect(state.calls).toEqual([
+      'stop:container-owned',
+      'remove:container-owned',
+      'remove-volume:ic-api-volume',
+      'remove-network:network-owned',
+    ]);
     expect(state.containers.map((value) => value.id)).toEqual(['container-foreign']);
     expect(state.networks.map((value) => value.id)).toEqual(['network-foreign']);
+    expect(state.volumes.map((value) => value.id)).toEqual(['foreign-volume']);
     expect(loadDockerWorkloadLease(fixture.path).resources.every((resource) => resource.removal !== null)).toBe(true);
   });
 
@@ -93,6 +102,37 @@ describe('Docker-workload exact outer-resource revocation', () => {
     expect(state.calls).toEqual([]);
     expect(state.containers).toHaveLength(1);
     expect(loadDockerWorkloadLease(fixture.path).resources[0].removal).toBeNull();
+  });
+
+  it('recovers a volume create-before-observation window only with exact generation ownership', async () => {
+    const fixture = leaseFixture();
+    createDockerWorkloadLease(fixture.path, fixture.options);
+    request(fixture, 'api-volume', 'volume', 'daemon-api', 'ic-api-volume');
+    const state = runtimeState(
+      fixture.options.generation,
+      [],
+      [],
+      [volume('ic-api-volume', fixture.options.generation)],
+    );
+
+    await revokeDockerWorkloadOuterResources(state.runtime, fixture.path, fixture.options.generation);
+    expect(state.calls).toEqual(['remove-volume:ic-api-volume']);
+    expect(loadDockerWorkloadLease(fixture.path).resources[0]).toMatchObject({
+      observedId: 'ic-api-volume',
+      removal: { proof: 'immutable-id-absent', identity: 'ic-api-volume' },
+    });
+  });
+
+  it('refuses to remove a colliding foreign volume name', async () => {
+    const fixture = leaseFixture();
+    createDockerWorkloadLease(fixture.path, fixture.options);
+    request(fixture, 'api-volume', 'volume', 'daemon-api', 'ic-api-volume');
+    const state = runtimeState(fixture.options.generation, [], [], [volume('ic-api-volume', 'foreign-generation')]);
+
+    await expect(
+      revokeDockerWorkloadOuterResources(state.runtime, fixture.path, fixture.options.generation),
+    ).rejects.toThrow(/wrong generation label/u);
+    expect(state.calls).toEqual([]);
   });
 
   it('does not claim cleanup when the runtime silently fails to remove an exact ID', async () => {
@@ -182,7 +222,7 @@ function leaseFixture(): {
 function request(
   fixture: ReturnType<typeof leaseFixture>,
   requestId: string,
-  kind: 'container' | 'network',
+  kind: 'container' | 'network' | 'volume',
   role: string,
   requestedName: string,
 ): void {
@@ -216,17 +256,31 @@ function network(id: string, name: string, generation: string): DockerNetworkInf
   };
 }
 
+function volume(name: string, generation: string): DockerVolumeInfo {
+  return {
+    id: name,
+    name,
+    created: '2026-07-20T12:00:00Z',
+    labels: { 'com.ironcurtain.docker-workload.generation': generation },
+    driver: 'local',
+    mountpoint: `/var/lib/docker/volumes/${name}/_data`,
+  };
+}
+
 function runtimeState(
   _generation: string,
   initialContainers: readonly DockerContainerInfo[],
   initialNetworks: readonly DockerNetworkInfo[] = [],
+  initialVolumes: readonly DockerVolumeInfo[] = [],
 ) {
   const containers = structuredClone(initialContainers) as DockerContainerInfo[];
   const networks = structuredClone(initialNetworks) as DockerNetworkInfo[];
+  const volumes = structuredClone(initialVolumes) as DockerVolumeInfo[];
   const calls: string[] = [];
   const state = {
     containers,
     networks,
+    volumes,
     calls,
     removeFails: false,
     runtime: {
@@ -236,6 +290,9 @@ function runtimeState(
       },
       async listNetworks() {
         return structuredClone(networks);
+      },
+      async listVolumes() {
+        return structuredClone(volumes);
       },
       async stop(id: string) {
         calls.push(`stop:${id}`);
@@ -254,6 +311,11 @@ function runtimeState(
         calls.push(`remove-network:${id}`);
         const index = networks.findIndex((networkValue) => networkValue.id === id);
         if (index !== -1) networks.splice(index, 1);
+      },
+      async removeVolume(id: string) {
+        calls.push(`remove-volume:${id}`);
+        const index = volumes.findIndex((volumeValue) => volumeValue.id === id);
+        if (index !== -1) volumes.splice(index, 1);
       },
     },
   };

--- a/test/docker/docker-workload-admission.test.ts
+++ b/test/docker/docker-workload-admission.test.ts
@@ -11,6 +11,7 @@ import { assertDockerWorkloadVariantAdmitted, resolveDockerWorkloadConfig } from
 const registerBuiltinAdapters = vi.fn();
 const resolveRuntimeKind = vi.fn();
 const checkAppleContainerAvailable = vi.fn();
+const checkDockerAvailable = vi.fn();
 
 vi.mock('../../src/docker/agent-registry.js', () => ({
   registerBuiltinAdapters,
@@ -25,10 +26,12 @@ vi.mock('../../src/docker/container-runtime.js', () => ({
   resolveRuntimeKind,
 }));
 vi.mock('../../src/docker/apple-container-manager.js', () => ({ checkAppleContainerAvailable }));
+vi.mock('../../src/docker/docker-probe.js', () => ({ checkDockerAvailable }));
 
 beforeEach(() => {
   vi.clearAllMocks();
   checkAppleContainerAvailable.mockResolvedValue({ available: true });
+  checkDockerAvailable.mockResolvedValue({ available: true });
 });
 
 function admittedAppleConfig() {
@@ -54,13 +57,31 @@ describe('secure nested Docker resolved-variant admission', () => {
     ).not.toThrow();
   });
 
-  it('rejects an enabled capability resolved to Docker', () => {
-    expect(() => assertDockerWorkloadVariantAdmitted(admittedAppleConfig(), 'docker')).toThrow(
-      /currently admits only the Apple Container developer slice/u,
-    );
+  it('admits an enabled capability resolved to Docker on Darwin', () => {
+    expect(() => assertDockerWorkloadVariantAdmitted(admittedAppleConfig(), 'docker', 'darwin')).not.toThrow();
   });
 
-  it('rejects a Docker-resolved opt-in before adapter, runtime, image, relay, or daemon work', async () => {
+  it('rejects an unavailable Docker runtime before adapter, runtime, image, relay, or daemon work', async () => {
+    resolveRuntimeKind.mockResolvedValueOnce('docker');
+    checkDockerAvailable.mockResolvedValueOnce({
+      available: false,
+      reason: 'Docker not available',
+      detailedMessage: 'Start Docker Desktop.',
+    });
+    const { ensureDockerImage } = await import('../../src/docker/docker-infrastructure.js');
+    await expect(
+      ensureDockerImage('claude-code', {
+        containerRuntime: 'auto',
+        dockerWorkload: admittedAppleConfig(),
+      } as ResolvedUserConfig),
+    ).rejects.toThrow(/Docker runtime is unavailable: Docker not available/u);
+    expect(registerBuiltinAdapters).not.toHaveBeenCalled();
+    expect(resolveRuntimeKind).toHaveBeenCalledOnce();
+    expect(checkDockerAvailable).toHaveBeenCalledOnce();
+    expect(checkAppleContainerAvailable).not.toHaveBeenCalled();
+  });
+
+  it('rejects Docker Desktop image mediation before adapter, image, relay, or sidecar work', async () => {
     resolveRuntimeKind.mockResolvedValueOnce('docker');
     const { ensureDockerImage } = await import('../../src/docker/docker-infrastructure.js');
     await expect(
@@ -68,9 +89,10 @@ describe('secure nested Docker resolved-variant admission', () => {
         containerRuntime: 'auto',
         dockerWorkload: admittedAppleConfig(),
       } as ResolvedUserConfig),
-    ).rejects.toThrow(/currently admits only the Apple Container developer slice/u);
+    ).rejects.toThrow(/supports only networkAccess "offline"/u);
     expect(registerBuiltinAdapters).not.toHaveBeenCalled();
-    expect(resolveRuntimeKind).toHaveBeenCalledOnce();
+    expect(checkDockerAvailable).toHaveBeenCalledOnce();
+    expect(checkAppleContainerAvailable).not.toHaveBeenCalled();
   });
 
   it('preserves feature-off adapter-before-runtime error ordering', async () => {
@@ -84,6 +106,7 @@ describe('secure nested Docker resolved-variant admission', () => {
     expect(registerBuiltinAdapters).toHaveBeenCalledOnce();
     expect(resolveRuntimeKind).not.toHaveBeenCalled();
     expect(checkAppleContainerAvailable).not.toHaveBeenCalled();
+    expect(checkDockerAvailable).not.toHaveBeenCalled();
   });
 
   it('rejects an unavailable explicit Apple runtime before adapter or image work', async () => {
@@ -121,7 +144,12 @@ describe('secure nested Docker admission — prepareDockerInfrastructure', () =>
     rmSync(home, { recursive: true, force: true });
   });
 
-  it('rejects after read-only runtime resolution but before feature infrastructure provisioning', async () => {
+  it('rejects unavailable Docker after read-only runtime resolution but before feature infrastructure provisioning', async () => {
+    checkDockerAvailable.mockResolvedValueOnce({
+      available: false,
+      reason: 'Docker not available',
+      detailedMessage: 'Start Docker Desktop.',
+    });
     const { prepareDockerInfrastructure } = await import('../../src/docker/docker-infrastructure.js');
     const { getDockerWorkloadRoot } = await import('../../src/config/paths.js');
 
@@ -143,7 +171,7 @@ describe('secure nested Docker admission — prepareDockerInfrastructure', () =>
         join(home, 'escalations'),
         'bundle-fuse-001' as BundleId,
       ),
-    ).rejects.toThrow(/currently admits only the Apple Container developer slice/u);
+    ).rejects.toThrow(/Docker runtime is unavailable: Docker not available/u);
 
     // Effective runtime resolution is read-only. At this seam rejection
     // precedes the active-profile stamp and feature-attributable adapter,
@@ -153,6 +181,8 @@ describe('secure nested Docker admission — prepareDockerInfrastructure', () =>
     expect(readdirSync(home)).toEqual([]);
     expect(registerBuiltinAdapters).not.toHaveBeenCalled();
     expect(resolveRuntimeKind).toHaveBeenCalledOnce();
+    expect(checkDockerAvailable).toHaveBeenCalledOnce();
+    expect(checkAppleContainerAvailable).not.toHaveBeenCalled();
   });
 
   it('preserves feature-off provider-before-runtime error ordering', async () => {
@@ -179,6 +209,7 @@ describe('secure nested Docker admission — prepareDockerInfrastructure', () =>
 
     expect(resolveRuntimeKind).not.toHaveBeenCalled();
     expect(checkAppleContainerAvailable).not.toHaveBeenCalled();
+    expect(checkDockerAvailable).not.toHaveBeenCalled();
     expect(readdirSync(home)).toEqual([]);
   });
 

--- a/test/docker/docker-workload-egress.test.ts
+++ b/test/docker/docker-workload-egress.test.ts
@@ -40,7 +40,7 @@ const packageProxies: PackageEgressProxy[] = [];
 
 beforeAll(() => {
   caDirectory = mkdtempSync(join(tmpdir(), 'workload-egress-ca-'));
-  ca = loadOrCreateCA(caDirectory);
+  ca = loadOrCreateCA(join(caDirectory, 'ca'));
 });
 
 afterAll(() => {

--- a/test/docker/docker-workload-wiring.test.ts
+++ b/test/docker/docker-workload-wiring.test.ts
@@ -29,7 +29,9 @@ import {
   createSessionContainers,
   destroyDockerInfrastructure,
   dockerWorkloadSessionMetadata,
+  ensureDockerDesktopSidecarImage,
   ledgerOuterResourceCreate,
+  selectDockerDesktopResourcePartition,
   selectOuterContainerResources,
   type DockerInfrastructure,
   type PreContainerInfrastructure,
@@ -977,5 +979,65 @@ describe('Docker-workload wiring — outer resource envelope', () => {
         { cpus: 8, memoryMb: 16_384 },
       ),
     ).toEqual({ memoryMb: 2048, cpus: 1.5 });
+  });
+
+  it('partitions the Docker Desktop aggregate without double-counting the sidecar', () => {
+    const partition = selectDockerDesktopResourcePartition(
+      {
+        dockerResources: { memoryMb: 7777, cpus: 7 },
+        dockerWorkload: {
+          enabled: true,
+          networkAccess: 'offline',
+          acceptObservedDiskRisk: true,
+          resources: { memoryMb: 1536, cpus: 1.25, pids: { desired: 512, required: false }, diskMb: null },
+        },
+      },
+      { cpus: 8, memoryMb: 16_384 },
+    );
+
+    expect(partition).toEqual({
+      sidecar: { memoryMb: 512, cpus: 0.25, pidsLimit: 512 },
+      agent: { memoryMb: 1024, cpus: 1 },
+    });
+    expect(partition.sidecar.memoryMb + (partition.agent.memoryMb ?? 0)).toBe(1536);
+    expect(partition.sidecar.cpus + (partition.agent.cpus ?? 0)).toBe(1.25);
+  });
+
+  it('fails a Docker Desktop aggregate that cannot leave bounded resources for both containers', () => {
+    expect(() =>
+      selectDockerDesktopResourcePartition(
+        {
+          dockerResources: { memoryMb: 7777, cpus: 7 },
+          dockerWorkload: {
+            enabled: true,
+            networkAccess: 'offline',
+            acceptObservedDiskRisk: true,
+            resources: { memoryMb: 768, cpus: 0.4, pids: { desired: 512, required: false }, diskMb: null },
+          },
+        },
+        { cpus: 8, memoryMb: 16_384 },
+      ),
+    ).toThrow(/requires at least 1024 MiB and 0\.5 CPU/u);
+  });
+
+  it('builds the purpose-built Desktop daemon once and reuses its hash-labeled image', async () => {
+    let storedHash: string | undefined;
+    const buildImage = vi.fn(
+      async (_tag: string, _dockerfile: string, _context: string, labels?: Record<string, string>) => {
+        storedHash = labels?.['ironcurtain.build-hash'];
+      },
+    );
+    const runtime = {
+      getImageLabel: vi.fn(async () => storedHash),
+      buildImage,
+    } as unknown as ContainerRuntime;
+
+    await expect(ensureDockerDesktopSidecarImage(runtime)).resolves.toBe('ironcurtain-nested-daemon:latest');
+    await expect(ensureDockerDesktopSidecarImage(runtime)).resolves.toBe('ironcurtain-nested-daemon:latest');
+
+    expect(buildImage).toHaveBeenCalledOnce();
+    expect(buildImage.mock.calls[0]?.[1]).toMatch(/docker\/nested-daemon\/Dockerfile$/u);
+    expect(buildImage.mock.calls[0]?.[2]).toMatch(/docker\/nested-daemon$/u);
+    expect(storedHash).toMatch(/^[a-f0-9]{64}$/u);
   });
 });

--- a/test/docker/nested-daemon-image.test.ts
+++ b/test/docker/nested-daemon-image.test.ts
@@ -26,6 +26,17 @@ describe('purpose-built rootless nested daemon image', () => {
     expect(dockerfile).not.toMatch(/tcp:\/\//u);
   });
 
+  it('bakes the private API root and no-new-keyring runc wrapper with exact metadata', () => {
+    expect(dockerfile).toContain('install -d -o 1000 -g 1000 -m 0700 /out/api');
+    expect(dockerfile).toContain(
+      'COPY --from=shim-build --chown=1000:1000 --chmod=0700 /out/api/ /run/ironcurtain-docker/',
+    );
+    expect(dockerfile).toContain(
+      'COPY --from=shim-build --chown=0:0 --chmod=0555 /out/runc /usr/local/lib/ironcurtain/runc',
+    );
+    expect(dockerfile.indexOf('/run/ironcurtain-docker/')).toBeLessThan(dockerfile.indexOf('USER rootless'));
+  });
+
   it('contains qualification identity labels and no catalog or credential material', () => {
     for (const label of [
       'ironcurtain.build-hash-schema',

--- a/test/docker/nested-daemon-wiring.test.ts
+++ b/test/docker/nested-daemon-wiring.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createSessionContainers,
   ledgerOuterResourceCreate,
+  resolveNestedDockerAgentWiring,
   stopDockerWorkloadEgress,
   type PreContainerInfrastructure,
 } from '../../src/docker/docker-infrastructure.js';
@@ -38,6 +39,7 @@ import {
   APPLE_VM_DOCKER_WORKLOAD_NETWORK_ENV,
   APPLE_VM_SELECTED_AGENT_ARTIFACT_DIR,
 } from '../../src/docker-workload/apple-private-docker.js';
+import { DOCKER_DESKTOP_SIDECAR_DOCKER_HOST } from '../../src/docker-workload/docker-desktop-sidecar.js';
 import {
   admitDockerWorkloadBundle,
   type DockerWorkloadBundleHandle,
@@ -155,8 +157,9 @@ function makeCore(
   } = {},
 ): PreContainerInfrastructure {
   const runtimeKind = overrides.runtimeKind ?? 'apple-container';
-  const admittedApple = overrides.dockerWorkload !== undefined && runtimeKind === 'apple-container';
-  const bootstrap = admittedApple ? createTestAppleVmDockerWorkloadBootstrap(tempDir) : undefined;
+  const admitted = overrides.dockerWorkload !== undefined;
+  const admittedApple = admitted && runtimeKind === 'apple-container';
+  const bootstrap = admitted ? createTestAppleVmDockerWorkloadBootstrap(tempDir) : undefined;
   const buildShimContract =
     admittedApple && overrides.networkAccess === 'packages' ? getDockerBuildShimStagingContract('packages') : undefined;
   if (bootstrap) docker.getImageId = async () => bootstrap.artifact.appleImageId;
@@ -206,6 +209,26 @@ function makeCore(
     endCaptureSession: async () => {},
     dockerWorkload: overrides.dockerWorkload,
     dockerWorkloadBootstrap: bootstrap,
+    dockerDesktopAgentAccess:
+      admitted && runtimeKind === 'docker'
+        ? {
+            dockerHost: DOCKER_DESKTOP_SIDECAR_DOCKER_HOST,
+            networkName: APPLE_VM_DOCKER_WORKLOAD_NETWORK,
+            agentApiMount: {
+              name: 'ic-desktop-api-test',
+              target: '/run/ironcurtain-docker',
+              readonly: true,
+              noCopy: true,
+            },
+          }
+        : undefined,
+    dockerDesktopResources:
+      admitted && runtimeKind === 'docker'
+        ? {
+            sidecar: { memoryMb: 512, cpus: 0.25, pidsLimit: 512 },
+            agent: { memoryMb: 1024, cpus: 1 },
+          }
+        : undefined,
     dockerWorkloadEgress:
       overrides.networkAccess === 'images' || overrides.networkAccess === 'packages'
         ? {
@@ -1128,13 +1151,52 @@ describe('nested daemon — egress transports', () => {
   });
 });
 
-describe('nested daemon — unimplemented backend fails closed', () => {
-  it('refuses an admitted bundle on the docker backend instead of skipping the daemon', async () => {
+describe('nested daemon — Docker Desktop agent capability', () => {
+  it('mounts only the qualified API volume and activates after the ledgered agent starts', async () => {
     const { runtime, handle } = await admitBundle();
-    const core = makeCore(runtime.runtime, { dockerWorkload: handle, runtimeKind: 'docker' });
+    const capturing = capturingRuntime(runtime);
+    const core = makeCore(capturing.runtime, { dockerWorkload: handle, runtimeKind: 'docker' });
 
-    await expect(createSessionContainers(core, makeConfig())).rejects.toThrow(/not implemented on the docker backend/u);
-    expect(runtime.events).toEqual([]);
+    await createSessionContainers(core, makeConfig());
+
+    expect(capturing.config().image).toBe(core.imageResolution?.immutableImageId);
+    expect(capturing.config().env.DOCKER_HOST).toBe(DOCKER_DESKTOP_SIDECAR_DOCKER_HOST);
+    expect(capturing.config().env[APPLE_VM_DOCKER_WORKLOAD_NETWORK_ENV]).toBe(APPLE_VM_DOCKER_WORKLOAD_NETWORK);
+    expect(capturing.config().trustedCreateOptions?.namedVolumeMounts).toEqual([
+      {
+        name: 'ic-desktop-api-test',
+        target: '/run/ironcurtain-docker',
+        readonly: true,
+        noCopy: true,
+      },
+    ]);
+    expect(capturing.config().mounts).not.toContainEqual(
+      expect.objectContaining({ target: APPLE_VM_SELECTED_AGENT_ARTIFACT_DIR }),
+    );
+    expect(capturing.config().fullyVisibleProc).toBe(false);
+    expect(loadDockerWorkloadLease(handle.leasePath).status).toBe('active');
+  });
+
+  it('rejects mutable or copy-up Desktop API grants', () => {
+    const dockerWorkload = {} as DockerWorkloadBundleHandle;
+    const bootstrap = createTestAppleVmDockerWorkloadBootstrap(tempDir);
+    expect(() =>
+      resolveNestedDockerAgentWiring({
+        runtimeKind: 'docker',
+        dockerWorkload,
+        dockerWorkloadBootstrap: bootstrap,
+        dockerDesktopAgentAccess: {
+          dockerHost: DOCKER_DESKTOP_SIDECAR_DOCKER_HOST,
+          networkName: APPLE_VM_DOCKER_WORKLOAD_NETWORK,
+          agentApiMount: {
+            name: 'ic-desktop-api-test',
+            target: '/run/ironcurtain-docker',
+            readonly: false,
+            noCopy: true,
+          },
+        },
+      }),
+    ).toThrow(/read-only no-copy capability/u);
   });
 
   it('resolveNestedDaemonBundle is inert without a bundle on any backend', () => {

--- a/test/docker/package-egress-proxy.test.ts
+++ b/test/docker/package-egress-proxy.test.ts
@@ -31,7 +31,7 @@ let auditCounter = 0;
 
 beforeAll(() => {
   caDir = mkdtempSync(join(tmpdir(), 'ironcurtain-package-egress-ca-'));
-  ca = loadOrCreateCA(caDir);
+  ca = loadOrCreateCA(join(caDir, 'ca'));
   upstreamCredentials = createUpstreamCredentials(ca);
 });
 

--- a/test/docker/pty-cleanup.test.ts
+++ b/test/docker/pty-cleanup.test.ts
@@ -47,7 +47,9 @@ vi.mock('../../src/docker/claude-md-seed.js', () => ({ buildDockerClaudeMd: () =
 
 vi.mock('../../src/docker/docker-infrastructure.js', () => ({
   prepareDockerInfrastructure: async () => state.infrastructure,
-  activateAppleVmDockerWorkload: vi.fn(),
+  activateNestedDockerWorkload: vi.fn(),
+  resolveNestedDockerAgentWiring: () => ({ appleNestedDaemon: undefined, env: {}, namedVolumeMounts: [] }),
+  resolveNestedDockerOuterAgentImage: (_infra: unknown, image: string) => image,
   buildAgentUidRemap: () => ({}),
   buildUdsSocketMounts: () => [],
   buildDockerWorkloadEgressMounts: () => [],

--- a/test/docker/pty-nested-ordering.test.ts
+++ b/test/docker/pty-nested-ordering.test.ts
@@ -108,10 +108,22 @@ vi.mock('../../src/docker/docker-infrastructure.js', () => ({
     infra.dockerBuildShim === undefined
       ? []
       : infra.dockerBuildShim.artifacts.map(({ source, target, readonly }) => ({ source, target, readonly })),
-  activateAppleVmDockerWorkload: async (options: {
+  resolveNestedDockerAgentWiring: (infra: { dockerWorkload?: unknown }) => ({
+    appleNestedDaemon: infra.dockerWorkload,
+    env:
+      infra.dockerWorkload === undefined
+        ? {}
+        : {
+            DOCKER_HOST: 'unix:///run/ironcurtain-docker/docker.sock',
+            IRONCURTAIN_DOCKER_NETWORK: 'ironcurtain',
+          },
+    namedVolumeMounts: [],
+  }),
+  resolveNestedDockerOuterAgentImage: (_infra: unknown, image: string) => image,
+  activateNestedDockerWorkload: async (options: {
     runtime: unknown;
     containerId: string;
-    nestedDaemon?: unknown;
+    dockerWorkload?: unknown;
     bootstrap?: unknown;
     dockerWorkloadEgress?: {
       networkAccess: 'images' | 'packages';
@@ -120,11 +132,11 @@ vi.mock('../../src/docker/docker-infrastructure.js', () => ({
     };
     dockerBuildShim?: { contract: unknown; buildTrustCanary: unknown };
   }) => {
-    if (options.nestedDaemon === undefined || options.bootstrap === undefined) return;
+    if (options.dockerWorkload === undefined || options.bootstrap === undefined) return;
     await state.startAppleVmDockerWorkload({
       runtime: options.runtime,
       containerId: options.containerId,
-      nestedDaemon: options.nestedDaemon,
+      nestedDaemon: options.dockerWorkload,
       bootstrap: options.bootstrap,
       networkAccess: options.dockerWorkloadEgress?.networkAccess ?? 'offline',
       dockerBuildShim: options.dockerBuildShim?.contract,

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import chalk from 'chalk';
@@ -40,6 +40,7 @@ import {
   checkActiveRuntime,
   checkAnnotationDrift,
   checkAppleContainer,
+  checkCertificateAuthority,
   checkConstitutionDrift,
   checkDocker,
   checkDockerResources,
@@ -49,8 +50,10 @@ import {
   checkRosetta,
   checkServerCredentials,
   collectDeclaredEnvVars,
+  repairCertificateAuthorityStorage,
   type CheckResult,
 } from '../src/doctor/checks.js';
+import { loadOrCreateCA } from '../src/docker/ca.js';
 import type { AgentId } from '../src/docker/agent-adapter.js';
 import type { ProbeResult } from '../src/doctor/mcp-liveness.js';
 import type { IronCurtainConfig, MCPServerConfig } from '../src/config/types.js';
@@ -196,6 +199,112 @@ describe('checkNodeVersion', () => {
 
   it('fails for unparseable input', () => {
     expect(checkNodeVersion('not-a-version').status).toBe('fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: checkCertificateAuthority
+// ---------------------------------------------------------------------------
+
+describe('checkCertificateAuthority', () => {
+  it('reports uninitialized storage without creating it', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const caDir = resolve(root, 'ca');
+    try {
+      const result = checkCertificateAuthority(caDir);
+      expect(result.status).toBe('ok');
+      expect(result.message).toMatch(/not initialized/u);
+      expect(existsSync(caDir)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports uninitialized storage when the IronCurtain home does not exist', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const caDir = resolve(root, 'missing-home', 'ca');
+    try {
+      const result = checkCertificateAuthority(caDir);
+      expect(result.status).toBe('ok');
+      expect(result.message).toMatch(/not initialized/u);
+      expect(existsSync(resolve(root, 'missing-home'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates a missing IronCurtain home only during explicit repair', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const home = resolve(root, 'missing-home');
+    const caDir = resolve(home, 'ca');
+    try {
+      expect(repairCertificateAuthorityStorage(caDir).status).toBe('ok');
+      expect(existsSync(home)).toBe(true);
+      expect(existsSync(caDir)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('warns about valid storage that requires migration without modifying it', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const source = loadOrCreateCA(resolve(root, 'source'));
+    const caDir = resolve(root, 'ca');
+    mkdirSync(caDir, { mode: 0o700 });
+    writeFileSync(resolve(caDir, 'ca-cert.pem'), readFileSync(source.certPath), { mode: 0o644 });
+    writeFileSync(resolve(caDir, 'ca-key.pem'), readFileSync(source.keyPath), { mode: 0o600 });
+    try {
+      const result = checkCertificateAuthority(caDir);
+      expect(result.status).toBe('warn');
+      expect(result.message).toMatch(/will be migrated/u);
+      expect(existsSync(resolve(caDir, 'current.json'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails with the startup error for incomplete legacy storage', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const caDir = resolve(root, 'ca');
+    mkdirSync(caDir, { mode: 0o700 });
+    writeFileSync(resolve(caDir, 'ca-key.pem'), 'incomplete', { mode: 0o600 });
+    try {
+      const result = checkCertificateAuthority(caDir);
+      expect(result.status).toBe('fail');
+      expect(result.message).toMatch(/CA is incomplete/u);
+      expect(result.hint).toContain(caDir);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when the CA directory has unsafe permissions', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const caDir = resolve(root, 'ca');
+    mkdirSync(caDir, { mode: 0o770 });
+    chmodSync(caDir, 0o770);
+    try {
+      const result = checkCertificateAuthority(caDir);
+      expect(result.status).toBe('fail');
+      expect(result.message).toMatch(/group- or world-writable/u);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('repairs exposed CA storage by reporting its quarantine path', () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'ironcurtain-doctor-ca-'));
+    const caDir = resolve(root, 'ca');
+    const authority = loadOrCreateCA(caDir);
+    chmodSync(authority.keyPath, 0o644);
+    try {
+      const result = repairCertificateAuthorityStorage(caDir);
+      expect(result.status).toBe('ok');
+      expect(result.message).toMatch(/quarantined previous state at .*ca\.quarantine-/u);
+      expect(checkCertificateAuthority(caDir).status).toBe('ok');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 
@@ -715,7 +824,52 @@ describe('runDoctorCommand', () => {
     const { output, exitCode } = await captureOutput(() => runDoctorCommand(['--help']));
     expect(output).toContain('ironcurtain doctor');
     expect(output).toContain('--check-api');
+    expect(output).toContain('--repair');
     expect(exitCode).toBeUndefined();
+  });
+
+  it('parses repair as an explicit opt-in', async () => {
+    const { parseDoctorArgs } = await import('../src/doctor/doctor-command.js');
+    expect(parseDoctorArgs([]).repair).toBe(false);
+    expect(parseDoctorArgs(['--repair']).repair).toBe(true);
+  });
+
+  it('runs repair only when requested and prints a successful post-repair check', async () => {
+    const { runDoctorCommand } = await import('../src/doctor/doctor-command.js');
+    const probeStub = vi.fn(async (): Promise<ProbeResult> => ({ status: 'ok', toolCount: 1, elapsedMs: 10 }));
+    const repair = vi.fn(
+      (): CheckResult => ({
+        name: 'MITM CA repair',
+        status: 'ok',
+        message: '/tmp/ca.quarantine-test',
+      }),
+    );
+    const check = vi.fn(
+      (): CheckResult => ({ name: 'MITM CA storage', status: 'ok', message: 'verified generation gen-test' }),
+    );
+
+    const normal = await captureOutput(() =>
+      runDoctorCommand([], {
+        probeMcpServer: probeStub,
+        checkCertificateAuthority: check,
+        repairCertificateAuthorityStorage: repair,
+      }),
+    );
+    expect(normal.output).not.toContain('MITM CA repair');
+    expect(repair).not.toHaveBeenCalled();
+
+    check.mockClear();
+    const repaired = await captureOutput(() =>
+      runDoctorCommand(['--repair'], {
+        probeMcpServer: probeStub,
+        checkCertificateAuthority: check,
+        repairCertificateAuthorityStorage: repair,
+      }),
+    );
+    expect(repaired.output).toContain('MITM CA repair');
+    expect(repaired.output).toContain('ca.quarantine-test');
+    expect(repair).toHaveBeenCalledOnce();
+    expect(check).toHaveBeenCalledOnce();
   });
 
   it('prints all sections and a summary footer', async () => {
@@ -733,6 +887,7 @@ describe('runDoctorCommand', () => {
     const { output } = await captureOutput(() => runDoctorCommand([], { probeMcpServer: probeStub }));
     expect(output).toContain('Environment');
     expect(output).toContain('Configuration');
+    expect(output).toContain('MITM CA storage');
     expect(output).toContain('Credentials');
     expect(output).toContain('MCP servers');
     expect(output).toMatch(/Summary: \d+ ok, \d+ warn, \d+ fail/);

--- a/test/proxy-tools.test.ts
+++ b/test/proxy-tools.test.ts
@@ -100,7 +100,7 @@ describe('DynamicHostController', () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'proxy-tools-test-'));
-    ca = loadOrCreateCA(tmpDir);
+    ca = loadOrCreateCA(join(tmpDir, 'ca'));
 
     const fakeKey = generateFakeKey(testProvider.fakeKeyPrefix);
     proxy = createMitmProxy({
@@ -471,7 +471,7 @@ describe('MITM proxy control API', () => {
 
   beforeEach(async () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'control-api-integ-'));
-    ca = loadOrCreateCA(tmpDir);
+    ca = loadOrCreateCA(join(tmpDir, 'ca'));
 
     const fakeKey = generateFakeKey(testProvider.fakeKeyPrefix);
     proxy = createMitmProxy({


### PR DESCRIPTION
## Summary

- support offline nested Docker startup on macOS across Docker and Apple container backends
- make doctor inspect CA storage with the same validators used by loadOrCreateCA
- add explicit doctor --repair handling that hardens safe permissions, migrates valid legacy state, and quarantines plus rotates compromised or unverifiable CA state
- serialize CA startup and repair with a shared parent lock, preserve forensic state, and roll back failed publication

## Verification

- npm run lint
- npm run format:check
- npx tsc --noEmit
- npm run typecheck:scripts
- npm run build
- npm run check:cycles
- focused CA and doctor tests: 82 passed
- full root suite: 6,818 passed; the environment-dependent real-container PTY suite timed out waiting for container registration and repeated in isolation

Related to #447.