### PR TITLE
fix(metrics): recover from retention worker timeouts

### DIFF
--- a/src/llm-metrics/persistence/sqlite-repository.ts
+++ b/src/llm-metrics/persistence/sqlite-repository.ts
@@ -74,6 +74,11 @@ interface QueuedExchange {
   readonly bytes: number;
 }
 
+interface ActiveDelete {
+  callerSettled: boolean;
+  outstandingRequests: number;
+}
+
 export interface SqliteLlmMetricsRepositoryOptions {
   readonly databasePath: string;
   readonly processRunId?: string;
@@ -376,7 +381,7 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
   private checkpointTimer: NodeJS.Timeout | null = null;
   private activeFlush: Promise<void> | null = null;
   private activeClose: Promise<void> | null = null;
-  private activeDelete: Promise<LlmDeleteBeforeResult> | null = null;
+  private activeDelete: ActiveDelete | null = null;
   private nextRequestId = 1;
   private state: LlmMetricsRepositoryHealth['state'] = 'starting';
   private schemaVersion: number | null = null;
@@ -544,7 +549,6 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
   }
 
   async snapshotMaxSequence(): Promise<number> {
-    this.assertReadable();
     const value = await this.reader.request({ kind: 'snapshotMaxSequence' });
     if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
       throw new Error('Invalid snapshot response from LLM metrics worker');
@@ -553,7 +557,6 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
   }
 
   async scan(query: LlmExchangeScanQuery): Promise<readonly StoredLlmExchange[]> {
-    this.assertReadable();
     const value = await this.reader.request({ kind: 'scan', query });
     if (!Array.isArray(value)) throw new Error('Invalid scan response from LLM metrics worker');
     return value as readonly StoredLlmExchange[];
@@ -563,14 +566,13 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
     dimension: LlmStatisticsDimension,
     query: Omit<LlmExchangeScanQuery, 'cursor'>,
   ): Promise<readonly LlmDimensionCount[]> {
-    this.assertReadable();
     const value = await this.reader.request({ kind: 'dimensionValues', dimension, query });
     if (!Array.isArray(value)) throw new Error('Invalid dimension response from LLM metrics worker');
     return value as readonly LlmDimensionCount[];
   }
 
   async deleteBefore(cutoffMs: number, options: LlmDeleteBeforeOptions = {}): Promise<LlmDeleteBeforeResult> {
-    this.assertReadable();
+    this.assertWriterAvailable();
     if (this.closing) throw new LlmMetricsRepositoryUnavailableError('LLM metrics repository is closing');
     if (!Number.isSafeInteger(cutoffMs) || cutoffMs < 0) throw new Error('Invalid delete cutoff');
     const snapshotMaxSequence =
@@ -612,23 +614,25 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
       });
     }
 
-    const operation = this.performDeleteBefore(
+    const activity: ActiveDelete = { callerSettled: false, outstandingRequests: 0 };
+    this.activeDelete = activity;
+    return this.performDeleteBefore(
       cutoffMs,
       snapshotMaxSequence,
       chunkSize,
       maxRows,
       maxDurationMs,
       leaseDurationMs,
+      activity,
     )
       .catch((error: unknown) => {
         this.markDegraded(error);
         throw error;
       })
       .finally(() => {
-        this.activeDelete = null;
+        activity.callerSettled = true;
+        this.maybeClearActiveDelete(activity);
       });
-    this.activeDelete = operation;
-    return operation;
   }
 
   private async performDeleteBefore(
@@ -638,21 +642,33 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
     maxRows: number,
     maxDurationMs: number,
     leaseDurationMs: number,
+    activity: ActiveDelete,
   ): Promise<LlmDeleteBeforeResult> {
     const startedAt = performance.now();
-    let leaseAcquired = false;
+    const release = { needed: false, detached: false };
     try {
-      const leaseValue = await this.boundedMaintenanceRequest(
-        {
-          kind: 'beginDeleteBefore',
-          leaseName: DELETE_LEASE_NAME,
-          cutoffMs,
-          snapshotMaxSequence: requestedSnapshotMaxSequence,
-          leaseDurationMs,
-        },
-        maxDurationMs,
-        'LLM metrics retention lease acquisition timed out',
-      );
+      const leaseTimeoutMessage = 'LLM metrics retention lease acquisition timed out';
+      let leaseValue: WorkerResult;
+      try {
+        leaseValue = await this.boundedMaintenanceRequest(
+          activity,
+          {
+            kind: 'beginDeleteBefore',
+            leaseName: DELETE_LEASE_NAME,
+            cutoffMs,
+            snapshotMaxSequence: requestedSnapshotMaxSequence,
+            leaseDurationMs,
+          },
+          maxDurationMs,
+          leaseTimeoutMessage,
+        );
+      } catch (error) {
+        if (error instanceof Error && error.message === leaseTimeoutMessage) {
+          release.needed = true;
+          release.detached = true;
+        }
+        throw error;
+      }
       if (!this.isDeleteLeaseResult(leaseValue)) {
         throw new Error('Invalid retention lease response from LLM metrics worker');
       }
@@ -665,7 +681,7 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
           chunksProcessed: 0,
         };
       }
