### PR TITLE
Fix stale PTY socket on session resume

### DIFF
--- a/src/docker/pty-session.ts
+++ b/src/docker/pty-session.ts
@@ -628,6 +628,14 @@ async function runPtySessionAttempt(
     // deterministic in both modes.
     await docker.removeStaleContainer(mainContainerName);
 
+    // A crashed socat process leaves its UDS inode behind. Resumed sessions
+    // reuse the bundle ID (and therefore this pathname), and socat refuses to
+    // bind while the old entry exists. Clear it only after the old container
+    // has been removed and before the replacement container can start.
+    if (ptySockPath !== undefined) {
+      removeStalePtySocket(resolve(socketsDir, PTY_SOCK_NAME));
+    }
+
     if (infra.topology === 'tcp-hostonly') {
       // Apple container host-only mode: the agent VM reaches the host
       // proxies directly at the vmnet gateway, and the host connects
@@ -1501,6 +1509,33 @@ async function verifyInitialPtySize(
 }
 
 // --- Readiness polling ---
+
+/**
+ * Removes the UDS inode left by an unclean PTY listener shutdown.
+ *
+ * The caller must establish exclusive ownership and stop the prior listener
+ * before invoking this helper. Unexpected path types fail closed rather than
+ * being deleted from the host-owned runtime directory.
+ */
+export function removeStalePtySocket(path: string): void {
+  let stats: ReturnType<typeof lstatSync>;
+  try {
+    stats = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  if (!stats.isSocket()) {
+    throw new Error(`Refusing to replace non-socket PTY path ${path}`);
+  }
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+  logger.info(`Removed stale PTY socket ${path}`);
+}
 
 /**
  * Waits for the PTY socket file to appear (Linux UDS only). macOS TCP

--- a/test/pty-session.test.ts
+++ b/test/pty-session.test.ts
@@ -410,6 +410,75 @@ describe('PTY resize via socat', () => {
   });
 });
 
+// --- stale PTY socket cleanup ---
+
+describe('removeStalePtySocket', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pty-stale-socket-test-'));
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes a stale UDS inode so a replacement listener can bind', async () => {
+    const { removeStalePtySocket, waitForPtyReady } = await import('../src/docker/pty-session.js');
+    const sockPath = join(tempDir, 'pty.sock');
+    const listenerProgram = [
+      "const { createServer } = require('node:net');",
+      'const server = createServer();',
+      "server.listen(process.argv[1], () => process.stdout.write('ready\\n'));",
+    ].join('\n');
+    const stale = spawn(process.execPath, ['-e', listenerProgram, sockPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    await new Promise<void>((resolve, reject) => {
+      stale.once('error', reject);
+      stale.once('exit', (code, signal) => {
+        reject(new Error(`stale listener exited before binding (code=${code}, signal=${signal})`));
+      });
+      stale.stdout.once('data', () => resolve());
+    });
+    const staleExit = new Promise<void>((resolve) => stale.once('exit', () => resolve()));
+    stale.kill('SIGKILL');
+    await staleExit;
+    expect(existsSync(sockPath)).toBe(true);
+
+    removeStalePtySocket(sockPath);
+    expect(existsSync(sockPath)).toBe(false);
+
+    const { createServer } = await import('node:net');
+    const replacement = createServer();
+    await new Promise<void>((resolve, reject) => {
+      replacement.once('error', reject);
+      replacement.listen(sockPath, () => resolve());
+    });
+    try {
+      await expect(waitForPtyReady(sockPath)).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve) => replacement.close(() => resolve()));
+    }
+  });
+
+  it('is a no-op when no stale path exists', async () => {
+    const { removeStalePtySocket } = await import('../src/docker/pty-session.js');
+    expect(() => removeStalePtySocket(join(tempDir, 'missing.sock'))).not.toThrow();
+  });
+
+  it('refuses to remove an unexpected non-socket path', async () => {
+    const { removeStalePtySocket } = await import('../src/docker/pty-session.js');
+    const path = join(tempDir, 'pty.sock');
+    writeFileSync(path, 'preserve me');
+
+    expect(() => removeStalePtySocket(path)).toThrow(/Refusing to replace non-socket PTY path/u);
+    expect(readFileSync(path, 'utf8')).toBe('preserve me');
+  });
+});
+
 // --- waitForPtyReady regression tests ---
 //
 // Regression: a connect-based probe against a `socat ...,fork` listener spawns


### PR DESCRIPTION
## Summary

- remove an orphaned PTY Unix socket after the prior container is removed and before its replacement starts
- refuse to delete unexpected non-socket paths from the runtime directory
- reproduce the crash case with a SIGKILL listener and verify a replacement can bind

## Root cause

A hard-stopped socat listener leaves sockets/pty.sock behind. Resumed sessions reuse the bundle runtime directory, and the existing readiness check accepts that stale socket inode before the replacement socat process can bind. Socat then exits because the path already exists, which terminates the resumed session.

## Validation

- npm run format
- npm run lint
- npm run build
- npm test -- test/pty-session.test.ts test/docker/pty-cleanup.test.ts test/docker/pty-nested-ordering.test.ts (37 passed)
- npm test reached 333 passing files / 6,833 passing tests, then failed one unrelated live Docker/Goose UID-remap case because its container stopped; the isolated UID-remap suite reproduced that environment failure