-      leaseAcquired = true;
+      release.needed = true;
       const snapshotMaxSequence = leaseValue.snapshotMaxSequence;
       if (snapshotMaxSequence === null || snapshotMaxSequence === 0) {
         return {
@@ -691,18 +707,26 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
           };
         }
 
-        const chunkValue = await this.boundedMaintenanceRequest(
-          {
-            kind: 'deleteBeforeChunk',
-            leaseName: DELETE_LEASE_NAME,
-            cutoffMs,
-            snapshotMaxSequence,
-            chunkSize: Math.min(chunkSize, maxRows - deletedCount),
-            leaseDurationMs,
-          },
-          remainingDurationMs,
-          'LLM metrics retention chunk timed out',
-        );
+        const chunkTimeoutMessage = 'LLM metrics retention chunk timed out';
+        let chunkValue: WorkerResult;
+        try {
+          chunkValue = await this.boundedMaintenanceRequest(
+            activity,
+            {
+              kind: 'deleteBeforeChunk',
+              leaseName: DELETE_LEASE_NAME,
+              cutoffMs,
+              snapshotMaxSequence,
+              chunkSize: Math.min(chunkSize, maxRows - deletedCount),
+              leaseDurationMs,
+            },
+            remainingDurationMs,
+            chunkTimeoutMessage,
+          );
+        } catch (error) {
+          if (error instanceof Error && error.message === chunkTimeoutMessage) release.detached = true;
+          throw error;
+        }
         if (!this.isDeleteChunkResult(chunkValue)) {
           throw new Error('Invalid retention chunk response from LLM metrics worker');
         }
@@ -729,30 +753,48 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
         chunksProcessed,
       };
     } finally {
-      if (leaseAcquired && (this.state === 'ready' || this.state === 'degraded')) {
-        try {
-          await this.boundedMaintenanceRequest(
-            { kind: 'releaseMaintenanceLease', leaseName: DELETE_LEASE_NAME },
-            MAINTENANCE_RELEASE_TIMEOUT_MS,
-            'LLM metrics retention lease release timed out',
-          );
-        } catch (error) {
-          this.markDegraded(error);
-        }
+      if (release.needed && (this.state === 'ready' || this.state === 'degraded')) {
+        const cleanup = this.boundedMaintenanceRequest(
+          activity,
+          { kind: 'releaseMaintenanceLease', leaseName: DELETE_LEASE_NAME },
+          MAINTENANCE_RELEASE_TIMEOUT_MS,
+          'LLM metrics retention lease release timed out',
+        ).catch((error: unknown) => this.markDegraded(error));
+        if (release.detached) void cleanup;
+        else await cleanup;
       }
     }
   }
 
   private async boundedMaintenanceRequest(
+    activity: ActiveDelete,
     request: WriterRequestWithoutId,
     timeoutMs: number,
     timeoutMessage: string,
   ): Promise<WorkerResult> {
-    try {
-      return await withTimeout(this.request(request), timeoutMs, timeoutMessage);
-    } catch (error) {
-      if (error instanceof Error && error.message === timeoutMessage) this.disable(error);
-      throw error;
+    const underlying = this.trackMaintenanceRequest(activity, this.request(request));
+    const result = await withTimeout(underlying, timeoutMs, timeoutMessage);
+    this.markReady();
+    return result;
+  }
+
+  private trackMaintenanceRequest(activity: ActiveDelete, request: Promise<WorkerResult>): Promise<WorkerResult> {
+    activity.outstandingRequests++;
+    void request.then(
+      () => this.settleMaintenanceRequest(activity),
+      () => this.settleMaintenanceRequest(activity),
+    );
+    return request;
+  }
+
+  private settleMaintenanceRequest(activity: ActiveDelete): void {
+    activity.outstandingRequests = Math.max(0, activity.outstandingRequests - 1);
+    this.maybeClearActiveDelete(activity);
+  }
+
+  private maybeClearActiveDelete(activity: ActiveDelete): void {
+    if (this.activeDelete === activity && activity.callerSettled && activity.outstandingRequests === 0) {
+      this.activeDelete = null;
     }
   }
 
@@ -789,7 +831,7 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
     return !this.closing && (this.state === 'ready' || this.state === 'degraded');
   }
 
-  private assertReadable(): void {
+  private assertWriterAvailable(): void {
     if (this.state !== 'ready' && this.state !== 'degraded') {
       throw new LlmMetricsRepositoryUnavailableError(this.lastError ?? undefined);
     }
@@ -818,7 +860,7 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
         }
         this.persisted += value.inserted;
         this.duplicates += value.duplicates;
-        if (this.state === 'degraded') this.state = 'ready';
+        this.markReady();
       } catch (error) {
         this.recordBatchDrop(batch.length);
         this.markDegraded(error);
@@ -860,7 +902,7 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
   }
 
   private request(request: WriterRequestWithoutId): Promise<WorkerResult> {
-    this.assertReadable();
+    this.assertWriterAvailable();
     if (this.pending.size >= MAX_PENDING_WORKER_REQUESTS) {
       return Promise.reject(new LlmMetricsRepositoryUnavailableError('LLM metrics worker request limit reached'));
     }
@@ -920,8 +962,13 @@ export class SqliteLlmMetricsRepository implements LlmMetricsRepository {
     this.rejectPending(new LlmMetricsRepositoryUnavailableError(this.lastError));
     this.resolveReady?.();
     this.resolveReady = null;
-    void this.reader.close();
     void this.worker.terminate();
+  }
+
+  private markReady(): void {
+    if (this.state !== 'degraded') return;
+    this.state = 'ready';
+    this.lastError = null;
   }
 
   private markDegraded(error: unknown): void {

--- a/src/llm-metrics/query-service.ts
+++ b/src/llm-metrics/query-service.ts
@@ -1037,10 +1037,7 @@ export class LlmStatisticsQueryService implements LlmStatisticsReader {
   capabilities(): Promise<StatisticsCapabilities> {
     const health = this.repository.health();
     return Promise.resolve({
-      available:
-        (health.state === 'ready' || health.state === 'degraded') &&
-        health.readerState !== 'unavailable' &&
-        health.readerState !== 'closed',
+      available: health.readerState !== 'unavailable' && health.readerState !== 'closed',
       dtoVersion: DTO_VERSION,
       formulaVersion: FORMULA_VERSION,
       schemaVersion: health.schemaVersion,

--- a/src/llm-metrics/runtime.ts
+++ b/src/llm-metrics/runtime.ts
@@ -22,6 +22,9 @@ export interface LlmMetricsRuntimeOptions {
 
 const RETENTION_INTERVAL_MS = 6 * 60 * 60 * 1_000;
 const RETENTION_DAY_MS = 24 * 60 * 60 * 1_000;
+const RETENTION_RETRY_BASE_MS = 30_000;
+const RETENTION_RETRY_MAX_MS = 30 * 60 * 1_000;
+const RETENTION_RETRY_MAX_EXPONENT = Math.ceil(Math.log2(RETENTION_RETRY_MAX_MS / RETENTION_RETRY_BASE_MS));
 interface SharedRuntime {
   readonly databasePath: string;
   readonly repository: LlmMetricsRepository;
@@ -32,6 +35,8 @@ interface SharedRuntime {
   effectiveRetentionDays: number | null;
   retentionTimer?: ReturnType<typeof setInterval>;
   immediateRetentionTimer?: ReturnType<typeof setTimeout>;
+  retentionRetryTimer?: ReturnType<typeof setTimeout>;
+  retentionRetryAttempt: number;
   prunePromise?: Promise<void>;
   rerunPrune: boolean;
   closing: boolean;
@@ -65,6 +70,7 @@ async function createSharedRuntime(databasePath: string): Promise<SharedRuntime>
     retentionByLease: new Map(),
     references: 0,
     effectiveRetentionDays: null,
+    retentionRetryAttempt: 0,
     rerunPrune: false,
     closing: false,
   };
@@ -93,6 +99,25 @@ function clearRetentionTimers(shared: SharedRuntime): void {
   if (shared.retentionTimer !== undefined) clearInterval(shared.retentionTimer);
   shared.immediateRetentionTimer = undefined;
   shared.retentionTimer = undefined;
+  resetRetentionRetry(shared);
+}
+
+function resetRetentionRetry(shared: SharedRuntime): void {
+  if (shared.retentionRetryTimer !== undefined) clearTimeout(shared.retentionRetryTimer);
+  shared.retentionRetryTimer = undefined;
+  shared.retentionRetryAttempt = 0;
+}
+
+function scheduleRetentionRetry(shared: SharedRuntime): void {
+  if (shared.closing || shared.effectiveRetentionDays === null || shared.retentionRetryTimer !== undefined) return;
+  const exponent = Math.min(shared.retentionRetryAttempt, RETENTION_RETRY_MAX_EXPONENT);
+  const delayMs = Math.min(RETENTION_RETRY_BASE_MS * 2 ** exponent, RETENTION_RETRY_MAX_MS);
+  shared.retentionRetryAttempt += 1;
+  shared.retentionRetryTimer = setTimeout(() => {
+    shared.retentionRetryTimer = undefined;
+    if (shared.prunePromise === undefined) runRetentionPrune(shared);
+  }, delayMs);
+  shared.retentionRetryTimer.unref();
 }
 
 function runRetentionPrune(shared: SharedRuntime): void {
@@ -107,12 +132,17 @@ function runRetentionPrune(shared: SharedRuntime): void {
     try {
       const result = await shared.repository.deleteBefore(cutoffMs, BOUNDED_STATISTICS_DELETE_OPTIONS);
       // A large backlog is drained in separately bounded calls. setTimeout(0)
-      // below yields between calls; a busy repository waits for the periodic
-      // retry instead of competing with another process.
-      if (result.status === 'partial' && !shared.closing) shared.rerunPrune = true;
+      // below yields between calls. Busy repositories retry with bounded
+      // exponential backoff without waiting for the periodic fallback.
+      if (result.status === 'busy') scheduleRetentionRetry(shared);
+      else {
+        resetRetentionRetry(shared);
+        if (result.status === 'partial' && !shared.closing) shared.rerunPrune = true;
+      }
     } catch {
       // Retention is best-effort management work. Repository health remains
       // queryable and inference/session startup must never fail because of it.
+      scheduleRetentionRetry(shared);
     }
   })();
   shared.prunePromise = prune;

--- a/test/llm-metrics-persistence.test.ts
+++ b/test/llm-metrics-persistence.test.ts
@@ -769,13 +769,36 @@ describe('SQLite LLM metrics repository', () => {
     await opened.repository.close();
   });
 
-  it('bounds an unresponsive retention worker and exposes the failure in health', async () => {
+  it('keeps timed-out retention single-flight until its late lease cleanup settles', async () => {
     const opened = await repository({
       workerFactory: () =>
         new Worker(
           `const { parentPort } = require('node:worker_threads');
+           let firstDelete = true;
+           let leaseHeld = false;
+           let chain = Promise.resolve();
            parentPort.postMessage({ kind: 'ready', schemaVersion: 1 });
-           parentPort.on('message', () => {});`,
+           parentPort.on('message', (request) => {
+             chain = chain.then(async () => {
+               let value = null;
+               if (request.kind === 'beginDeleteBefore') {
+                 if (firstDelete) {
+                   firstDelete = false;
+                   await new Promise((resolve) => setTimeout(resolve, 75));
+                 }
+                 if (leaseHeld) value = { acquired: false, snapshotMaxSequence: null };
+                 else {
+                   leaseHeld = true;
+                   value = { acquired: true, snapshotMaxSequence: null };
+                 }
+               } else if (request.kind === 'releaseMaintenanceLease') {
+                 leaseHeld = false;
+               } else if (request.kind === 'insert') {
+                 value = { inserted: request.exchanges.length, duplicates: 0 };
+               }
+               parentPort.postMessage({ kind: 'result', id: request.id, value });
+             });
+           });`,
           { eval: true },
         ),
     });
@@ -789,12 +812,92 @@ describe('SQLite LLM metrics repository', () => {
     expect(performance.now() - enqueueStartedAt).toBeLessThan(100);
     await expect(deletion).rejects.toThrow(/lease acquisition timed out/);
     expect(opened.repository.health()).toMatchObject({
-      state: 'disabled',
-      dropped: 1,
-      queuedRecords: 0,
+      state: 'degraded',
+      dropped: 0,
+      queuedRecords: 1,
       lastError: expect.stringMatching(/lease acquisition timed out/),
     });
+
+    await expect(
+      opened.repository.deleteBefore(BASE_TIME, { maxDurationMs: 20, leaseDurationMs: 100 }),
+    ).resolves.toMatchObject({ status: 'busy' });
+    await delay(100);
+    await expect(
+      opened.repository.deleteBefore(BASE_TIME, { maxDurationMs: 20, leaseDurationMs: 100 }),
+    ).resolves.toMatchObject({ status: 'complete' });
+    await expect(opened.repository.flush()).resolves.toBeUndefined();
+    expect(opened.repository.health()).toMatchObject({ state: 'ready', persisted: 1, dropped: 0, queuedRecords: 0 });
     await opened.repository.close();
+  });
+
+  it('preserves degraded health when retention lease release fails', async () => {
+    const opened = await repository({
+      workerFactory: () =>
+        new Worker(
+          `const { parentPort } = require('node:worker_threads');
+           parentPort.postMessage({ kind: 'ready', schemaVersion: 1 });
+           parentPort.on('message', (request) => {
+             if (request.kind === 'beginDeleteBefore') {
+               parentPort.postMessage({
+                 kind: 'result', id: request.id, value: { acquired: true, snapshotMaxSequence: null }
+               });
+             } else if (request.kind === 'releaseMaintenanceLease') {
+               parentPort.postMessage({ kind: 'error', id: request.id, message: 'simulated lease release failure' });
+             } else {
+               parentPort.postMessage({ kind: 'result', id: request.id, value: null });
+             }
+           });`,
+          { eval: true },
+        ),
+    });
+
+    await expect(opened.repository.deleteBefore(BASE_TIME)).resolves.toMatchObject({ status: 'complete' });
+    expect(opened.repository.health()).toMatchObject({
+      state: 'degraded',
+      lastError: expect.stringMatching(/lease release failure/),
+    });
+    await opened.repository.close();
+  });
+
+  it('keeps the independent reader usable after a terminal writer failure', async () => {
+    const seeded = await repository();
+    seeded.repository.enqueue(exchange('exchange-before-writer-failure'));
+    await seeded.repository.flush();
+    await seeded.repository.close();
+
+    const repositoryWithFailedWriter = await SqliteLlmMetricsRepository.open({
+      databasePath: seeded.databasePath,
+      flushIntervalMs: 60_000,
+      flushTimeoutMs: 30,
+      closeTimeoutMs: 30,
+      workerFactory: () =>
+        new Worker(
+          `const { parentPort } = require('node:worker_threads');
+           parentPort.postMessage({ kind: 'ready', schemaVersion: 1 });
+           parentPort.on('message', () => {});`,
+          { eval: true },
+        ),
+    });
+    const query = { fromMs: BASE_TIME, toMs: BASE_TIME + 1_000, limit: 10 };
+
+    await expect(repositoryWithFailedWriter.scan(query)).resolves.toMatchObject([
+      { exchangeId: 'exchange-before-writer-failure' },
+    ]);
+    repositoryWithFailedWriter.enqueue(exchange('exchange-that-cannot-be-persisted'));
+    await repositoryWithFailedWriter.flush();
+    expect(repositoryWithFailedWriter.health()).toMatchObject({
+      state: 'disabled',
+      readerState: 'ready',
+      dropped: 1,
+    });
+    await expect(repositoryWithFailedWriter.scan(query)).resolves.toMatchObject([
+      { exchangeId: 'exchange-before-writer-failure' },
+    ]);
+    await expect(new LlmStatisticsQueryService(repositoryWithFailedWriter).capabilities()).resolves.toMatchObject({
+      available: true,
+      health: { state: 'disabled', readerState: 'ready' },
+    });
+    await repositoryWithFailedWriter.close();
   });
 
   it('bounds its queue and fails open when persistence cannot accept another record', async () => {

--- a/test/llm-metrics-retention-runtime.test.ts
+++ b/test/llm-metrics-retention-runtime.test.ts
@@ -50,6 +50,8 @@ import { acquireLlmMetricsRuntime, type LlmMetricsRuntimeLease } from '../src/ll
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const RETENTION_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+const RETENTION_RETRY_BASE_MS = 30_000;
+const RETENTION_RETRY_MAX_MS = 30 * 60 * 1_000;
 
 describe('LLM metrics runtime retention', () => {
   const directories: string[] = [];
@@ -138,6 +140,74 @@ describe('LLM metrics runtime retention', () => {
     expect(deleteBefore).toHaveBeenCalledTimes(2);
     expect(deleteBefore).toHaveBeenNthCalledWith(1, Date.now() - DAY_MS - 1, expect.any(Object));
     expect(deleteBefore).toHaveBeenNthCalledWith(2, Date.now() - DAY_MS, expect.any(Object));
+  });
+
+  it('retries retention failures with exponential backoff capped at thirty minutes', async () => {
+    const deleteBefore = vi.mocked(repositoryMocks.repository.deleteBefore);
+    deleteBefore.mockRejectedValue(new Error('simulated retention timeout'));
+    const lease = await acquireLlmMetricsRuntime({ databasePath: await databasePath(), retentionDays: 1 });
+    leases.push(lease);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deleteBefore).toHaveBeenCalledTimes(1);
+
+    const retryDelays = [
+      RETENTION_RETRY_BASE_MS,
+      RETENTION_RETRY_BASE_MS * 2,
+      RETENTION_RETRY_BASE_MS * 4,
+      RETENTION_RETRY_BASE_MS * 8,
+      RETENTION_RETRY_BASE_MS * 16,
+      RETENTION_RETRY_BASE_MS * 32,
+      RETENTION_RETRY_MAX_MS,
+      RETENTION_RETRY_MAX_MS,
+    ];
+    for (const [index, delayMs] of retryDelays.entries()) {
+      await vi.advanceTimersByTimeAsync(delayMs - 1);
+      expect(deleteBefore).toHaveBeenCalledTimes(index + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(deleteBefore).toHaveBeenCalledTimes(index + 2);
+    }
+
+    await lease.release();
+    deleteBefore.mockClear();
+    await vi.advanceTimersByTimeAsync(RETENTION_RETRY_MAX_MS);
+    expect(deleteBefore).not.toHaveBeenCalled();
+  });
+
+  it('does not bypass backoff when a retry deadline overlaps an active prune', async () => {
+    const deleteBefore = vi.mocked(repositoryMocks.repository.deleteBefore);
+    const failure = new Error('simulated retention timeout');
+    let rejectActivePrune: ((reason?: unknown) => void) | undefined;
+    deleteBefore
+      .mockRejectedValueOnce(failure)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectActivePrune = reject;
+          }),
+      )
+      .mockRejectedValue(failure);
+    const path = await databasePath();
+    const initialLease = await acquireLlmMetricsRuntime({ databasePath: path, retentionDays: 30 });
+    leases.push(initialLease);
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(RETENTION_RETRY_BASE_MS - 1);
+    const shorterLease = await acquireLlmMetricsRuntime({ databasePath: path, retentionDays: 1 });
+    leases.push(shorterLease);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deleteBefore).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(deleteBefore).toHaveBeenCalledTimes(2);
+    rejectActivePrune?.(failure);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(deleteBefore).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(RETENTION_RETRY_BASE_MS * 2 - 1);
+    expect(deleteBefore).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(deleteBefore).toHaveBeenCalledTimes(3);
   });
 
   it('does not schedule pruning without a finite retention window and clears timers on final release', async () => {


### PR DESCRIPTION
## Summary

- keep the independent SQLite statistics reader available after a terminal writer failure
- treat retention timeouts as degraded, retain single-flight ownership until late worker requests settle, and restore health after recovery
- retry busy or failed retention work with exponential backoff capped at 30 minutes

## Validation

- npm run format
- npm run lint
- npm run build
- npm test -- test/llm-metrics-persistence.test.ts test/llm-metrics-retention-runtime.test.ts
- npm test
- pre-commit formatting and lint checks
- pre-push circular-dependency check